### PR TITLE
Avoid unnecessary CAS operation when writing EOF marker

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -438,7 +438,7 @@ public abstract class AbstractWire implements Wire {
                     pos += BytesUtil.padOffset(pos);
 
                 if (MEMORY.safeAlignedInt(pos)) {
-                    if (bytes.compareAndSwapInt(pos, 0, END_OF_DATA)) {
+                    if (bytes.readVolatileInt(pos) == 0 && bytes.compareAndSwapInt(pos, 0, END_OF_DATA)) {
                         bytes.writePosition(pos + SPB_HEADER_SIZE);
                         write("EOF");
                         return true;


### PR DESCRIPTION
Fixes OpenHFT/Chronicle-Queue#1141

The theory is here, the CAS operation causes a mapped page to be changed to read/write which triggers an update to mtime regardless of whether the CAS results in an update. It meant in queue, when `normaliseEOFs` was called on the creation of a new appender, all the roll cycles' mtime was updated to now, even if no change was made to the file.