### PR TITLE
Polish: replace deprecated build() with get()

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/TextMethodTester.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextMethodTester.java
@@ -18,6 +18,7 @@ import java.util.function.Function;
 /*
  * Created by Peter Lawrey on 17/05/2017.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class TextMethodTester<T> {
     private final String input;
     private final Class<T> outputClass;
@@ -98,7 +99,7 @@ public class TextMethodTester<T> {
         MethodWriterBuilder<T> methodWriterBuilder = wire2.methodWriterBuilder(outputClass)
                 .methodWriterListener(methodWriterListener);
         if (genericEvent != null) methodWriterBuilder.genericEvent(genericEvent);
-        T writer0 = methodWriterBuilder.build();
+        T writer0 = methodWriterBuilder.get();
         T writer = retainLast == null
                 ? writer0
                 : cachedMethodWriter(writer0);

--- a/src/test/java/net/openhft/chronicle/wire/VanillaMethodReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/VanillaMethodReaderTest.java
@@ -19,6 +19,7 @@ import java.util.stream.IntStream;
 
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 interface MockMethods {
@@ -32,6 +33,7 @@ interface MockMethods {
 /*
  * Created by Peter Lawrey on 17/05/2017.
  */
+@SuppressWarnings("rawtypes")
 public class VanillaMethodReaderTest {
 
     A instance;
@@ -156,7 +158,7 @@ public class VanillaMethodReaderTest {
         Wire wire = new TextWire(Bytes.elasticHeapByteBuffer(256));
         MRTListener writer = wire.methodWriterBuilder(MRTListener.class)
                 .methodWriterListener((m, a) -> IntStream.range(0, a.length).filter(i -> a[i] instanceof MRT1).forEach(i -> ((MRT1) a[i]).value = "x"))
-                .build();
+                .get();
         writer.timed(1234567890L);
         writer.top(new MRT1("one"));
         writer.top(new MRT2("one", "two"));
@@ -276,6 +278,7 @@ public class VanillaMethodReaderTest {
             Overloaded writer2 = wire2.methodWriter(Overloaded.class);
             Wire wire = new TextWire(Bytes.from("method: [ ]\n"));
             MethodReader reader = wire.methodReader(writer2);
+            assertNotNull(reader);
 //            reader.readOne();
 
             String s = map.keySet().toString();

--- a/src/test/java/net/openhft/chronicle/wire/VanillaMethodWriterBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/VanillaMethodWriterBuilderTest.java
@@ -59,7 +59,7 @@ public class VanillaMethodWriterBuilderTest {
     private String doUseMethodId(boolean useMethodIds) {
         HexDumpBytes bytes = new HexDumpBytes();
         BinaryWire wire = new BinaryWire(bytes);
-        WithMethodId id = wire.methodWriterBuilder(WithMethodId.class).useMethodIds(useMethodIds).build();
+        WithMethodId id = wire.methodWriterBuilder(WithMethodId.class).useMethodIds(useMethodIds).get();
         id.method1("hello");
         id.method2(new MWB("world", 123, 3.456));
         id.method3(1234567890L);

--- a/src/test/java/net/openhft/chronicle/wire/VanillaWireParserTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/VanillaWireParserTest.java
@@ -18,7 +18,7 @@ public class VanillaWireParserTest {
     public void shouldDetermineMethodNamesFromMethodIds() {
         final BinaryWire wire = new BinaryWire(Bytes.allocateElasticDirect());
         final Speaker speaker =
-                wire.methodWriterBuilder(Speaker.class).useMethodIds(true).build();
+                wire.methodWriterBuilder(Speaker.class).useMethodIds(true).get();
         speaker.say("hello");
 
         final MethodReader reader = new VanillaMethodReaderBuilder(wire).build(impl());


### PR DESCRIPTION
Replace deprecated `build()` method with `get()` and suppress compiler warnings.