### PR TITLE
Cc appender fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
             <dependency>
                 <groupId>net.openhft</groupId>
                 <artifactId>chronicle-bom</artifactId>
-                <version>1.13.22</version>
+                <version>1.13.24-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -275,7 +275,7 @@ public abstract class AbstractWire implements Wire {
             }
 
             if (lastPosition != null) {
-                long lastPositionValue = lastPosition.getValue();
+                long lastPositionValue = lastPosition.getVolatileValue();
                 // do we jump forward if there has been writes else where.
                 if (lastPositionValue > bytes.writePosition() + ignoreHeaderCountIfNumberOfBytesBehindExceeds) {
                     headerNumber(Long.MIN_VALUE);
@@ -323,7 +323,7 @@ public abstract class AbstractWire implements Wire {
 
                 int len = lengthOf(header);
 
-                int nextHeader = lengthOf(bytes.readInt(pos + len + SPB_HEADER_SIZE));
+                int nextHeader = lengthOf(bytes.readVolatileInt(pos + len + SPB_HEADER_SIZE));
                 if (nextHeader > 1 << 10) {
                     int header2 = bytes.readVolatileInt(pos);
                     if (header2 != header) {

--- a/src/test/java/net/openhft/chronicle/wire/TextWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TextWireTest.java
@@ -509,8 +509,9 @@ public class TextWireTest {
     public void testZonedDateTime() {
         Wire wire = createWire();
         ZonedDateTime now = ZonedDateTime.now();
-        final ZonedDateTime max = ZonedDateTime.of(LocalDateTime.MAX, ZoneId.systemDefault());
-        final ZonedDateTime min = ZonedDateTime.of(LocalDateTime.MIN, ZoneId.systemDefault());
+        ZoneId zone = ZoneId.of("Europe/London");
+        final ZonedDateTime max = ZonedDateTime.of(LocalDateTime.MAX, zone);
+        final ZonedDateTime min = ZonedDateTime.of(LocalDateTime.MIN, zone);
         wire.write()
                 .zonedDateTime(now)
                 .write().zonedDateTime(max)


### PR DESCRIPTION
The LongReference `lastPosition` is readVolatile by every other accessor.
Unsure if the read of the nextHeader needs to be volatile or not.