### PR TITLE
Don't merge - Generated code sample for #202

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/GeneratedParseFunction.java
+++ b/src/main/java/net/openhft/chronicle/wire/GeneratedParseFunction.java
@@ -1,0 +1,212 @@
+package net.openhft.chronicle.wire;
+
+import net.openhft.chronicle.bytes.MethodReader;
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.util.ObjectUtils;
+
+import java.util.List;
+import java.util.function.Function;
+
+// TODO to be removed before merge
+// TODO code like this will be generated
+public class GeneratedParseFunction implements Function<WireIn, Boolean> {
+    // instances
+    private Object instance1;
+    private Object instance2;
+
+    // system parselets
+    private final WireParselet messageHistoryParselet;
+    private final WireParselet debugLoggingParselet;
+
+    // method name consumer SB
+    private final StringBuilder lastEventName = new StringBuilder(128);
+
+    // MyInterface1
+    private String call2arg1;
+
+    private long call3arg1;
+    private int call3arg2;
+
+    private Class call4arg1type = ObjectUtils.implementationToUse(byte[].class);
+    private byte[] call4arg1;
+    private double call4arg2;
+    private Class call4arg3type = ObjectUtils.implementationToUse(List.class);
+    private List call4arg3;
+
+    private Class call5arg1type = ObjectUtils.implementationToUse(Object.class);
+    private Object call5arg1;
+
+    private Class call6arg1type = ObjectUtils.implementationToUse(TestClassesStorage.MyCustomType1.class);
+    private TestClassesStorage.MyCustomType1 call6arg1 = ObjectUtils.newInstance(TestClassesStorage.MyCustomType1.class); // Marshallable initialization
+    private Class call6arg2type = ObjectUtils.implementationToUse(TestClassesStorage.MyCustomType2.class);
+    private TestClassesStorage.MyCustomType2 call6arg2;
+    private int call6arg3;
+
+    private Class call8arg1type = ObjectUtils.implementationToUse(TestClassesStorage.MyCustomType1.class);
+    private TestClassesStorage.MyCustomType1 call8arg1 = ObjectUtils.newInstance(TestClassesStorage.MyCustomType1.class); // Marshallable initialization
+
+    // MyInterface2
+    private boolean call9arg1;
+    private Class call9arg2type = ObjectUtils.implementationToUse(TestClassesStorage.MyCustomType2.class);
+    private TestClassesStorage.MyCustomType2 call9arg2;
+
+    // DoChain
+    private boolean call10arg1;
+
+    // chained calls results
+    private TestClassesStorage.DoChain call8res;
+    private TestClassesStorage.DoChain2 call10res;
+
+    // Numeric converters (created in case non-binary wire is used)
+//    private final MilliTimestampLongConverter call3arg1converter = new MilliTimestampLongConverter();
+//    private final Base32IntConverter call3arg2converter = new Base32IntConverter();
+
+    // flag for handling ignoreMethodBasedOnFirstArg
+    private boolean ignored;
+
+    public GeneratedParseFunction(Object instance1,
+                                  Object instance2,
+                                  WireParselet messageHistoryParselet,
+                                  WireParselet debugLoggingParselet) {
+        this.instance1 = instance1;
+        this.instance2 = instance2;
+        this.messageHistoryParselet = messageHistoryParselet;
+        this.debugLoggingParselet = debugLoggingParselet;
+    }
+
+    @Override
+    public Boolean apply(WireIn wireIn) {
+        String methodName;
+        ValueIn valueIn;
+
+        if (wireIn.bytes().peekUnsignedByte() == BinaryWireCode.FIELD_NUMBER) {
+            int methodId = (int) wireIn.readEventNumber();
+            valueIn = wireIn.getValueIn();
+
+            switch (methodId) {
+                case 5:
+                    methodName = "call5";
+                    break;
+
+                default:
+                    return false;
+            }
+        }
+        else {
+            lastEventName.setLength(0);
+
+            valueIn = wireIn.readEventName(lastEventName);
+
+            // todo: avoid String object creation ?
+            methodName = lastEventName.toString();
+        }
+
+        try {
+            if (Jvm.isDebug())
+                debugLoggingParselet.accept(methodName, valueIn);
+
+            switch (methodName) {
+                case MethodReader.HISTORY:
+                    messageHistoryParselet.accept(MethodReader.HISTORY, valueIn);
+                    break;
+
+                case "call1":
+                    valueIn.skipValue();
+                    ((TestClassesStorage.MyInterface1)instance1).call1();
+                    break;
+
+                case "call2":
+                    call2arg1 = valueIn.text();
+                    ((TestClassesStorage.MyInterface1)instance1).call2(call2arg1);
+                    break;
+
+                case "call3":
+                    valueIn.sequence(this, (f, v) -> {
+                        f.call3arg1 = v.int64();
+                        // f.call3arg1 = call3arg1converter.parse(v.text()); - in case of non-binary wire
+                        f.call3arg2 = v.int32();
+                        // f.call3arg2 = call3arg2converter.parse(v.text()); - in case of non-binary wire
+                    });
+                    ((TestClassesStorage.MyInterface1)instance1).call3(call3arg1, call3arg2);
+                    break;
+
+                case "call4":
+                    valueIn.sequence(this, (f, v) -> {
+                        f.call4arg1 = v.object(f.call4arg1, f.call4arg1type);
+                        f.call4arg2 = v.float64();
+                        f.call4arg3 = v.object(f.call4arg3, f.call4arg3type);
+                    });
+                    ((TestClassesStorage.MyInterface1)instance1).call4(call4arg1, call4arg2, call4arg3);
+                    break;
+
+                case "call5":
+                    call5arg1 = valueIn.object(call5arg1, call5arg1type);
+                    ((TestClassesStorage.MyInterface1)instance1).call5(call5arg1);
+                    break;
+
+                case "call6":
+                    valueIn.sequence(this, (f, v) -> {
+                        f.call6arg1 = v.object(f.call6arg1, f.call6arg1type);
+                        f.call6arg2 = v.object(f.call6arg2, f.call6arg2type);
+                        f.call6arg3 = v.int32();
+                    });
+                    ((TestClassesStorage.MyInterface1)instance1).call6(call6arg1, call6arg2, call6arg3);
+                    break;
+
+                case "call7":
+                    valueIn.skipValue();
+                    ((TestClassesStorage.MyInterface1)instance1).call7();
+                    break;
+
+                case "call8":
+                    call8arg1 = valueIn.object(call8arg1, call8arg1type);
+                    call8res = ((TestClassesStorage.MyInterface1)instance1).call8(call8arg1);
+                    break;
+
+                case "call9":
+                    ignored = false;
+
+                    valueIn.sequence(this, (f, v) -> {
+                        f.call9arg1 = v.bool();
+
+                        if (((MethodFilterOnFirstArg)f.instance2).ignoreMethodBasedOnFirstArg("call9", f.call9arg1)) {
+                            f.ignored = true;
+                        } else {
+                            f.call9arg2 = v.object(f.call9arg2, f.call9arg2type);
+                        }
+                    });
+
+                    if (!ignored)
+                        ((TestClassesStorage.MyInterface2)instance2).call9(call9arg1, call9arg2);
+
+                    break;
+
+                case "call10":
+                    call10arg1 = valueIn.bool();
+                    call10res = call8res.call10(call10arg1);
+                    break;
+
+                case "call12":
+                    valueIn.skipValue();
+                    call10res.call12();
+                    break;
+
+                case "call14":
+                    valueIn.skipValue();
+                    call8res.call14();
+                    break;
+
+                default:
+                    return false;
+            }
+
+            return true;
+        }
+        catch (Exception e) {
+            Jvm.warn().on(this.getClass(), "Failure to dispatch message, " +
+                    "will retry to process without generated code: " + methodName + "()", e);
+
+            return false;
+        }
+    }
+}

