### PR TITLE
Avoid lambda allocations in VanillaMessageHistory

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/VanillaMessageHistory.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMessageHistory.java
@@ -44,8 +44,8 @@ public class VanillaMessageHistory extends SelfDescribingMarshallable implements
     private final long[] timingsArray = new long[MESSAGE_HISTORY_LENGTH * 2];
 
     // To avoid lambda allocations
-    private final BiConsumer<VanillaMessageHistory, ValueOut> acceptSourcesConsumer = this::acceptSources;
-    private final BiConsumer<VanillaMessageHistory, ValueOut> acceptTimingsConsumer = this::acceptTimings;
+    private final transient BiConsumer<VanillaMessageHistory, ValueOut> acceptSourcesConsumer = this::acceptSources;
+    private final transient BiConsumer<VanillaMessageHistory, ValueOut> acceptTimingsConsumer = this::acceptTimings;
 
     // true if these change have been written
     private transient boolean dirty;


### PR DESCRIPTION
I don't know a better way to work this around.
Even JVM 17 fails to handle non-static method references without allocation under some conditions
![image](https://user-images.githubusercontent.com/2736390/203527680-c025d923-7649-42ad-acb8-69a521984eae.png)
