### PR TITLE
Avoid an off-by-one error in GeneratedProxyClass#from()

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/GeneratedProxyClass.java
+++ b/src/main/java/net/openhft/chronicle/wire/GeneratedProxyClass.java
@@ -53,9 +53,11 @@ public enum GeneratedProxyClass {
             if (!interfaceClazz.isInterface())
                 throw new IllegalArgumentException("expecting and interface instead of class=" + interfaceClazz.getName());
 
-            int i = 0;
-            for (Method dm : interfaceClazz.getMethods()) {
-                i++;
+            Method[] dms = interfaceClazz.getMethods();
+            int n = dms.length;
+
+            for (int i = 0; i < n; ++i) {
+                Method dm = dms[i];
                 if (dm.isDefault() || Modifier.isStatic(dm.getModifiers()))
                     continue;
 


### PR DESCRIPTION
This fix addresses the failing test HelloWorldTest#testWithAsQueueService() in Chronicle-Queue.  The unpatched code generates the code below (the index on the right should be `0` on the JVM where the test is run):

    //  public void hello(java.lang.String arg0) {
    methods[0]=net.openhft.chronicle.queue.service.HelloWorldTest.CloseableHelloWorld.class.getMethods()[1];

Note: another consideration is whether the order of methods in the array remains the same from one invocation of getMethods() to another; javadoc for Class.html#getMethods() doesn't discuss this.