### PR TITLE
Polish: suppress compiler warnings

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AbstractAnyWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractAnyWire.java
@@ -33,6 +33,7 @@ import java.util.function.Supplier;
  *
  * @author Rob Austin.
  */
+@SuppressWarnings("rawtypes")
 public abstract class AbstractAnyWire extends AbstractWire implements Wire {
 
     @NotNull

--- a/src/main/java/net/openhft/chronicle/wire/AbstractFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractFieldInfo.java
@@ -5,6 +5,7 @@ import static net.openhft.chronicle.wire.WireType.TEXT;
 /*
  * Created by peter.lawrey@chronicle.software on 24/07/2017
  */
+@SuppressWarnings("rawtypes")
 public abstract class AbstractFieldInfo implements FieldInfo {
     protected final String name;
     protected final Class type;

--- a/src/main/java/net/openhft/chronicle/wire/AbstractMethodWriterInvocationHandler.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractMethodWriterInvocationHandler.java
@@ -86,6 +86,7 @@ public abstract class AbstractMethodWriterInvocationHandler extends AbstractInvo
         writeEvent0(wire, method, args, methodName, 1);
     }
 
+    @SuppressWarnings("unchecked")
     private void writeEvent0(Wire wire, @NotNull Method method, Object[] args, String methodName, int oneParam) {
         ParameterHolderSequenceWriter phsw = parameterMap.computeIfAbsent(method, ParameterHolderSequenceWriter::new);
         Bytes<?> bytes = wire.bytes();

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -50,6 +50,7 @@ import static net.openhft.chronicle.wire.BinaryWireCode.*;
 /**
  * This Wire is a binary translation of TextWire which is a sub set of YAML.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class BinaryWire extends AbstractWire implements Wire {
     private static final UTF8StringInterner UTF8 = new UTF8StringInterner(4096);
     private static final Bit8StringInterner BIT8 = new Bit8StringInterner(1024);
@@ -322,6 +323,7 @@ public class BinaryWire extends AbstractWire implements Wire {
         }
     }
 
+    @SuppressWarnings("incomplete-switch")
     public void readWithLength(@NotNull WireOut wire, int len) {
         long lim = bytes.readLimit();
         try {

--- a/src/main/java/net/openhft/chronicle/wire/CSVWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/CSVWire.java
@@ -36,6 +36,7 @@ public class CSVWire extends TextWire {
 
     private final List<String> header = new ArrayList<>();
 
+    @SuppressWarnings("rawtypes")
     public CSVWire(@NotNull Bytes bytes, boolean use8bit) {
         super(bytes, use8bit);
         while (lineStart == 0) {
@@ -46,6 +47,7 @@ public class CSVWire extends TextWire {
         }
     }
 
+    @SuppressWarnings("rawtypes")
     public CSVWire(@NotNull Bytes bytes) {
         this(bytes, false);
     }

--- a/src/main/java/net/openhft/chronicle/wire/CharSequenceObjectMap.java
+++ b/src/main/java/net/openhft/chronicle/wire/CharSequenceObjectMap.java
@@ -5,12 +5,14 @@ import net.openhft.chronicle.core.util.StringUtils;
 
 public class CharSequenceObjectMap<T> {
     private static final int K0 = 0x6d0f27bd;
+    @SuppressWarnings("unused")
     private static final int M0 = 0x5bc80bad;
 
     final String[] keys;
     final T[] values;
     final int mask;
 
+    @SuppressWarnings("unchecked")
     public CharSequenceObjectMap(int capacity) {
         int nextPower2 = Maths.nextPower2(capacity, 16);
         keys = new String[nextPower2];

--- a/src/main/java/net/openhft/chronicle/wire/DefaultValueIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/DefaultValueIn.java
@@ -38,6 +38,7 @@ import java.util.function.*;
 /*
  * Created by peter.lawrey on 02/02/2016.
  */
+@SuppressWarnings("rawtypes")
 public class DefaultValueIn implements ValueIn {
     private final WireIn wireIn;
     Object defaultValue;
@@ -341,12 +342,14 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    @SuppressWarnings("unchecked")
     @Nullable
     @Override
     public <T> T applyToMarshallable(Function<WireIn, T> marshallableReader) {
         return (T) defaultValue;
     }
 
+    @SuppressWarnings("unchecked")
     @Nullable
     @Override
     public <T> T typedMarshallable() throws IORuntimeException {
@@ -441,6 +444,7 @@ public class DefaultValueIn implements ValueIn {
         return o.floatValue();
     }
 
+    @SuppressWarnings("unchecked")
     @Nullable
     @Override
     public <T> Class<T> typeLiteral() throws IORuntimeException, BufferUnderflowException {

--- a/src/main/java/net/openhft/chronicle/wire/DeferredTypeWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/DeferredTypeWire.java
@@ -35,6 +35,7 @@ import java.util.function.Supplier;
  *
  * @author Rob Austin.
  */
+@SuppressWarnings("rawtypes")
 @Deprecated(/*TODO Add tests, or delete?*/)
 public class DeferredTypeWire extends AbstractAnyWire implements Wire {
 

--- a/src/main/java/net/openhft/chronicle/wire/Demarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/Demarshallable.java
@@ -36,6 +36,7 @@ public interface Demarshallable {
         @Override
         protected Constructor<Demarshallable> computeValue(@NotNull Class<?> type) {
             try {
+                @SuppressWarnings("unchecked")
                 @NotNull Constructor<Demarshallable> declaredConstructor =
                         (Constructor<Demarshallable>)
                                 type.getDeclaredConstructor(WireIn.class);
@@ -47,6 +48,7 @@ public interface Demarshallable {
         }
     };
 
+    @SuppressWarnings("unchecked")
     @NotNull
     static <T extends Demarshallable> T newInstance(@NotNull Class<T> clazz, WireIn wireIn) {
         try {

--- a/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
@@ -25,6 +25,7 @@ public interface FieldInfo {
 
     String name();
 
+    @SuppressWarnings("rawtypes")
     Class type();
 
     BracketType bracketType();
@@ -50,5 +51,6 @@ public interface FieldInfo {
 
     void set(Object object, double value) throws IllegalArgumentException;
 
+    @SuppressWarnings("rawtypes")
     Class genericType(int index);
 }

--- a/src/main/java/net/openhft/chronicle/wire/GeneratedProxyClass.java
+++ b/src/main/java/net/openhft/chronicle/wire/GeneratedProxyClass.java
@@ -15,6 +15,7 @@ import java.util.Set;
  *
  * The purpose of this class is to generate a proxy that will re-use the arg[]
  */
+@SuppressWarnings("restriction")
 public enum GeneratedProxyClass {
     ;
 
@@ -24,6 +25,7 @@ public enum GeneratedProxyClass {
      * @param interfaces an interface class
      * @return a proxy class from an interface class or null if it can't be created
      */
+    @SuppressWarnings("rawtypes")
     public static Class from(Set<Class> interfaces, String className) {
         int maxArgs = 0;
         LinkedHashSet<Method> methods = new LinkedHashSet<>();

--- a/src/main/java/net/openhft/chronicle/wire/HashWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/HashWire.java
@@ -39,6 +39,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
+@SuppressWarnings("rawtypes")
 public class HashWire implements WireOut, BytesComment {
     private static final ThreadLocal<HashWire> hwTL = new ThreadLocal<HashWire>() {
         @Override

--- a/src/main/java/net/openhft/chronicle/wire/JSONWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/JSONWire.java
@@ -29,12 +29,15 @@ import static net.openhft.chronicle.bytes.NativeBytes.nativeBytes;
  * At the moment, this is a cut down version of the YAML wire format.
  */
 public class JSONWire extends TextWire {
+    @SuppressWarnings("rawtypes")
     static final BytesStore COMMA = BytesStore.from(",");
 
+    @SuppressWarnings("rawtypes")
     public JSONWire(@NotNull Bytes bytes, boolean use8bit) {
         super(bytes, use8bit);
     }
 
+    @SuppressWarnings("rawtypes")
     public JSONWire(@NotNull Bytes bytes) {
         this(bytes, false);
     }

--- a/src/main/java/net/openhft/chronicle/wire/KeyedMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/KeyedMarshallable.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
  * @author Rob Austin.
  */
 public interface KeyedMarshallable {
+    @SuppressWarnings("rawtypes")
     default void writeKey(@NotNull Bytes bytes) {
         Wires.writeKey(this, bytes);
     }

--- a/src/main/java/net/openhft/chronicle/wire/Marshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/Marshallable.java
@@ -134,6 +134,7 @@ public interface Marshallable extends WriteMarshallable, ReadMarshallable, Reset
         Wires.writeMarshallable(this, wire);
     }
 
+    @SuppressWarnings("unchecked")
     @NotNull
     default <T> T deepCopy() {
         return (T) Wires.deepCopy(this);

--- a/src/main/java/net/openhft/chronicle/wire/MarshallableIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableIn.java
@@ -73,6 +73,7 @@ public interface MarshallableIn {
      * @param using used to read the document
      * @return {@code true} if successful
      */
+    @SuppressWarnings("rawtypes")
     default boolean readBytes(@NotNull Bytes using) {
         try (@NotNull DocumentContext dc = readingDocument()) {
             if (!dc.isPresent())
@@ -126,6 +127,7 @@ public interface MarshallableIn {
      *
      * @return the Map, or null if no message is waiting.
      */
+    @SuppressWarnings("unchecked")
     @Nullable
     default <K, V> Map<K, V> readMap() {
         try (@NotNull DocumentContext dc = readingDocument()) {

--- a/src/main/java/net/openhft/chronicle/wire/MarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableOut.java
@@ -174,6 +174,7 @@ public interface MarshallableOut {
      * @return a proxy which implements the primary interface (additional interfaces have to be
      * cast)
      */
+    @SuppressWarnings("rawtypes")
     @NotNull
     default <T> T methodWriter(@NotNull Class<T> tClass, Class... additional) {
         return methodWriter(false, tClass, additional);
@@ -188,6 +189,7 @@ public interface MarshallableOut {
      * @return a proxy which implements the primary interface (additional interfaces have to be
      * cast)
      */
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @NotNull
     default <T> T methodWriter(boolean metaData, @NotNull Class<T> tClass, Class... additional) {
         Class[] interfaces = ObjectUtils.addAll(tClass, additional);

--- a/src/main/java/net/openhft/chronicle/wire/ParameterHolderSequenceWriter.java
+++ b/src/main/java/net/openhft/chronicle/wire/ParameterHolderSequenceWriter.java
@@ -8,11 +8,13 @@ import java.util.function.BiConsumer;
 
 // lambda was causing garbage
 class ParameterHolderSequenceWriter {
+    @SuppressWarnings("rawtypes")
     final Class[] parameterTypes;
     final BiConsumer<Object[], ValueOut> from0;
     final BiConsumer<Object[], ValueOut> from1;
     final long methodId;
 
+    @SuppressWarnings("unchecked")
     protected ParameterHolderSequenceWriter(Method method) {
         this.parameterTypes = method.getParameterTypes();
         this.from0 = (a, v) -> {

--- a/src/main/java/net/openhft/chronicle/wire/ReadAnyWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/ReadAnyWire.java
@@ -32,6 +32,7 @@ import java.util.function.Supplier;
  *
  * @author Rob Austin.
  */
+@SuppressWarnings("rawtypes")
 public class ReadAnyWire extends AbstractAnyWire implements Wire {
 
     public ReadAnyWire(@NotNull Bytes bytes) {

--- a/src/main/java/net/openhft/chronicle/wire/ScalarStrategy.java
+++ b/src/main/java/net/openhft/chronicle/wire/ScalarStrategy.java
@@ -56,6 +56,7 @@ class ScalarStrategy<T> implements SerializationStrategy<T> {
         return BracketType.NONE;
     }
 
+    @SuppressWarnings("rawtypes")
     @NotNull
     @Override
     public T newInstance(Class type) {

--- a/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
+++ b/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
@@ -35,6 +35,7 @@ import java.util.*;
 /*
  * Created by Peter Lawrey on 10/05/16.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public enum SerializationStrategies implements SerializationStrategy {
     MARSHALLABLE {
         @NotNull

--- a/src/main/java/net/openhft/chronicle/wire/TextReadDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextReadDocumentContext.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
  * Created by Peter Lawrey on 24/12/15.
  */
 public class TextReadDocumentContext implements ReadDocumentContext {
+    @SuppressWarnings("rawtypes")
     public static final BytesStore MSG_SEP = BytesStore.from("---");
     @Nullable
     protected TextWire wire;

--- a/src/main/java/net/openhft/chronicle/wire/ValueIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueIn.java
@@ -37,6 +37,7 @@ import java.util.function.*;
 /**
  * Read in data after reading a field.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public interface ValueIn {
     Consumer<ValueIn> DISCARD = v -> {
     };

--- a/src/main/java/net/openhft/chronicle/wire/ValueOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueOut.java
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
 /**
  * Write out data after writing a field.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public interface ValueOut {
 
     int SMALL_MESSAGE = 64;

--- a/src/main/java/net/openhft/chronicle/wire/VanillaFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaFieldInfo.java
@@ -34,6 +34,7 @@ import static net.openhft.chronicle.wire.WireMarshaller.WIRE_MARSHALLER_CL;
 /*
  * Created by Peter Lawrey on 18/10/16.
  */
+@SuppressWarnings("rawtypes")
 public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
 
     private final Class parent;
@@ -122,6 +123,7 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void set(Object object, Object value) throws IllegalArgumentException {
         Object value2 = ObjectUtils.convertTo(type, value);

--- a/src/main/java/net/openhft/chronicle/wire/VanillaMessageHistory.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMessageHistory.java
@@ -28,6 +28,7 @@ import java.util.function.Supplier;
 /*
  * Created by Peter Lawrey on 27/03/16.
  */
+@SuppressWarnings("rawtypes")
 public class VanillaMessageHistory extends AbstractMarshallable implements MessageHistory {
     public static final int MESSAGE_HISTORY_LENGTH = 20;
     private static final ThreadLocal<MessageHistory> THREAD_LOCAL =

--- a/src/main/java/net/openhft/chronicle/wire/VanillaMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMethodReader.java
@@ -46,6 +46,7 @@ import static net.openhft.chronicle.wire.VanillaWireParser.SKIP_READABLE_BYTES;
 /*
  * Created by Peter Lawrey on 24/03/16.
  */
+@SuppressWarnings("rawtypes")
 public class VanillaMethodReader implements MethodReader {
 
     static final Object[] NO_ARGS = {};
@@ -318,6 +319,7 @@ public class VanillaMethodReader implements MethodReader {
         return o instanceof Marshallable ? o : null;
     }
 
+    @SuppressWarnings("unchecked")
     public void addParseletForMethod(Object o, @NotNull Method m, @NotNull Class[] parameterTypes, MethodFilterOnFirstArg methodFilterOnFirstArg) {
         Jvm.setAccessible(m); // turn off security check to make a little faster
         @NotNull Object[] args = new Object[parameterTypes.length];

--- a/src/main/java/net/openhft/chronicle/wire/VanillaMethodWriterBuilder.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMethodWriterBuilder.java
@@ -36,6 +36,7 @@ import java.util.function.Supplier;
 /*
  * Created by Peter Lawrey on 28/03/16.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class VanillaMethodWriterBuilder<T> implements Supplier<T>, MethodWriterBuilder<T> {
 
     private final List<Class> interfaces = new ArrayList<>();

--- a/src/main/java/net/openhft/chronicle/wire/WireDumper.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireDumper.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 /*
  * Created by Peter Lawrey on 09/07/16.
  */
+@SuppressWarnings("rawtypes")
 public class WireDumper {
     @NotNull
     private final WireIn wireIn;

--- a/src/main/java/net/openhft/chronicle/wire/WireInternal.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireInternal.java
@@ -37,6 +37,7 @@ import static net.openhft.chronicle.wire.Wires.toIntU30;
 /*
  * Created by peter.lawrey on 16/01/15.
  */
+@SuppressWarnings({"rawtypes","unchecked"})
 public enum WireInternal {
     ;
     static final StringInterner INTERNER = new StringInterner(Integer.getInteger("wire.interner.size", 4096));

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -41,6 +41,7 @@ import static net.openhft.chronicle.wire.Wires.acquireStringBuilder;
 /*
  * Created by Peter Lawrey on 16/03/16.
  */
+@SuppressWarnings({"restriction", "rawtypes", "unchecked"})
 public class WireMarshaller<T> {
     public static final Class[] UNEXPECTED_FIELDS_PARAMETER_TYPES = {Object.class, ValueIn.class};
     private static final FieldAccess[] NO_FIELDS = {};

--- a/src/main/java/net/openhft/chronicle/wire/WireObjectInput.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireObjectInput.java
@@ -53,6 +53,7 @@ class WireObjectInput implements ObjectInput {
         return read(b, 0, b.length);
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
     public int read(@NotNull byte[] b, int off, int len) throws IOException {
         final long remaining = wire.bytes().readRemaining();

--- a/src/main/java/net/openhft/chronicle/wire/WireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireOut.java
@@ -58,6 +58,7 @@ public interface WireOut extends WireCommon, MarshallableOut {
         return write(key);
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     default ValueOut writeEvent(Class expectedType, Object eventKey) {
         if (eventKey instanceof WireKey)
             return writeEventName((WireKey) eventKey);

--- a/src/main/java/net/openhft/chronicle/wire/WireSerializedLambda.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireSerializedLambda.java
@@ -29,6 +29,7 @@ import java.util.List;
 /**
  * Helper calls to support serialization of lambdas in Wire formats.
  */
+@SuppressWarnings("rawtypes")
 public class WireSerializedLambda implements ReadMarshallable, ReadResolvable {
 
     private Class<?> capturingClass;

--- a/src/main/java/net/openhft/chronicle/wire/WireType.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireType.java
@@ -51,6 +51,7 @@ import static net.openhft.chronicle.core.io.IOTools.*;
 /**
  * A selection of prebuilt wire types.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public enum WireType implements Function<Bytes, Wire>, LicenceCheck {
 
     TEXT {
@@ -202,7 +203,7 @@ public enum WireType implements Function<Bytes, Wire>, LicenceCheck {
         public Wire apply(Bytes bytes) {
 
             try {
-                @NotNull @SuppressWarnings("unchecked")
+                @NotNull
                 Class<Wire> aClass = (Class) Class.forName("software.chronicle.wire.DeltaWire");
                 final Constructor<Wire> declaredConstructor = aClass.getDeclaredConstructor(Bytes.class);
                 return declaredConstructor.newInstance(bytes);

--- a/src/main/java/net/openhft/chronicle/wire/Wires.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wires.java
@@ -59,6 +59,7 @@ import static net.openhft.chronicle.wire.WireType.TEXT;
 /*
  * Created by Peter Lawrey on 31/08/15.
  */
+@SuppressWarnings({"rawtypes","unchecked"})
 public enum Wires {
     ;
     public static final int LENGTH_MASK = -1 >>> 2;

--- a/src/main/java/net/openhft/chronicle/wire/WriteDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/WriteDocumentContext.java
@@ -55,6 +55,7 @@ public class WriteDocumentContext implements DocumentContext {
     }
 
     @Override
+    @SuppressWarnings("rawtypes")
     public void close() {
         @NotNull Bytes bytes = wire().bytes();
         long position1 = bytes.writePosition();

--- a/src/test/java/net/openhft/chronicle/wire/BinaryInTextTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryInTextTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import static junit.framework.TestCase.assertEquals;
 
 public class BinaryInTextTest {
+    @SuppressWarnings("rawtypes")
     @Test
     public void testBytesFromText() {
         Bytes a = Marshallable.fromString(Bytes.class, "A==");
@@ -40,6 +41,7 @@ public class BinaryInTextTest {
                 "}\n", bit.toString());
     }
 
+    @SuppressWarnings("rawtypes")
     static class BIT extends AbstractMarshallable {
         Bytes b;
         BytesStore c;

--- a/src/test/java/net/openhft/chronicle/wire/BinaryToTextTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryToTextTest.java
@@ -29,6 +29,7 @@ public class BinaryToTextTest {
 
     @Test
     public void test() {
+        @SuppressWarnings("rawtypes")
         Bytes tbytes = Bytes.elasticByteBuffer();
         @NotNull Wire tw = new BinaryWire(tbytes);
         tw.writeDocument(false, w -> w.write(() -> "key").text("hello"));

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWire2Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWire2Test.java
@@ -39,6 +39,7 @@ import static org.junit.Assert.*;
 /*
  * Created by peter.lawrey on 06/02/15.
  */
+@SuppressWarnings("rawtypes")
 public class BinaryWire2Test {
     @NotNull
     Bytes bytes = nativeBytes();

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireHeadersTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireHeadersTest.java
@@ -44,6 +44,7 @@ public class BinaryWireHeadersTest {
 
     @Test
     public void testHeaderNumbers() throws TimeoutException, EOFException, StreamCorruptedException {
+        @SuppressWarnings("rawtypes")
         @NotNull BytesStore store = NativeBytesStore.elasticByteBuffer();
         @NotNull Wire wire = new BinaryWire(store.bytesForWrite()).headerNumber(0L);
         @NotNull Wire wire2 = new BinaryWire(store.bytesForWrite()).headerNumber(0L);
@@ -91,6 +92,7 @@ public class BinaryWireHeadersTest {
 
     @Test(timeout = 3000, expected = TimeoutException.class)
     public void testConcurrentHeaderNumbers() throws TimeoutException, EOFException, StreamCorruptedException {
+        @SuppressWarnings("rawtypes")
         @NotNull BytesStore store = NativeBytesStore.elasticByteBuffer();
         @NotNull Wire wire = new BinaryWire(store.bytesForWrite()).headerNumber(0L);
         @NotNull Wire wire2 = new BinaryWire(store.bytesForWrite()).headerNumber(0L);

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireNumbersTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireNumbersTest.java
@@ -105,6 +105,7 @@ public class BinaryWireNumbersTest {
     }
 
     public void test(@NotNull WriteValue expected, @NotNull WriteValue perform) {
+        @SuppressWarnings("rawtypes")
         @NotNull Bytes bytes1 = nativeBytes();
         @NotNull Wire wire1 = new BinaryWire(bytes1, true, false, false, Integer.MAX_VALUE, "binary", false);
         assert wire1.startUse();
@@ -112,6 +113,7 @@ public class BinaryWireNumbersTest {
 
         assertEquals("Length for fixed length doesn't match for " + TextWire.asText(wire1), len, bytes1.readRemaining());
 
+        @SuppressWarnings("rawtypes")
         @NotNull Bytes bytes2 = nativeBytes();
         @NotNull Wire wire2 = new BinaryWire(bytes2);
         perform.writeValue(wire2.write());

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWirePerfTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWirePerfTest.java
@@ -37,6 +37,7 @@ public class BinaryWirePerfTest {
     final boolean fixed;
     final boolean numericField;
     final boolean fieldLess;
+    @SuppressWarnings("rawtypes")
     @NotNull
     Bytes bytes = nativeBytes();
 

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireStringInternerTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireStringInternerTest.java
@@ -29,6 +29,7 @@ public final class BinaryWireStringInternerTest {
     private final Random random = new Random(SEED_WITHOUT_COLLISIONS);
     private final String[] testData = new String[DATA_SET_SIZE];
     private final String[] internedStrings = new String[DATA_SET_SIZE];
+    @SuppressWarnings("rawtypes")
     private final Bytes heapBytes = Bytes.elasticHeapByteBuffer(4096);
     private final BinaryWire wire = BinaryWire.binaryOnly(heapBytes);
 

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireTest.java
@@ -49,6 +49,7 @@ public class BinaryWireTest {
     final boolean numericField;
     final boolean fieldLess;
     final int compressedSize;
+    @SuppressWarnings("rawtypes")
     @NotNull
     Bytes bytes = nativeBytes();
 
@@ -669,6 +670,7 @@ public class BinaryWireTest {
                 .write()
                 .bytes(allBytes);
         System.out.println(bytes.toDebugString());
+        @SuppressWarnings("rawtypes")
         @NotNull NativeBytes allBytes2 = nativeBytes();
         wire.read().bytes(b -> assertEquals(0, b.readRemaining()))
                 .read().bytes(b -> assertEquals("Hello", b.toString()))

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireWithMappedBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireWithMappedBytesTest.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.assertEquals;
  * Created by Peter Lawrey on 18/01/16.
  */
 public class BinaryWireWithMappedBytesTest {
+    @SuppressWarnings("rawtypes")
     @Test
     public void testRefAtStart() throws FileNotFoundException {
         @NotNull File file = new File(OS.TARGET, "testRefAtStart.map");

--- a/src/test/java/net/openhft/chronicle/wire/BitSetTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BitSetTest.java
@@ -9,6 +9,7 @@ import java.util.BitSet;
 /**
  * Created by Rob Austin
  */
+@SuppressWarnings("rawtypes")
 public class BitSetTest {
 
     @Test

--- a/src/test/java/net/openhft/chronicle/wire/CSVBytesMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/CSVBytesMarshallableTest.java
@@ -35,6 +35,7 @@ enum CcyPair {
 /*
  * Created by peter.lawrey on 03/12/2015.
  */
+@SuppressWarnings("rawtypes")
 public class CSVBytesMarshallableTest {
     Bytes bytes = Bytes.from(
             "1.09029,1.090305,EURUSD,2,1,EBS\n" +
@@ -93,6 +94,7 @@ public class CSVBytesMarshallableTest {
     }
 }
 
+@SuppressWarnings("rawtypes")
 class FXPrice implements BytesMarshallable {
     public double bidprice;
     public double offerprice;

--- a/src/test/java/net/openhft/chronicle/wire/CopyTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/CopyTest.java
@@ -50,6 +50,7 @@ public class CopyTest {
         );
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testCopy() {
         Bytes bytesFrom = Bytes.elasticHeapByteBuffer(64);
@@ -83,6 +84,7 @@ public class CopyTest {
         return aClass;
     }
 
+    @SuppressWarnings("unused")
     private static class AClass extends AbstractMarshallable {
         Map<CcyPair, String> map;
         String[] array;

--- a/src/test/java/net/openhft/chronicle/wire/FIX42Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/FIX42Test.java
@@ -86,6 +86,7 @@ public class FIX42Test {
     final boolean fixed;
     final boolean numericField;
     final boolean fieldLess;
+    @SuppressWarnings("rawtypes")
     @NotNull
     Bytes bytes = nativeBytes();
 

--- a/src/test/java/net/openhft/chronicle/wire/FloatDtoTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/FloatDtoTest.java
@@ -9,6 +9,7 @@ import static net.openhft.chronicle.wire.WireMarshaller.WIRE_MARSHALLER_CL;
 /**
  * @author Rob Austin.
  */
+@SuppressWarnings("rawtypes")
 public class FloatDtoTest {
 
     @Test
@@ -23,12 +24,14 @@ public class FloatDtoTest {
 
     private static class Key extends AbstractMarshallable implements
             KeyedMarshallable {
+        @SuppressWarnings("unused")
         int uiid;
 
         Key(int uiid) {
             this.uiid = uiid;
         }
 
+        @SuppressWarnings("unchecked")
         @Override
         public void writeKey(@NotNull Bytes bytes) {
             WIRE_MARSHALLER_CL.get(Key.class).writeKey(this, bytes);
@@ -38,6 +41,7 @@ public class FloatDtoTest {
 
     private static class Value extends Key implements Marshallable {
 
+        @SuppressWarnings("unused")
         final float myFloat;
 
         Value(int uiid,

--- a/src/test/java/net/openhft/chronicle/wire/ForwardAndBackwardCompatibilityTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ForwardAndBackwardCompatibilityTest.java
@@ -110,6 +110,7 @@ public class ForwardAndBackwardCompatibilityTest {
     @Test
     public void testCheckThatNewDataAddedToADocumentDoesNotEffectOldReads() {
 
+        @SuppressWarnings("rawtypes")
         Bytes b = Bytes.elasticByteBuffer();
         try {
             Wire w = WireType.FIELDLESS_BINARY.apply(b);

--- a/src/test/java/net/openhft/chronicle/wire/HexDumpTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/HexDumpTest.java
@@ -14,6 +14,7 @@ public class HexDumpTest {
         if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN)
             return;
 
+        @SuppressWarnings("rawtypes")
         Bytes b = new HexDumpBytes();
         b.writeInt(0x0a0b0c0d);
         assertEquals("0d 0c 0b 0a\n", b.toHexString());

--- a/src/test/java/net/openhft/chronicle/wire/IgnoreHighOrderBitsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/IgnoreHighOrderBitsTest.java
@@ -19,9 +19,11 @@ public class IgnoreHighOrderBitsTest {
      */
     @Test
     public void testWriteByte() throws IOException {
+        @SuppressWarnings("rawtypes")
         final Bytes bytes = Bytes.elasticByteBuffer();
         try {
             final Wire wire = new BinaryWire(bytes);
+            @SuppressWarnings("resource")
             DataOutput out = new WireObjectOutput(wire);
             int b = 256;
             out.write(b); // expecting 0 to be written

--- a/src/test/java/net/openhft/chronicle/wire/InnerMapTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/InnerMapTest.java
@@ -51,6 +51,7 @@ public class InnerMapTest {
                 "  }\n" +
                 "}\n", asString);
 
+        @SuppressWarnings("rawtypes")
         Bytes b = Bytes.elasticByteBuffer();
         @NotNull Wire w = new BinaryWire(b);     // works with text fails with binary
 

--- a/src/test/java/net/openhft/chronicle/wire/JSON222IndividualTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/JSON222IndividualTest.java
@@ -54,6 +54,7 @@ public class JSON222IndividualTest {
 
     @Test
     public void nestedSeq() {
+        @SuppressWarnings("rawtypes")
         @NotNull List list = Arrays.asList(3L, Arrays.asList(4L));
         checkSerialized("[\n" +
                 "  3,\n" +

--- a/src/test/java/net/openhft/chronicle/wire/JSON222Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/JSON222Test.java
@@ -63,6 +63,7 @@ public class JSON222Test {
         return list;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Test//(timeout = 500)
     public void testJSON() throws IOException {
         int len = Maths.toUInt31(file.length());

--- a/src/test/java/net/openhft/chronicle/wire/Marshallable2Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/Marshallable2Test.java
@@ -42,6 +42,7 @@ public class Marshallable2Test {
         );
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testObject() {
         Bytes bytes = Bytes.elasticHeapByteBuffer(64);
@@ -55,6 +56,7 @@ public class Marshallable2Test {
         Assert.assertEquals(source, target);
     }
 
+    @SuppressWarnings("unused")
     private static class Outer extends AbstractMarshallable {
         String name;
         Inner1 inner1;

--- a/src/test/java/net/openhft/chronicle/wire/MethodFilterOnFirstArgTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MethodFilterOnFirstArgTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertEquals;
 
 // only extend MethodFilterOnFirstArg for testing purposes.
 // Don't do this unless you need to record your filtering choices.
+@SuppressWarnings("rawtypes")
 interface MockMethods2 extends MethodFilterOnFirstArg {
     void method1(MockDto dto);
 
@@ -16,6 +17,7 @@ interface MockMethods2 extends MethodFilterOnFirstArg {
     void method3(MockDto dto, MockDto dto2);
 }
 
+@SuppressWarnings("rawtypes")
 public class MethodFilterOnFirstArgTest {
     @Test
     public void ignoreMethodBasedOnFirstArg() throws IOException {
@@ -29,6 +31,7 @@ public class MethodFilterOnFirstArgTest {
     }
 }
 
+@SuppressWarnings("rawtypes")
 class MockMethods2Impl implements MockMethods2, MethodFilterOnFirstArg {
     private final MockMethods2 out;
 
@@ -51,6 +54,7 @@ class MockMethods2Impl implements MockMethods2, MethodFilterOnFirstArg {
         out.method3(dto, dto2);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public boolean ignoreMethodBasedOnFirstArg(String methodName, Object firstArg) {
         out.ignoreMethodBasedOnFirstArg(methodName, firstArg);

--- a/src/test/java/net/openhft/chronicle/wire/NestedMapsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/NestedMapsTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertTrue;
 /*
  * Created by Peter Lawrey on 21/04/16.
  */
+@SuppressWarnings("rawtypes")
 @RunWith(value = Parameterized.class)
 public class NestedMapsTest {
     private final WireType wireType;
@@ -51,6 +52,7 @@ public class NestedMapsTest {
         );
     }
 
+    @SuppressWarnings("incomplete-switch")
     @Test
     public void testMapped() {
         @NotNull Mapped m = new Mapped();
@@ -172,6 +174,7 @@ public class NestedMapsTest {
         bytes.release();
     }
 
+    @SuppressWarnings("incomplete-switch")
     @Test
     public void testMappedTopLevel() {
         @NotNull Mapped m = new Mapped();

--- a/src/test/java/net/openhft/chronicle/wire/PrimitiveTypeWrappersTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/PrimitiveTypeWrappersTest.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 /**
  * @author Rob Austin.
  */
+@SuppressWarnings("rawtypes")
 @RunWith(value = Parameterized.class)
 public class PrimitiveTypeWrappersTest {
 
@@ -50,6 +51,7 @@ public class PrimitiveTypeWrappersTest {
         );
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testNumbers() {
         @NotNull final Class[] types = new Class[]{Byte.class,

--- a/src/test/java/net/openhft/chronicle/wire/ProjectTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ProjectTest.java
@@ -48,6 +48,7 @@ public class ProjectTest {
         return list;
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testProject() throws Exception {
         @NotNull Dto1 dto1 = new Dto1();
@@ -84,6 +85,7 @@ public class ProjectTest {
         BytesUtil.checkRegisteredBytes();
     }
 
+    @SuppressWarnings("rawtypes")
     static class Dto1 extends AbstractMarshallable {
         @NotNull
         Map m = new HashMap<>();
@@ -91,6 +93,7 @@ public class ProjectTest {
         long someValue;
     }
 
+    @SuppressWarnings("rawtypes")
     static class Dto2 extends AbstractMarshallable {
         long someValue;
         String anotherField;

--- a/src/test/java/net/openhft/chronicle/wire/RFCExamplesTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/RFCExamplesTest.java
@@ -33,6 +33,7 @@ public class RFCExamplesTest {
     map.put(2, "world");
     map.put(3, "bye");
      */
+    @SuppressWarnings("rawtypes")
     @Test
     public void testPuts() {
         @NotNull Bytes bytes = Bytes.allocateElasticDirect();
@@ -144,6 +145,7 @@ put: [ 3, bye ]
                 "‡٠٠٠٠٠٠٠٠", bytes.toDebugString());
     }
 
+    @SuppressWarnings("rawtypes")
     public void clear(@NotNull Bytes bytes) {
         bytes.clear();
         bytes.zeroOut(0, bytes.realCapacity());

--- a/src/test/java/net/openhft/chronicle/wire/ReadDocumentContextTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ReadDocumentContextTest.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Rob Austin.
  */
+@SuppressWarnings("rawtypes")
 public class ReadDocumentContextTest {
     @Ignore("The ability to write incomplete documents is deprecated, and will be removed in a future release")
     @Test

--- a/src/test/java/net/openhft/chronicle/wire/StrangeTextCombination.java
+++ b/src/test/java/net/openhft/chronicle/wire/StrangeTextCombination.java
@@ -35,6 +35,7 @@ import java.util.Collection;
 @RunWith(value = Parameterized.class)
 public class StrangeTextCombination {
     private WireType wireType;
+    @SuppressWarnings("rawtypes")
     private Bytes bytes;
 
     public StrangeTextCombination(WireType wireType) {

--- a/src/test/java/net/openhft/chronicle/wire/StreamMain.java
+++ b/src/test/java/net/openhft/chronicle/wire/StreamMain.java
@@ -33,6 +33,7 @@ public class StreamMain {
             if (wt == WireType.CSV)
                 continue;
 
+            @SuppressWarnings("rawtypes")
             @NotNull Bytes b = Bytes.allocateElasticDirect();
             Wire w = wt.apply(b);
             w.writeDocument(true, w2 -> w2.write(() -> "header")

--- a/src/test/java/net/openhft/chronicle/wire/TextCompatibilityTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TextCompatibilityTest.java
@@ -75,6 +75,7 @@ public class TextCompatibilityTest {
         list.add(args);
     }
 
+    @SuppressWarnings("rawtypes")
     private static void runTest(String filename, String expectedFilename, boolean print) {
         String expected = null;
         try {

--- a/src/test/java/net/openhft/chronicle/wire/TextMethodTesterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TextMethodTesterTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertEquals;
  * Created by Peter Lawrey on 17/05/2017.
  */
 public class TextMethodTesterTest {
+    @SuppressWarnings("rawtypes")
     @Test
     public void run() throws IOException {
         TextMethodTester test = new TextMethodTester<>(

--- a/src/test/java/net/openhft/chronicle/wire/UnicodeStringTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/UnicodeStringTest.java
@@ -17,6 +17,7 @@ import static net.openhft.chronicle.bytes.NativeBytes.nativeBytes;
 
 @RunWith(value = Parameterized.class)
 public class UnicodeStringTest {
+    @SuppressWarnings("rawtypes")
     @NotNull
     static Bytes bytes = nativeBytes();
     static Wire wire = createWire();

--- a/src/test/java/net/openhft/chronicle/wire/WireInternalTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireInternalTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
+@SuppressWarnings("rawtypes")
 public class WireInternalTest {
 
     @Test

--- a/src/test/java/net/openhft/chronicle/wire/WireSerializedLambdaTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireSerializedLambdaTest.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.*;
 /*
  * Created by Peter Lawrey on 23/06/15.
  */
+@SuppressWarnings("unchecked")
 public class WireSerializedLambdaTest {
     static {
         ClassAliasPool.CLASS_ALIASES.addAlias(Fun.class);

--- a/src/test/java/net/openhft/chronicle/wire/WireTests.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireTests.java
@@ -41,7 +41,7 @@ import java.util.List;
 /**
  * @author Rob Austin.
  */
-
+@SuppressWarnings("rawtypes")
 @RunWith(value = Parameterized.class)
 public class WireTests {
 

--- a/src/test/java/net/openhft/chronicle/wire/WiresTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WiresTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.*;
 /*
  * Created by rob on 14/06/2017.
  */
+@SuppressWarnings("rawtypes")
 public class WiresTest {
 
     private final BytesContainer container1 = new BytesContainer();

--- a/src/test/java/net/openhft/chronicle/wire/YamlSpecTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/YamlSpecTest.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 /**
  * Created by Rob Austin
  */
+@SuppressWarnings("rawtypes")
 public class YamlSpecTest {
     static String DIR = "/yaml/spec/";
 

--- a/src/test/java/net/openhft/chronicle/wire/YamlSpecificationTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/YamlSpecificationTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertEquals;
 /*
  * Created by Peter Lawrey on 25/08/15.
  */
+@SuppressWarnings("rawtypes")
 @RunWith(Parameterized.class)
 public class YamlSpecificationTest {
     static {

--- a/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/BytesMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/BytesMarshallableTest.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
 
+@SuppressWarnings("rawtypes")
 @RunWith(value = Parameterized.class)
 public class BytesMarshallableTest {
     private final WireType wireType;
@@ -38,6 +39,7 @@ public class BytesMarshallableTest {
         return wireType.apply(Bytes.elasticHeapByteBuffer(64));
     }
 
+    @SuppressWarnings("incomplete-switch")
     @Test
     public void primitiveDto() {
         Wire wire = createWire();
@@ -73,6 +75,7 @@ public class BytesMarshallableTest {
         }
     }
 
+    @SuppressWarnings("incomplete-switch")
     @Test
     public void primitiveDto2() {
         Wire wire = createWire();

--- a/src/test/java/net/openhft/chronicle/wire/compact/DotNetTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/compact/DotNetTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
  * Created by Peter Lawrey on 14/05/16.
  */
 public class DotNetTest {
+    @SuppressWarnings("rawtypes")
     @Test
     public void testCode() {
         final Bytes bytes = Bytes.fromHexString("000000: B9 06 75 73 65 72 49 64 E5 61 6E 64 72 65 B9 06\n" +

--- a/src/test/java/net/openhft/chronicle/wire/map/MapWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/map/MapWireTest.java
@@ -38,8 +38,10 @@ import static org.junit.Assert.assertEquals;
 @RunWith(value = Parameterized.class)
 public class MapWireTest {
     private final WireType wireType;
+    @SuppressWarnings("rawtypes")
     private final Map m;
 
+    @SuppressWarnings("rawtypes")
     public MapWireTest(WireType wireType, Map m) {
         this.wireType = wireType;
         this.m = m;
@@ -66,6 +68,7 @@ public class MapWireTest {
         return list;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Test
     public void writeMap() {
         Bytes bytes = Bytes.elasticByteBuffer();

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/BytesUsageTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/BytesUsageTest.java
@@ -9,6 +9,7 @@ import static junit.framework.TestCase.assertEquals;
 
 public class BytesUsageTest {
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testBytes() {
         BytesStore value = Bytes.from("helloWorld");
@@ -25,6 +26,7 @@ public class BytesUsageTest {
         assertEquals(Bytes.from("AhelloWorld"), bw.clOrdId());
     }
 
+    @SuppressWarnings("rawtypes")
     static class BytesWrapper extends AbstractMarshallable {
         Bytes clOrdId = Bytes.allocateElasticDirect();
 

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/EnumWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/EnumWireTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertSame;
 /**
  * @author greg allen
  */
+@SuppressWarnings("rawtypes")
 @RunWith(Parameterized.class)
 public class EnumWireTest {
     private final Function<Bytes, Wire> createWire;

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/MarshallableWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/MarshallableWireTest.java
@@ -70,6 +70,7 @@ public class MarshallableWireTest {
         return list;
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void writeMarshallable() {
         Bytes bytes = Bytes.elasticByteBuffer();

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/ScalarValues.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/ScalarValues.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 /*
  * Created by Peter Lawrey on 09/05/16.
  */
+@SuppressWarnings("rawtypes")
 public class ScalarValues extends AbstractMarshallable {
     boolean flag;
     byte b;

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/WithDefaults.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/WithDefaults.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.NotNull;
 /*
  * Created by Peter Lawrey on 26/05/2017.
  */
+@SuppressWarnings("rawtypes")
 public class WithDefaults extends AbstractMarshallable {
     Bytes bytes = Bytes.fromString("Hello");
     String text = "Hello";

--- a/src/test/java/net/openhft/chronicle/wire/reordered/ReorderedTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/reordered/ReorderedTest.java
@@ -57,8 +57,10 @@ public class ReorderedTest {
         outerClass2.addListB().setTextNumber("num2B", 22);
     }
 
+    @SuppressWarnings("rawtypes")
     private final Function<Bytes, Wire> wireType;
 
+    @SuppressWarnings("rawtypes")
     public ReorderedTest(Function<Bytes, Wire> wireType) {
         this.wireType = wireType;
     }
@@ -72,6 +74,7 @@ public class ReorderedTest {
         );
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testWithReorderedFields() {
         Bytes bytes = Bytes.elasticByteBuffer();
@@ -96,6 +99,7 @@ public class ReorderedTest {
         bytes.release();
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testTopLevel() {
         Bytes bytes = Bytes.elasticByteBuffer();

--- a/src/test/java/net/openhft/chronicle/wire/reuse/NestedClassTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/reuse/NestedClassTest.java
@@ -58,12 +58,15 @@ public class NestedClassTest {
         outerClass2.addListB().setTextNumber("num2B", 22);
     }
 
+    @SuppressWarnings("rawtypes")
     private final Function<Bytes, Wire> wireType;
 
+    @SuppressWarnings("rawtypes")
     public NestedClassTest(Function<Bytes, Wire> wireType) {
         this.wireType = wireType;
     }
 
+    @SuppressWarnings("rawtypes")
     @Parameterized.Parameters
     public static Collection<Object[]> combinations() {
         return Arrays.asList(
@@ -76,6 +79,7 @@ public class NestedClassTest {
         );
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testMultipleReads() {
         Bytes bytes = Bytes.elasticByteBuffer();

--- a/src/test/java/net/openhft/chronicle/wire/reuse/WireCollectionTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/reuse/WireCollectionTest.java
@@ -42,6 +42,7 @@ import static org.junit.Assert.assertEquals;
  * Created by peter.lawrey on 01/02/2016.
  */
 @Ignore("TODO FIX")
+@SuppressWarnings("rawtypes")
 @RunWith(value = Parameterized.class)
 public class WireCollectionTest {
     static {

--- a/src/test/java/net/openhft/chronicle/wire/serializable/ScalarValues.java
+++ b/src/test/java/net/openhft/chronicle/wire/serializable/ScalarValues.java
@@ -32,6 +32,7 @@ import static net.openhft.chronicle.wire.WireType.TEXT;
 /*
  * Created by Peter Lawrey on 09/05/16.
  */
+@SuppressWarnings("rawtypes")
 public class ScalarValues implements Serializable {
     boolean flag;
     byte b;

--- a/src/test/java/net/openhft/chronicle/wire/serializable/SerializableWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/serializable/SerializableWireTest.java
@@ -70,6 +70,7 @@ public class SerializableWireTest {
         return list;
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void writeMarshallable() {
         Bytes bytes = Bytes.elasticByteBuffer();

--- a/src/test/java/net/openhft/chronicle/wire/type/conversions/binary/ConventionsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/type/conversions/binary/ConventionsTest.java
@@ -29,8 +29,10 @@ import java.nio.ByteBuffer;
 /*
  * Created by Rob Austin
  */
+@SuppressWarnings("unchecked")
 public class ConventionsTest {
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testTypeConversionsMaxValue() throws NoSuchFieldException, IllegalAccessException {
 
@@ -50,6 +52,7 @@ public class ConventionsTest {
         }
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testTypeConversionsMinValue() throws IllegalAccessException, NoSuchFieldException {
 
@@ -68,6 +71,7 @@ public class ConventionsTest {
         }
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testTypeConversionsSmallNumber() {
 
@@ -83,6 +87,7 @@ public class ConventionsTest {
 
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testTypeConversionsConvertViaString() throws NoSuchFieldException, IllegalAccessException {
 


### PR DESCRIPTION
Suppress compiler warnings for 'rawtypes', 'unchecked' conversions, 'incomplete-switch' blocks, 'unused' code, and use of 'restricted' APIs.