### PR TITLE
Reset wire valueIn state when starting Binary read DocumentContext

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/BinaryReadDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryReadDocumentContext.java
@@ -152,6 +152,7 @@ public class BinaryReadDocumentContext implements ReadDocumentContext {
     @Override
     public void start() {
         rollback = false;
+        wire.getValueIn().resetState();
         wire.getValueOut().resetBetweenDocuments();
         readPosition = readLimit = -1;
         @NotNull final Bytes<?> bytes = wire.bytes();


### PR DESCRIPTION
Fixes #311, Fixes ChronicleEnterprise/Chronicle-Queue-Enterprise#258