### PR TITLE
Fix breaks introduced by ClassNotFoundRuntimeException

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -3225,7 +3225,7 @@ public class BinaryWire extends AbstractWire implements Wire {
             final Class clazz;
             try {
                 clazz = classLookup().forName(sb);
-            } catch (ClassNotFoundException e) {
+            } catch (ClassNotFoundRuntimeException e) {
                 throw new IORuntimeException(e);
             }
 
@@ -3283,7 +3283,7 @@ public class BinaryWire extends AbstractWire implements Wire {
 
             try {
                 return classLookup().forName(sb);
-            } catch (ClassNotFoundException e) {
+            } catch (ClassNotFoundRuntimeException e) {
                 Jvm.warn().on(BinaryWire.this.getClass(), "Unable to find class " + sb);
                 return null;
             }
@@ -3300,7 +3300,7 @@ public class BinaryWire extends AbstractWire implements Wire {
 
             try {
                 return sb == null ? null : classLookup().forName(sb);
-            } catch (ClassNotFoundException e) {
+            } catch (ClassNotFoundRuntimeException e) {
                 if (Wires.dtoInterface(tClass)) {
                     if (GENERATE_TUPLES)
                         return Wires.tupleFor(tClass, sb.toString());
@@ -3359,8 +3359,8 @@ public class BinaryWire extends AbstractWire implements Wire {
                     @Nullable StringBuilder sb = readUtf8();
                     try {
                         return classLookup().forName(sb);
-                    } catch (ClassNotFoundException e) {
-                        return unresolvedHandler.apply(sb, e);
+                    } catch (ClassNotFoundRuntimeException e) {
+                        return unresolvedHandler.apply(sb, e.getCause());
                     }
                 case NULL:
                     return null;
@@ -3728,7 +3728,7 @@ public class BinaryWire extends AbstractWire implements Wire {
                             final Class clazz2;
                             try {
                                 clazz2 = classLookup().forName(sb);
-                            } catch (ClassNotFoundException e) {
+                            } catch (ClassNotFoundRuntimeException e) {
                                 throw new IORuntimeException(e);
                             }
                             return object(null, clazz2);

--- a/src/main/java/net/openhft/chronicle/wire/JSONWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/JSONWire.java
@@ -400,12 +400,8 @@ public class JSONWire extends TextWire {
                 final StringBuilder sb = Wires.acquireStringBuilder();
                 sb.setLength(0);
                 this.wireIn().read(sb);
-                try {
-                    final Class<?> clazz = classLookup().forName(sb.subSequence(1, sb.length()));
-                    return parseType(null, clazz);
-                } catch (ReflectiveOperationException e) {
-                    throw new RuntimeException(e);
-                }
+                final Class<?> clazz = classLookup().forName(sb.subSequence(1, sb.length()));
+                return parseType(null, clazz);
             }
 
 /*
@@ -460,24 +456,20 @@ public class JSONWire extends TextWire {
                 final StringBuilder sb = Wires.acquireStringBuilder();
                 sb.setLength(0);
                 readTypeDefinition(sb);
-                try {
-                    final Class<?> overrideClass = classLookup().forName(sb.subSequence(1, sb.length()));
-                    if (!clazz.isAssignableFrom(overrideClass))
-                        throw new ClassCastException("Unable to cast " + overrideClass.getName() + " to " + clazz.getName());
-                    if (using != null && !overrideClass.isInstance(using))
-                        throw new ClassCastException("Unable to reuse a " + using.getClass().getName() + " as a " + overrideClass.getName());
-                    final E result = super.object(using, overrideClass);
+                final Class<?> overrideClass = classLookup().forName(sb.subSequence(1, sb.length()));
+                if (!clazz.isAssignableFrom(overrideClass))
+                    throw new ClassCastException("Unable to cast " + overrideClass.getName() + " to " + clazz.getName());
+                if (using != null && !overrideClass.isInstance(using))
+                    throw new ClassCastException("Unable to reuse a " + using.getClass().getName() + " as a " + overrideClass.getName());
+                final E result = super.object(using, overrideClass);
 
-                    // remove the closing bracket from the type definition
-                    consumePadding();
-                    final char endBracket = bytes.readChar();
-                    assert endBracket == '}' : "Missing end bracket }, got " + endBracket + " from " + bytes;
-                    consumePadding(1);
+                // remove the closing bracket from the type definition
+                consumePadding();
+                final char endBracket = bytes.readChar();
+                assert endBracket == '}' : "Missing end bracket }, got " + endBracket + " from " + bytes;
+                consumePadding(1);
 
-                    return result;
-                } catch (ReflectiveOperationException e) {
-                    throw new RuntimeException(e);
-                }
+                return result;
             }
         }
 

--- a/src/main/java/net/openhft/chronicle/wire/RawWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/RawWire.java
@@ -1034,8 +1034,8 @@ public class RawWire extends AbstractWire implements Wire {
             bytes.readUtf8(sb);
             try {
                 return classLookup.forName(sb);
-            } catch (ClassNotFoundException e) {
-                return unresolvedHandler.apply(sb, e);
+            } catch (ClassNotFoundRuntimeException e) {
+                return unresolvedHandler.apply(sb, e.getCause());
             }
         }
 

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -3067,7 +3067,7 @@ public class TextWire extends AbstractWire implements Wire {
                 bytes.readSkip(-1);
                 try {
                     return classLookup().forName(stringBuilder);
-                } catch (ClassNotFoundException e) {
+                } catch (ClassNotFoundRuntimeException e) {
                     Jvm.warn().on(getClass(), "Unable to find " + stringBuilder + " " + e);
                     return null;
                 }
@@ -3087,11 +3087,10 @@ public class TextWire extends AbstractWire implements Wire {
                 parseUntil(stringBuilder, END_OF_TYPE);
                 bytes.readSkip(-1);
                 try {
-
                     return classLookup().forName(stringBuilder);
                 } catch (NoClassDefFoundError e) {
                     throw new IORuntimeException("Unable to load class " + e, e);
-                } catch (ClassNotFoundException e) {
+                } catch (ClassNotFoundRuntimeException e) {
                     if (tClass == null) {
                         if (Wires.GENERATE_TUPLES) {
                             return Wires.tupleFor(null, stringBuilder.toString());
@@ -3109,7 +3108,7 @@ public class TextWire extends AbstractWire implements Wire {
                                     ? Wires.tupleFor(tClass, stringBuilder.toString())
                                     : classLookup().forName(className);
 
-                        } catch (ClassNotFoundException e1) {
+                        } catch (ClassNotFoundRuntimeException e1) {
                             Jvm.warn().on(getClass(), "ClassNotFoundException class=" + className);
                             return Wires.tupleFor(tClass, className);
                         }
@@ -3162,8 +3161,8 @@ public class TextWire extends AbstractWire implements Wire {
             parseUntil(stringBuilder, END_OF_TYPE);
             try {
                 return classLookup().forName(stringBuilder);
-            } catch (ClassNotFoundException e) {
-                return unresolvedHandler.apply(stringBuilder, e);
+            } catch (ClassNotFoundRuntimeException e) {
+                return unresolvedHandler.apply(stringBuilder, e.getCause());
             }
         }
 

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -2358,7 +2358,7 @@ public class YamlWire extends AbstractWire implements Wire {
             try {
                 yt.next();
                 return classLookup().forName(stringBuilder);
-            } catch (ClassNotFoundException e) {
+            } catch (ClassNotFoundRuntimeException e) {
                 Jvm.warn().on(getClass(), "Unable to find " + stringBuilder + " " + e);
                 return null;
             }


### PR DESCRIPTION
This commit https://github.com/OpenHFT/Chronicle-Core/commit/805d872c64d512e9da12e680d5b3507b53a9071b changed the method signature to some methods used by Wire, this fixes the try/catch blocks to compile again with the change.