### PR TITLE
Feature/method reader dont delegate to proxy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,8 +118,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <!-- Todo: remove explicit version when 3rd party BOM 3.22.2 is released-->
-            <version>5.8.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
@@ -159,7 +159,6 @@ public class GenerateMethodReader {
                 "import net.openhft.chronicle.wire.*;\n" +
                 "import net.openhft.chronicle.bytes.MethodReaderInterceptorReturns;\n" +
                 "\n" +
-                "import java.util.function.Supplier;\n" +
                 "import java.util.Map;\n" +
                 "import java.lang.reflect.Method;\n" +
                 "\n");
@@ -174,6 +173,7 @@ public class GenerateMethodReader {
         for (int i = 0; i < instances.length; i++) {
             sourceCode.append(format("private final Object instance%d;\n", i));
         }
+        sourceCode.append("private final WireParselet defaultParselet;\n");
         sourceCode.append("\n");
 
         if (hasRealInterceptorReturns()) {
@@ -201,11 +201,14 @@ public class GenerateMethodReader {
             sourceCode.append("\n");
         }
 
-        sourceCode.append(format("public %s(MarshallableIn in, WireParselet debugLoggingParselet," +
-                "Supplier<MethodReader> delegateSupplier, MethodReaderInterceptorReturns interceptor, " +
+        sourceCode.append(format("public %s(MarshallableIn in, " +
+                "WireParselet defaultParselet, " +
+                "WireParselet debugLoggingParselet, " +
+                "MethodReaderInterceptorReturns interceptor, " +
                 "Object[] metaInstances, " +
                 "Object[] instances) {\n" +
-                "super(in, debugLoggingParselet, delegateSupplier);\n", generatedClassName()));
+                "super(in, debugLoggingParselet);\n" +
+                "this.defaultParselet = defaultParselet;\n", generatedClassName()));
 
         if (hasRealInterceptorReturns())
             sourceCode.append("this.interceptor = interceptor;\n");
@@ -240,8 +243,9 @@ public class GenerateMethodReader {
         sourceCode.append(eventIdSwitchBlock);
 
         sourceCode.append("default:\n" +
-                "valueIn.skipValue();\n" +
-                "return false;\n" +
+                // below should be garbage-free if methodId is low. This will now drop through for defaultParselet
+                "lastEventName = Integer.toString(methodId);\n" +
+                "break;\n" +
                 "}\n" +
                 "}\n" +
                 "else {\n" +
@@ -260,19 +264,12 @@ public class GenerateMethodReader {
         sourceCode.append(eventNameSwitchBlock);
 
         sourceCode.append("default:\n" +
-                "valueIn.skipValue();\n" +
-                "return false;\n" +
+                "defaultParselet.accept(lastEventName, valueIn);\n" +
                 "}\n" +
                 "return true;\n" +
                 "} \n" +
                 "catch (InvocationTargetRuntimeException e) {\n" +
                 "throw e;\n" +
-                "}\n" +
-                "catch (Exception e) {\n" +
-                "Jvm.warn().on(this.getClass(), \"Failure to dispatch message, " +
-                "will retry to process without generated code: \" + lastEventName + \"(), " +
-                "bytes: \" + wireIn.bytes().toDebugString(), e);\n" +
-                "return false;\n" +
                 "}\n" +
                 "}\n");
 
@@ -315,18 +312,12 @@ public class GenerateMethodReader {
                 "catch (InvocationTargetRuntimeException e) {\n" +
                 "throw e;\n" +
                 "}\n" +
-                "catch (Exception e) {\n" +
-                "Jvm.warn().on(this.getClass(), \"Failure to dispatch message, " +
-                "will retry to process without generated code: \" + lastEventName + \"(), " +
-                "bytes: \" + wireIn.bytes().toDebugString(), e);\n" +
-                "return false;\n" +
-                "}\n" +
                 "}\n}\n");
 
         isSourceCodeGenerated = true;
 
         if (DUMP_CODE)
-            Jvm.startup().on(GenerateMethodReader.class, sourceCode.toString());
+            System.out.println(sourceCode.toString());
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/VanillaMethodWriterBuilder.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMethodWriterBuilder.java
@@ -121,6 +121,7 @@ public class VanillaMethodWriterBuilder<T> implements Builder<T>, MethodWriterBu
     @Deprecated(/* Replaced by UpdateInterceptor. To be removed in x.24 */)
     @NotNull
     public MethodWriterBuilder<T> methodWriterInterceptorReturns(MethodWriterInterceptorReturns methodWriterInterceptor) {
+        Jvm.warn().on(getClass(), "Support for methodWriterInterceptorReturns will be dropped in x.24. Use UpdateInterceptor instead");
         handlerSupplier.methodWriterInterceptorReturns(methodWriterInterceptor);
         return this;
     }
@@ -191,6 +192,9 @@ public class VanillaMethodWriterBuilder<T> implements Builder<T>, MethodWriterBu
             T t = createInstance();
             if (t != null)
                 return t;
+        } else {
+            Jvm.warn().on(getClass(), "Falling back to proxy method writer. Support for " +
+                    "proxy method writers will be dropped in x.25.");
         }
 
         @NotNull Class[] interfacesArr = interfaces.toArray(new Class[interfaces.size()]);
@@ -215,9 +219,9 @@ public class VanillaMethodWriterBuilder<T> implements Builder<T>, MethodWriterBu
             throw e;
         } catch (Throwable e) {
             classCache.put(fullClassName, COMPILE_FAILED);
-            // do nothing and drop through
-            if (Jvm.isDebugEnabled(getClass()))
-                Jvm.debug().on(getClass(), e);
+            Jvm.warn().on(getClass(), "Failed to compile generated method writer - " +
+                    "falling back to proxy method writer. Please report this failure as support for " +
+                    "proxy method writers will be dropped in x.25.", e);
         }
         return null;
     }

--- a/src/test/java/net/openhft/chronicle/wire/ChainedMethodsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ChainedMethodsTest.java
@@ -39,6 +39,8 @@ public class ChainedMethodsTest extends WireTestCommon {
 
     @Test
     public void chainedText() {
+        if (disableProxyCodegen)
+            expectException("Falling back to proxy method writer");
         TextWire wire = new TextWire(Bytes.allocateElasticOnHeap(128))
                 .useTextDocuments();
         ITop top = wire.methodWriter(ITop.class);
@@ -67,6 +69,8 @@ public class ChainedMethodsTest extends WireTestCommon {
 
     @Test
     public void chainedYaml() {
+        if (disableProxyCodegen)
+            expectException("Falling back to proxy method writer");
         YamlWire wire = new YamlWire(Bytes.allocateElasticOnHeap(128))
                 .useTextDocuments();
         ITop top = wire.methodWriter(ITop.class);
@@ -189,6 +193,8 @@ public class ChainedMethodsTest extends WireTestCommon {
 
     @Test
     public void testNestedReturnType() {
+        if (disableProxyCodegen)
+            expectException("Falling back to proxy method writer");
         Wire wire = new BinaryWire(Bytes.allocateElasticOnHeap(128));
         wire.usePadding(true);
         final NestedStart writer = wire.methodWriter(NestedStart.class);

--- a/src/test/java/net/openhft/chronicle/wire/MethodReaderDelegationTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MethodReaderDelegationTest.java
@@ -18,48 +18,78 @@
 package net.openhft.chronicle.wire;
 
 import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.MethodId;
 import net.openhft.chronicle.bytes.MethodReader;
 import net.openhft.chronicle.core.Mocker;
 import net.openhft.chronicle.core.util.InvocationTargetRuntimeException;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static junit.framework.TestCase.assertFalse;
 import static net.openhft.chronicle.wire.VanillaMethodReaderBuilder.DISABLE_READER_PROXY_CODEGEN;
 import static org.junit.Assert.*;
 
+@RunWith(Parameterized.class)
 public class MethodReaderDelegationTest extends WireTestCommon {
+    private boolean useMethodId;
+
+    public MethodReaderDelegationTest(boolean useMethodId) {
+        this.useMethodId = useMethodId;
+    }
+
+    @Parameterized.Parameters(name = "useMethodId={0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(
+                new Object[]{false},
+                new Object[]{true}
+        );
+    }
+
     @Test
     public void testUnsuccessfulCallIsDelegatedBinaryWire() {
         final BinaryWire wire = new BinaryWire(Bytes.allocateElasticOnHeap());
 
-        doTestUnsuccessfullCallIsDelegated(wire);
+        doTestUnsuccessfulCallIsDelegated(wire);
     }
 
     @Test
     public void testUnsuccessfulCallIsDelegatedTextWire() {
         final Wire wire = WireType.TEXT.apply(Bytes.allocateElasticOnHeap());
 
-        doTestUnsuccessfullCallIsDelegated(wire);
+        doTestUnsuccessfulCallIsDelegated(wire);
     }
 
     @Test
     public void testUnsuccessfulCallIsDelegatedYamlWire() {
         final Wire wire = WireType.TEXT.apply(Bytes.allocateElasticOnHeap());
 
-        doTestUnsuccessfullCallIsDelegated(wire);
+        doTestUnsuccessfulCallIsDelegated(wire);
     }
 
-    private void doTestUnsuccessfullCallIsDelegated(Wire wire) {
+    private void doTestUnsuccessfulCallIsDelegated(Wire wire) {
         wire.usePadding(true);
 
-        final MyInterface writer = wire.methodWriter(MyInterface.class);
+        final Class<? extends MyInterface> ifaceClass = useMethodId ? MyInterfaceMethodId.class : MyInterface.class;
+        final MyInterface writer = wire.methodWriter(ifaceClass);
+        assertFalse(Proxy.isProxyClass(writer.getClass()));
         writer.myCall();
 
+        final int myFallId = 2;
+        final String myFall = useMethodId ? Integer.toString(myFallId) : "myFall";
+
         try (DocumentContext dc = wire.acquireWritingDocument(false)) {
-            Objects.requireNonNull(dc.wire()).writeEventName("myFall").text("");
+            if (useMethodId) {
+                Objects.requireNonNull(dc.wire()).writeEventId(myFallId).text("");
+            } else
+                Objects.requireNonNull(dc.wire()).writeEventName("myFall").text("");
         }
 
         writer.myCall();
@@ -68,17 +98,18 @@ public class MethodReaderDelegationTest extends WireTestCommon {
         StringBuilder sb = new StringBuilder();
 
         final MethodReader reader = wire.methodReaderBuilder()
-                .defaultParselet((s, in) -> { // Default parselet handling is delegated to Vanilla reader.
+                .defaultParselet((s, in) -> {
                     delegatedMethodCall.set(s.toString());
                     in.skipValue();
                 })
-                .build(Mocker.intercepting(MyInterface.class, "*", sb::append));
+                .build(Mocker.intercepting(ifaceClass, "*", sb::append));
+        assertFalse(Proxy.isProxyClass(reader.getClass()));
 
         assertTrue(reader.readOne());
         assertNull(delegatedMethodCall.get());
 
         assertTrue(reader.readOne());
-        assertEquals("myFall", delegatedMethodCall.get());
+        assertEquals(myFall, delegatedMethodCall.get());
 
         assertTrue(reader.readOne());
 
@@ -86,21 +117,63 @@ public class MethodReaderDelegationTest extends WireTestCommon {
     }
 
     @Test
+    public void testUnsuccessfulCallNoDelegate() {
+        testUnsuccessfulCallNoDelegate(false);
+    }
+
+    @Test
+    public void testUnsuccessfulCallNoDelegateProxy() {
+        testUnsuccessfulCallNoDelegate(true);
+    }
+
+    private void testUnsuccessfulCallNoDelegate(boolean proxy) {
+        if (proxy)
+            System.setProperty(DISABLE_READER_PROXY_CODEGEN, "true");
+
+        try {
+            final BinaryWire wire = new BinaryWire(Bytes.allocateElasticOnHeap());
+            final MyInterface writer = wire.methodWriter(MyInterface.class);
+            writer.myCall();
+
+            try (DocumentContext dc = wire.acquireWritingDocument(false)) {
+                Objects.requireNonNull(dc.wire()).writeEventName("myFall").text("");
+            }
+
+            writer.myCall();
+
+            StringBuilder sb = new StringBuilder();
+            final MethodReader reader = wire.methodReaderBuilder()
+                    .build(Mocker.intercepting(MyInterface.class, "*", sb::append));
+
+            assertTrue(reader.readOne());
+            assertTrue(reader.readOne());
+            assertTrue(reader.readOne());
+            assertFalse(reader.readOne());
+
+            assertEquals("*myCall[]*myCall[]", sb.toString());
+        } finally {
+            System.clearProperty(DISABLE_READER_PROXY_CODEGEN);
+        }
+    }
+
+    @Test
     public void testUserExceptionsAreNotDelegated() {
         final BinaryWire wire = new BinaryWire(Bytes.allocateElasticOnHeap());
         wire.usePadding(true);
 
-        final MyInterface writer = wire.methodWriter(MyInterface.class);
+        final Class<? extends MyInterface> ifaceClass = useMethodId ? MyInterfaceMethodId.class : MyInterface.class;
+        final MyInterface writer = wire.methodWriter(ifaceClass);
 
         writer.myCall();
 
         AtomicInteger exceptionsThrown = new AtomicInteger();
 
-        final MethodReader reader = wire.methodReader((MyInterface) () -> {
+        final MyInterface myInterface = () -> {
             exceptionsThrown.incrementAndGet();
 
             throw new IllegalStateException("This is an exception by design");
-        });
+        };
+        final MethodReader reader = wire.methodReader(useMethodId ? (MyInterfaceMethodId) () -> myInterface.myCall() : myInterface);
 
         assertThrows(InvocationTargetRuntimeException.class, () -> reader.readOne());
     }
@@ -140,12 +213,14 @@ public class MethodReaderDelegationTest extends WireTestCommon {
 
         try {
             final Wire wire = WireType.TEXT.apply(Bytes.allocateElasticOnHeap());
-            final MyInterface writer = wire.methodWriter(MyInterface.class);
+            final Class<? extends MyInterface> ifaceClass = useMethodId ? MyInterfaceMethodId.class : MyInterface.class;
+            final MyInterface writer = wire.methodWriter(ifaceClass);
             writer.myCall();
 
-            final MethodReader reader = wire.methodReader((MyInterface) () -> {
+            final MyInterface myInterface = () -> {
                 throw new IllegalStateException("This is an exception by design");
-            });
+            };
+            final MethodReader reader = wire.methodReader(useMethodId ? (MyInterfaceMethodId) () -> myInterface.myCall() : myInterface);
             assertEquals(proxy, reader instanceof VanillaMethodReader);
 
             assertThrows(InvocationTargetRuntimeException.class, () -> reader.readOne());
@@ -170,12 +245,14 @@ public class MethodReaderDelegationTest extends WireTestCommon {
 
         try {
             final Wire wire = WireType.TEXT.apply(Bytes.allocateElasticOnHeap());
-            final MyInterfaceLong writer = wire.methodWriter(MyInterfaceLong.class);
+            final Class<? extends MyInterfaceLong> ifaceClass = useMethodId ? MyInterfaceLongMethodId.class : MyInterfaceLong.class;
+            final MyInterfaceLong writer = wire.methodWriter(ifaceClass);
             writer.myCall(1L);
 
-            final MethodReader reader = wire.methodReader((MyInterfaceLong) (l) -> {
+            final MyInterfaceLong myInterface = (l) -> {
                 throw new IllegalStateException("This is an exception by design");
-            });
+            };
+            final MethodReader reader = wire.methodReader(useMethodId ? (MyInterfaceLongMethodId) (l) -> myInterface.myCall(l) : myInterface);
             assertEquals(proxy, reader instanceof VanillaMethodReader);
 
             assertThrows(InvocationTargetRuntimeException.class, () -> reader.readOne());
@@ -188,7 +265,17 @@ public class MethodReaderDelegationTest extends WireTestCommon {
         void myCall();
     }
 
+    interface MyInterfaceMethodId extends MyInterface {
+        @MethodId(1)
+        void myCall();
+    }
+
     interface MyInterfaceLong {
+        void myCall(long l);
+    }
+
+    interface MyInterfaceLongMethodId extends MyInterfaceLong {
+        @MethodId(2)
         void myCall(long l);
     }
 }

--- a/src/test/java/net/openhft/chronicle/wire/UpdateInterceptorReturnTypeTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/UpdateInterceptorReturnTypeTest.java
@@ -29,6 +29,8 @@ public class UpdateInterceptorReturnTypeTest extends WireTestCommon {
     @Before
     public void setUp() {
         System.setProperty(DISABLE_WRITER_PROXY_CODEGEN, String.valueOf(disableProxyCodegen));
+        if (disableProxyCodegen)
+            expectException("Falling back to proxy method writer");
     }
 
     @After

--- a/src/test/java/net/openhft/chronicle/wire/method/MethodWriterProxy2Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/MethodWriterProxy2Test.java
@@ -9,6 +9,7 @@ public class MethodWriterProxy2Test extends MethodWriter2Test {
     @Before
     public void before() {
         System.setProperty("disableProxyCodegen", "true");
+        expectException("Falling back to proxy method writer");
     }
 
     @After

--- a/src/test/java/net/openhft/chronicle/wire/method/MethodWriterProxyTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/MethodWriterProxyTest.java
@@ -15,6 +15,7 @@ public class MethodWriterProxyTest extends MethodWriterTest {
     @Before
     public void before() {
         System.setProperty("disableProxyCodegen", "true");
+        expectException("Falling back to proxy method writer");
     }
 
     @After


### PR DESCRIPTION
Replaces #454 which was closed in error - see also comments made there

This PR builds upon the following fixes: #456 #457 #458 #472 

This PR stops generated method readers falling back to proxy method readers. If you get a problem with generated method readers then you can always disable them with `-DdisableReaderProxyCodegen`.

It also ensures that problems with generated method readers/writer compilation are logged at warning level and the user is asked to report the problem, and that when we fall back to proxies we see a log warning the user that support will be dropped.

We should now be able to drop proxy method readers/writers in x.25.

