### PR TITLE
Bug: set time-zone to ensure time-zone dependent tests pass

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <argLine>-Duser.timezone=UTC</argLine>
                     <forkCount>1</forkCount>
                     <reuseForks>false</reuseForks>
                 </configuration>


### PR DESCRIPTION
The WireToOutputStreamTest fail unless the JVM time-zone is GMT.