### PR TITLE
Feature/dont assume impl class

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
@@ -293,13 +293,6 @@ public class GenerateMethodReader {
             Class<?> parameterType = parameterTypes[i];
 
             final String typeName = parameterType.getCanonicalName();
-
-            if (!parameterType.isPrimitive()) {
-                // this used to use ObjectUtils.implementationToUse to determine the type and mutable
-                // object but this is not appropriate, especially for an interface type - see #253
-                fields.append(format("private %s %sarg%dtype = %s.class;\n", "Class", m.getName(), i, typeName));
-            }
-
             fields.append(format("private %s %sarg%d;\n", typeName, m.getName(), i));
         }
 
@@ -514,7 +507,8 @@ public class GenerateMethodReader {
         } else if (CharSequence.class.isAssignableFrom(argumentType)) {
             return format("%s = %s.text();\n", argumentName, valueInName);
         } else {
-            return format("%s = %s.object(checkRecycle(%s), %stype);\n", argumentName, valueInName, argumentName, argumentName);
+            final String typeName = argumentType.getCanonicalName();
+            return format("%s = %s.object(checkRecycle(%s), %s.class);\n", argumentName, valueInName, argumentName, typeName);
         }
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
@@ -297,6 +297,8 @@ public class GenerateMethodReader {
             if (parameterType.isPrimitive())
                 fields.append(format("private %s %sarg%d;\n", typeName, m.getName(), i));
             else {
+                // this used to use ObjectUtils.implementationToUse to determine the type and mutable
+                // object but this is not appropriate, especially for an interface type - see #253
                 fields.append(format("private %s %sarg%dtype = %s.class;\n", "Class", m.getName(), i, typeName));
                 fields.append(format("private %s %sarg%d;\n", typeName, m.getName(), i));
             }

--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
@@ -294,14 +294,13 @@ public class GenerateMethodReader {
 
             final String typeName = parameterType.getCanonicalName();
 
-            if (parameterType.isPrimitive())
-                fields.append(format("private %s %sarg%d;\n", typeName, m.getName(), i));
-            else {
+            if (!parameterType.isPrimitive()) {
                 // this used to use ObjectUtils.implementationToUse to determine the type and mutable
                 // object but this is not appropriate, especially for an interface type - see #253
                 fields.append(format("private %s %sarg%dtype = %s.class;\n", "Class", m.getName(), i, typeName));
-                fields.append(format("private %s %sarg%d;\n", typeName, m.getName(), i));
             }
+
+            fields.append(format("private %s %sarg%d;\n", typeName, m.getName(), i));
         }
 
         if (chainReturnType != null)

--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
@@ -23,7 +23,6 @@ import net.openhft.chronicle.bytes.MethodReaderInterceptorReturns;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.Maths;
 import net.openhft.chronicle.core.util.Annotations;
-import net.openhft.chronicle.core.util.ObjectUtils;
 import net.openhft.chronicle.wire.utils.JavaSourceCodeFormatter;
 import net.openhft.chronicle.wire.utils.SourceCodeFormatter;
 import org.jetbrains.annotations.NotNull;
@@ -298,16 +297,8 @@ public class GenerateMethodReader {
             if (parameterType.isPrimitive())
                 fields.append(format("private %s %sarg%d;\n", typeName, m.getName(), i));
             else {
-                fields.append(format("private %s %sarg%dtype = ObjectUtils.implementationToUse(%s.class);\n",
-                        "Class", m.getName(), i, typeName));
-
-                final Class<?> implToUse = ObjectUtils.implementationToUse(parameterType);
-
-                if (ReadMarshallable.class.isAssignableFrom(implToUse)) {
-                    fields.append(format("private %s %sarg%d = ObjectUtils.newInstance(%s.class);\n",
-                            typeName, m.getName(), i, implToUse.getCanonicalName()));
-                } else
-                    fields.append(format("private %s %sarg%d;\n", typeName, m.getName(), i));
+                fields.append(format("private %s %sarg%dtype = %s.class;\n", "Class", m.getName(), i, typeName));
+                fields.append(format("private %s %sarg%d;\n", typeName, m.getName(), i));
             }
         }
 

--- a/src/test/java/net/openhft/chronicle/wire/method/MethodWriterByInterfaceTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/MethodWriterByInterfaceTest.java
@@ -13,9 +13,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.StringWriter;
+import java.lang.reflect.Proxy;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class MethodWriterByInterfaceTest {
     @Before
@@ -33,6 +33,7 @@ public class MethodWriterByInterfaceTest {
         TextWire tw = new TextWire(Bytes.allocateElasticOnHeap());
         MWBI0 mwbi0 = tw.methodWriter(MWBI0.class);
         mwbi0.method(new MWBImpl("name", 1234567890123456L));
+        assertFalse(Proxy.isProxyClass(mwbi0.getClass()));
         assertEquals("method: {\n" +
                 "  name: name,\n" +
                 "  time: 2009-02-13T23:31:30.123456\n" +
@@ -40,6 +41,7 @@ public class MethodWriterByInterfaceTest {
                 "...\n", tw.toString());
         StringWriter sw = new StringWriter();
         MethodReader reader = tw.methodReader(Mocker.logging(MWBI0.class, "", sw));
+        assertFalse(Proxy.isProxyClass(reader.getClass()));
         assertTrue(reader.readOne());
         assertEquals("method[!net.openhft.chronicle.wire.method.MethodWriterByInterfaceTest$MWBImpl {\n" +
                 "  name: name,\n" +


### PR DESCRIPTION
Hey @glukos please take a look - the test for this is attached to https://github.com/ChronicleEnterprise/Chronicle-FIX/issues/556 (but @Ignored). This PR fixes it. All Wire tests pass although `net.openhft.chronicle.wire.method.MethodWriterByInterfaceTest#writeReadViaImplementation` seems to be flakier on TC for some reason.