### PR TITLE
Test AbstractCommonMarshallable does not use self describing message

### DIFF
--- a/src/test/java/net/openhft/chronicle/wire/AbstractCommonMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/AbstractCommonMarshallableTest.java
@@ -1,0 +1,14 @@
+package net.openhft.chronicle.wire;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class AbstractCommonMarshallableTest {
+
+    @Test
+    void doesNotUseSelfDescribingMessagesByDefault() {
+        assertFalse(new AbstractCommonMarshallable() {
+        }.usesSelfDescribingMessage());
+    }
+}


### PR DESCRIPTION
This flipped between 2.20 and 2.22, let's make sure it doesn't flip again (automated test > comment at the top of the file)