### PR TITLE
Fix Flaky single quote tests in TestWireTest and YamlWireTest

### DIFF
--- a/src/test/java/net/openhft/chronicle/wire/TextWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TextWireTest.java
@@ -725,6 +725,7 @@ public class TextWireTest extends WireTestCommon {
 
     @Test
     public void testSingleQuote() {
+        ClassAliasPool.CLASS_ALIASES.addAlias(NestedA.class);
         NestedA a = Marshallable.fromString("!NestedA {\n" +
                 "  b: !NestedB,\n" +
                 "  value: 12345\n" +

--- a/src/test/java/net/openhft/chronicle/wire/YamlWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/YamlWireTest.java
@@ -702,6 +702,7 @@ public class YamlWireTest extends WireTestCommon {
 
     @Test
     public void testSingleQuote() {
+        ClassAliasPool.CLASS_ALIASES.addAlias(YNestedA.class);
         YNestedA a = Marshallable.fromString("!YNestedA {\n" +
                 "  b: !YNestedB,\n" +
                 "  value: 12345\n" +


### PR DESCRIPTION
`TestWireTest#singleQuote` and `YamlWireTest#singleQuote` rely on the `testTypeWithEmpty` test in both files to be run first or else errors such as: `java.lang.NoClassDefFoundError: Unable to load NestedA, is a class alias missing.` will appear. This is because the `NestedA` class has not been added to the ClassAliasPool if the `singleQuote` test is run by itself.