### PR TITLE
Implement safer toString method

### DIFF
--- a/src/test/java/net/openhft/chronicle/wire/TextWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TextWireTest.java
@@ -2103,6 +2103,12 @@ public class TextWireTest extends WireTestCommon {
         @LongConversion(HexaDecimalConverter.class)
         long hexa2;
 
+        @Override
+        public void writeMarshallable(@NotNull WireOut wire) {
+            wire.write("hexadecimal").rawText(Long.toHexString(hexadecimal));
+            wire.write("hexa2").rawText(Long.toHexString(hexa2));
+        }
+
         public TwoLongs(long hexadecimal, long hexa2) {
             this.hexadecimal = hexadecimal;
             this.hexa2 = hexa2;


### PR DESCRIPTION
# Description
Test `net.openhft.chronicle.wire.TextWireTest.longConverter` will fail under [NonDex](https://github.com/TestingResearchIllinois/NonDex) which detects flakiness under non-deterministic environment. 

## To reproduce
```
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex \
    -Dtest=net.openhft.chronicle.wire.TextWireTest#longConverter
```

## Issue
The root cause is that ```getDeclaredFields()``` is non-deterministic, which has been a concern for a while.

When calling method ```toString()``` on the ```TwoLongs```, the internal implementation [getAllFields](https://github.com/OpenHFT/Chronicle-Wire/blob/ea/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java#L138) uses the function which cause the test to fail. 
```java
public static void getAllField(@NotNull Class clazz, @NotNull Map<String, Field> map) {
    for (@NotNull Field field : clazz.getDeclaredFields()) 
    ...
```

There are several similar tests which are potentially non-deterministic. I will update them as well if this approach is acceptable. 