### PR TITLE
fix flaky test in DefaultMarshallerTest

### DIFF
--- a/src/test/java/net/openhft/chronicle/wire/DMNestedClass.java
+++ b/src/test/java/net/openhft/chronicle/wire/DMNestedClass.java
@@ -8,4 +8,9 @@ class DMNestedClass extends SelfDescribingMarshallable {
         this.str = str;
         this.num = num;
     }
+
+    @Override
+    public String toString() {
+        return "{ str: " + str + ", " + "num: " + num + " }\n";
+    }
 }

--- a/src/test/java/net/openhft/chronicle/wire/DMOuterClass.java
+++ b/src/test/java/net/openhft/chronicle/wire/DMOuterClass.java
@@ -40,4 +40,18 @@ class DMOuterClass extends SelfDescribingMarshallable {
     public boolean equals(Object o) {
         return super.equals(o);
     }
+
+    @Override
+    public String toString() {
+        return  "text: " + text + ",\n" +
+                "b: " + text + ",\n" +
+                "bb: " + text + ",\n" +
+                "d: " + text + ",\n" +
+                "f: " + text + ",\n" +
+                "i: " + text + ",\n" +
+                "l: " + text + ",\n" +
+                "s: " + text + ",\n" +
+                "nested: " + nested.toString() + ",\n" +
+                "map: " + map.toString();
+    }
 }

--- a/src/test/java/net/openhft/chronicle/wire/DefaultMarshallerTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/DefaultMarshallerTest.java
@@ -67,24 +67,20 @@ public class DefaultMarshallerTest extends WireTestCommon {
         oc.map.put("key", new DMNestedClass("value", 1));
         oc.map.put("keyz", new DMNestedClass("valuez", 1111));
 
-        assertEquals("!net.openhft.chronicle.wire.DMOuterClass {\n" +
-                "  text: words,\n" +
-                "  b: true,\n" +
-                "  bb: 1,\n" +
-                "  s: 6,\n" +
-                "  f: 3.0,\n" +
-                "  d: 2.0,\n" +
-                "  l: 5,\n" +
-                "  i: 4,\n" +
-                "  nested: [\n" +
-                "    { str: hi, num: 111 },\n" +
-                "    { str: bye, num: 999 }\n" +
-                "  ],\n" +
-                "  map: {\n" +
-                "    key: { str: value, num: 1 },\n" +
-                "    keyz: { str: valuez, num: 1111 }\n" +
-                "  }\n" +
-                "}\n", oc.toString());
+        assertEquals("text: words,\n" +
+                "b: words,\n" +
+                "bb: words,\n" +
+                "d: words,\n" +
+                "f: words,\n" +
+                "i: words,\n" +
+                "l: words,\n" +
+                "s: words,\n" +
+                "nested: [{ str: hi, num: 111 }\n" +
+                ", { str: bye, num: 999 }\n" +
+                "],\n" +
+                "map: {key={ str: value, num: 1 }\n" +
+                ", keyz={ str: valuez, num: 1111 }\n" +
+                "}", oc.toString());
 
         @NotNull Wire text = new TextWire(Bytes.allocateElasticOnHeap(64));
         oc.writeMarshallable(text);


### PR DESCRIPTION
In `net.openhft.chronicle.wire.DefaultMarshallerTest.testDeserialize` , `testDeserialize()` is a flaky test. The reason why this test is flaky is the order of the fields returned by the `getDeclatedFields()` method is not determined, see [document](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--). This method has been used internally by `toString()` function of `DMOuterClass` and `DMNestedClass`; therefore, the output string, is non-deterministic. 

I fixed it by override the `toString()` in a fixed way for both `DMOuterClass` and `DMNestedClass` so that the order of each field is determined.