### PR TITLE
Remove delegate fallback to proxy from generated MethodReader to proxied MethodReader

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,8 +118,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <!-- Todo: remove explicit version when 3rd party BOM 3.22.2 is released-->
-            <version>5.8.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/net/openhft/chronicle/wire/AbstractGeneratedMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractGeneratedMethodReader.java
@@ -28,20 +28,17 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 import static java.lang.ThreadLocal.withInitial;
 import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
 
 /**
  * Base class for generated method readers.
- * In case generated instance fails to perform a read, it's delegated to lazy-initialized {@link VanillaMethodReader}.
  */
 public abstract class AbstractGeneratedMethodReader implements MethodReader {
     private static final Consumer<MessageHistory> NO_OP_MH_CONSUMER = Mocker.ignored(Consumer.class);
     private final MarshallableIn in;
     protected final WireParselet debugLoggingParselet;
-    private final Supplier<MethodReader> delegateSupplier;
 
     protected MessageHistory messageHistory;
     protected boolean dataEventProcessed;
@@ -74,11 +71,9 @@ public abstract class AbstractGeneratedMethodReader implements MethodReader {
     private static final MessageHistoryThreadLocal TEMP_MESSAGE_HISTORY = new MessageHistoryThreadLocal();
 
     protected AbstractGeneratedMethodReader(MarshallableIn in,
-                                            WireParselet debugLoggingParselet,
-                                            Supplier<MethodReader> delegateSupplier) {
+                                            WireParselet debugLoggingParselet) {
         this.in = in;
         this.debugLoggingParselet = debugLoggingParselet;
-        this.delegateSupplier = delegateSupplier;
     }
 
     /**
@@ -243,7 +238,7 @@ public abstract class AbstractGeneratedMethodReader implements MethodReader {
                 context.rollbackOnClose();
         }
 
-        return ok || delegate().readOne();
+        return ok;
     }
 
     public void throwExceptionIfClosed() {
@@ -304,13 +299,6 @@ public abstract class AbstractGeneratedMethodReader implements MethodReader {
             messageHistory = MessageHistory.get();
 
         return messageHistory;
-    }
-
-    private MethodReader delegate() {
-        if (delegate == null)
-            delegate = delegateSupplier.get();
-
-        return delegate;
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
@@ -159,7 +159,6 @@ public class GenerateMethodReader {
                 "import net.openhft.chronicle.wire.*;\n" +
                 "import net.openhft.chronicle.bytes.MethodReaderInterceptorReturns;\n" +
                 "\n" +
-                "import java.util.function.Supplier;\n" +
                 "import java.util.Map;\n" +
                 "import java.lang.reflect.Method;\n" +
                 "\n");
@@ -202,10 +201,10 @@ public class GenerateMethodReader {
         }
 
         sourceCode.append(format("public %s(MarshallableIn in, WireParselet debugLoggingParselet," +
-                "Supplier<MethodReader> delegateSupplier, MethodReaderInterceptorReturns interceptor, " +
+                "MethodReaderInterceptorReturns interceptor, " +
                 "Object[] metaInstances, " +
                 "Object[] instances) {\n" +
-                "super(in, debugLoggingParselet, delegateSupplier);\n", generatedClassName()));
+                "super(in, debugLoggingParselet);\n", generatedClassName()));
 
         if (hasRealInterceptorReturns())
             sourceCode.append("this.interceptor = interceptor;\n");

--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
@@ -173,6 +173,7 @@ public class GenerateMethodReader {
         for (int i = 0; i < instances.length; i++) {
             sourceCode.append(format("private final Object instance%d;\n", i));
         }
+        sourceCode.append("private final WireParselet defaultParselet;\n");
         sourceCode.append("\n");
 
         if (hasRealInterceptorReturns()) {
@@ -200,11 +201,14 @@ public class GenerateMethodReader {
             sourceCode.append("\n");
         }
 
-        sourceCode.append(format("public %s(MarshallableIn in, WireParselet debugLoggingParselet," +
+        sourceCode.append(format("public %s(MarshallableIn in, " +
+                "WireParselet defaultParselet, " +
+                "WireParselet debugLoggingParselet, " +
                 "MethodReaderInterceptorReturns interceptor, " +
                 "Object[] metaInstances, " +
                 "Object[] instances) {\n" +
-                "super(in, debugLoggingParselet);\n", generatedClassName()));
+                "super(in, debugLoggingParselet);\n" +
+                "this.defaultParselet = defaultParselet;\n", generatedClassName()));
 
         if (hasRealInterceptorReturns())
             sourceCode.append("this.interceptor = interceptor;\n");
@@ -259,8 +263,8 @@ public class GenerateMethodReader {
         sourceCode.append(eventNameSwitchBlock);
 
         sourceCode.append("default:\n" +
-                "valueIn.skipValue();\n" +
-                "return false;\n" +
+                "defaultParselet.accept(lastEventName, valueIn);\n" +
+                "return true;\n" +
                 "}\n" +
                 "return true;\n" +
                 "} \n" +

--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
@@ -315,10 +315,7 @@ public class GenerateMethodReader {
                 "throw e;\n" +
                 "}\n" +
                 "catch (Exception e) {\n" +
-                "Jvm.warn().on(this.getClass(), \"Failure to dispatch message, " +
-                "will retry to process without generated code: \" + lastEventName + \"(), " +
-                "bytes: \" + wireIn.bytes().toDebugString(), e);\n" +
-                "return false;\n" +
+                "throw new InvocationTargetRuntimeException(e);\n" +
                 "}\n" +
                 "}\n}\n");
 

--- a/src/main/java/net/openhft/chronicle/wire/VanillaMethodReaderBuilder.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMethodReaderBuilder.java
@@ -78,6 +78,7 @@ public class VanillaMethodReaderBuilder implements MethodReaderBuilder {
     @Deprecated(/* Not used. To be removed in x.25 */)
     @NotNull
     public MethodReaderBuilder ignoreDefaults(boolean ignoreDefaults) {
+        Jvm.warn().on(getClass(), "Support for ignoreDefaults will soon be dropped");
         this.ignoreDefaults = ignoreDefaults;
         return this;
     }
@@ -138,7 +139,6 @@ public class VanillaMethodReaderBuilder implements MethodReaderBuilder {
             }
         } catch (Throwable e) {
             classCache.put(fullClassName, COMPILE_FAILED);
-            // do nothing and drop through
             Jvm.warn().on(getClass(), "Failed to compile generated method reader - falling back to proxy method reader. Please report this failure.", e);
         }
 

