### PR TITLE
Implement checkstyle checking for JUnit classnames

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -435,6 +435,45 @@
                 </executions>
             </plugin>
 
+            <!-- This would end up in java-parent-pom or something -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <configLocation>net/openhft/quality/checkstyle/checkstyle.xml</configLocation>
+                    <failOnViolation>true</failOnViolation>
+                    <logViolationsToConsole>true</logViolationsToConsole>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                </configuration>
+                <dependencies>
+                    <!--
+                        Choose the latest version that supports Java 8
+
+                        See https://checkstyle.sourceforge.io/#JRE_and_JDK
+                    -->
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>9.3</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>net.openhft</groupId>
+                        <artifactId>chronicle-quality-rules</artifactId>
+                        <version>1.23ea4</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
         </plugins>
     </build>
 


### PR DESCRIPTION
To prevent ChronicleSoftware/RootPom#284

I basically commented out ALL the checkstyle rules because we need to work out an approach to start enabling them. We should probably look at enabling them slowly and perhaps enforcing that the count doesn't increase... There are some good ones in there.

Might be worth considering https://findbugs.sourceforge.net/ as well

This is really just a POC, we should probably put that plugin in the `java-parent-pom`

See the links to the broken builds below