### PR TITLE
Band-aid fix for 328 on 21 branch

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/JSONWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/JSONWire.java
@@ -121,6 +121,14 @@ public class JSONWire extends TextWire {
     }
 
     @Override
+    public ValueOut writeEvent(Class expectedType, Object eventKey) {
+        if (eventKey instanceof Number) {
+            return writeEventName(eventKey.toString());
+        }
+        return super.writeEvent(expectedType, eventKey);
+    }
+
+    @Override
     public void copyTo(@NotNull WireOut wire) {
         throw new UnsupportedOperationException();
     }

--- a/src/test/java/net/openhft/chronicle/wire/JSONWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/JSONWireTest.java
@@ -309,6 +309,7 @@ public class JSONWireTest extends WireTestCommon {
                 "\"doubleMap\":{\"1.28\":\"number\",\"2.56\":\"number\"}\n" +
                 "}", text);
         MapWithIntegerKeysHolder mh2 = JSON.fromString(MapWithIntegerKeysHolder.class, text);
+        assertEquals(mh, mh2);
     }
 
     static class MapWithIntegerKeysHolder extends SelfDescribingMarshallable {

--- a/src/test/java/net/openhft/chronicle/wire/JSONWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/JSONWireTest.java
@@ -304,10 +304,9 @@ public class JSONWireTest extends WireTestCommon {
         mh.doubleMap.put(2.56, "number");
         final String text = JSON.asString(mh);
         assertEquals("" +
-                "{\"intMap\":{\"1111\":\"ones\",\"2222\":\"twos\"},\n" +
-                "\"longMap\":{\"888888888888\":\"eights\",\"999999999999\":\"nines\"},\n" +
-                "\"doubleMap\":{\"1.28\":\"number\",\"2.56\":\"number\"}\n" +
-                "}", text);
+                "\"intMap\":{\"1111\":\"ones\",\"2222\":\"twos\"}, " +
+                "\"longMap\":{\"888888888888\":\"eights\",\"999999999999\":\"nines\"}, " +
+                "\"doubleMap\":{\"1.28\":\"number\",\"2.56\":\"number\"}", text);
         MapWithIntegerKeysHolder mh2 = JSON.fromString(MapWithIntegerKeysHolder.class, text);
         assertEquals(mh, mh2);
     }

--- a/src/test/java/net/openhft/chronicle/wire/JSONWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/JSONWireTest.java
@@ -293,6 +293,30 @@ public class JSONWireTest extends WireTestCommon {
         assertNotNull(list);
     }
 
+    @Test
+    public void nestedMapWithIntegerKeys() {
+        MapWithIntegerKeysHolder mh = new MapWithIntegerKeysHolder();
+        mh.intMap.put(1111, "ones");
+        mh.intMap.put(2222, "twos");
+        mh.longMap.put(888888888888L, "eights");
+        mh.longMap.put(999999999999L, "nines");
+        mh.doubleMap.put(1.28, "number");
+        mh.doubleMap.put(2.56, "number");
+        final String text = JSON.asString(mh);
+        assertEquals("" +
+                "{\"intMap\":{\"1111\":\"ones\",\"2222\":\"twos\"},\n" +
+                "\"longMap\":{\"888888888888\":\"eights\",\"999999999999\":\"nines\"},\n" +
+                "\"doubleMap\":{\"1.28\":\"number\",\"2.56\":\"number\"}\n" +
+                "}", text);
+        MapWithIntegerKeysHolder mh2 = JSON.fromString(MapWithIntegerKeysHolder.class, text);
+    }
+
+    static class MapWithIntegerKeysHolder extends SelfDescribingMarshallable {
+        Map<Integer, String> intMap = new LinkedHashMap<>();
+        Map<Long, String> longMap = new LinkedHashMap<>();
+        Map<Double, String> doubleMap = new LinkedHashMap<>();
+    }
+
     static class MapHolder extends SelfDescribingMarshallable {
         Map<RetentionPolicy, Double> map;
     }

--- a/src/test/java/net/openhft/chronicle/wire/issue/Issue328Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/issue/Issue328Test.java
@@ -28,7 +28,7 @@ public class Issue328Test {
         final String expected = IntStream.range(0, size)
                 .boxed()
                 .map(i -> String.format("\"%d\":\"%d\"", i, i))
-                .collect(Collectors.joining(",", "{", "}"));
+                .collect(Collectors.joining(","));
 
         // Note: The output should pass a test at https://jsonlint.com/
 

--- a/src/test/java/net/openhft/chronicle/wire/issue/Issue328Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/issue/Issue328Test.java
@@ -1,0 +1,38 @@
+package net.openhft.chronicle.wire.issue;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.wire.JSONWire;
+import net.openhft.chronicle.wire.Wire;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+
+public class Issue328Test {
+
+    @Test
+    public void map() {
+        final Wire wire = new JSONWire(Bytes.elasticByteBuffer());
+        final int size = 3;
+        // keys must be strings in JSON
+        final Map<Integer, String> map = IntStream.range(0, size)
+                .boxed()
+                .collect(Collectors.toMap(Function.identity(), i -> Integer.toString(i)));
+
+        wire.getValueOut().object(map);
+        final String actual = wire.toString();
+        final String expected = IntStream.range(0, size)
+                .boxed()
+                .map(i -> String.format("\"%d\":\"%d\"", i, i))
+                .collect(Collectors.joining(",", "{", "}"));
+
+        // Note: The output should pass a test at https://jsonlint.com/
+
+        System.out.println("actual = " + actual);
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
This is by no means a generic fix for #328, but it does fix the specific case of serializing maps with Number subclasses as keys to JSON

It also doesn't change any existing behaviour except for the specific case addressed which was broken. It should be sufficient until the user can upgrade to .22 and get the proper fix.