### PR TITLE
604 escape unicode characters in json

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/JSONWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/JSONWire.java
@@ -424,6 +424,45 @@ public class JSONWire extends TextWire {
         bytes.writeUnsignedByte('"');
     }
 
+    // https://www.rfc-editor.org/rfc/rfc7159#section-7
+    protected void escape0(@NotNull CharSequence s, @NotNull Quotes quotes) {
+        for (int i = 0; i < s.length(); i++) {
+            char ch = s.charAt(i);
+            switch (ch) {
+                case '\b':
+                    bytes.append("\\b");
+                    break;
+                case '\t':
+                    bytes.append("\\t");
+                    break;
+                case '\f':
+                    bytes.append("\\f");
+                    break;
+                case '\n':
+                    bytes.append("\\n");
+                    break;
+                case '\r':
+                    bytes.append("\\r");
+                    break;
+                case '"':
+                    if (ch == quotes.q) {
+                        bytes.writeUnsignedByte('\\').writeUnsignedByte(ch);
+                    } else {
+                        bytes.writeUnsignedByte(ch);
+                    }
+                    break;
+                case '\\':
+                    bytes.writeUnsignedByte('\\').writeUnsignedByte(ch);
+                    break;
+                default:
+                    if (ch < ' ' || ch > 127)
+                        appendU4(ch);
+                    else
+                        bytes.append(ch);
+                    break;
+            }
+        }
+    }
     @Override
     public ValueOut writeEvent(Class expectedType, Object eventKey) {
         return super.writeEvent(String.class, "" + eventKey);

--- a/src/main/java/net/openhft/chronicle/wire/JSONWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/JSONWire.java
@@ -407,7 +407,7 @@ public class JSONWire extends TextWire {
     protected Quotes needsQuotes(@NotNull CharSequence s) {
         for (int i = 0; i < s.length(); i++) {
             char ch = s.charAt(i);
-            if (ch == '"' || ch < ' ')
+            if (ch == '"' || ch < ' ' || ch == '\\')
                 return Quotes.DOUBLE;
         }
         return Quotes.NONE;

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -121,6 +121,7 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
     }
 
+    // https://yaml.org/spec/1.2.2/#escaped-characters
     public static <ACS extends Appendable & CharSequence> void unescape(@NotNull ACS sb) {
         int end = 0;
         int length = sb.length();
@@ -162,6 +163,12 @@ public class TextWire extends YamlWireOut<TextWire> {
                     case '_':
                         ch = 0xA0;
                         break;
+                    case 'L':
+                        ch = 0x2028;
+                        break;
+                    case 'P':
+                        ch = 0x2029;
+                        break;
                     case 'x':
                         ch = (char)
                                 (Character.getNumericValue(sb.charAt(++i)) * 16 +
@@ -191,18 +198,6 @@ public class TextWire extends YamlWireOut<TextWire> {
         // reset it.
         sct.isStopChar(' ');
         return sct;
-    }
-
-    private static void checkConsecutiveSpaces(@NotNull StringBuilder sb) {
-        if (sb.length() == 0)
-            return;
-        char lastCh = sb.charAt(0);
-        for (int i = 1; i < sb.length() - 1; i++) {
-            char ch2 = sb.charAt(i);
-            if (lastCh <= ' ' && ch2 <= ' ')
-                throw new IORuntimeException("Cannot have multiple consecutive spaces in a field name '" + sb + "'");
-            lastCh = ch2;
-        }
     }
 
     /**
@@ -435,8 +430,7 @@ public class TextWire extends YamlWireOut<TextWire> {
                 parseUntil(sb, getEscapingEndOfText());
             }
             unescape(sb);
-            // check no consecutive spaces.
-            checkConsecutiveSpaces(sb);
+
         } catch (BufferUnderflowException e) {
             Jvm.debug().on(getClass(), e);
         }

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -88,6 +88,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         return tw.toString();
     }
 
+    // https://yaml.org/spec/1.2.2/#escaped-characters
     private static <ACS extends Appendable & CharSequence> void unescape(@NotNull ACS sb,
                                                                          char blockQuote) {
         int end = 0;
@@ -135,6 +136,12 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                         break;
                     case '_':
                         ch = 0xA0;
+                        break;
+                    case 'L':
+                        ch = 0x2028;
+                        break;
+                    case 'P':
+                        ch = 0x2029;
                         break;
                     case 'x':
                         ch = (char)

--- a/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
@@ -186,36 +186,37 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         bytes.writeUnsignedByte(quotes.q);
     }
 
+    // https://yaml.org/spec/1.2.2/#escaped-characters
     protected void escape0(@NotNull CharSequence s, @NotNull Quotes quotes) {
         for (int i = 0; i < s.length(); i++) {
             char ch = s.charAt(i);
             switch (ch) {
                 case '\0':
-                    bytes.appendUtf8("\\0");
+                    bytes.append("\\0");
                     break;
                 case 7:
-                    bytes.appendUtf8("\\a");
+                    bytes.append("\\a");
                     break;
                 case '\b':
-                    bytes.appendUtf8("\\b");
+                    bytes.append("\\b");
                     break;
                 case '\t':
-                    bytes.appendUtf8("\\t");
+                    bytes.append("\\t");
                     break;
                 case '\n':
-                    bytes.appendUtf8("\\n");
+                    bytes.append("\\n");
                     break;
                 case 0xB:
-                    bytes.appendUtf8("\\v");
+                    bytes.append("\\v");
                     break;
-                case 0xC:
-                    bytes.appendUtf8("\\f");
+                case '\f':
+                    bytes.append("\\f");
                     break;
                 case '\r':
-                    bytes.appendUtf8("\\r");
+                    bytes.append("\\r");
                     break;
                 case 0x1B:
-                    bytes.appendUtf8("\\e");
+                    bytes.append("\\e");
                     break;
                 case '"':
                     if (ch == quotes.q) {
@@ -234,11 +235,20 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
                 case '\\':
                     bytes.writeUnsignedByte('\\').writeUnsignedByte(ch);
                     break;
+//                case '/':
+//                    bytes.writeUnsignedByte('\\').writeUnsignedByte(ch);
+//                    break;
                 case 0x85:
                     bytes.appendUtf8("\\N");
                     break;
                 case 0xA0:
                     bytes.appendUtf8("\\_");
+                    break;
+                case 0x2028:
+                    bytes.appendUtf8("\\L");
+                    break;
+                case 0x2029:
+                    bytes.appendUtf8("\\P");
                     break;
                 default:
                     if (ch > 255)
@@ -259,7 +269,7 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         bytes.append(HEXADECIMAL[ch & 0xF]);
     }
 
-    private void appendU4(char ch) {
+    protected void appendU4(char ch) {
         bytes.append('\\');
         bytes.append('u');
         bytes.append(HEXADECIMAL[ch >> 12]);

--- a/src/test/java/net/openhft/chronicle/wire/JSONWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/JSONWireTest.java
@@ -31,6 +31,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.*;
+import java.util.stream.IntStream;
 
 import static junit.framework.TestCase.assertNull;
 import static net.openhft.chronicle.wire.WireType.JSON;
@@ -377,6 +378,18 @@ public class JSONWireTest extends WireTestCommon {
         wire.getValueOut().marshallable(foo);
 
         assertEquals("{\"a\":{\"b\":\"c\"}}", bytes.toString());
+    }
+
+    @Test
+    public void escapeUnicodeValues() {
+        Map<Object, Object> map = new HashMap<>();
+        IntStream.rangeClosed(0x0000, 0x001F)
+                .forEach(code -> {
+                    map.put("key", (char)code);
+
+                    final String text = JSON.asString(map);
+                    assertEquals("{\"key\":\"" + String.format("\\u%04x", code) + "\"}", text);
+                });
     }
 
     private static class Value extends SelfDescribingMarshallable {

--- a/src/test/java/net/openhft/chronicle/wire/JSONWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/JSONWireTest.java
@@ -383,12 +383,36 @@ public class JSONWireTest extends WireTestCommon {
     @Test
     public void escapeUnicodeValues() {
         Map<Object, Object> map = new HashMap<>();
-        IntStream.rangeClosed(0x0000, 0x001F)
+        IntStream.rangeClosed(0x0000, 0x0020)
                 .forEach(code -> {
-                    map.put("key", (char)code);
+                    map.put("key", (char) code);
 
                     final String text = JSON.asString(map);
-                    assertEquals("{\"key\":\"" + String.format("\\u%04x", code) + "\"}", text);
+                    String val;
+                    switch (code) {
+                        case '\b':
+                            val = "\\b";
+                            break;
+                        case '\f':
+                            val = "\\f";
+                            break;
+                        case '\n':
+                            val = "\\n";
+                            break;
+                        case '\r':
+                            val = "\\r";
+                            break;
+                        case '\t':
+                            val = "\\t";
+                            break;
+                        case ' ':
+                            val = " ";
+                            break;
+                        default:
+                            val = String.format("\\u%04X", code);
+                            break;
+                    }
+                    assertEquals("{\"key\":\"" + val + "\"}", text);
                 });
     }
 


### PR DESCRIPTION
JSON was copying behaviour from TextWIre, but the escape character behaviour differs.

Added reference to the spec in each case.