### PR TITLE
Warn reliably when we encounter an unresolvable class

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -3437,11 +3437,10 @@ public class BinaryWire extends AbstractWire implements Wire {
             try {
                 return sb == null ? null : classLookup().forName(sb);
             } catch (ClassNotFoundRuntimeException e) {
-                if (Wires.dtoInterface(tClass)) {
-                    if (GENERATE_TUPLES)
-                        return Wires.tupleFor(tClass, sb.toString());
-                    Jvm.warn().on(getClass(), "Unknown class, perhaps you need to define an alias", e);
+                if (Wires.dtoInterface(tClass) && GENERATE_TUPLES) {
+                    return Wires.tupleFor(tClass, sb.toString());
                 }
+                Jvm.warn().on(getClass(), "Unknown class (" + sb + "), perhaps you need to define an alias", e);
                 return null;
             }
         }
@@ -3560,7 +3559,7 @@ public class BinaryWire extends AbstractWire implements Wire {
 
         @Override
         @Nullable
-        public Object marshallable(@Nullable Object object, @NotNull SerializationStrategy strategy)
+        public Object marshallable(@NotNull Object object, @NotNull SerializationStrategy strategy)
                 throws BufferUnderflowException, IORuntimeException {
             if (this.isNull())
                 return null;

--- a/src/main/java/net/openhft/chronicle/wire/DefaultValueIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/DefaultValueIn.java
@@ -374,7 +374,7 @@ public class DefaultValueIn implements ValueIn {
 
     @Nullable
     @Override
-    public Object marshallable(@NotNull Object object, SerializationStrategy strategy) throws BufferUnderflowException, IORuntimeException {
+    public Object marshallable(@NotNull Object object, @NotNull SerializationStrategy strategy) throws BufferUnderflowException, IORuntimeException {
         return defaultValue;
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -3136,14 +3136,13 @@ public class TextWire extends AbstractWire implements Wire {
                 bytes.readSkip(-1);
                 try {
                     return classLookup().forName(stringBuilder);
-                } catch (NoClassDefFoundError e) {
-                    throw new IORuntimeException("Unable to load class " + e, e);
                 } catch (ClassNotFoundRuntimeException e) {
                     if (tClass == null) {
                         if (Wires.GENERATE_TUPLES) {
                             return Wires.tupleFor(null, stringBuilder.toString());
                         }
-                        throw new NoClassDefFoundError("Unable to load " + stringBuilder + ", is a class alias missing.");
+                        Jvm.warn().on(TextWire.class, "Unable to load " + stringBuilder + ", is a class alias missing.");
+                        return null;
                     }
 
                     final String className = tClass.getName();

--- a/src/main/java/net/openhft/chronicle/wire/ValueIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueIn.java
@@ -429,7 +429,7 @@ public interface ValueIn {
     }
 
     @Nullable
-    Object marshallable(Object object, SerializationStrategy strategy)
+    Object marshallable(@NotNull Object object, @NotNull SerializationStrategy strategy)
             throws BufferUnderflowException, IORuntimeException;
 
     default boolean marshallable(@NotNull Serializable object) throws BufferUnderflowException, IORuntimeException {
@@ -545,6 +545,7 @@ public interface ValueIn {
     @Nullable
     Class typePrefix();
 
+    @Nullable
     default Object typePrefixOrObject(Class tClass) {
         return typePrefix();
     }

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -753,6 +753,7 @@ public class WireMarshaller<T> {
                             !type.isEnum() &&
                             !read.isTyped()) {
                         // retain the null value of object
+                        Jvm.warn().on(getClass(), "Ignoring exception and setting field '" + field.getName() + "' to null", e);
                     } else {
                         Jvm.rethrow(e);
                     }

--- a/src/test/java/net/openhft/chronicle/wire/AbstractUntypedFieldTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/AbstractUntypedFieldTest.java
@@ -49,6 +49,20 @@ class AbstractUntypedFieldTest extends WireTestCommon {
         assertNull(holder.a);
     }
 
+    @ParameterizedTest
+    @MethodSource("provideWire")
+    void missingAliasesShouldLogWarnings(Function<Bytes<byte[]>, Wire> wireConstruction) {
+        final Bytes<byte[]> bytes = Bytes.from("!net.openhft.chronicle.wire.AbstractUntypedFieldShouldBeNull$Holder {\n" +
+                "  a: !MissingAlias {\n" +
+                "  }\n" +
+                "}");
+        final Wire textWire = wireConstruction.apply(bytes);
+
+        expectException("Ignoring exception and setting field 'a' to null");
+        expectException("Cannot find a class for MissingAlias are you missing an alias?");
+        assertNull(textWire.getValueIn().object(Holder.class).a);
+    }
+
     static abstract class A {
     }
 

--- a/src/test/java/net/openhft/chronicle/wire/TextWireAgitatorTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TextWireAgitatorTest.java
@@ -1,25 +1,19 @@
 package net.openhft.chronicle.wire;
 
-import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import java.util.Map;
+
+import static org.junit.Assert.*;
 
 // Test created as a result of agitator tests i.e. random character changes
 public class TextWireAgitatorTest extends WireTestCommon {
-    @Test(expected = IORuntimeException.class)
-    public void lowerCaseClass() {
-        if (!OS.isWindows())
-            throw new IORuntimeException("Only fails this way on Windows");
-        TextWireTest.MyDto myDto = Marshallable.fromString("!" + TextWireTest.MyDto.class.getName() + " { }");
-        assertEquals("!net.openhft.chronicle.wire.TextWireTest$MyDto {\n" +
-                "  strings: [  ]\n" +
-                "}\n", myDto.toString());
 
-        TextWireTest.MyDto myDto2 = Marshallable.fromString("!" + TextWireTest.MyDto.class.getName().toLowerCase() + " { }");
-        assertNotNull(myDto2);
+    @Test
+    public void lowerCaseClass() {
+        expectException("Unable to load net.openhft.chronicle.wire.textwiretest$mydto, is a class alias missing");
+        assertTrue(Marshallable.fromString("!" + TextWireTest.MyDto.class.getName().toLowerCase() + " { }") instanceof Map);
     }
 
     @Test(expected = IORuntimeException.class)

--- a/src/test/java/net/openhft/chronicle/wire/UnknownEnumTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/UnknownEnumTest.java
@@ -9,8 +9,7 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class UnknownEnumTest extends WireTestCommon {
 
@@ -26,7 +25,7 @@ public class UnknownEnumTest extends WireTestCommon {
     }
 
     @Test
-    public void testUnknownEnum() {
+    public void testUnknownDynamicEnum() {
         Wire wire = createWire();
         wire.write("value").text("Maybe");
 
@@ -39,6 +38,13 @@ public class UnknownEnumTest extends WireTestCommon {
         assertEquals("Maybe", maybe);
     }
 
+    @Test
+    public void testUnknownStaticEnum() {
+        Wire wire = createWire();
+        wire.write("value").text("Maybe");
+
+        assertThrows(IllegalArgumentException.class, () -> wire.read("value").asEnum(StrictYesNo.class));
+    }
    // private enum Temp {
        // FIRST
    // }
@@ -63,6 +69,7 @@ public class UnknownEnumTest extends WireTestCommon {
        // }
        // System.out.println();
 
+        expectException("Unknown class (net.openhft.chronicle.wire.UnknownEnumTest$Temp), perhaps you need to define an alias");
         final Bytes<ByteBuffer> bytes = Bytes.wrapForRead(ByteBuffer.wrap(SERIALISED_MAP_DATA));
 
         final Wire wire = WireType.BINARY.apply(bytes);
@@ -88,6 +95,11 @@ public class UnknownEnumTest extends WireTestCommon {
     }
 
     enum YesNo implements DynamicEnum {
+        Yes,
+        No
+    }
+
+    enum StrictYesNo {
         Yes,
         No
     }

--- a/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/NestedGenericTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/NestedGenericTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.*;
 public class NestedGenericTest extends WireTestCommon {
     @Test
     public void testGeneric() {
-        expectException("BytesMarshallable found in field which is not matching exactly, the object may not unmarshall correctly if that type is not specified: " +
+        ignoreException("BytesMarshallable found in field which is not matching exactly, the object may not unmarshall correctly if that type is not specified: " +
                 "net.openhft.chronicle.wire.bytesmarshallable.NestedGenericTest$A. The warning will not repeat so there may be more types affected.");
         Bytes bytes = Bytes.allocateElasticOnHeap();
         Wire wire = WireType.BINARY.apply(bytes);

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/TwoArraysTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/TwoArraysTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertEquals;
 public class TwoArraysTest extends WireTestCommon {
     @Test
     public void testTwoArrays() {
-        expectException("BytesMarshallable found in field which is not matching exactly");
+        ignoreException("BytesMarshallable found in field which is not matching exactly");
         Bytes bytes = new HexDumpBytes();
         Wire wire = new BinaryWire(bytes);
         TwoArrays ta = new TwoArrays(4, 8);

--- a/src/test/java/net/openhft/chronicle/wire/method/MethodWriter2Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/MethodWriter2Test.java
@@ -34,7 +34,7 @@ public class MethodWriter2Test extends WireTestCommon {
 
     @Test
     public void allowThroughNoArg() {
-        expectException("Generated code to call updateInterceptor for public abstract void net.openhft.chronicle.wire.method.FundingListener.fundingPrimitive(int) will box and generate garbage");
+        ignoreException("Generated code to call updateInterceptor for public abstract void net.openhft.chronicle.wire.method.FundingListener.fundingPrimitive(int) will box and generate garbage");
         check(true, ARGUMENT.NONE);
     }
 


### PR DESCRIPTION
This is a relatively minimal fix for for #424. I was wary of changing behaviour too much so opted to stop at making the behaviour a bit more consistent when an explicit class name can't be resolved.

I also added the ability to expect vs ignore exceptions consistent with the newer approaches seen in Queue etc. this allows us to test that warnings are being logged when these errors are encountered.