### PR TITLE
Render zero correctly in SymbolsLongConverter. Fixes #649

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/converter/SymbolsLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/SymbolsLongConverter.java
@@ -63,6 +63,11 @@ public class SymbolsLongConverter implements LongConverter {
 
     @Override
     public void append(StringBuilder text, long value) {
+        if (value == 0) {
+            text.append(decode[0]);
+            return;
+        }
+
         final int start = text.length();
         if (value < 0) {
             int v = (int) Long.remainderUnsigned(value, factor);

--- a/src/test/java/net/openhft/chronicle/wire/Base85LongConverterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/Base85LongConverterTest.java
@@ -34,7 +34,7 @@ public class Base85LongConverterTest extends WireTestCommon {
     public void parse() {
         LongConverter c = Base85LongConverter.INSTANCE;
         // System.out.println(c.asString(-1L));
-        for (String s : ",a,ab,abc,abcd,ab.de,123=56,1234567,12345678,zzzzzzzzz,+ko2&)z.0".split(",")) {
+        for (String s : "a,ab,abc,abcd,ab.de,123=56,1234567,12345678,zzzzzzzzz,+ko2&)z.0".split(",")) {
             long v = c.parse(s);
             StringBuilder sb = new StringBuilder();
             c.append(sb, v);
@@ -89,6 +89,20 @@ public class Base85LongConverterTest extends WireTestCommon {
     public void allSafeCharsYamlWire() {
         Wire wire = new YamlWire(Bytes.allocateElasticOnHeap()).useTextDocuments();
         allSafeChars(wire);
+    }
+
+    @Test
+    public void willParseEmptyStringAsZero() {
+        assertEquals(0, Base85LongConverter.INSTANCE.converter.parse(""));
+    }
+
+    @Test
+    public void testEncodeAndDecodeZero() {
+        assertEquals(0, Base85LongConverter.INSTANCE.converter.parse("0"));
+        assertEquals("0", Base85LongConverter.INSTANCE.converter.asText(0).toString());
+        StringBuilder b = new StringBuilder();
+        Base85LongConverter.INSTANCE.append(b, 0);
+        assertEquals("0", b.toString());
     }
 
     private void allSafeChars(Wire wire) {


### PR DESCRIPTION
See #649 for details

Slight change of behaviour because empty string will not round-trip correctly, but I don't think we should expect it to. I believe parsing an empty string as zero is just an alternative to throwing a `NumberFormatException`. We should still write zeroes as they would be written in a base-whatever encoding.