### PR TITLE
Extend zero writes after end of append context to ensure the complete…

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -332,13 +332,17 @@ public abstract class AbstractWire implements Wire {
         }
 
 
-        // clear up to the next 4 bytes to explicitly indicate "no more data"
-        // if there aren't at least 4 bytes remaining, then region not yet mapped and will be cleared when mapped
+        // clear up to the next 8 bytes to explicitly indicate "no more data" (8 covers int + max padding)
+        // if there aren't at least 8 bytes remaining, then clear what we can (any new mapping will be 0 anyway)
         // also clears any dirty bits left by a failed writer/appender
         // does not get added to the length
-        final BytesStore bytesStore = bytes.bytesStore();
-        if (bytesStore.capacity() - pos >= 4 && bytesStore.readInt(pos) != 0) {
-            bytesStore.writeInt(pos, 0);
+        final BytesStore<?, ?> bytesStore = bytes.bytesStore();
+        if (bytesStore.capacity() - pos >= 8 ) {
+            bytesStore.writeLong(pos, 0);
+        } else {
+            long remain = bytesStore.capacity() - pos;
+            for(int i=0; i<remain; ++i)
+                bytesStore.writeByte(pos + i, 0);
         }
 
         final long value = pos - position - 4;

--- a/src/test/java/net/openhft/chronicle/wire/ChronicleBitSetTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ChronicleBitSetTest.java
@@ -19,6 +19,8 @@ package net.openhft.chronicle.wire;
 
 import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.bytes.NativeBytes;
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.io.IOTools;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
@@ -43,11 +45,15 @@ public class ChronicleBitSetTest extends WireTestCommon {
     private final ChronicleBitSet emptyBS128;
 
     public ChronicleBitSetTest(Class clazz) {
+        assumeTrue(Jvm.is64bit());
         this.clazz = clazz;
         emptyBS0 = createBitSet();
         emptyBS1 = createBitSet(1);
         emptyBS127 = createBitSet(127);
         emptyBS128 = createBitSet(128);
+    }
+
+    private void assumeTrue(boolean bit) {
     }
 
     @NotNull
@@ -1111,7 +1117,9 @@ public class ChronicleBitSetTest extends WireTestCommon {
     }
 
     private ChronicleBitSet cloneBitSet(ChronicleBitSet b1, int size) {
-        final ChronicleBitSet bitSet = createBitSet(new BinaryWire(Bytes.allocateElasticOnHeap()), size);
+        NativeBytes<Void> bytes = Bytes.allocateElasticDirect();
+        IOTools.unmonitor(bytes);
+        final ChronicleBitSet bitSet = createBitSet(new BinaryWire(bytes), size);
         bitSet.copyFrom(b1);
         closeables.add(bitSet);
         return bitSet;

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/TriviallyCopyableMarketDataTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/TriviallyCopyableMarketDataTest.java
@@ -1,15 +1,18 @@
 package net.openhft.chronicle.wire.marshallable;
 
 import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.pool.ClassAliasPool;
 import net.openhft.chronicle.wire.Marshallable;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
+import static org.junit.Assume.assumeFalse;
 
 public class TriviallyCopyableMarketDataTest {
     @Test
     public void test() {
+        assumeFalse(Jvm.isAzulZing());
         ClassAliasPool.CLASS_ALIASES.addAlias(TriviallyCopyableMarketData.class, "MarketData");
         final String str = "" +
                 "!MarketData {\n" +


### PR DESCRIPTION
… next header (int + any padding offset) is guaranteed to be 0 (NONE/EOF) (#481)

Co-authored-by: rogersimmons <roger.simmons@higherfrequencytrading.com>