### PR TITLE
Added test and fix for JSONWire handling of null String.

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/JSONWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/JSONWire.java
@@ -168,5 +168,10 @@ public class JSONWire extends TextWire {
     }
 
     class JSONValueIn extends TextValueIn {
+        @Override
+        public String text() {
+            String text = super.text();
+            return text == null || text.equals("null") ? null : text;
+        }
     }
 }


### PR DESCRIPTION
JSOWire was reading the null value as a string, which ruined comparison using TEXT.asString().