### PR TITLE
Use expectException rather than serializing an comparing exception keys

### DIFF
--- a/src/test/java/net/openhft/chronicle/wire/UnsupportedChangesTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/UnsupportedChangesTest.java
@@ -19,12 +19,7 @@
 package net.openhft.chronicle.wire;
 
 import net.openhft.chronicle.core.Jvm;
-import net.openhft.chronicle.core.onoes.ExceptionKey;
-import net.openhft.chronicle.core.onoes.LogLevel;
 import org.junit.Test;
-
-import java.util.Collections;
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -33,25 +28,18 @@ import static org.junit.Assume.assumeFalse;
 public class UnsupportedChangesTest extends WireTestCommon {
     @Test
     public void scalarToMarshallable() {
-        Map<ExceptionKey, Integer> exceptions = Jvm.recordExceptions(true);
-
         Nested nested = Marshallable.fromString(Nested.class, "{\n" +
                 "inner: 128\n" +
                 "}\n");
         assertEquals("!net.openhft.chronicle.wire.UnsupportedChangesTest$Nested {\n" +
                 "  inner: !!null \"\"\n" +
                 "}\n", nested.toString());
-        ExceptionKey ek = new ExceptionKey(LogLevel.WARN,
-                WireMarshaller.ObjectFieldAccess.class,
-                "Unable to parse field: inner, as a marshallable as it is 128",
-                exceptions.keySet().iterator().next().throwable);
-        assertEquals(Collections.singletonMap(ek, 1), exceptions);
+        expectException("Unable to parse field: inner, as a marshallable as it is 128");
     }
 
     @Test
     public void marshallableToScalar() {
         assumeFalse(Jvm.isArm());
-        Map<ExceptionKey, Integer> exceptions = Jvm.recordExceptions(true);
 
         Wrapper wrapper = Marshallable.fromString(Wrapper.class, "{\n" +
                 "pnl: { a: 128, b: 1.0 },\n" +
@@ -61,14 +49,11 @@ public class UnsupportedChangesTest extends WireTestCommon {
                 "  pnl: 0.0,\n" +
                 "  second: 123.4\n" +
                 "}\n", wrapper.toString());
-
-        assertEquals("{ExceptionKey{level=WARN, clazz=class net.openhft.chronicle.wire.TextWire$TextValueIn, message='Unable to read {a=128, b=1.0} as a double.', throwable=}=1}", exceptions.toString());
+        expectException("Unable to read {a=128, b=1.0} as a double.");
     }
 
     @Test
     public void marshallableToScala2r() {
-        Map<ExceptionKey, Integer> exceptions = Jvm.recordExceptions(true);
-
         IntWrapper wrapper = Marshallable.fromString(IntWrapper.class, "{\n" +
                 "pnl: { a: 128, b: 1.0 },\n" +
                 "second: 1234," +
@@ -77,8 +62,7 @@ public class UnsupportedChangesTest extends WireTestCommon {
                 "  pnl: 0,\n" +
                 "  second: 1234\n" +
                 "}\n", wrapper.toString());
-
-        assertEquals("{ExceptionKey{level=WARN, clazz=class net.openhft.chronicle.wire.TextWire$TextValueIn, message='Unable to read {a=128, b=1.0} as a long.', throwable=}=1}", exceptions.toString());
+        expectException("Unable to read {a=128, b=1.0} as a long.");
     }
 
     @Test


### PR DESCRIPTION
These were from '17 I wonder if that predates `expectException`