### PR TITLE
Fix flaky useInterceptor

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -36,6 +36,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.Arrays;
+import java.util.Comparator;
 
 import static net.openhft.chronicle.core.UnsafeMemory.*;
 
@@ -135,7 +137,9 @@ public class WireMarshaller<T> {
     public static void getAllField(@NotNull Class clazz, @NotNull Map<String, Field> map) {
         if (clazz != Object.class && clazz != AbstractCommonMarshallable.class)
             getAllField(clazz.getSuperclass(), map);
-        for (@NotNull Field field : clazz.getDeclaredFields()) {
+        Field[] sortedFields = clazz.getDeclaredFields();
+        Arrays.sort(sortedFields, Comparator.comparing(Field::getName));
+        for (@NotNull Field field : sortedFields) {
             if ((field.getModifiers() & (Modifier.STATIC | Modifier.TRANSIENT)) != 0)
                 continue;
             if ("ordinal".equals(field.getName()) && Enum.class.isAssignableFrom(clazz))

--- a/src/test/java/net/openhft/chronicle/wire/AbstractClassGeneratorTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/AbstractClassGeneratorTest.java
@@ -88,41 +88,41 @@ public class AbstractClassGeneratorTest extends WireTestCommon {
         String theTimeIs = "The time is " + LocalDateTime.now();
         doTest(ui, theTimeIs);
         assertEquals("accept: !net.openhft.chronicle.wire.MyTypes {\n" +
-                "  text: Hello World,\n" +
-                "  flag: false,\n" +
                 "  b: 0,\n" +
-                "  s: 0,\n" +
                 "  ch: \"\\0\",\n" +
-                "  i: 0,\n" +
-                "  f: 0.0,\n" +
                 "  d: 0.0,\n" +
-                "  l: 0\n" +
+                "  f: 0.0,\n" +
+                "  flag: false,\n" +
+                "  i: 0,\n" +
+                "  l: 0,\n" +
+                "  s: 0,\n" +
+                "  text: Hello World\n" +
                 "}\n" +
                 "return: true\n" +
                 "\n" +
                 "accept: !net.openhft.chronicle.wire.MyTypes {\n" +
-                "  text: block,\n" +
-                "  flag: false,\n" +
                 "  b: 0,\n" +
-                "  s: 0,\n" +
                 "  ch: \"\\0\",\n" +
-                "  i: 0,\n" +
-                "  f: 0.0,\n" +
                 "  d: 0.0,\n" +
-                "  l: 0\n" +
+                "  f: 0.0,\n" +
+                "  flag: false,\n" +
+                "  i: 0,\n" +
+                "  l: 0,\n" +
+                "  s: 0,\n" +
+                "  text: block\n" +
                 "}\n" +
                 "return: false\n" +
                 "\n" +
                 "accept: !net.openhft.chronicle.wire.MyTypes {\n" +
-                "  text: \"" + theTimeIs + "\",\n" +
-                "  flag: false,\n" +
                 "  b: 0,\n" +
-                "  s: 0,\n" +
                 "  ch: \"\\0\",\n" +
-                "  i: 0,\n" +
-                "  f: 0.0,\n" +
                 "  d: 0.0,\n" +
-                "  l: 0\n" +
+                "  f: 0.0,\n" +
+                "  flag: false,\n" +
+                "  i: 0,\n" +
+                "  l: 0,\n" +
+                "  s: 0,\n" +
+                "  text: \"" + theTimeIs + "\"\n" +
                 "}\n" +
                 "return: true\n" +
                 "\n", sw.toString());


### PR DESCRIPTION
The test ```AbstractClassGeneratorTest.useInterceptor``` fails due to a different order in string comparison. From code trace, the root cause is the method ```WireMarshaller.getAllField```,  which calls on Java's reflection API ```getDeclaredFields```, which does not return fields in a guaranteed order. 
This PR proposes to sort the returned fields and make it deterministic.