### PR TITLE
Add reproduction and solution for long generated class names. Fixes #643

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/VanillaMethodWriterBuilder.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMethodWriterBuilder.java
@@ -21,6 +21,7 @@ import net.openhft.chronicle.bytes.*;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.io.Closeable;
 import net.openhft.chronicle.core.util.Builder;
+import net.openhft.chronicle.wire.internal.MethodWriterClassNameGenerator;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -59,6 +60,7 @@ public class VanillaMethodWriterBuilder<T> implements Builder<T>, MethodWriterBu
     private final boolean disableProxyGen = Jvm.getBoolean(DISABLE_WRITER_PROXY_CODEGEN, false);
     private final Set<Class<?>> interfaces = Collections.synchronizedSet(new LinkedHashSet<>());
 
+    private final MethodWriterClassNameGenerator methodWriterClassNameGenerator;
     private final String packageName;
     private ClassLoader classLoader;
     @NotNull
@@ -82,6 +84,7 @@ public class VanillaMethodWriterBuilder<T> implements Builder<T>, MethodWriterBu
         //  Maybe have an option to always use current thread class loader?
         this.classLoader = clsLdr != null ? clsLdr : getClass().getClassLoader();
         this.handlerSupplier = new MethodWriterInvocationHandlerSupplier(handlerSupplier);
+        this.methodWriterClassNameGenerator = new MethodWriterClassNameGenerator();
     }
 
     @NotNull
@@ -149,25 +152,13 @@ public class VanillaMethodWriterBuilder<T> implements Builder<T>, MethodWriterBu
     }
 
     /**
-     * because we cache the classes in {@code classCache}, its very important to come up with a name that is unique for what the class does.
+     * because we cache the classes in {@code classCache}, it's very important to come up with a name that is unique for what the class does.
      *
      * @return the name of the new class
      */
     @NotNull
     private String getClassName() {
-        final StringBuilder sb = new StringBuilder();
-
-        interfaces.forEach(i -> {
-            if (i.getEnclosingClass() != null)
-                sb.append(i.getEnclosingClass().getSimpleName());
-            sb.append(i.getSimpleName());
-        });
-        sb.append(this.genericEvent == null ? "" : this.genericEvent);
-        sb.append(this.metaData ? "MetadataAware" : "");
-        sb.append(updateInterceptor != null ? "Intercepting" : "");
-        sb.append(toFirstCapCase(wireType().toString().replace("_", "")));
-        sb.append("MethodWriter");
-        return sb.toString();
+        return methodWriterClassNameGenerator.getClassName(interfaces, genericEvent, metaData, updateInterceptor != null, wireType());
     }
 
     @NotNull

--- a/src/main/java/net/openhft/chronicle/wire/internal/MethodWriterClassNameGenerator.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/MethodWriterClassNameGenerator.java
@@ -1,0 +1,49 @@
+package net.openhft.chronicle.wire.internal;
+
+import net.openhft.chronicle.core.Maths;
+import net.openhft.chronicle.wire.Base32LongConverter;
+import net.openhft.chronicle.wire.LongConverter;
+import net.openhft.chronicle.wire.WireType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Set;
+
+public class MethodWriterClassNameGenerator {
+
+    private static final int MAXIMUM_CLASS_NAME_LENGTH = 255 - ".class".length();
+    /**
+     * This long converter must produce only characters that are safe to appear in filenames
+     */
+    private static final LongConverter CLASSNAME_HASH_LONG_CONVERTER = Base32LongConverter.INSTANCE;
+    private static final int MAX_LENGTH_OF_HASH = CLASSNAME_HASH_LONG_CONVERTER.asText(Long.MIN_VALUE).length();
+
+    @NotNull
+    public String getClassName(@NotNull Set<Class<?>> interfaces, @Nullable String genericEvent, boolean metaData, boolean intercepting, @NotNull WireType wireType) {
+        final StringBuilder sb = new StringBuilder();
+
+        interfaces.forEach(i -> {
+            if (i.getEnclosingClass() != null)
+                sb.append(i.getEnclosingClass().getSimpleName());
+            sb.append(i.getSimpleName());
+        });
+        int endOfInterfacesIndex = sb.length();
+        sb.append(genericEvent == null ? "" : genericEvent);
+        sb.append(metaData ? "MetadataAware" : "");
+        sb.append(intercepting ? "Intercepting" : "");
+        sb.append(toFirstCapCase(wireType.toString().replace("_", "")));
+        sb.append("MethodWriter");
+        if (sb.length() > MAXIMUM_CLASS_NAME_LENGTH) {
+            int firstIndexTruncated = endOfInterfacesIndex - (sb.length() - MAXIMUM_CLASS_NAME_LENGTH) - MAX_LENGTH_OF_HASH;
+            final long hashOfNonTruncatedClassName = Maths.hash64(sb);
+            sb.delete(firstIndexTruncated, endOfInterfacesIndex);
+            sb.insert(firstIndexTruncated, Base32LongConverter.INSTANCE.asText(hashOfNonTruncatedClassName));
+        }
+        return sb.toString();
+    }
+
+    @NotNull
+    private String toFirstCapCase(@NotNull String name) {
+        return Character.toUpperCase(name.charAt(0)) + name.substring(1).toLowerCase();
+    }
+}

