### PR TITLE
Brackets on json wire test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,11 +90,6 @@
         </dependency>
 
         <dependency>
-            <groupId>net.openhft</groupId>
-            <artifactId>compiler</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
         </dependency>

--- a/src/main/java/net/openhft/chronicle/wire/JSONWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/JSONWire.java
@@ -499,18 +499,23 @@ public class JSONWire extends TextWire {
 
         @Override
         public void start(boolean metaData) {
+            int count = this.count;
             super.start(metaData);
-            bytes.append('{');
-            start = bytes.writePosition();
+            if (count == 0) {
+                bytes.append('{');
+                start = bytes.writePosition();
+            }
         }
 
         @Override
         public void close() {
             super.close();
-            if (bytes.writePosition() == start) {
-                bytes.writeSkip(-1);
-            } else {
-                bytes.append('}');
+            if (count == 0) {
+                if (bytes.writePosition() == start) {
+                    bytes.writeSkip(-1);
+                } else {
+                    bytes.append('}');
+                }
             }
         }
     }

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -103,8 +103,8 @@ public class TextWire extends AbstractWire implements Wire {
     private final StringBuilder sb = new StringBuilder();
     protected long lineStart = 0;
     private DefaultValueIn defaultValueIn;
-    private WriteDocumentContext writeContext;
-    private ReadDocumentContext readContext;
+    protected WriteDocumentContext writeContext;
+    protected ReadDocumentContext readContext;
     private boolean strict = false;
     private boolean addTimeStamps = false;
     private boolean trimFirstCurly = true;

--- a/src/main/java/net/openhft/chronicle/wire/TextWriteDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWriteDocumentContext.java
@@ -25,7 +25,7 @@ public class TextWriteDocumentContext implements WriteDocumentContext {
     protected Wire wire;
     private boolean metaData;
     private volatile boolean notComplete;
-    private int count = 0;
+    protected int count = 0;
     private boolean chainedElement;
     private boolean rollback;
 

--- a/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
@@ -81,9 +81,9 @@ public class HTTPMarshallableOut implements MarshallableOut {
         this.url = builder.url();
 
         if (wireType == WireType.JSON)
-            this.wire = new JSONWire(allocateElasticOnHeap()).useTypes(true).trimFirstCurly(false).useTextDocuments();
+            this.wire = new JSONWire(allocateElasticOnHeap()).useTypes(true).trimFirstCurly(true).useTextDocuments();
         else if (wireType == WireType.JSON_ONLY) {
-            this.wire = new JSONWire(allocateElasticOnHeap()).useTypes(true).useTextDocuments();
+            this.wire = new JSONWire(allocateElasticOnHeap()).useTypes(true).trimFirstCurly(false).useTextDocuments();
         } else
             this.wire = wireType.apply(allocateElasticDirect());
 
@@ -92,12 +92,12 @@ public class HTTPMarshallableOut implements MarshallableOut {
 
     void startWire() {
         wire.clear();
-        if (wire instanceof JSONWire)
+        if (wire instanceof JSONWire && !((JSONWire) wire).trimFirstCurly())
             wire.bytes().append('{').readPosition(1);
     }
 
     void endWire() {
-        if (wire instanceof JSONWire)
+        if (wire instanceof JSONWire && !((JSONWire) wire).trimFirstCurly())
             wire.bytes().append('}').append('\n').readPosition(0);
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
@@ -28,7 +28,6 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-import static net.openhft.chronicle.bytes.Bytes.allocateElasticDirect;
 import static net.openhft.chronicle.bytes.Bytes.allocateElasticOnHeap;
 
 /**
@@ -57,7 +56,9 @@ public class HTTPMarshallableOut implements MarshallableOut {
                     endWire();
                     try (final OutputStream out = conn.getOutputStream()) {
                         final Bytes<byte[]> bytes = (Bytes<byte[]>) wire.bytes();
-                        out.write(bytes.underlyingObject(), 0, (int) bytes.readLimit());
+                        final byte[] b = bytes.underlyingObject();
+                        assert b != null;
+                        out.write(b, 0, (int) bytes.readLimit());
                     }
 
                     final int responseCode = conn.getResponseCode();
@@ -82,23 +83,22 @@ public class HTTPMarshallableOut implements MarshallableOut {
 
         if (wireType == WireType.JSON)
             this.wire = new JSONWire(allocateElasticOnHeap()).useTypes(true).trimFirstCurly(true).useTextDocuments();
-        else if (wireType == WireType.JSON_ONLY) {
-            this.wire = new JSONWire(allocateElasticOnHeap()).useTypes(true).trimFirstCurly(false).useTextDocuments();
-        } else
-            this.wire = wireType.apply(allocateElasticDirect());
+        else
+            this.wire = wireType.apply(allocateElasticOnHeap());
 
         startWire();
     }
 
     void startWire() {
         wire.clear();
-        if (wire instanceof JSONWire && !((JSONWire) wire).trimFirstCurly())
-            wire.bytes().append('{').readPosition(1);
     }
 
     void endWire() {
-        if (wire instanceof JSONWire && !((JSONWire) wire).trimFirstCurly())
-            wire.bytes().append('}').append('\n').readPosition(0);
+        if (!wire.isBinary()) {
+            final Bytes<?> bytes = wire.bytes();
+            if (bytes.peekUnsignedByte(bytes.writePosition() - 1) >= ' ')
+                bytes.append('\n');
+        }
     }
 
     @Override

--- a/src/test/java/net/openhft/chronicle/wire/BracketsOnJSONWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BracketsOnJSONWireTest.java
@@ -1,10 +1,11 @@
 package net.openhft.chronicle.wire;
 
 import net.openhft.chronicle.bytes.Bytes;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertEquals;
 
 public class BracketsOnJSONWireTest {
 
@@ -19,12 +20,13 @@ public class BracketsOnJSONWireTest {
 
         final Bytes<ByteBuffer> t = Bytes.elasticByteBuffer();
         Wire wire = WireType.JSON_ONLY.apply(t);
-        wire.methodWriter(Printer.class).print("hello");
+        wire.methodWriter(Printer.class)
+                .print("hello");
 
-        Assert.assertEquals("{", "" + (char) wire.bytes().peekUnsignedByte());
+        assertEquals("{\"print\":\"hello\"}", wire.toString());
 
         wire.methodReader((Printer) msg -> actual = msg).readOne();
-        Assert.assertEquals("hello", actual);
+        assertEquals("hello", actual);
     }
 
 

--- a/src/test/java/net/openhft/chronicle/wire/BracketsOnJSONWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BracketsOnJSONWireTest.java
@@ -1,0 +1,31 @@
+package net.openhft.chronicle.wire;
+
+import net.openhft.chronicle.bytes.Bytes;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+public class BracketsOnJSONWireTest {
+
+    String actual;
+
+    interface Printer {
+        void print(String msg);
+    }
+
+    @Test
+    public void test() {
+
+        final Bytes<ByteBuffer> t = Bytes.elasticByteBuffer();
+        Wire wire = WireType.JSON_ONLY.apply(t);
+        wire.methodWriter(Printer.class).print("hello");
+
+        Assert.assertEquals("{", "" + (char) wire.bytes().peekUnsignedByte());
+
+        wire.methodReader((Printer) msg -> actual = msg).readOne();
+        Assert.assertEquals("hello", actual);
+    }
+
+
+}

--- a/src/test/java/net/openhft/chronicle/wire/internal/StringConsumerMarshallableOutTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/internal/StringConsumerMarshallableOutTest.java
@@ -44,9 +44,9 @@ public class StringConsumerMarshallableOutTest {
     public void saysJson() {
         final WireType wireType = WireType.JSON_ONLY;
         final String expected = "" +
-                "\"say\":\"One\"\n" +
-                "\"say\":\"Two\"\n" +
-                "\"say\":\"Three\"\n";
+                "{\"say\":\"One\"}\n" +
+                "{\"say\":\"Two\"}\n" +
+                "{\"say\":\"Three\"}\n";
         doTest(wireType, expected);
     }
 


### PR DESCRIPTION
Json wire is missing '{' and '}' - see net.openhft.chronicle.wire.BracketsOnJSONWireTest

relatest to https://github.com/OpenHFT/Chronicle-Wire/issues/566