### PR TITLE
Polish: assert on unused variables

### DIFF
--- a/src/test/java/net/openhft/chronicle/wire/MarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MarshallableTest.java
@@ -47,14 +47,17 @@ public class MarshallableTest {
     @Test(expected = IllegalArgumentException.class)
     public void testFromString2() {
         Object o = Marshallable.fromString("\"");
+        assertNotNull(o);
     }
 
     @Ignore("Undefined behaviour")
     @Test(expected = IllegalArgumentException.class)
     public void testFromString3() {
         Object o = Marshallable.fromString("'");
+        assertNotNull(o);
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testBytesMarshallable() {
         @NotNull Marshallable m = new MyTypes();
@@ -67,6 +70,7 @@ public class MarshallableTest {
         m.readMarshallable(wire);
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testEquals() {
         @NotNull final Bytes bytes = nativeBytes();

--- a/src/test/java/net/openhft/chronicle/wire/RawWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/RawWireTest.java
@@ -41,6 +41,7 @@ import static org.junit.Assert.*;
 
 public class RawWireTest {
 
+    @SuppressWarnings("rawtypes")
     @NotNull
     Bytes bytes = nativeBytes();
 
@@ -272,6 +273,7 @@ public class RawWireTest {
         // ok as blank matches anything
         @NotNull AtomicLong i = new AtomicLong();
         IntConsumer ic = i::set;
+        assertNotNull(ic);
         LongStream.rangeClosed(1, 3).forEach(e -> {
             wire.read().int64(i, AtomicLong::set);
             assertEquals(e, i.get());
@@ -430,6 +432,7 @@ public class RawWireTest {
     }
 
     @Ignore("todo fix :currently using NoBytesStore so will fail with UnsupportedOperationException")
+    @SuppressWarnings("rawtypes")
     @Test
     public void testBytes() {
         @NotNull Wire wire = createWire();

--- a/src/test/java/net/openhft/chronicle/wire/TextWireAgitatorTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TextWireAgitatorTest.java
@@ -5,6 +5,7 @@ import net.openhft.chronicle.core.io.IORuntimeException;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 // Test created as a result of agitator tests i.e. random character changes
 public class TextWireAgitatorTest {
@@ -18,6 +19,7 @@ public class TextWireAgitatorTest {
                 "}\n", myDto.toString());
 
         TextWireTest.MyDto myDto2 = Marshallable.fromString("!" + TextWireTest.MyDto.class.getName().toLowerCase() + " { }");
+        assertNotNull(myDto2);
     }
 
     @Test(expected = IORuntimeException.class)
@@ -36,6 +38,7 @@ public class TextWireAgitatorTest {
         MyFlagged mf = Marshallable.fromString("!net.openhft.chronicle.wire.TextWireAgitatorTest$MyFlagged {\n" +
                 "  flag: not-false\n" +
                 "}");
+        assertNotNull(mf);
     }
 
     static class MyFlagged extends AbstractMarshallable {

--- a/src/test/java/net/openhft/chronicle/wire/TextWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TextWireTest.java
@@ -54,6 +54,7 @@ import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.*;
 
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class TextWireTest {
 
     Bytes bytes;
@@ -641,7 +642,6 @@ public class TextWireTest {
                 "Test: !" + name1 + " # \n", wire.toString());
 
         // ok as blank matches anything
-        @NotNull StringBuilder sb = new StringBuilder();
         Stream.of("MyType", "AlsoMyType", name1).forEach(e -> {
             wire.read().typePrefix(e, Assert::assertEquals);
         });
@@ -672,7 +672,7 @@ public class TextWireTest {
                 "  b: !NestedB,\n" +
                 "  value: 12345\n" +
                 "}");
-
+        assertNotNull(a);
     }
 
     @Test
@@ -978,6 +978,7 @@ public class TextWireTest {
         assertEquals(fieldLen, len, 1);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testMapReadAndWriteStrings() {
         @NotNull final Bytes bytes = nativeBytes();
@@ -1034,6 +1035,7 @@ public class TextWireTest {
                 fromString.toString());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     @Ignore
     public void testMapReadAndWriteIntegers() {
@@ -1073,6 +1075,7 @@ public class TextWireTest {
         expectWithSnakeYaml("{1=11, 2=2, 3=3}", wire);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testMapReadAndWriteMarshable() {
         @NotNull final Bytes bytes = nativeBytes();
@@ -1967,10 +1970,6 @@ public class TextWireTest {
             // FAILS
             Wires.readMarshallable(this, wire, false);
         }
-    }
-
-    private static class WithMap extends AbstractMarshallable {
-        private Map<CcyPair, String> innerMap = new HashMap<>();
     }
 
     static class DtoWithBytesField extends AbstractMarshallable {

--- a/src/test/java/net/openhft/chronicle/wire/UsingTestMarshallable.java
+++ b/src/test/java/net/openhft/chronicle/wire/UsingTestMarshallable.java
@@ -66,6 +66,7 @@ public class UsingTestMarshallable {
     @Test
     public void testMarshall() {
 
+        @SuppressWarnings("rawtypes")
         Bytes bytes = Bytes.elasticByteBuffer();
         @NotNull Wire wire = new BinaryWire(bytes);
 
@@ -95,6 +96,7 @@ public class UsingTestMarshallable {
             @NotNull SortedFilter sortedFilter = new SortedFilter();
 
             boolean add = sortedFilter.marshableFilters.add(expected);
+            Assert.assertTrue(add);
             wire.write().marshallable(sortedFilter);
         }
 


### PR DESCRIPTION
Assert unused variables, suppress deprecation warnings on intentional use of deprecated APIs, and remove unused code.