--- a/src/test/java/net/openhft/chronicle/wire/internal/MethodWriterClassNameGeneratorTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/internal/MethodWriterClassNameGeneratorTest.java
@@ -1,0 +1,93 @@
+package net.openhft.chronicle.wire.internal;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.wire.WireType;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class MethodWriterClassNameGeneratorTest {
+
+    private final MethodWriterClassNameGenerator classNameGenerator = new MethodWriterClassNameGenerator();
+
+    @Test
+    public void testGetClassName() {
+        assertEquals("MethodWriterClassNameGeneratorTestJustAnInterfaceYamlMethodWriter",
+                generatedClassName(null, false, false, WireType.YAML, JustAnInterface.class));
+    }
+
+    @Test
+    public void testGetClassNameIncludesMetadata() {
+        assertEquals("MethodWriterClassNameGeneratorTestJustAnInterfaceMetadataAwareJsonMethodWriter",
+                generatedClassName(null, true, false, WireType.JSON, JustAnInterface.class));
+    }
+
+    @Test
+    public void testGetClassNameIncludesIntercepting() {
+        assertEquals("MethodWriterClassNameGeneratorTestJustAnInterfaceInterceptingBinarylightMethodWriter",
+                generatedClassName(null, false, true, WireType.BINARY_LIGHT, JustAnInterface.class));
+    }
+
+    @Test
+    public void testGetClassNameIncludesGenericEvent() {
+        assertEquals("MethodWriterClassNameGeneratorTestJustAnInterfaceFooBarBinaryMethodWriter",
+                generatedClassName("FooBar", false, false, WireType.BINARY, JustAnInterface.class));
+    }
+
+    @Test
+    public void testGetClassNameIncludesAllModifiers() {
+        assertEquals("MethodWriterClassNameGeneratorTestJustAnInterfaceFooBarMetadataAwareInterceptingRawMethodWriter",
+                generatedClassName("FooBar", true, true, WireType.RAW, JustAnInterface.class));
+    }
+
+    @Test
+    public void testGetClassNameTruncatesInterfaceNamesWhenMaxFilenameLengthIsExceeded() {
+        assertEquals("MethodWriterClassNameGeneratorTestNewOrderSingleListenerOmsHedgerTradeListenerOpenOrdersListenerPaidGivenTickListener1MethodWriterClassNameGeneratorTestNewOrderSingleListenerOmsHedgerTradeListenerOpenOrdersListenerPaidGi5JWELPHK3VKNITextMethodWriter",
+                generatedClassName(null, false, false, WireType.TEXT,
+                        NewOrderSingleListenerOmsHedgerTradeListenerOpenOrdersListenerPaidGivenTickListener1.class,
+                        NewOrderSingleListenerOmsHedgerTradeListenerOpenOrdersListenerPaidGivenTickListener2.class));
+    }
+
+    @Test
+    public void testGetClassNameIncludesAllModifiersTruncated() {
+        assertEquals("MethodWriterClassNameGeneratorTestNewOrderSingleListenerOmsHedgerTradeListenerOpenOrdersListenerPaidGivenTickListener1MethodWriterClassNameGeneratorTestNewOrderSingleListenerOmsHCTPGPS5OJWMSQFooBarMetadataAwareInterceptingFieldlessbinaryMethodWriter",
+                generatedClassName("FooBar", true, true, WireType.FIELDLESS_BINARY,
+                        NewOrderSingleListenerOmsHedgerTradeListenerOpenOrdersListenerPaidGivenTickListener1.class,
+                        NewOrderSingleListenerOmsHedgerTradeListenerOpenOrdersListenerPaidGivenTickListener2.class));
+    }
+
+    @Test
+    public void testTruncatedClassNamesDifferWhenOnlyTruncatedPortionDiffers() {
+        String cn1 = generatedClassName(null, false, false, WireType.TEXT,
+                NewOrderSingleListenerOmsHedgerTradeListenerOpenOrdersListenerPaidGivenTickListener1.class,
+                NewOrderSingleListenerOmsHedgerTradeListenerOpenOrdersListenerPaidGivenTickListener2.class);
+        String cn2 = generatedClassName(null, false, false, WireType.TEXT,
+                NewOrderSingleListenerOmsHedgerTradeListenerOpenOrdersListenerPaidGivenTickListener1.class,
+                NewOrderSingleListenerOmsHedgerTradeListenerOpenOrdersListenerPaidGi_DiffersInTheTruncatedPortion.class);
+        Jvm.startup().on(MethodWriterClassNameGeneratorTest.class, "Must differ:\n" + cn1 + "\n" + cn2);
+        assertNotEquals(cn1, cn2);
+    }
+
+    private String generatedClassName(String genericEvent, boolean metaData, boolean intercepting, WireType wireType, Class<?>... interfaces) {
+        Set<Class<?>> setOfClasses = new LinkedHashSet<>(Arrays.asList(interfaces));
+        return classNameGenerator.getClassName(setOfClasses, genericEvent, metaData, intercepting, wireType);
+    }
+
+    interface JustAnInterface {
+
+    }
+
+    interface NewOrderSingleListenerOmsHedgerTradeListenerOpenOrdersListenerPaidGivenTickListener1 {
+    }
+
+    interface NewOrderSingleListenerOmsHedgerTradeListenerOpenOrdersListenerPaidGivenTickListener2 {
+    }
+
+    interface NewOrderSingleListenerOmsHedgerTradeListenerOpenOrdersListenerPaidGi_DiffersInTheTruncatedPortion {
+    }
+}