--- a/src/main/java/net/openhft/chronicle/wire/VanillaMethodReaderBuilder.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMethodReaderBuilder.java
@@ -129,11 +129,11 @@ public class VanillaMethodReaderBuilder implements MethodReaderBuilder {
             try {
                 final Class<?> generatedClass = Class.forName(fullClassName);
 
-                return instanceForGeneratedClass(vanillaSupplier, generatedClass, impls);
+                return instanceForGeneratedClass(generatedClass, impls);
             } catch (ClassNotFoundException e) {
                 Class<?> clazz = classCache.computeIfAbsent(fullClassName, name -> generateMethodReader.createClass());
                 if (clazz != null && clazz != COMPILE_FAILED) {
-                    return instanceForGeneratedClass(vanillaSupplier, clazz, impls);
+                    return instanceForGeneratedClass(clazz, impls);
                 }
             }
         } catch (Throwable e) {
@@ -146,15 +146,14 @@ public class VanillaMethodReaderBuilder implements MethodReaderBuilder {
     }
 
     @NotNull
-    private MethodReader instanceForGeneratedClass(Supplier<MethodReader> vanillaSupplier,
-                                                   Class<?> generatedClass, Object[] impls
-    ) throws InstantiationException, IllegalAccessException, InvocationTargetException {
+    private MethodReader instanceForGeneratedClass(Class<?> generatedClass, Object[] impls)
+            throws InstantiationException, IllegalAccessException, InvocationTargetException {
         final Constructor<?> constructor = generatedClass.getConstructors()[0];
 
         WireParselet debugLoggingParselet = VanillaMethodReader::logMessage;
 
         return (MethodReader) constructor.newInstance(
-                in, debugLoggingParselet, vanillaSupplier, methodReaderInterceptorReturns, metaDataHandler, impls);
+                in, debugLoggingParselet, methodReaderInterceptorReturns, metaDataHandler, impls);
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/wire/VanillaMethodWriterBuilder.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMethodWriterBuilder.java
@@ -121,6 +121,7 @@ public class VanillaMethodWriterBuilder<T> implements Builder<T>, MethodWriterBu
     @Deprecated(/* Replaced by UpdateInterceptor. To be removed in x.24 */)
     @NotNull
     public MethodWriterBuilder<T> methodWriterInterceptorReturns(MethodWriterInterceptorReturns methodWriterInterceptor) {
+        Jvm.warn().on(getClass(), "Support for methodWriterInterceptorReturns will soon be dropped. Use UpdateInterceptor instead");
         handlerSupplier.methodWriterInterceptorReturns(methodWriterInterceptor);
         return this;
     }
@@ -215,9 +216,7 @@ public class VanillaMethodWriterBuilder<T> implements Builder<T>, MethodWriterBu
             throw e;
         } catch (Throwable e) {
             classCache.put(fullClassName, COMPILE_FAILED);
-            // do nothing and drop through
-            if (Jvm.isDebugEnabled(getClass()))
-                Jvm.debug().on(getClass(), e);
+            Jvm.warn().on(getClass(), "Failed to compile generated method writer - falling back to proxy method writer. Please report this failure.", e);
         }
         return null;
     }


### PR DESCRIPTION
But unfortunately some tests fail. 

* `net.openhft.chronicle.wire.MethodReaderDelegationTest#testUnsuccessfulCallIsDelegatedTextWire` and friends fails because we don't support `defaultParselet` with generated code
* `net.openhft.chronicle.wire.VanillaWireParserTest#shouldDetermineMethodNamesFromMethodIds` fails because the test itself is broken - see https://github.com/OpenHFT/Chronicle-Wire/pull/456 for a fix
* `net.openhft.chronicle.wire.method.HandleSkippedValueReadsTest#test` - requires more investigation

And in addition:

* generated MethodReaders don't support [ignoreDefaults ](https://github.com/OpenHFT/Chronicle-Wire/blob/3bcca1204a447b3ca07d9745f17b981404a3de53/src/main/java/net/openhft/chronicle/wire/VanillaMethodReaderBuilder.java#L118). We should [deprecate this property](https://github.com/OpenHFT/Chronicle-Wire/pull/457) and discuss whether we need to support in generated code until gone
* generated MethodWriters don't support [handlerSupplier.methodWriterInterceptorReturns()](https://github.com/OpenHFT/Chronicle-Wire/blob/3bcca1204a447b3ca07d9745f17b981404a3de53/src/main/java/net/openhft/chronicle/wire/VanillaMethodWriterBuilder.java#L189). We should [deprecate this property](https://github.com/OpenHFT/Chronicle-Wire/pull/457) and discuss whether we need to support in generated code until gone