### PR TITLE
Issue/467

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/JSONWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/JSONWire.java
@@ -459,7 +459,7 @@ public class JSONWire extends TextWire {
 
         @Override
         protected void trimWhiteSpace() {
-            if (sep.endsWith('\n') || sep.endsWith(' '))
+            if (bytes.endsWith('\n') || bytes.endsWith(' '))
                 bytes.writeSkip(-1);
         }
 

--- a/src/main/java/net/openhft/chronicle/wire/internal/FileMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/FileMarshallableOut.java
@@ -42,7 +42,7 @@ public class FileMarshallableOut implements MarshallableOut {
         }
     };
 
-    public FileMarshallableOut(MarshallableOutBuilder builder, WireType wIreType) {
+    public FileMarshallableOut(MarshallableOutBuilder builder, WireType wireType) {
         this.url = builder.url();
         assert url.getProtocol().equals("file");
         final String query = url.getQuery();
@@ -50,7 +50,7 @@ public class FileMarshallableOut implements MarshallableOut {
             QueryWire queryWire = new QueryWire(Bytes.from(query));
             options.readMarshallable(queryWire);
         }
-        this.wire = wIreType.apply(Bytes.allocateElasticOnHeap());
+        this.wire = wireType.apply(Bytes.allocateElasticOnHeap());
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/wire/internal/StringConsumerMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/StringConsumerMarshallableOut.java
@@ -1,0 +1,41 @@
+package net.openhft.chronicle.wire.internal;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.wire.*;
+
+import java.util.function.Consumer;
+
+public class StringConsumerMarshallableOut implements MarshallableOut {
+    private Consumer<String> stringConsumer;
+    private Wire wire;
+    private final DocumentContextHolder dcHolder = new DocumentContextHolder() {
+        @Override
+        public void close() {
+            if (chainedElement())
+                return;
+            super.close();
+            if (wire.bytes().isEmpty())
+                return;
+
+            stringConsumer.accept(wire.bytes().toString());
+            wire.clear();
+        }
+    };
+
+    public StringConsumerMarshallableOut(Consumer<String> stringConsumer, WireType wireType) {
+        this.stringConsumer = stringConsumer;
+        this.wire = wireType.apply(Bytes.allocateElasticOnHeap());
+    }
+
+    @Override
+    public DocumentContext writingDocument(boolean metaData) throws UnrecoverableTimeoutException {
+        dcHolder.documentContext(wire.writingDocument(metaData));
+        return dcHolder;
+    }
+
+    @Override
+    public DocumentContext acquireWritingDocument(boolean metaData) throws UnrecoverableTimeoutException {
+        dcHolder.documentContext(wire.acquireWritingDocument(metaData));
+        return dcHolder;
+    }
+}

--- a/src/test/java/net/openhft/chronicle/wire/internal/StringConsumerMarshallableOutTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/internal/StringConsumerMarshallableOutTest.java
@@ -1,0 +1,53 @@
+package net.openhft.chronicle.wire.internal;
+
+import net.openhft.chronicle.wire.MarshallableOut;
+import net.openhft.chronicle.wire.WireType;
+import org.junit.Test;
+
+import java.io.StringWriter;
+
+import static org.junit.Assert.assertEquals;
+
+public class StringConsumerMarshallableOutTest {
+    @Test
+    public void saysYaml() {
+        final WireType wireType = WireType.YAML_ONLY;
+        final String expected = "" +
+                "say: One\n" +
+                "...\n" +
+                "say: Two\n" +
+                "...\n" +
+                "say: Three\n" +
+                "...\n";
+        doTest(wireType, expected);
+    }
+
+    @Test
+    public void saysJson() {
+        final WireType wireType = WireType.JSON_ONLY;
+        final String expected = "" +
+                "\"say\":\"One\"\n" +
+                "\"say\":\"Two\"\n" +
+                "\"say\":\"Three\"\n";
+        doTest(wireType, expected);
+    }
+
+    private void doTest(WireType wireType, String expected) {
+        StringWriter sw = new StringWriter();
+        MarshallableOut out = new StringConsumerMarshallableOut(s -> {
+            sw.append(s);
+            if (!s.endsWith("\n"))
+                sw.append('\n');
+        }, wireType);
+        final Says says = out.methodWriter(Says.class);
+        says.say("One");
+        says.say("Two");
+        says.say("Three");
+        assertEquals(expected,
+                sw.toString());
+    }
+
+    interface Says {
+        void say(String text);
+    }
+}

--- a/src/test/java/net/openhft/chronicle/wire/issue/Issue327Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/issue/Issue327Test.java
@@ -74,7 +74,7 @@ public class Issue327Test extends WireTestCommon {
 
     @Test
     public void intArray() {
-        test(() -> IntStream.range(0, 4).toArray(), "{\"@int[]\":[ 0,1,2,3 ]}", "[ 0,1,2,3 ]");
+        test(() -> IntStream.range(0, 4).toArray(), "{\"@int[]\":[0,1,2,3 ]}", "[0,1,2,3 ]");
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/JSONWithAMapTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/JSONWithAMapTest.java
@@ -1,0 +1,105 @@
+package net.openhft.chronicle.wire.marshallable;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.OnHeapBytes;
+import net.openhft.chronicle.wire.Marshallable;
+import net.openhft.chronicle.wire.SelfDescribingMarshallable;
+import net.openhft.chronicle.wire.Wire;
+import net.openhft.chronicle.wire.WireType;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static net.openhft.chronicle.core.pool.ClassAliasPool.CLASS_ALIASES;
+
+public class JSONWithAMapTest {
+    @Test
+    public void test1() {
+        final String expected = "{\"@ResponseItem\":{\"index\":\"4ab100000005\",\"key\":\"seqNumber\",\"payload\":null}}";
+
+        final String input = "!ResponseItem {\n" +
+                "  index: \"4ab100000005\",\n" +
+                "  key: seqNumber,\n" +
+                "}";
+
+        doTest(expected, input);
+    }
+
+    @Test
+    public void test2() {
+        final String input = "!ResponseItem {\n" +
+                "  index: \"4ab100000005\",\n" +
+                "  key: seqNumber,\n" +
+                "  payload: {\n" +
+                "  }\n" +
+                "}";
+        final String expected = "{\"@ResponseItem\":{\"index\":\"4ab100000005\",\"key\":\"seqNumber\",\"payload\":{}}}";
+
+        doTest(expected, input);
+    }
+
+    @Test
+    public void test5() {
+
+        final String input = "!ResponseItem {\n" +
+                "  index: \"4ab100000005\",\n" +
+                "  key: seqNumber,\n" +
+                "  payload: {\n" +
+                "    eventId: periodicUpdate,\n" +
+                "    eventTime: 1652109920838805734,\n" +
+                "    seqNumbers: [\n" +
+                "      {\n" +
+                "        sessionID: {\n" +
+                "          localCompID: SERVER,\n" +
+                "          remoteCompID: CLIENT,\n" +
+                "          localSubID: !!null \"\",\n" +
+                "          remoteSubID: !!null \"\"\n" +
+                "        },\n" +
+                "        rSeq: !short 1517,\n" +
+                "        wSeq: !short 1519,\n" +
+                "        isActive: true,\n" +
+                "        isConnected: false\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  }\n" +
+                "}";
+        final String expected = "{\"@ResponseItem\":{\"index\":\"4ab100000005\",\"key\":\"seqNumber\",\"payload\":{\"eventId\":\"periodicUpdate\",\"eventTime\":1652109920838805734,\"seqNumbers\":[ {\"sessionID\":{\"localCompID\":\"SERVER\",\"remoteCompID\":\"CLIENT\",\"localSubID\":null,\"remoteSubID\":null},\"rSeq\":1517,\"wSeq\":1519,\"isActive\":true,\"isConnected\":false} ]}}}";
+
+        doTest(expected, input);
+    }
+
+    private void doTest(String expected, String input) {
+        CLASS_ALIASES.addAlias(ResponseItem.class);
+        ResponseItem responseItem = Marshallable.fromString(ResponseItem.class, input);
+
+        OnHeapBytes buffer = Bytes.allocateElasticOnHeap();
+        final Wire jsonWire = WireType.JSON_ONLY.apply(buffer);
+        jsonWire.getValueOut().object(responseItem);
+
+        String actual = buffer.toString();
+
+        int openBracket = 0;
+        int closeBracket = 0;
+        for (int i = 0; i < actual.length(); i++) {
+            if (actual.charAt(i) == '{')
+                openBracket++;
+            if (actual.charAt(i) == '}')
+                closeBracket++;
+        }
+
+        // check the number of '{' match the number of '}'
+        Assert.assertTrue("openBracket=" + openBracket + ",closeBracket=" + closeBracket, openBracket == closeBracket);
+
+        // DON'T CHANGE THE EXPECTED JSON IT IS CORRECT ! - please use this website to validate the json - https://jsonformatter.org
+        Assert.assertEquals(expected, actual);
+    }
+
+    static class ResponseItem extends SelfDescribingMarshallable {
+        private final Bytes<?> key = Bytes.elasticByteBuffer();
+        @NotNull String index;
+        private Object payload;
+    }
+}
+
+
+

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/JSONWithAMapTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/JSONWithAMapTest.java
@@ -95,8 +95,8 @@ public class JSONWithAMapTest {
     }
 
     static class ResponseItem extends SelfDescribingMarshallable {
-        private final Bytes<?> key = Bytes.elasticByteBuffer();
         @NotNull String index;
+        Bytes<?> key = Bytes.elasticByteBuffer();
         private Object payload;
     }
 }


### PR DESCRIPTION
I have no idea why the *MarshallableOut classes have been included here. They are in develop.
e.g. https://github.com/OpenHFT/Chronicle-Wire/blob/develop/src/main/java/net/openhft/chronicle/wire/internal/StringConsumerMarshallableOut.java