--- a/src/main/java/net/openhft/chronicle/wire/LazyDelegatingWireParser.java
+++ b/src/main/java/net/openhft/chronicle/wire/LazyDelegatingWireParser.java
@@ -1,0 +1,58 @@
+package net.openhft.chronicle.wire;
+
+import net.openhft.chronicle.bytes.Bytes;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Wrapper for handling method reader events with generated code.
+ * Attempts to perform best-effort processing with a generated parsing function {@link #parseOneFunction}.
+ * In case it is unsuccessful, processing is delegated to a lazy-initialized {@link #delegate}.
+ */
+public class LazyDelegatingWireParser implements WireParser {
+    private final Function<WireIn, Boolean> parseOneFunction;
+    private final Supplier<WireParser> delegateSupplier;
+    private WireParser delegate;
+
+    public LazyDelegatingWireParser(Function<WireIn, Boolean> parseOneFunction,
+                                    Supplier<WireParser> delegateSupplier) {
+        this.parseOneFunction = parseOneFunction;
+        this.delegateSupplier = delegateSupplier;
+    }
+
+    @Override
+    public WireParselet getDefaultConsumer() {
+        return delegate().getDefaultConsumer();
+    }
+
+    @Override
+    public void parseOne(@NotNull WireIn wireIn) {
+        final Bytes<?> bytes = wireIn.bytes();
+        long start = bytes.readPosition();
+
+        if (parseOneFunction.apply(wireIn))
+            return;
+
+        bytes.readPosition(start);
+        delegate().parseOne(wireIn);
+    }
+
+    @Override
+    public WireParselet lookup(CharSequence name) {
+        return delegate().lookup(name);
+    }
+
+    @Override
+    public @NotNull VanillaWireParser register(String keyName, WireParselet valueInConsumer) {
+        return delegate().register(keyName, valueInConsumer);
+    }
+
+    private WireParser delegate() {
+        if (delegate == null)
+            delegate = delegateSupplier.get();
+
+        return delegate;
+    }
+}

--- a/src/main/java/net/openhft/chronicle/wire/TestClassesStorage.java
+++ b/src/main/java/net/openhft/chronicle/wire/TestClassesStorage.java
@@ -1,0 +1,74 @@
+package net.openhft.chronicle.wire;
+
+import net.openhft.chronicle.bytes.MethodId;
+import net.openhft.chronicle.core.annotation.DontChain;
+
+import java.util.List;
+
+// TODO to be removed before merge
+public class TestClassesStorage {
+    public interface MyInterface1 {
+        void call1();
+
+        void call2(String s);
+
+        void call3(@LongConversion(MilliTimestampLongConverter.class) long l, @IntConversion(Base32IntConverter.class) int i);
+
+        void call4(byte[] arr, double d, List<Boolean> list);
+
+        @MethodId(value = 5)
+        void call5(Object o);
+
+        void call6(MyCustomType1 marshallable, MyCustomType2 type3, int x);
+
+        DoNotChain call7();
+
+        DoChain call8(MyCustomType1 marshallable);
+    }
+
+    public interface MyInterface2 extends MethodFilterOnFirstArg {
+        void call9(boolean b, MyCustomType2 type2);
+    }
+
+    public interface DoChain {
+        DoChain2 call10(boolean b);
+
+        ClassesAreNotChained call14();
+    }
+
+    @DontChain
+    public interface DoNotChain {
+        void call11(int i);
+    }
+
+    public interface DoChain2 {
+        void call12();
+    }
+
+    interface MyCustomInterface1 extends Marshallable {
+
+    }
+
+    public static class MyCustomType1 implements MyCustomInterface1 {
+        int x;
+        String s;
+        MyCustomType2 b;
+
+        public MyCustomType1() {
+            this.x = 421;
+            this.s = "few";
+            this.b = new MyCustomType2();
+            b.d = 0.321e-4;
+        }
+    }
+
+    public static class MyCustomType2 {
+        double d;
+    }
+
+    public static class ClassesAreNotChained {
+        void call13() {
+            System.out.println(1);
+        }
+    }
+}


### PR DESCRIPTION
Please don't merge. It's just a sandbox for further development of https://github.com/OpenHFT/Chronicle-Wire/issues/202.
Points worth paying attention to:
1. Instead of generating code of custom MethodReader, I chose to generate custom WireParser (specifically, function responsible for WireParser#parseOne execution). This approach should minimize number of "copypasted" lines that should be taken from an existing code and inserted into a generated one.
2. LazyDelegatingWireParser is introduced. It attempts to handle input using generated #parseOne function, but saves an option to use lazy-created VanillaWireParser in case something goes wrong.
3. GeneratedParseFunction - code like this will be generated in runtime. It's example for two interfaces (code is present in `TestClassesStorage`).
3.1. Seems like we can't get rid of both `String` creation (line 100) and `Map` lookup. I chose to keep String creation.
3.2. Marshallable instances are created in advance via `ObjectUtils.newInstance` like in `VanillaMethodReader`. 
3.3. Objects types are calculated in advance via `ObjectUtils.implementationToUse` like in `VanillaMethodReader`, though I'm not sure it makes any effect.