### PR TITLE
Fix broken test

### DIFF
--- a/src/test/java/net/openhft/chronicle/wire/SerializableObjectTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/SerializableObjectTest.java
@@ -56,7 +56,8 @@ final class SerializableObjectTest extends WireTestCommon {
                     "javafx.",
                     "javax.swing",
                     "javax.print",
-                    "apple.security"
+                    "apple.security",
+                    "org.apache.maven.surefire.shared.lang3.text"
             )
             .collect(Collectors.collectingAndThen(toSet(), Collections::unmodifiableSet));
 


### PR DESCRIPTION
Hi @minborg I seem to have broken this test when I bumped the java parent POM. I don't know why.

I do know the version of surefire changed, so that could be it, but I'm not sure. In any case I have to exclude this package now, or you get the error:
```
[ERROR]   Run 172: SerializableObjectTest.lambda$test$17:333 » IllegalArgument Unable to deserialize class org.apache.maven.surefire.shared.lang3.text.StrBuilder
```