### PR TITLE
Failing test for the JSONWire formatting of list field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
             <dependency>
                 <groupId>net.openhft</groupId>
                 <artifactId>chronicle-bom</artifactId>
-                <version>1.14.29-SNAPSHOT</version>
+                <version>1.14.30-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/test/java/net/openhft/chronicle/wire/JSONWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/JSONWireTest.java
@@ -110,8 +110,27 @@ public class JSONWireTest {
         // fails due to a trailing space if we don't call toString.
         // assertEquals(lists1, lists2);
         assertEquals(lists1.toString(), lists2.toString());
-
-        wire.bytes().release();
+        try {
+            assertEquals("!net.openhft.chronicle.wire.JSONWireTest$TwoLists {\n" +
+                    "  name: !!null \"\",\n" +
+                    "  list1: [\n" +
+                    "    { name: !!null \"\", number1: 0, number2: 0.0 },\n" +
+                    "    { name: !!null \"\", number1: 1, number2: 10.0 },\n" +
+                    "    { name: !!null \"\", number1: 2, number2: 20.0 },\n" +
+                    "    { name: !!null \"\", number1: 3, number2: 30.0 },\n" +
+                    "    { name: !!null \"\", number1: 4, number2: 40.0 }\n" +
+                    "  ],\n" +
+                    "  list2: [\n" +
+                    "    { name: !!null \"\", number1: 0, number2: 0.0 },\n" +
+                    "    { name: !!null \"\", number1: 1, number2: 10.0 },\n" +
+                    "    { name: !!null \"\", number1: 2, number2: 20.0 },\n" +
+                    "    { name: !!null \"\", number1: 3, number2: 30.0 },\n" +
+                    "    { name: !!null \"\", number1: 4, number2: 40.0 }\n" +
+                    "  ]\n" +
+                    "}\n", lists1.toString());
+        } finally {
+            wire.bytes().release();
+        }
     }
 
     @Test


### PR DESCRIPTION
Fields of type List<Marshallable> inside a marshallable have an issue with the 'leaf' fomatting of the list items. It seems like maybe the seperator should be ',\n' but it ends up being just ','