### PR TITLE
Update to latest 3rd party bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
             <dependency>
                 <groupId>net.openhft</groupId>
                 <artifactId>third-party-bom</artifactId>
-                <version>3.22.3</version>
+                <version>3.23.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -57,12 +57,6 @@
                 <version>2.24ea-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>1.33</version>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
This reverts commit 0a94a90053f858a0370d27e0f40c076ec8e912ec. (re-applies the commit that reverted)

This PR a placeholder until snakeyaml 1.34 released