### PR TITLE
Deprecate unused/unsupported VanillaMethodWriterBuilder methods

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
@@ -379,7 +379,6 @@ public class GenerateMethodReader {
      * @param anInterface        Interface which method is processed.
      * @param instanceFieldName  In generated code, method is executed on field with this name.
      * @param methodFilter       <code>true</code> if passed interface is marked with {@link MethodFilterOnFirstArg}.
-     * @param switchBlock
      * @param eventIdSwitchBlock
      */
     private void handleMethod(Method m, Class<?> anInterface, String instanceFieldName, boolean methodFilter, SourceCodeFormatter eventNameSwitchBlock, SourceCodeFormatter eventIdSwitchBlock) {

--- a/src/main/java/net/openhft/chronicle/wire/MethodWriterInvocationHandlerSupplier.java
+++ b/src/main/java/net/openhft/chronicle/wire/MethodWriterInvocationHandlerSupplier.java
@@ -42,11 +42,13 @@ public class MethodWriterInvocationHandlerSupplier implements Supplier<MethodWri
         this.recordHistory = recordHistory;
     }
 
+    @Deprecated(/* to be removed in x.24 */)
     public MethodWriterInvocationHandlerSupplier methodWriterInterceptorReturns(MethodWriterInterceptorReturns methodWriterInterceptorReturns) {
         this.methodWriterInterceptorReturns = methodWriterInterceptorReturns;
         return this;
     }
 
+    @Deprecated(/* to be removed in x.24 */)
     public MethodWriterInterceptorReturns methodWriterInterceptorReturns() {
         return methodWriterInterceptorReturns;
     }

--- a/src/main/java/net/openhft/chronicle/wire/VanillaMethodReaderBuilder.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMethodReaderBuilder.java
@@ -70,10 +70,12 @@ public class VanillaMethodReaderBuilder implements MethodReaderBuilder {
                 Long.toHexString(sourceIndex) + " ~ " + (int) sourceIndex;
     }
 
+    @Deprecated(/* Not used. To be removed in x.25 */)
     public boolean ignoreDefaults() {
         return ignoreDefaults;
     }
 
+    @Deprecated(/* Not used. To be removed in x.25 */)
     @NotNull
     public MethodReaderBuilder ignoreDefaults(boolean ignoreDefaults) {
         this.ignoreDefaults = ignoreDefaults;

--- a/src/main/java/net/openhft/chronicle/wire/VanillaMethodWriterBuilder.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMethodWriterBuilder.java
@@ -118,6 +118,7 @@ public class VanillaMethodWriterBuilder<T> implements Builder<T>, MethodWriterBu
         return this;
     }
 
+    @Deprecated(/* Replaced by UpdateInterceptor. To be removed in x.24 */)
     @NotNull
     public MethodWriterBuilder<T> methodWriterInterceptorReturns(MethodWriterInterceptorReturns methodWriterInterceptor) {
         handlerSupplier.methodWriterInterceptorReturns(methodWriterInterceptor);


### PR DESCRIPTION
These are not used in any of our code, and not exercised by any unit tests