### PR TITLE
Method reader fails to process chained calls if interim method accepts zero / two or more arguments

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/VanillaMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMethodReader.java
@@ -344,7 +344,7 @@ public class VanillaMethodReader implements MethodReader {
                 Object invoke = invoke(contextSupplier.get(), m, NO_ARGS);
                 if (invoke != null)
                     context[0] = invoke;
-                if (o2 != null)
+                else if (o2 != null)
                     context[0] = o2;
             } catch (Exception i) {
                 Jvm.warn().on(contextClass(contextSupplier), "Failure to dispatch message: " + name + "()", i);
@@ -384,7 +384,7 @@ public class VanillaMethodReader implements MethodReader {
                 Object invoke = invoke(contextSupplier.get(), m, args);
                 if (invoke != null)
                     context[0] = invoke;
-                if (o2 != null)
+                else if (o2 != null)
                     context[0] = o2;
             } catch (Exception i) {
                 Jvm.warn().on(contextClass(contextSupplier), "Failure to dispatch message: " + name + " " + Arrays.toString(args), i);
@@ -438,7 +438,7 @@ public class VanillaMethodReader implements MethodReader {
                 Object invoke = invoke(contextSupplier.get(), m, args);
                 if (invoke != null)
                     context[0] = invoke;
-                if (o2 != null)
+                else if (o2 != null)
                     context[0] = o2;
             } catch (Exception i) {
                 Jvm.warn().on(contextClass(contextSupplier), "Failure to dispatch message: " + name + " " + Arrays.toString(args), i);

--- a/src/test/java/net/openhft/chronicle/wire/ITop.java
+++ b/src/test/java/net/openhft/chronicle/wire/ITop.java
@@ -4,4 +4,8 @@ interface ITop {
     IMid mid(String name);
 
     IMid2 mid2(String name);
+
+    IMid midNoArg();
+
+    IMid midTwoArgs(int i, long l);
 }


### PR DESCRIPTION
Should fix https://github.com/OpenHFT/Chronicle-Wire/issues/206