--- a/src/test/java/net/openhft/chronicle/wire/method/GenerateMethodWriterInheritanceTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/GenerateMethodWriterInheritanceTest.java
@@ -98,6 +98,18 @@ public class GenerateMethodWriterInheritanceTest extends WireTestCommon {
         wire.methodWriter(GenerateMethodWriterInheritanceTest.class);
     }
 
+    @Test
+    public void testGenerateForLongGeneratedClassName() {
+        final Wire wire = BINARY.apply(Bytes.elasticByteBuffer());
+
+        wire.methodWriter(
+                NewOrderSingleListenerOmsHedgerTradeListenerOpenOrdersListenerPaidGivenTickListener1.class,
+                NewOrderSingleListenerOmsHedgerTradeListenerOpenOrdersListenerPaidGivenTickListener2.class,
+                NewOrderSingleListenerOmsHedgerTradeListenerOpenOrdersListenerPaidGivenTickListener3.class
+        );
+    }
+
+
     interface AnInterface {
         void sayHello(String name);
     }
@@ -143,6 +155,18 @@ public class GenerateMethodWriterInheritanceTest extends WireTestCommon {
         public void sayHello(String name) {
             callRegistered.set(true);
         }
+    }
+
+    interface NewOrderSingleListenerOmsHedgerTradeListenerOpenOrdersListenerPaidGivenTickListener1 {
+
+    }
+
+    interface NewOrderSingleListenerOmsHedgerTradeListenerOpenOrdersListenerPaidGivenTickListener2 {
+
+    }
+
+    interface NewOrderSingleListenerOmsHedgerTradeListenerOpenOrdersListenerPaidGivenTickListener3 {
+
     }
 }
 


### PR DESCRIPTION
This detects when we're about to try and create a filename with > 255 characters ([which is the limit for the linux ext* filesystems](https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits)). And truncates the concatenated list of interfaces, replacing the last ~15 characters with a Base32 encoded (filename safe) 64-bit hash of the original pre-truncation file name.

This should produce deterministic and unique filenames that don't blow the file-system limits.