### PR TITLE
Remove deprecated APIs in 2.24

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AbstractMethodWriterInvocationHandler.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractMethodWriterInvocationHandler.java
@@ -38,7 +38,6 @@ public abstract class AbstractMethodWriterInvocationHandler extends AbstractInvo
     };
     protected boolean recordHistory;
     protected String genericEvent = "";
-    private MethodWriterInterceptorReturns methodWriterInterceptorReturns;
     private BiConsumer<Method, Object[]> handleInvoke;
     private boolean useMethodIds;
 
@@ -49,14 +48,8 @@ public abstract class AbstractMethodWriterInvocationHandler extends AbstractInvo
 
     @Override
     protected Object doInvoke(Object proxy, Method method, Object[] args) {
+        handleInvoke(method, args);
 
-        if (methodWriterInterceptorReturns != null) {
-            this.proxy.set(proxy);
-            // TODO: ignores retval
-            methodWriterInterceptorReturns.intercept(method, args, onMethod);
-        } else {
-            handleInvoke(method, args);
-        }
         return method.getReturnType().isInterface() ? proxy : null;
     }
 
@@ -115,11 +108,6 @@ public abstract class AbstractMethodWriterInvocationHandler extends AbstractInvo
     @Override
     public void recordHistory(boolean recordHistory) {
         this.recordHistory = recordHistory;
-    }
-
-    @Override
-    public void methodWriterInterceptorReturns(MethodWriterInterceptorReturns methodWriterInterceptorReturns) {
-        this.methodWriterInterceptorReturns = methodWriterInterceptorReturns;
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -18,7 +18,7 @@
 package net.openhft.chronicle.wire;
 
 import net.openhft.chronicle.bytes.Bytes;
-import net.openhft.chronicle.bytes.BytesComment;
+import net.openhft.chronicle.bytes.HexDumpBytesDescription;
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.BytesUtil;
 import net.openhft.chronicle.bytes.util.DecoratedBufferUnderflowException;
@@ -161,7 +161,7 @@ public abstract class AbstractWire implements Wire {
     }
 
     @Override
-    public BytesComment<?> bytesComment() {
+    public HexDumpBytesDescription<?> bytesComment() {
         return bytes;
     }
 
@@ -499,16 +499,6 @@ public abstract class AbstractWire implements Wire {
     @Override
     public void parent(Object parent) {
         this.parent = parent;
-    }
-
-    @Override
-    public boolean startUse() {
-        return true;
-    }
-
-    @Override
-    public boolean endUse() {
-        return true;
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/wire/BinaryMethodWriterInvocationHandler.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryMethodWriterInvocationHandler.java
@@ -32,14 +32,6 @@ public class BinaryMethodWriterInvocationHandler extends AbstractMethodWriterInv
         this(tClass, metaData, () -> marshallableOut);
     }
 
-    /**
-     * @deprecated to be removed in x.24
-     */
-    @Deprecated(/* to be removed in x.24 */)
-    public BinaryMethodWriterInvocationHandler(final boolean metaData, Supplier<MarshallableOut> marshallableOutSupplier) {
-        this(Object.class, metaData, marshallableOutSupplier);
-    }
-
     public BinaryMethodWriterInvocationHandler(Class<?> tClass, final boolean metaData, Supplier<MarshallableOut> marshallableOutSupplier) {
         super(tClass);
         this.marshallableOutSupplier = marshallableOutSupplier;

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -252,8 +252,8 @@ public class BinaryWire extends AbstractWire implements Wire {
     public void copyTo(@NotNull WireOut wire) {
         if (wire.getClass() == getClass()) {
             final Bytes<?> bytes2 = wire.bytes();
-            if (bytes2.retainsComments())
-                bytes2.comment("passed-through");
+            if (bytes2.retainedHexDumpDescription())
+                bytes2.writeHexDumpDescription("passed-through");
             bytes2.write(this.bytes);
             this.bytes.readPosition(this.bytes.readLimit());
             return;
@@ -1124,8 +1124,8 @@ public class BinaryWire extends AbstractWire implements Wire {
     @NotNull
     @Override
     public ValueOut writeEventName(@NotNull CharSequence name) {
-        if (bytes.retainsComments())
-            bytes.comment(name + ": (event)");
+        if (bytes.retainedHexDumpDescription())
+            bytes.writeHexDumpDescription(name + ": (event)");
         writeCode(EVENT_NAME).write8bit(name);
         return valueOut;
     }
@@ -1138,8 +1138,8 @@ public class BinaryWire extends AbstractWire implements Wire {
 
     @Override
     public ValueOut writeEventId(String name, int methodId) {
-        if (bytes.retainsComments())
-            bytes.comment(name + " (" + methodId + ")");
+        if (bytes.retainedHexDumpDescription())
+            bytes.writeHexDumpDescription(name + " (" + methodId + ")");
         writeCode(FIELD_NUMBER).writeStopBit(methodId);
         return valueOut;
     }
@@ -1210,8 +1210,8 @@ public class BinaryWire extends AbstractWire implements Wire {
     }
 
     private void writeField(@NotNull CharSequence name) {
-        if (bytes.retainsComments())
-            bytes.comment(name + ":");
+        if (bytes.retainedHexDumpDescription())
+            bytes.writeHexDumpDescription(name + ":");
         int len = name.length();
         if (len < 0x20) {
             writeField0(name, len);
@@ -1234,8 +1234,8 @@ public class BinaryWire extends AbstractWire implements Wire {
     }
 
     private void writeField(int code) {
-        if (bytes.retainsComments())
-            bytes.comment(Integer.toString(code));
+        if (bytes.retainedHexDumpDescription())
+            bytes.writeHexDumpDescription(Integer.toString(code));
         writeCode(FIELD_NUMBER);
         bytes.writeStopBit(code);
     }
@@ -1406,8 +1406,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @NotNull
         @Override
         public WireOut nu11() {
-            if (bytes.retainsComments())
-                bytes.comment("null");
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription("null");
             writeCode(NULL);
             return BinaryWire.this;
         }
@@ -1419,8 +1419,8 @@ public class BinaryWire extends AbstractWire implements Wire {
                 nu11();
 
             } else {
-                if (bytes.retainsComments())
-                    bytes.comment(s);
+                if (bytes.retainedHexDumpDescription())
+                    bytes.writeHexDumpDescription(s);
                 long utflen = AppendableUtil.findUtf8Length(s);
                 if (utflen < 0x20) {
                     bytes.writeUnsignedByte((int) (STRING_0 + utflen)).appendUtf8(s);
@@ -1440,8 +1440,8 @@ public class BinaryWire extends AbstractWire implements Wire {
                 writeCode(NULL);
 
             } else {
-                if (bytes.retainsComments())
-                    bytes.comment(s);
+                if (bytes.retainedHexDumpDescription())
+                    bytes.writeHexDumpDescription(s);
                 int len = s.length();
                 if (len < 0x20)
                     len = (int) AppendableUtil.findUtf8Length(s);
@@ -1584,8 +1584,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @Override
         @NotNull
         public WireOut fixedInt8(byte i8) {
-            if (bytes.retainsComments())
-                bytes.comment(Integer.toString(i8));
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(Integer.toString(i8));
             writeCode(INT8).writeByte(i8);
             return BinaryWire.this;
         }
@@ -1593,8 +1593,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @NotNull
         @Override
         public WireOut uint8checked(int u8) {
-            if (bytes.retainsComments())
-                bytes.comment(Integer.toString(u8));
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(Integer.toString(u8));
             writeCode(UINT8).writeUnsignedByte(u8);
             return BinaryWire.this;
         }
@@ -1608,8 +1608,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @Override
         @NotNull
         public WireOut fixedInt16(short i16) {
-            if (bytes.retainsComments())
-                bytes.comment(Integer.toString(i16));
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(Integer.toString(i16));
             writeCode(INT16).writeShort(i16);
             return BinaryWire.this;
         }
@@ -1617,8 +1617,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @NotNull
         @Override
         public WireOut uint16checked(int u16) {
-            if (bytes.retainsComments())
-                bytes.comment(Integer.toString(u16));
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(Integer.toString(u16));
             writeCode(UINT16).writeUnsignedShort(u16);
             return BinaryWire.this;
         }
@@ -1626,8 +1626,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @NotNull
         @Override
         public WireOut utf8(int codepoint) {
-            if (bytes.retainsComments())
-                bytes.comment(new String(Character.toChars(codepoint)));
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(new String(Character.toChars(codepoint)));
             writeCode(UINT16);
             bytes.appendUtf8(codepoint);
             return BinaryWire.this;
@@ -1642,16 +1642,16 @@ public class BinaryWire extends AbstractWire implements Wire {
         @Override
         @NotNull
         public WireOut fixedInt32(int i32) {
-            if (bytes.retainsComments())
-                bytes.comment(Integer.toString(i32));
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(Integer.toString(i32));
             writeCode(INT32).writeInt(i32);
             return BinaryWire.this;
         }
 
         @NotNull
         public WireOut fixedOrderedInt32(int i32) {
-            if (bytes.retainsComments())
-                bytes.comment(Integer.toString(i32));
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(Integer.toString(i32));
             writeCode(INT32).writeOrderedInt(i32);
             return BinaryWire.this;
         }
@@ -1659,8 +1659,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @NotNull
         @Override
         public WireOut uint32checked(long u32) {
-            if (bytes.retainsComments())
-                bytes.comment(Long.toUnsignedString(u32));
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(Long.toUnsignedString(u32));
             writeCode(UINT32).writeUnsignedInt(u32);
             return BinaryWire.this;
         }
@@ -1674,8 +1674,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @Override
         @NotNull
         public WireOut fixedInt64(long i64) {
-            if (bytes.retainsComments())
-                bytes.comment(Long.toString(i64));
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(Long.toString(i64));
             writeCode(INT64).writeLong(i64);
             return BinaryWire.this;
         }
@@ -1689,8 +1689,8 @@ public class BinaryWire extends AbstractWire implements Wire {
 
         @NotNull
         private WireOut fixedOrderedInt64(long i64) {
-            if (bytes.retainsComments())
-                bytes.comment(Long.toString(i64));
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(Long.toString(i64));
             writeAlignTo(8, 1);
             writeCode(INT64).writeOrderedLong(i64);
             return BinaryWire.this;
@@ -1699,8 +1699,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @NotNull
         @Override
         public WireOut int64array(long capacity) {
-            if (bytes.retainsComments())
-                bytes.comment(Long.toString(capacity));
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(Long.toString(capacity));
             writeAlignTo(8, 1);
             writeCode(I64_ARRAY);
             BinaryLongArrayReference.lazyWrite(bytes, capacity);
@@ -1739,8 +1739,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @Override
         @NotNull
         public WireOut fixedFloat32(float f) {
-            if (bytes.retainsComments())
-                bytes.comment(Float.toString(f));
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(Float.toString(f));
             writeCode(FLOAT32).writeFloat(f);
             return BinaryWire.this;
         }
@@ -1754,8 +1754,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @Override
         @NotNull
         public WireOut fixedFloat64(double d) {
-            if (bytes.retainsComments())
-                bytes.comment(Double.toString(d));
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(Double.toString(d));
             writeCode(FLOAT64).writeDouble(d);
             return BinaryWire.this;
         }
@@ -1764,8 +1764,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @Override
         public WireOut time(@NotNull LocalTime localTime) {
             final String text = localTime.toString();
-            if (bytes.retainsComments())
-                bytes.comment(text);
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(text);
             writeCode(TIME).writeUtf8(text);
             return BinaryWire.this;
         }
@@ -1774,8 +1774,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @Override
         public WireOut zonedDateTime(@NotNull ZonedDateTime zonedDateTime) {
             final String text = zonedDateTime.toString();
-            if (bytes.retainsComments())
-                bytes.comment(text);
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(text);
             writeCode(ZONED_DATE_TIME).writeUtf8(text);
             return BinaryWire.this;
         }
@@ -1784,8 +1784,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @Override
         public WireOut date(@NotNull LocalDate localDate) {
             final String text = localDate.toString();
-            if (bytes.retainsComments())
-                bytes.comment(text);
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(text);
             writeCode(DATE).writeUtf8(text);
             return BinaryWire.this;
         }
@@ -1794,8 +1794,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @Override
         public WireOut dateTime(@NotNull LocalDateTime localDateTime) {
             final String text = localDateTime.toString();
-            if (bytes.retainsComments())
-                bytes.comment(text);
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(text);
             writeCode(DATE_TIME).writeUtf8(text);
             return BinaryWire.this;
         }
@@ -1803,8 +1803,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @NotNull
         @Override
         public ValueOut typePrefix(CharSequence typeName) {
-            if (bytes.retainsComments())
-                bytes.comment(typeName);
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(typeName);
             if (typeName != null)
                 writeCode(TYPE_PREFIX).writeUtf8(typeName);
             return this;
@@ -1818,8 +1818,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @NotNull
         @Override
         public WireOut typeLiteral(CharSequence typeName) {
-            if (bytes.retainsComments())
-                bytes.comment(typeName);
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(typeName);
             if (typeName == null)
                 nu11();
             else
@@ -1830,8 +1830,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @NotNull
         @Override
         public WireOut typeLiteral(@Nullable Class type) {
-            if (bytes.retainsComments() && type != null)
-                bytes.comment(type.getName());
+            if (bytes.retainedHexDumpDescription() && type != null)
+                bytes.writeHexDumpDescription(type.getName());
             if (type == null)
                 nu11();
             else
@@ -1842,8 +1842,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @NotNull
         @Override
         public WireOut typeLiteral(@NotNull BiConsumer<Class, Bytes<?>> typeTranslator, @Nullable Class type) {
-            if (bytes.retainsComments())
-                bytes.comment(type == null ? null : type.getName());
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(type == null ? null : type.getName());
             writeCode(TYPE_LITERAL);
             typeTranslator.accept(type, bytes);
             return BinaryWire.this;
@@ -1852,8 +1852,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @NotNull
         @Override
         public WireOut uuid(@NotNull UUID uuid) {
-            if (bytes.retainsComments())
-                bytes.comment(uuid.toString());
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(uuid.toString());
             writeCode(UUID).writeLong(uuid.getMostSignificantBits()).writeLong(uuid.getLeastSignificantBits());
             return BinaryWire.this;
         }
@@ -1861,8 +1861,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @NotNull
         @Override
         public WireOut int32forBinding(int value) {
-            if (bytes.retainsComments())
-                bytes.comment("int32 for binding");
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription("int32 for binding");
             writeAlignTo(Integer.BYTES, 1);
             fixedInt32(value);
             return BinaryWire.this;
@@ -1871,8 +1871,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @NotNull
         @Override
         public WireOut int64forBinding(long value) {
-            if (bytes.retainsComments())
-                bytes.comment("int64 for binding");
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription("int64 for binding");
             writeAlignTo(Long.BYTES, 1);
             fixedOrderedInt64(value);
             return BinaryWire.this;
@@ -1881,8 +1881,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @NotNull
         @Override
         public WireOut int32forBinding(int value, @NotNull IntValue intValue) {
-            if (bytes.retainsComments())
-                bytes.comment("int32 for binding");
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription("int32 for binding");
             int32forBinding(value);
             ((BinaryIntReference) intValue).bytesStore(bytes, bytes.writePosition() - 4, 4);
             return BinaryWire.this;
@@ -1891,8 +1891,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @NotNull
         @Override
         public WireOut int64forBinding(long value, @NotNull LongValue longValue) {
-            if (bytes.retainsComments())
-                bytes.comment("int64 for binding");
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription("int64 for binding");
             int64forBinding(value);
             ((BinaryLongReference) longValue).bytesStore(bytes, bytes.writePosition() - 8, 8);
             return BinaryWire.this;
@@ -1918,8 +1918,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @NotNull
         @Override
         public <T> WireOut sequence(T t, @NotNull BiConsumer<T, ValueOut> writer) {
-            if (bytes.retainsComments())
-                bytes.comment("sequence");
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription("sequence");
             writeCode(BYTES_LENGTH32);
             long position = bytes.writePosition();
             bytes.writeInt(0);
@@ -1941,8 +1941,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @NotNull
         @Override
         public <T, K> WireOut sequence(T t, K kls, @NotNull TriConsumer<T, K, ValueOut> writer) {
-            if (bytes.retainsComments())
-                bytes.comment("sequence");
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription("sequence");
             writeCode(BYTES_LENGTH32);
             long position = bytes.writePosition();
             bytes.writeInt(0);
@@ -1956,8 +1956,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @NotNull
         @Override
         public WireOut marshallable(@NotNull WriteMarshallable object) {
-            if (bytes.retainsComments())
-                bytes.comment(object.getClass().getSimpleName());
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(object.getClass().getSimpleName());
             final BinaryLengthLength binaryLengthLength = object.binaryLengthLength();
             long pos = binaryLengthLength.initialise(bytes);
 
@@ -1972,8 +1972,8 @@ public class BinaryWire extends AbstractWire implements Wire {
 
         @Override
         public WireOut bytesMarshallable(WriteBytesMarshallable object) {
-            if (bytes.retainsComments())
-                bytes.comment(object.getClass().getSimpleName());
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(object.getClass().getSimpleName());
             writeCode(BYTES_LENGTH32);
             long position = bytes.writePosition();
             bytes.writeInt(0);
@@ -1990,8 +1990,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         @NotNull
         @Override
         public WireOut marshallable(@NotNull Serializable object) {
-            if (bytes.retainsComments())
-                bytes.comment(object.getClass().getSimpleName());
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(object.getClass().getSimpleName());
             writeCode(BYTES_LENGTH32);
             long position = bytes.writePosition();
             bytes.writeInt(0);
@@ -2036,15 +2036,15 @@ public class BinaryWire extends AbstractWire implements Wire {
 
         @Override
         public WireOut writeInt(IntConverter intConverter, int i) {
-            if (bytes.retainsComments())
-                bytes.comment(intConverter.asString(i));
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(intConverter.asString(i));
             return writeInt(i);
         }
 
         @Override
         public WireOut writeLong(LongConverter longConverter, long l) {
-            if (bytes.retainsComments())
-                bytes.comment(longConverter.asString(l));
+            if (bytes.retainedHexDumpDescription())
+                bytes.writeHexDumpDescription(longConverter.asString(l));
             return writeLong(l);
         }
 
@@ -2294,20 +2294,20 @@ public class BinaryWire extends AbstractWire implements Wire {
         private boolean writeAsFixedPoint(float l, long l6) {
             long i2 = l6 / 10000;
             if (i2 / 1e2f == l) {
-                if (bytes.retainsComments()) bytes.comment(i2 + "/1e2");
+                if (bytes.retainedHexDumpDescription()) bytes.writeHexDumpDescription(i2 + "/1e2");
                 writeCode(FLOAT_STOP_2).writeStopBit(i2);
                 return true;
             }
 
             long i4 = l6 / 100;
             if (i4 / 1e4f == l) {
-                if (bytes.retainsComments()) bytes.comment(i4 + "/1e4");
+                if (bytes.retainedHexDumpDescription()) bytes.writeHexDumpDescription(i4 + "/1e4");
                 writeCode(FLOAT_STOP_4).writeStopBit(i4);
                 return true;
             }
 
             if (l6 / 1e6f == l) {
-                if (bytes.retainsComments()) bytes.comment(l6 + "/1e6");
+                if (bytes.retainedHexDumpDescription()) bytes.writeHexDumpDescription(l6 + "/1e6");
                 writeCode(FLOAT_STOP_6).writeStopBit(l6);
                 return true;
             }
@@ -2317,20 +2317,20 @@ public class BinaryWire extends AbstractWire implements Wire {
         private boolean writeAsFixedPoint(double l, long l6) {
             long i2 = l6 / 10000;
             if (i2 / 1e2 == l) {
-                if (bytes.retainsComments()) bytes.comment(i2 + "/1e2");
+                if (bytes.retainedHexDumpDescription()) bytes.writeHexDumpDescription(i2 + "/1e2");
                 writeCode(FLOAT_STOP_2).writeStopBit(i2);
                 return true;
             }
 
             long i4 = l6 / 100;
             if (i4 / 1e4 == l) {
-                if (bytes.retainsComments()) bytes.comment(i4 + "/1e4");
+                if (bytes.retainedHexDumpDescription()) bytes.writeHexDumpDescription(i4 + "/1e4");
                 writeCode(FLOAT_STOP_4).writeStopBit(i4);
                 return true;
             }
 
             if (l6 / 1e6 == l) {
-                if (bytes.retainsComments()) bytes.comment(l6 + "/1e6");
+                if (bytes.retainedHexDumpDescription()) bytes.writeHexDumpDescription(l6 + "/1e6");
                 writeCode(FLOAT_STOP_6).writeStopBit(l6);
                 return true;
             }

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWriteDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWriteDocumentContext.java
@@ -45,7 +45,7 @@ public class BinaryWriteDocumentContext implements WriteDocumentContext {
         }
         @NotNull Bytes<?> bytes = wire().bytes();
         bytes.writePositionForHeader(wire.usePadding());
-        bytes.comment("msg-length");
+        bytes.writeHexDumpDescription("msg-length");
         this.position = bytes.writePosition();
         metaDataBit = metaData ? Wires.META_DATA : 0;
         tmpHeader = metaDataBit | Wires.NOT_COMPLETE | Wires.UNKNOWN_LENGTH;

--- a/src/main/java/net/openhft/chronicle/wire/HashWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/HashWire.java
@@ -18,7 +18,7 @@
 package net.openhft.chronicle.wire;
 
 import net.openhft.chronicle.bytes.Bytes;
-import net.openhft.chronicle.bytes.BytesComment;
+import net.openhft.chronicle.bytes.HexDumpBytesDescription;
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.CommonMarshallable;
 import net.openhft.chronicle.core.Maths;
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
 @SuppressWarnings("rawtypes")
-public class HashWire implements WireOut, BytesComment {
+public class HashWire implements WireOut, HexDumpBytesDescription {
     private static final ThreadLocal<HashWire> hwTL = new ThreadLocal<HashWire>() {
         @Override
         protected HashWire initialValue() {
@@ -111,16 +111,6 @@ public class HashWire implements WireOut, BytesComment {
 
     @Override
     public void parent(Object parent) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean startUse() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean endUse() {
         throw new UnsupportedOperationException();
     }
 
@@ -258,7 +248,7 @@ public class HashWire implements WireOut, BytesComment {
     }
 
     @Override
-    public BytesComment<?> bytesComment() {
+    public HexDumpBytesDescription<?> bytesComment() {
         return this;
     }
 
@@ -287,7 +277,7 @@ public class HashWire implements WireOut, BytesComment {
 
     @Override
     public boolean isBinary() {
-        return false; // as byte() doesn't make sense to access
+        return true; // text wire is orders of magnitude slower
     }
 
     @NotNull

--- a/src/main/java/net/openhft/chronicle/wire/JSONWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/JSONWire.java
@@ -452,12 +452,6 @@ public class JSONWire extends TextWire {
     }
 
     @Override
-    @Deprecated(/* To be removed in 2.24 */)
-    @NotNull
-    protected TextStopCharsTesters strictEndOfText() {
-        return TextStopCharsTesters.STRICT_END_OF_TEXT_JSON;
-    }
-
     @NotNull
     protected Supplier<StopCharsTester> strictEndOfTextEscaping() {
         return STRICT_END_OF_TEXT_JSON_ESCAPING;

--- a/src/main/java/net/openhft/chronicle/wire/MethodWriterInvocationHandlerSupplier.java
+++ b/src/main/java/net/openhft/chronicle/wire/MethodWriterInvocationHandlerSupplier.java
@@ -26,7 +26,6 @@ import java.util.function.Supplier;
 public class MethodWriterInvocationHandlerSupplier implements Supplier<MethodWriterInvocationHandler> {
     private final Supplier<MethodWriterInvocationHandler> supplier;
     private boolean recordHistory;
-    private MethodWriterInterceptorReturns methodWriterInterceptorReturns;
     private Closeable closeable;
     private boolean disableThreadSafe;
     private String genericEvent;
@@ -40,17 +39,6 @@ public class MethodWriterInvocationHandlerSupplier implements Supplier<MethodWri
 
     public void recordHistory(boolean recordHistory) {
         this.recordHistory = recordHistory;
-    }
-
-    @Deprecated(/* to be removed in x.24 */)
-    public MethodWriterInvocationHandlerSupplier methodWriterInterceptorReturns(MethodWriterInterceptorReturns methodWriterInterceptorReturns) {
-        this.methodWriterInterceptorReturns = methodWriterInterceptorReturns;
-        return this;
-    }
-
-    @Deprecated(/* to be removed in x.24 */)
-    public MethodWriterInterceptorReturns methodWriterInterceptorReturns() {
-        return methodWriterInterceptorReturns;
     }
 
     public void onClose(Closeable closeable) {
@@ -72,7 +60,6 @@ public class MethodWriterInvocationHandlerSupplier implements Supplier<MethodWri
     private MethodWriterInvocationHandler newHandler() {
         MethodWriterInvocationHandler h = supplier.get();
         h.genericEvent(genericEvent);
-        h.methodWriterInterceptorReturns(methodWriterInterceptorReturns);
         h.onClose(closeable);
         h.recordHistory(recordHistory);
         h.useMethodIds(useMethodIds);

--- a/src/main/java/net/openhft/chronicle/wire/TextMethodWriterInvocationHandler.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextMethodWriterInvocationHandler.java
@@ -123,14 +123,4 @@ public class TextMethodWriterInvocationHandler extends AbstractMethodWriterInvoc
             }
         };
     }
-
-    @Deprecated(/* To be removed in x.24 */)
-    enum NoOp implements Consumer<Object[]>, IgnoresEverything {
-        INSTANCE;
-
-        @Override
-        public void accept(Object[] objects) {
-            // Do nothing
-        }
-    }
 }

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -109,7 +109,6 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     public static String asText(@NotNull Wire wire) {
-        assert wire.startUse();
         NativeBytes<Void> bytes = nativeBytes();
         try {
             long pos = wire.bytes().readPosition();
@@ -119,7 +118,6 @@ public class TextWire extends YamlWireOut<TextWire> {
             return tw.toString();
         } finally {
             bytes.releaseLast();
-            assert wire.endUse();
         }
     }
 
@@ -529,15 +527,8 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     @NotNull
-    @Deprecated(/* To be removed in 2.24 - use strictEndOfTextEscaping */)
-    protected TextStopCharsTesters strictEndOfText() {
-        return TextStopCharsTesters.STRICT_END_OF_TEXT;
-    }
-
-    @NotNull
     protected Supplier<StopCharsTester> strictEndOfTextEscaping() {
-        return strictEndOfText() == TextStopCharsTesters.STRICT_END_OF_TEXT ?
-                STRICT_END_OF_TEXT_ESCAPING : strictEndOfText()::escaping;
+        return STRICT_END_OF_TEXT_ESCAPING;
     }
 
     @NotNull

--- a/src/main/java/net/openhft/chronicle/wire/VanillaMessageHistory.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMessageHistory.java
@@ -16,7 +16,7 @@
 package net.openhft.chronicle.wire;
 
 import net.openhft.chronicle.bytes.Bytes;
-import net.openhft.chronicle.bytes.BytesComment;
+import net.openhft.chronicle.bytes.HexDumpBytesDescription;
 import net.openhft.chronicle.bytes.BytesIn;
 import net.openhft.chronicle.bytes.BytesOut;
 import net.openhft.chronicle.bytes.util.BinaryLengthLength;
@@ -201,14 +201,14 @@ public class VanillaMessageHistory extends SelfDescribingMarshallable implements
     @Override
     public void writeMarshallable(@NotNull BytesOut<?> b) {
         BytesOut<?> bytes = b;
-        bytes.comment("sources")
+        bytes.writeHexDumpDescription("sources")
                 .writeUnsignedByte(sources);
         for (int i = 0; i < sources; i++)
             bytes.writeInt(sourceIdArray[i]);
         for (int i = 0; i < sources; i++)
             bytes.writeLong(sourceIndexArray[i]);
 
-        bytes.comment("timings")
+        bytes.writeHexDumpDescription("timings")
                 .writeUnsignedByte(timings + 1);// one more time for this output
         for (int i = 0; i < timings; i++) {
             bytes.writeLong(timingsArray[i]);
@@ -222,21 +222,21 @@ public class VanillaMessageHistory extends SelfDescribingMarshallable implements
     }
 
     private void acceptSources(VanillaMessageHistory t, ValueOut out) {
-        BytesComment<?> b = bytesComment(out);
+        HexDumpBytesDescription<?> b = bytesComment(out);
 
         for (int i = 0; i < t.sources; i++) {
             if (b != null)
-                b.comment("source id & index");
+                b.writeHexDumpDescription("source id & index");
             out.uint32(t.sourceIdArray[i]);
             out.int64_0x(t.sourceIndexArray[i]);
         }
     }
 
     private void acceptTimings(VanillaMessageHistory t, ValueOut out) {
-        BytesComment<?> b = bytesComment(out);
+        HexDumpBytesDescription<?> b = bytesComment(out);
         for (int i = 0; i < t.timings; i++) {
             if (b != null)
-                b.comment("timing in nanos");
+                b.writeHexDumpDescription("timing in nanos");
             out.int64(t.timingsArray[i]);
         }
         if (!(out.wireOut() instanceof HashWire))
@@ -244,12 +244,12 @@ public class VanillaMessageHistory extends SelfDescribingMarshallable implements
     }
 
     @Nullable
-    private BytesComment<?> bytesComment(ValueOut out) {
+    private HexDumpBytesDescription<?> bytesComment(ValueOut out) {
         final WireOut wireOut = out.wireOut();
-        BytesComment<?> b = null;
+        HexDumpBytesDescription<?> b = null;
         if (!(wireOut instanceof HashWire)) {
             b = wireOut.bytes();
-            if (!b.retainsComments())
+            if (!b.retainedHexDumpDescription())
                 b = null;
         }
         return b;

--- a/src/main/java/net/openhft/chronicle/wire/VanillaMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMethodReader.java
@@ -57,15 +57,6 @@ public class VanillaMethodReader implements MethodReader {
     private boolean closeIn = false;
     private boolean closed;
 
-    @Deprecated(/* To be removed in x.24 */)
-    public VanillaMethodReader(MarshallableIn in,
-                               boolean ignoreDefault,
-                               WireParselet defaultParselet,
-                               MethodReaderInterceptorReturns methodReaderInterceptorReturns,
-                               @NotNull Object... objects) {
-        this(in, ignoreDefault, defaultParselet, SKIP_READABLE_BYTES, methodReaderInterceptorReturns, objects);
-    }
-
     public VanillaMethodReader(MarshallableIn in,
                                boolean ignoreDefault,
                                WireParselet defaultParselet,

--- a/src/main/java/net/openhft/chronicle/wire/VanillaMethodWriterBuilder.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMethodWriterBuilder.java
@@ -121,14 +121,6 @@ public class VanillaMethodWriterBuilder<T> implements Builder<T>, MethodWriterBu
         return this;
     }
 
-    @Deprecated(/* Replaced by UpdateInterceptor. To be removed in x.24 */)
-    @NotNull
-    public MethodWriterBuilder<T> methodWriterInterceptorReturns(MethodWriterInterceptorReturns methodWriterInterceptor) {
-        Jvm.warn().on(getClass(), "Support for methodWriterInterceptorReturns will be dropped in x.24. Use UpdateInterceptor instead");
-        handlerSupplier.methodWriterInterceptorReturns(methodWriterInterceptor);
-        return this;
-    }
-
     @NotNull
     public MethodWriterBuilder<T> disableThreadSafe(boolean theadSafe) {
         handlerSupplier.disableThreadSafe(theadSafe);
@@ -191,7 +183,7 @@ public class VanillaMethodWriterBuilder<T> implements Builder<T>, MethodWriterBu
                     Jvm.debug().on(getClass(), e);
             }
         }
-        if (!disableProxyGen && handlerSupplier.methodWriterInterceptorReturns() == null) {
+        if (!disableProxyGen) {
             T t = createInstance();
             if (t != null)
                 return t;

--- a/src/main/java/net/openhft/chronicle/wire/WireCommon.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireCommon.java
@@ -18,7 +18,7 @@
 package net.openhft.chronicle.wire;
 
 import net.openhft.chronicle.bytes.Bytes;
-import net.openhft.chronicle.bytes.BytesComment;
+import net.openhft.chronicle.bytes.HexDumpBytesDescription;
 import net.openhft.chronicle.bytes.CommonMarshallable;
 import net.openhft.chronicle.core.pool.ClassLookup;
 import net.openhft.chronicle.core.values.*;
@@ -69,7 +69,7 @@ public interface WireCommon {
      *
      * @return the bytes() but only for comment
      */
-    BytesComment<?> bytesComment();
+    HexDumpBytesDescription<?> bytesComment();
 
     /**
      * Creates and returns a new {@link IntValue}. The {@link IntValue} implementation that is
@@ -138,22 +138,6 @@ public interface WireCommon {
      * @param parent to set, or null if there isn't one.
      */
     void parent(Object parent);
-
-    /**
-     * Doesn't do anything
-     *
-     * @return true
-     */
-    @Deprecated(/* to be removed in x.24 */)
-    boolean startUse();
-
-    /**
-     * Doesn't do anything
-     *
-     * @return true always, so it can be used in an assert line
-     */
-    @Deprecated(/* to be removed in x.24 */)
-    boolean endUse();
 
     /**
      * If a message is marked as NOT_COMPLETE is it still present.

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -18,7 +18,7 @@
 package net.openhft.chronicle.wire;
 
 import net.openhft.chronicle.bytes.Bytes;
-import net.openhft.chronicle.bytes.BytesComment;
+import net.openhft.chronicle.bytes.HexDumpBytesDescription;
 import net.openhft.chronicle.core.*;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.io.IOTools;
@@ -259,15 +259,15 @@ public class WireMarshaller<T> {
     }
 
     public void writeMarshallable(T t, @NotNull WireOut out) {
-        BytesComment bytes = out.bytesComment();
-        bytes.indent(+1);
+        HexDumpBytesDescription bytes = out.bytesComment();
+        bytes.adjustHexDumpIndentation(+1);
         try {
             for (@NotNull FieldAccess field : fields)
                 field.write(t, out);
         } catch (IllegalAccessException e) {
             throw new AssertionError(e);
         }
-        bytes.indent(-1);
+        bytes.adjustHexDumpIndentation(-1);
     }
 
     public void writeMarshallable(T t, Bytes<?> bytes) {

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -87,16 +87,11 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     public static String asText(@NotNull Wire wire) {
-        assert wire.startUse();
-        try {
-            long pos = wire.bytes().readPosition();
-            @NotNull Wire tw = Wire.newYamlWireOnHeap();
-            wire.copyTo(tw);
-            wire.bytes().readPosition(pos);
-            return tw.toString();
-        } finally {
-            assert wire.endUse();
-        }
+        long pos = wire.bytes().readPosition();
+        @NotNull Wire tw = Wire.newYamlWireOnHeap();
+        wire.copyTo(tw);
+        wire.bytes().readPosition(pos);
+        return tw.toString();
     }
 
     private static <ACS extends Appendable & CharSequence> void unescape(@NotNull ACS sb,

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWire2Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWire2Test.java
@@ -64,7 +64,6 @@ public class BinaryWire2Test extends WireTestCommon {
         bytes.clear();
         @NotNull BinaryWire wire = new BinaryWire(bytes, false, false, false, 32, "lzw", false);
         wire.usePadding(usePadding);
-        assert wire.startUse();
         return wire;
     }
 
@@ -584,7 +583,7 @@ public class BinaryWire2Test extends WireTestCommon {
     public void testCompression(String comp) {
         bytes.clear();
         @NotNull Wire wire = new BinaryWire(bytes, false, false, false, 32, comp, false);
-        assert wire.startUse();
+
         @NotNull String str = "xxxxxxxxxxxxxxxx2xxxxxxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyyyyyyy2yyyyyyyyyyyyyyyyy";
         BytesStore bytes = Bytes.from(str);
 

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireNumbersTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireNumbersTest.java
@@ -98,7 +98,7 @@ public class BinaryWireNumbersTest extends WireTestCommon {
         @SuppressWarnings("rawtypes")
         @NotNull Bytes<?> bytes1 = allocateElasticOnHeap();
         @NotNull Wire wire1 = new BinaryWire(bytes1, true, false, false, Integer.MAX_VALUE, "binary", false);
-        assert wire1.startUse();
+
         expected.writeValue(wire1.write());
 
         assertEquals("Length for fixed length doesn't match for " + TextWire.asText(wire1), len, bytes1.readRemaining());

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWirePerfTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWirePerfTest.java
@@ -66,7 +66,7 @@ public class BinaryWirePerfTest extends WireTestCommon {
         @NotNull Wire wire = testId == -1
                 ? new RawWire(bytes)
                 : new BinaryWire(bytes, fixed, numericField, fieldLess, Integer.MAX_VALUE, "lzw", false);
-        assert wire.startUse();
+
         return wire;
     }
 
@@ -103,8 +103,8 @@ public class BinaryWirePerfTest extends WireTestCommon {
 
             b.readMarshallable(wire);
         }
-        long rate = (System.nanoTime() - start) / runs;
-        assert wire.startUse();
+        //long rate = (System.nanoTime() - start) / runs;
+
        // System.out.printf("(vars) %,d : %,d ns avg, len= %,d%n", t, rate, wire.bytes().readPosition());
     }
 

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireTest.java
@@ -134,7 +134,6 @@ public class BinaryWireTest extends WireTestCommon {
         bytes.clear();
         @NotNull BinaryWire wire = new BinaryWire(bytes, fixed, numericField, fieldLess, compressedSize, "lzw", false);
         wire.usePadding(true);
-        assert wire.startUse();
         return wire;
     }
 

--- a/src/test/java/net/openhft/chronicle/wire/FIX42Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/FIX42Test.java
@@ -112,7 +112,7 @@ public class FIX42Test extends WireTestCommon {
         @NotNull Wire wire = testId < 0
                 ? WireType.TEXT.apply(bytes)
                 : new BinaryWire(bytes, fixed, numericField, fieldLess, Integer.MAX_VALUE, "binary", true);
-        assert wire.startUse();
+
         return wire;
     }
 

--- a/src/test/java/net/openhft/chronicle/wire/PrimitiveTypeWrappersTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/PrimitiveTypeWrappersTest.java
@@ -124,7 +124,7 @@ public class PrimitiveTypeWrappersTest extends WireTestCommon {
     private Wire wireFactory() {
         @NotNull final Bytes<?> bytes = Bytes.allocateElasticOnHeap();
         @NotNull Wire wire = (isTextWire) ? WireType.TEXT.apply(bytes) : new BinaryWire(bytes);
-        assert wire.startUse();
+
         return wire;
     }
 }

--- a/src/test/java/net/openhft/chronicle/wire/ReadmeChapter1Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/ReadmeChapter1Test.java
@@ -349,8 +349,6 @@ To write in binary instead
         @NotNull Wire wire2 = new BinaryWire(bytes2);
         wire2.usePadding(true);
 
-        assert wire2.startUse();
-
         wire2.writeDocument(false, data);
        // System.out.println(Wires.fromSizePrefixedBlobs(bytes2));
 
@@ -442,7 +440,6 @@ To write in binary instead
         @NotNull Wire wire2 = new BinaryWire(bytes2);
         wire2.usePadding(true);
 
-        assert wire2.startUse();
         wire2.writeDocument(false, w -> w.write(() -> "mydata")
                 .sequence(v -> Stream.of(data).forEach(v::object)));
        // System.out.println(Wires.fromSizePrefixedBlobs(bytes2));

--- a/src/test/java/net/openhft/chronicle/wire/UnicodeStringTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/UnicodeStringTest.java
@@ -71,7 +71,7 @@ public class UnicodeStringTest extends WireTestCommon {
         final boolean fieldLess = false;
         final int compressedSize = 128;
         @NotNull BinaryWire wire = new BinaryWire(bytes, fixed, numericField, fieldLess, compressedSize, "lzw", false);
-        assert wire.startUse();
+
         return wire;
     }
 

--- a/src/test/java/net/openhft/chronicle/wire/ValueOutTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ValueOutTest.java
@@ -50,11 +50,9 @@ public class ValueOutTest extends TestCase {
 
     @Test
     public void test() {
-
         final Wire wire = wireType.apply(Bytes.elasticByteBuffer());
         wire.usePadding(wire.isBinary());
 
-        assert wire.startUse();
         @NotNull final byte[] expected = "this is my byte array".getBytes(ISO_8859_1);
         wire.writeDocument(false, w ->
                 w.write().object(expected)
@@ -74,11 +72,9 @@ public class ValueOutTest extends TestCase {
 
     @Test
     public void testRequestedType() {
-
         final Wire wire = wireType.apply(Bytes.elasticByteBuffer());
         wire.usePadding(wire.isBinary());
 
-        assert wire.startUse();
         @NotNull final byte[] expected = "this is my byte array".getBytes(ISO_8859_1);
         wire.writeDocument(false, w -> w.write().object(expected));
 
@@ -94,11 +90,9 @@ public class ValueOutTest extends TestCase {
 
     @Test
     public void testAllBytes() {
-
         final Wire wire = wireType.apply(Bytes.elasticByteBuffer());
         wire.usePadding(wire.isBinary());
 
-        assert wire.startUse();
         for (int i = -128; i < 127; i++) {
 
             @NotNull final byte[] expected = {(byte) i};

--- a/src/test/java/net/openhft/chronicle/wire/WireResourcesTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireResourcesTest.java
@@ -46,7 +46,6 @@ public class WireResourcesTest extends WireTestCommon {
 
         Wire wire = WireType.TEXT.apply(mb);
 
-        assert wire.startUse();
         wire.headerNumber(0);
 
         assertEquals(1, mb.mappedFile().refCount());
@@ -54,7 +53,6 @@ public class WireResourcesTest extends WireTestCommon {
         assertEquals(1, mb.mappedFile().refCount());
 
         wire.updateFirstHeader();
-        assert wire.endUse();
 
         assertEquals(1, mb.mappedFile().refCount());
         assertEquals(1, mb.refCount());
@@ -87,11 +85,9 @@ public class WireResourcesTest extends WireTestCommon {
 
         assertEquals(1, wire.bytes().refCount());
 
-        assert wire.startUse();
         wire.headerNumber(1);
         wire.writeFirstHeader();
         wire.updateFirstHeader();
-        assert wire.endUse();
 
         wire.bytes().releaseLast(test);
         BackgroundResourceReleaser.releasePendingResources();
@@ -111,7 +107,6 @@ public class WireResourcesTest extends WireTestCommon {
         assertEquals(1, t.refCount()); // not really using it yet
         assertEquals(1, t.mappedFile().refCount());
 
-        assert wire.startUse();
         wire.headerNumber(1);
         assertEquals(1, t.refCount());
         assertEquals(1, t.mappedFile().refCount()); // not really using it yet
@@ -126,7 +121,6 @@ public class WireResourcesTest extends WireTestCommon {
 
         wire.bytes().writeSkip(128000);
         wire.updateFirstHeader();
-        assert wire.endUse();
 
         writeMessage(wire);
 

--- a/src/test/java/net/openhft/chronicle/wire/WireSerializedLambdaTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireSerializedLambdaTest.java
@@ -96,7 +96,7 @@ public class WireSerializedLambdaTest extends WireTestCommon {
     @Test
     public void testBinaryWire() {
         @NotNull Wire wire = new BinaryWire(new HexDumpBytes());
-        assert wire.startUse();
+
         SerializableFunction<String, String> fun = String::toUpperCase;
         wire.write(() -> "one").object(fun)
                 .write(() -> "two").object(Fun.ADD_A)

--- a/src/test/java/net/openhft/chronicle/wire/passthrough/GenericPassTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/passthrough/GenericPassTest.java
@@ -98,7 +98,7 @@ public class GenericPassTest {
         final DocumentContextBroker dcb = wire1.methodWriter(DocumentContextBroker.class);
         try (DocumentContext dc = dcb.via("pass")) {
             dc.wire().bytes()
-                    .comment("opaque message")
+                    .writeHexDumpDescription("opaque message")
                     .writeUnsignedByte(0x82);
         }
         assertEquals("" +

--- a/src/test/java/net/openhft/chronicle/wire/reuse/WireCollectionTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/reuse/WireCollectionTest.java
@@ -72,7 +72,6 @@ public class WireCollectionTest extends WireTestCommon {
     public void testMultipleReads() {
         Bytes<?> bytes = Bytes.elasticByteBuffer();
         Wire wire = wireType.apply(bytes);
-        assert wire.startUse();
 
         wire.writeDocument(true, collection);
        // System.out.println(Wires.fromSizePrefixedBlobs(bytes));


### PR DESCRIPTION
Remove padding selection and start/end methods
Switch HashWire to binary mode - closes #307