### PR TITLE
Use UnsafeMemory.unsafe(Get|Set)XXX to get and set fields in FieldInfo, ChronicleEnterprise/Chronicle-FIX#969

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/DynamicEnum.java
+++ b/src/main/java/net/openhft/chronicle/wire/DynamicEnum.java
@@ -20,7 +20,7 @@ public interface DynamicEnum extends CoreDynamicEnum, Marshallable {
         E nums = cache.valueOf(e.name());
         List<FieldInfo> fieldInfos = e.$fieldInfos();
         for (FieldInfo fieldInfo : fieldInfos) {
-            fieldInfo.set(nums, fieldInfo.get(e));
+            fieldInfo.copy(e, nums);
         }
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/Wires.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wires.java
@@ -82,7 +82,7 @@ public enum Wires {
         }
         return ANY_OBJECT;
     });
-    static final ClassLocal<FieldInfoPair> FIELD_INFOS = ClassLocal.withInitial(VanillaFieldInfo::lookupClass);
+    static final ClassLocal<FieldInfoPair> FIELD_INFOS = ClassLocal.withInitial(FieldInfo::lookupClass);
     static final ClassLocal<Function<String, Marshallable>> MARSHALLABLE_FUNCTION = ClassLocal.withInitial(tClass -> {
         Class[] interfaces = {Marshallable.class, tClass};
         if (tClass == Marshallable.class)

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/CharFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/CharFieldInfo.java
@@ -1,0 +1,44 @@
+package net.openhft.chronicle.wire.internal.fieldinfo;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.UnsafeMemory;
+import net.openhft.chronicle.wire.BracketType;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Field;
+
+public final class CharFieldInfo extends UnsafeFieldInfo {
+
+    public CharFieldInfo(String name, Class type, BracketType bracketType, @NotNull Field field) {
+        super(name, type, bracketType, field);
+    }
+
+    @Override
+    public char getChar(Object object) {
+        try {
+            return UnsafeMemory.unsafeGetChar(object, getOffset());
+        } catch (@NotNull NoSuchFieldException e) {
+            Jvm.debug().on(CharFieldInfo.class, e);
+            return Character.MAX_VALUE;
+        }
+    }
+
+    @Override
+    public void set(Object object, char value) throws IllegalArgumentException {
+        try {
+            UnsafeMemory.unsafePutChar(object, getOffset(), value);
+        } catch (@NotNull NoSuchFieldException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
+    public boolean isEqual(Object a, Object b) {
+        return getChar(a) == getChar(b);
+    }
+
+    @Override
+    public void copy(Object source, Object destination) {
+        set(destination, getChar(source));
+    }
+}

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/DoubleFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/DoubleFieldInfo.java
@@ -1,0 +1,44 @@
+package net.openhft.chronicle.wire.internal.fieldinfo;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.UnsafeMemory;
+import net.openhft.chronicle.wire.BracketType;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Field;
+
+public final class DoubleFieldInfo extends UnsafeFieldInfo {
+
+    public DoubleFieldInfo(String name, Class type, BracketType bracketType, @NotNull Field field) {
+        super(name, type, bracketType, field);
+    }
+
+    @Override
+    public double getDouble(Object object) {
+        try {
+            return UnsafeMemory.unsafeGetDouble(object, getOffset());
+        } catch (@NotNull NoSuchFieldException e) {
+            Jvm.debug().on(DoubleFieldInfo.class, e);
+            return Double.NaN;
+        }
+    }
+
+    @Override
+    public void set(Object object, double value) throws IllegalArgumentException {
+        try {
+            UnsafeMemory.unsafePutDouble(object, getOffset(), value);
+        } catch (@NotNull NoSuchFieldException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
+    public boolean isEqual(Object a, Object b) {
+        return getDouble(a) == getDouble(b);
+    }
+
+    @Override
+    public void copy(Object source, Object destination) {
+        set(destination, getDouble(source));
+    }
+}

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/IntFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/IntFieldInfo.java
@@ -1,0 +1,44 @@
+package net.openhft.chronicle.wire.internal.fieldinfo;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.UnsafeMemory;
+import net.openhft.chronicle.wire.BracketType;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Field;
+
+public final class IntFieldInfo extends UnsafeFieldInfo {
+
+    public IntFieldInfo(String name, Class type, BracketType bracketType, @NotNull Field field) {
+        super(name, type, bracketType, field);
+    }
+
+    @Override
+    public int getInt(Object object) {
+        try {
+            return UnsafeMemory.unsafeGetInt(object, getOffset());
+        } catch (@NotNull NoSuchFieldException e) {
+            Jvm.debug().on(IntFieldInfo.class, e);
+            return Integer.MIN_VALUE;
+        }
+    }
+
+    @Override
+    public void set(Object object, int value) throws IllegalArgumentException {
+        try {
+            UnsafeMemory.unsafePutInt(object, getOffset(), value);
+        } catch (@NotNull NoSuchFieldException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
+    public boolean isEqual(Object a, Object b) {
+        return getInt(a) == getInt(b);
+    }
+
+    @Override
+    public void copy(Object source, Object destination) {
+        set(destination, getInt(source));
+    }
+}

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/LongFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/LongFieldInfo.java
@@ -1,0 +1,44 @@
+package net.openhft.chronicle.wire.internal.fieldinfo;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.UnsafeMemory;
+import net.openhft.chronicle.wire.BracketType;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Field;
+
+public final class LongFieldInfo extends UnsafeFieldInfo {
+
+    public LongFieldInfo(String name, Class type, BracketType bracketType, @NotNull Field field) {
+        super(name, type, bracketType, field);
+    }
+
+    @Override
+    public long getLong(Object object) {
+        try {
+            return UnsafeMemory.unsafeGetLong(object, getOffset());
+        } catch (@NotNull NoSuchFieldException e) {
+            Jvm.debug().on(LongFieldInfo.class, e);
+            return Long.MIN_VALUE;
+        }
+    }
+
+    @Override
+    public void set(Object object, long value) throws IllegalArgumentException {
+        try {
+            UnsafeMemory.unsafePutLong(object, getOffset(), value);
+        } catch (@NotNull NoSuchFieldException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
+    public boolean isEqual(Object a, Object b) {
+        return getLong(a) == getLong(b);
+    }
+
+    @Override
+    public void copy(Object source, Object destination) {
+        set(destination, getLong(source));
+    }
+}

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/ObjectFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/ObjectFieldInfo.java
@@ -1,0 +1,48 @@
+package net.openhft.chronicle.wire.internal.fieldinfo;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.UnsafeMemory;
+import net.openhft.chronicle.core.util.ObjectUtils;
+import net.openhft.chronicle.wire.BracketType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Field;
+import java.util.Objects;
+
+public final class ObjectFieldInfo extends UnsafeFieldInfo {
+
+    public ObjectFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
+        super(name, type, bracketType, field);
+    }
+
+    @Override
+    public @Nullable Object get(Object object) {
+        try {
+            return UnsafeMemory.unsafeGetObject(object, getOffset());
+        } catch (@NotNull NoSuchFieldException e) {
+            Jvm.debug().on(ObjectFieldInfo.class, e);
+            return null;
+        }
+    }
+
+    @Override
+    public void set(Object object, Object value) throws IllegalArgumentException {
+        Object value2 = ObjectUtils.convertTo(type, value);
+        try {
+            UnsafeMemory.unsafePutObject(object, getOffset(), value2);
+        } catch (@NotNull NoSuchFieldException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
+    public boolean isEqual(Object a, Object b) {
+        return Objects.deepEquals(get(a), get(b));
+    }
+
+    @Override
+    public void copy(Object source, Object destination) {
+        set(destination, get(source));
+    }
+}

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/UnsafeFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/UnsafeFieldInfo.java
@@ -1,0 +1,25 @@
+package net.openhft.chronicle.wire.internal.fieldinfo;
+
+import net.openhft.chronicle.core.UnsafeMemory;
+import net.openhft.chronicle.wire.BracketType;
+import net.openhft.chronicle.wire.VanillaFieldInfo;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Field;
+
+@SuppressWarnings("deprecation" /* The parent class will either be moved to internal or cease to exist in x.25 */)
+class UnsafeFieldInfo extends VanillaFieldInfo {
+    private static final long UNSET_OFFSET = Long.MAX_VALUE;
+    private transient long offset = UNSET_OFFSET;
+
+    public UnsafeFieldInfo(String name, Class type, BracketType bracketType, @NotNull Field field) {
+        super(name, type, bracketType, field);
+    }
+
+    protected long getOffset() throws NoSuchFieldException {
+        if (this.offset == UNSET_OFFSET) {
+            offset = UnsafeMemory.unsafeObjectFieldOffset(getField());
+        }
+        return this.offset;
+    }
+}

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/FieldInfoTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/FieldInfoTest.java
@@ -51,31 +51,31 @@ public class FieldInfoTest extends WireTestCommon {
                 new ScalarValues(1),
         };
         @NotNull String[] fields = {
-                "[!FieldInfo {\n" +
+                "[!net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: values,\n" +
                         "  type: !type net.openhft.chronicle.wire.marshallable.ScalarValues,\n" +
                         "  bracketType: MAP,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.Nested\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: strings,\n" +
                         "  type: !type !seq,\n" +
                         "  bracketType: SEQ,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.Nested\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: ints,\n" +
                         "  type: !type !set,\n" +
                         "  bracketType: SEQ,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.Nested\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: map,\n" +
                         "  type: !type !map,\n" +
                         "  bracketType: MAP,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.Nested\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: array,\n" +
                         "  type: !type String[],\n" +
                         "  bracketType: SEQ,\n" +
@@ -100,13 +100,13 @@ public class FieldInfoTest extends WireTestCommon {
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.CharFieldInfo {\n" +
                         "  name: ch,\n" +
                         "  type: !type char,\n" +
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.IntFieldInfo {\n" +
                         "  name: i,\n" +
                         "  type: !type int,\n" +
                         "  bracketType: NONE,\n" +
@@ -118,130 +118,136 @@ public class FieldInfoTest extends WireTestCommon {
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.LongFieldInfo {\n" +
                         "  name: l,\n" +
                         "  type: !type long,\n" +
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.DoubleFieldInfo {\n" +
                         "  name: d,\n" +
                         "  type: !type double,\n" +
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: flag2,\n" +
                         "  type: !type java.lang.Boolean,\n" +
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: b2,\n" +
                         "  type: !type byte,\n" +
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: s2,\n" +
                         "  type: !type short,\n" +
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: ch2,\n" +
                         "  type: !type Char,\n" +
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: i2,\n" +
                         "  type: !type int,\n" +
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: f2,\n" +
                         "  type: !type Float32,\n" +
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: l2,\n" +
                         "  type: !type long,\n" +
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: d2,\n" +
                         "  type: !type Float64,\n" +
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: aClass,\n" +
                         "  type: !type type,\n" +
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: policy,\n" +
                         "  type: !type java.lang.annotation.RetentionPolicy,\n" +
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: text,\n" +
                         "  type: !type String,\n" +
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: date,\n" +
                         "  type: !type Date,\n" +
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: time,\n" +
                         "  type: !type Time,\n" +
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: dateTime,\n" +
                         "  type: !type DateTime,\n" +
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: zonedDateTime,\n" +
                         "  type: !type ZonedDateTime,\n" +
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: uuid,\n" +
                         "  type: !type UUID,\n" +
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: bi,\n" +
                         "  type: !type java.math.BigInteger,\n" +
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: bd,\n" +
                         "  type: !type java.math.BigDecimal,\n" +
                         "  bracketType: NONE,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
-                        ", !FieldInfo {\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
                         "  name: file,\n" +
                         "  type: !type java.io.File,\n" +
                         "  bracketType: NONE,\n" +
+                        "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
+                        "}\n" +
+                        ", !net.openhft.chronicle.wire.internal.fieldinfo.ObjectFieldInfo {\n" +
+                        "  name: dynamicEnum,\n" +
+                        "  type: !type net.openhft.chronicle.wire.marshallable.TestDynamicEnum,\n" +
+                        "  bracketType: UNKNOWN,\n" +
                         "  parent: !type net.openhft.chronicle.wire.marshallable.ScalarValues\n" +
                         "}\n" +
                         "]",

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/ScalarValues.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/ScalarValues.java
@@ -17,6 +17,7 @@
 
 package net.openhft.chronicle.wire.marshallable;
 
+import net.openhft.chronicle.wire.DynamicEnum;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 
 import java.io.File;
@@ -57,6 +58,7 @@ public class ScalarValues extends SelfDescribingMarshallable {
     BigInteger bi;
     BigDecimal bd;
     File file;
+    TestDynamicEnum dynamicEnum;
 
    // Path path;
 
@@ -93,5 +95,13 @@ public class ScalarValues extends SelfDescribingMarshallable {
         bi = BigInteger.valueOf(i);
         bd = BigDecimal.valueOf(i);
         file = new File("/tmp/" + i);
+        dynamicEnum = TestDynamicEnum.THREE;
     }
+}
+
+
+enum TestDynamicEnum implements DynamicEnum {
+    ONE,
+    TWO,
+    THREE
 }


### PR DESCRIPTION
This change switches to using unsafeGet/unsafePut to get and set fields instead of using Field#get and Field#set.

We're still missing some specific get/set methods for some primitives in the FieldInfo interface, these will fall back to the reflection implementation which will box/unbox.

I made the first steps towards internalising all the `FieldInfo` implementations.