### PR TITLE
Deprecate AbstractCommonMarshallable in preparation to move it package-private

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AbstractCommonMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractCommonMarshallable.java
@@ -21,7 +21,10 @@ import net.openhft.chronicle.bytes.BytesMarshallable;
 
 /**
  * This uses bytes marshallable, non self describing messages by default.
+ *
+ * @deprecated This will become package-private in x.25 use {@link SelfDescribingMarshallable} or {@link BytesInBinaryMarshallable} instead
  */
+@Deprecated(/* to be made package-private in x.25 */)
 public abstract class AbstractCommonMarshallable implements Marshallable, BytesMarshallable {
     @Override
     public boolean equals(Object o) {


### PR DESCRIPTION
Fixes #507

We have seen people extending this directly in the wild, some time between BOM 2.20 and 2.22 it flipped from being self describing to being not. It's probably better that descenders make that choice explicitly by descending from SelfDescribingMarshallable or BytesInBinaryMarshallable than relying on the default here.