### PR TITLE
Support for null marshallble fields defined using abstract types 

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/Wires.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wires.java
@@ -60,7 +60,7 @@ import static net.openhft.chronicle.wire.WireType.TEXT;
 /*
  * Created by Peter Lawrey on 31/08/15.
  */
-@SuppressWarnings({"rawtypes","unchecked"})
+@SuppressWarnings({"rawtypes", "unchecked"})
 public enum Wires {
     ;
     public static final int LENGTH_MASK = -1 >>> 2;
@@ -435,18 +435,20 @@ public enum Wires {
 
     @Nullable
     public static <E> E objectMap(ValueIn in, @Nullable E using, @Nullable Class clazz, SerializationStrategy<E> strategy) {
+        boolean nullObject = false;
         if (clazz == Object.class)
             strategy = MAP;
-        if (using == null)
+        if (using == null) {
             using = (E) strategy.newInstance(clazz);
+            nullObject = using == null && strategy == MARSHALLABLE;
+        }
         if (Throwable.class.isAssignableFrom(clazz))
             return (E) WireInternal.throwable(in, false, (Throwable) using);
 
-        if (using == null)
+        if (using == null && !nullObject)
             throw new IllegalStateException("failed to create instance of clazz=" + clazz + " is it aliased?");
-
-        @Nullable Object ret = in.marshallable(using, strategy);
-        return readResolve(ret);
+        else
+            return readResolve(in.marshallable(using, strategy));
     }
 
     @NotNull
@@ -585,6 +587,7 @@ public enum Wires {
 
         private static SimpleDateFormat sdf = new SimpleDateFormat("EEE MMM d HH:mm:ss zzz yyyy");
         private static SimpleDateFormat sdf2 = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
+
         static {
             sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
             sdf2.setTimeZone(TimeZone.getTimeZone("GMT"));


### PR DESCRIPTION
Currently, null marshallble fields (of marshallable classes) defined using abstract types causing an exception to be thrown on high-level object unmarshalling. This incurs a peformance penalty ( exception handling/formatting, logging setup, etc) for what is considered to be a normal part of object deserialization/ unmarshalling.

This PR fixes this behavior.