### PR TITLE
Fix DecoratedBufferUnderflowException after 4d69ee9e

### DIFF
--- a/src/test/java/net/openhft/chronicle/wire/reproducer/ResetWeirdBehaviour.java
+++ b/src/test/java/net/openhft/chronicle/wire/reproducer/ResetWeirdBehaviour.java
@@ -1,0 +1,34 @@
+package net.openhft.chronicle.wire.reproducer;
+
+import net.openhft.chronicle.core.io.Closeable;
+import net.openhft.chronicle.wire.SelfDescribingMarshallable;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ResetWeirdBehaviour {
+    @Test
+    public void test() throws Exception {
+        Event event = new Event();
+        Assert.assertFalse(event.isClosed());
+
+        event.reset();
+        Assert.assertFalse(event.isClosed());
+    }
+
+
+    public static class Event extends SelfDescribingMarshallable implements Closeable {
+        private boolean isClosed;
+
+        //other fields
+
+        @Override
+        public void close() {
+            isClosed = true;
+        }
+
+        @Override
+        public boolean isClosed() {
+            return isClosed;
+        }
+    }
+}


### PR DESCRIPTION
We faced with next exception in our tests:

net.openhft.chronicle.bytes.util.DecoratedBufferUnderflowException: Offset: -1, start: 0, size: 1, capacity: 32
	at net.openhft.chronicle.bytes.HeapBytesStore.checkBounds(HeapBytesStore.java:397)
	at net.openhft.chronicle.bytes.HeapBytesStore.checkOffset(HeapBytesStore.java:387)
	at net.openhft.chronicle.bytes.HeapBytesStore.readByte(HeapBytesStore.java:143)
	at net.openhft.chronicle.bytes.RandomDataInput.readUnsignedByte(RandomDataInput.java:87)
	at net.openhft.chronicle.bytes.AbstractBytesStore.peekUnsignedByte(AbstractBytesStore.java:40)
	at net.openhft.chronicle.bytes.AbstractBytes.peekUnsignedByte(AbstractBytes.java:678)
	at net.openhft.chronicle.wire.TextMethodTester.run(TextMethodTester.java:181)

It was introduced by "Fix handling of deserializing `null` for abstract classes, and tidy up Bytes which were not being released, closes https://github.com/OpenHFT/Chronicle-Wire/issues/165" where the direct buffer was replaced by on heap one.

There you could find possible fix (at least, it helps with our tests).