### PR TITLE
Fix flaky testReserialize

### DIFF
--- a/src/test/java/net/openhft/chronicle/wire/BinaryInTextTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryInTextTest.java
@@ -5,6 +5,7 @@ import net.openhft.chronicle.bytes.BytesStore;
 import org.junit.Test;
 
 import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class BinaryInTextTest extends WireTestCommon {
     @SuppressWarnings("rawtypes")
@@ -35,10 +36,15 @@ public class BinaryInTextTest extends WireTestCommon {
                 "b: !!binary AAAAAAA=,\n" +
                 "c: !!binary CCCCCCCC,\n" +
                 "}");
-        assertEquals("!net.openhft.chronicle.wire.BinaryInTextTest$BIT {\n" +
+        String bitToString = bit.toString();
+        assertTrue(bitToString.equals("!net.openhft.chronicle.wire.BinaryInTextTest$BIT {\n" +
                 "  b: !!binary AAAAAAA=,\n" +
                 "  c: !!binary CCCCCCCC\n" +
-                "}\n", bit.toString());
+                "}\n") ||
+                bitToString.equals("!net.openhft.chronicle.wire.BinaryInTextTest$BIT {\n" +
+                        "  c: !!binary CCCCCCCC,\n" +
+                        "  b: !!binary AAAAAAA=\n" +
+                        "}\n"));
     }
 
     @SuppressWarnings("rawtypes")


### PR DESCRIPTION
The test ```BinaryInTextTest.testReserialize```
sometimes fails due to a different order in string comparison. From code trace, the root cause is the method ```WireMarshaller.getAllField```, which calls on Java's reflection API ```getDeclaredFields```, which does not return fields in a guaranteed order.
This PR proposes to consider 2 possible sequences in ```assertEquals``` without changing the ```getDeclaredFields``` behaviour.