### PR TITLE
Update tests to work with YAML wire #509

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -344,7 +344,7 @@ public class WireMarshaller<T> {
     }
 
     public boolean matchesFieldName(StringBuilder sb, FieldAccess field) {
-        return sb.length() == 0 || StringUtils.isEqual(field.field.getName(), sb);
+        return sb.length() == 0 || StringUtils.equalsCaseIgnore(field.field.getName(), sb);
     }
 
     public void writeKey(T t, Bytes<?> bytes) {

--- a/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
@@ -73,6 +73,7 @@ public class YamlTokeniser {
         blockQuote = 0;
         hasSequenceEntry = false;
         lastKeyPosition = -1;
+        pushed.clear();
         last = YamlToken.STREAM_START;
         pushContext0(YamlToken.STREAM_START, NO_INDENT);
     }
@@ -658,6 +659,10 @@ public class YamlTokeniser {
 
     public long lineStart() {
         return lineStart;
+    }
+
+    public void lineStart(long lineStart) {
+        this.lineStart = lineStart;
     }
 
     public long blockStart() {

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -196,6 +196,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                 () -> newTextMethodWriterInvocationHandler(tClass));
         for (Class aClass : additional)
             builder.addInterface(aClass);
+        useTextDocuments();
         builder.marshallableOut(this);
         return builder.build();
     }
@@ -252,6 +253,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         if (readContext == null)
             useBinaryDocuments();
         readContext.start();
+        yt.lineStart(bytes.readPosition());
     }
 
     @NotNull
@@ -453,6 +455,10 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     public <K> K readEvent(@NotNull Class<K> expectedClass) throws InvalidMarshallableException {
         startEventIfTop();
         switch (yt.current()) {
+            case MAPPING_START:
+                yt.next();
+                assert yt.current() == YamlToken.MAPPING_KEY;
+                // Deliberate fall-through
             case MAPPING_KEY:
                 YamlToken next = yt.next();
                 if (next == YamlToken.MAPPING_KEY) {
@@ -539,6 +545,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                     return rereadWire.valueIn;
                 }
             }
+            // Next lines not covered by any tests
         }
         YamlTokeniser.YTContext yc = yt.topContext();
         int minIndent = yc.indent;
@@ -550,7 +557,8 @@ public class YamlWire extends YamlWireOut<YamlWire> {
 
             if (!StringUtils.startsWith(sb, "-"))
                 keys.push(lastKeyPosition);
-            valueIn.consumeAny(minIndent);
+            // Avoid consuming '}' but consume to next mapping key
+            valueIn.consumeAny(minIndent >= 0 ? minIndent : Integer.MAX_VALUE);
         }
 
         return defaultValueIn;
@@ -610,11 +618,10 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     @NotNull
     @Override
     public Wire readComment(@NotNull StringBuilder s) {
-        sb.setLength(0);
+        s.setLength(0);
         if (yt.current() == YamlToken.COMMENT) {
-            // Skip the initial '#'
-            YamlToken next = yt.next();
-            sb.append(yt.text());
+            s.append(yt.text());
+            yt.next();
         }
         return this;
     }
@@ -753,11 +760,12 @@ public class YamlWire extends YamlWireOut<YamlWire> {
             yt.next(Integer.MIN_VALUE);
         } else {
             while (yt.current() == YamlToken.MAPPING_KEY) {
-                yt.next();
                 valueIn.consumeAny(minIndent);
             }
         }
-        if (yt.current() == YamlToken.MAPPING_END || yt.current() == YamlToken.DOCUMENT_END || yt.current() == YamlToken.NONE) {
+        if (yt.current() == YamlToken.MAPPING_END ||
+                yt.current() == YamlToken.DOCUMENT_END ||
+                yt.current() == YamlToken.NONE) {
             yt.next(Integer.MIN_VALUE);
             return;
         }
@@ -1344,7 +1352,6 @@ public class YamlWire extends YamlWireOut<YamlWire> {
             while (true) {
                 switch (yt.current()) {
                     case SEQUENCE_ENTRY:
-                        yt.next(Integer.MIN_VALUE);
                         tReader.accept(t, kls, YamlWire.this.valueIn);
                         continue;
 
@@ -1381,9 +1388,11 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         public boolean hasNextSequenceItem() {
             consumePadding();
             switch (yt.current()) {
+                // Perhaps should be negative selection instead of positive
                 case SEQUENCE_START:
-                case TEXT:
                 case SEQUENCE_ENTRY:
+                // Allows scalar value to be converted into singleton array
+                case TEXT:
                     return true;
             }
             return false;
@@ -1474,7 +1483,20 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         @Override
         public <T> WireIn typeLiteralAsText(T t, @NotNull BiConsumer<T, CharSequence> classNameConsumer)
                 throws IORuntimeException, BufferUnderflowException {
-            throw new UnsupportedOperationException(yt.toString());
+            if (yt.current() != YamlToken.TAG)
+                throw new UnsupportedOperationException(yt.toString());
+
+            if (!yt.isText("type"))
+                throw new UnsupportedOperationException(yt.text());
+
+            if (yt.next() != YamlToken.TEXT)
+                throw new UnsupportedOperationException(yt.toString());
+
+            StringBuilder stringBuilder = acquireStringBuilder();
+            textTo(stringBuilder);
+            classNameConsumer.accept(t, stringBuilder);
+
+            return YamlWire.this;
         }
 
         @Override

--- a/src/test/java/net/openhft/chronicle/wire/DeserializeFromNakedFileTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/DeserializeFromNakedFileTest.java
@@ -20,29 +20,51 @@ package net.openhft.chronicle.wire;
 
 import net.openhft.chronicle.bytes.BytesMarshallable;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
 
+@RunWith(value = Parameterized.class)
 public class DeserializeFromNakedFileTest extends WireTestCommon {
+    private final WireType wireType;
+
+    public DeserializeFromNakedFileTest(WireType wireType) {
+        this.wireType = wireType;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> combinations() {
+        Object[][] list = {
+                {WireType.TEXT},
+                {WireType.YAML}
+        };
+        return Arrays.asList(list);
+    }
+
     @Test
     public void testPOJO() throws IOException {
-        PlainOldJavaClass res = Marshallable.fromFile(PlainOldJavaClass.class, "naked.yaml");
+        PlainOldJavaClass res = wireType.fromFile(PlainOldJavaClass.class, "naked.yaml");
 
         assertEquals(20, res.heartBtInt);
     }
 
     @Test
     public void testSelfDescribing() throws IOException {
-        SelfDescribingClass res = Marshallable.fromFile(SelfDescribingClass.class, "naked.yaml");
+        SelfDescribingClass res = wireType.fromFile(SelfDescribingClass.class, "naked.yaml");
 
         assertEquals(20, res.heartBtInt);
     }
 
     @Test
     public void testBytes() throws IOException {
-        BytesClass res = Marshallable.fromFile(BytesClass.class, "naked.yaml");
+        assumeFalse(wireType == WireType.YAML);
+        BytesClass res = wireType.fromFile(BytesClass.class, "naked.yaml");
 
         // The result of parsing first 4 bytes as integer value
         assertEquals(0x72616548, res.heartBtInt);

--- a/src/test/java/net/openhft/chronicle/wire/NestedMapsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/NestedMapsTest.java
@@ -38,13 +38,12 @@ public class NestedMapsTest extends WireTestCommon {
         this.wireType = wireType;
     }
 
-    @Parameterized.Parameters
+    @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> wireTypes() {
         return Arrays.asList(
                 new Object[]{WireType.JSON},
                 new Object[]{WireType.TEXT},
-                // TODO FIX
-//                new Object[]{WireType.YAML_ONLY},
+                new Object[]{WireType.YAML_ONLY},
                 new Object[]{WireType.BINARY},
                 new Object[]{WireType.FIELDLESS_BINARY}
         );

--- a/src/test/java/net/openhft/chronicle/wire/TextBinaryWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TextBinaryWireTest.java
@@ -31,6 +31,8 @@ import java.util.function.ObjIntConsumer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 @RunWith(value = Parameterized.class)
 public class TextBinaryWireTest extends WireTestCommon {
@@ -42,13 +44,14 @@ public class TextBinaryWireTest extends WireTestCommon {
         this.wireType = wireType;
     }
 
-    @Parameterized.Parameters
+    @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> combinations() {
         Object[][] list = {
                 {WireType.BINARY},
                 {WireType.FIELDLESS_BINARY},
                 {WireType.RAW},
                 {WireType.TEXT},
+                {WireType.YAML},
                 {WireType.JSON}
         };
         return Arrays.asList(list);
@@ -87,21 +90,21 @@ public class TextBinaryWireTest extends WireTestCommon {
 
     @Test
     public void testReadComment() {
-        if (wireType == WireType.TEXT || wireType == WireType.BINARY) {
-            Wire wire = createWire();
-            wire.writeComment("This is a comment");
-            @NotNull StringBuilder sb = new StringBuilder();
-            wire.readComment(sb);
-            assertEquals("This is a comment", sb.toString());
+        assumeTrue(wireType == WireType.TEXT || wireType == WireType.BINARY || wireType == WireType.YAML);
 
-            wire.bytes().releaseLast();
-        }
+        Wire wire = createWire();
+        wire.writeComment("This is a comment");
+        @NotNull StringBuilder sb = new StringBuilder();
+        wire.readComment(sb);
+        assertEquals("This is a comment", sb.toString());
+
+        wire.bytes().releaseLast();
     }
 
     @Test
     public void readFieldAsObject() {
-        if (wireType == WireType.RAW || wireType == WireType.FIELDLESS_BINARY)
-            return;
+        assumeFalse(wireType == WireType.RAW || wireType == WireType.FIELDLESS_BINARY);
+
         Wire wire = createWire();
         wire.write("CLASS").text("class")
                 .write("RUNTIME").text("runtime");
@@ -117,8 +120,8 @@ public class TextBinaryWireTest extends WireTestCommon {
 
     @Test
     public void readFieldAsLong() {
-        if (wireType == WireType.RAW || wireType == WireType.FIELDLESS_BINARY)
-            return;
+        assumeFalse(wireType == WireType.RAW || wireType == WireType.FIELDLESS_BINARY);
+
         Wire wire = createWire();
         // todo fix to ensure a field number is used.
         wire.writeEvent(Long.class, 1L).text("class")
@@ -138,8 +141,7 @@ public class TextBinaryWireTest extends WireTestCommon {
 
     @Test
     public void testConvertToNum() {
-        if (wireType == WireType.RAW)
-            return;
+        assumeFalse(wireType == WireType.RAW || /* No support for bool conversions */ wireType == WireType.YAML);
 
         Wire wire = createWire();
         wire.write("a").bool(false)

--- a/src/test/java/net/openhft/chronicle/wire/WireSerializedLambdaTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireSerializedLambdaTest.java
@@ -98,7 +98,6 @@ public class WireSerializedLambdaTest extends WireTestCommon {
         doTestText(WireType.TEXT);
     }
 
-    @Ignore(/* TODO FIX */)
     @Test
     public void testYamlWire() {
         doTestText(WireType.YAML_ONLY);

--- a/src/test/java/net/openhft/chronicle/wire/reordered/NestedReadSubset.java
+++ b/src/test/java/net/openhft/chronicle/wire/reordered/NestedReadSubset.java
@@ -23,50 +23,41 @@ import net.openhft.chronicle.wire.WireIn;
 import net.openhft.chronicle.wire.WireOut;
 import org.jetbrains.annotations.NotNull;
 
-public class NestedClass implements Marshallable {
+public class NestedReadSubset implements Marshallable {
     String text;
     String text2;
     double number;
     double number2;
-    double number4; // out of order
-    NestedClass doublyNested;
+    double number4;
 
     @Override
     public void readMarshallable(@NotNull WireIn wire) throws IORuntimeException {
-        wire.read(() -> "text").text(this, (t, v) -> t.text = v)
-                .read(() -> "text2").text(this, (t, v) -> t.text2 = v)
-                .read(() -> "doublyNested").object(NestedClass.class, this, (t, v) -> t.doublyNested = v)
-                .read(() -> "number").float64(this, (t, v) -> t.number = v)
-                .read(() -> "number2").float64(this, (t, v) -> t.number2 = v)
-                .read(() -> "number4").float64(this, (t, v) -> t.number4 = v);
+        String text = wire.read("text").text();
+        double number = wire.read("number").float64();
+        setTextNumber(text, number);
     }
 
     @Override
     public void writeMarshallable(@NotNull WireOut wire) {
-        // write version has 2 extra fields but is missing two fields
+        // write version has way more fields
         wire.write(() -> "text").text(text)
+                .write(() -> "number").float64(number)
                 .write(() -> "text3").text("is text3")
                 .write(() -> "number4").float64(number4)
-                .write(() -> "number").float64(number)
-                .write(() -> "doublyNested").object(doublyNested)
                 .write(() -> "number3").float64(333.3);
     }
 
-    public NestedClass setTextNumber(String text, double number) {
+    public NestedReadSubset setTextNumber(String text, double number) {
         this.text = text;
         this.number = number;
         this.number4 = number * 4;
         return this;
     }
 
-    public void nest(String text, double number) {
-        this.doublyNested = new NestedClass().setTextNumber(text, number);
-    }
-
     @NotNull
     @Override
     public String toString() {
-        return "NestedClass{" +
+        return "NestedReadSubset{" +
                 "text='" + text + '\'' +
                 ", text2='" + text2 + '\'' +
                 ", number=" + number +

--- a/src/test/java/net/openhft/chronicle/wire/reordered/ReorderedTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/reordered/ReorderedTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Function;
@@ -47,28 +48,33 @@ public class ReorderedTest extends WireTestCommon {
         outerClass1.clearListB();
         outerClass2.clearListB();
         outerClass1.addListA().setTextNumber("num1A", 11);
-        outerClass1.addListB().setTextNumber("num1B", 12);
-        outerClass1.addListA().setTextNumber("num1AA", 111);
+        outerClass1.addListB().setTextNumber("num1B", 12).nest("num1Bbis", 121);
+        outerClass1.addListA().setTextNumber("num1AA", 111).nest("num1AAbis", 1111);
         outerClass1.addListB().setTextNumber("num1BB", 122);
         outerClass2.addListA().setTextNumber("num2A", 21);
-        outerClass2.addListB().setTextNumber("num2B", 22);
+        outerClass2.addListB().setTextNumber("num2B", 22).nest("num2Bbis", 222);
+
+        nestedReadSubsets = Arrays.asList(
+                new NestedReadSubset().setTextNumber("one", 1.1),
+                new NestedReadSubset().setTextNumber("two", 2.2));
     }
 
     @SuppressWarnings("rawtypes")
     private final Function<Bytes<?>, Wire> wireType;
+    private static final Collection<NestedReadSubset> nestedReadSubsets;
 
     @SuppressWarnings("rawtypes")
     public ReorderedTest(Function<Bytes<?>, Wire> wireType) {
         this.wireType = wireType;
     }
 
-    @Parameterized.Parameters
+    @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> combinations() {
         return Arrays.asList(new Object[][]{
                 {WireType.JSON},
                 {WireType.TEXT},
-                // TODO FIX
-                // {WireType.YAML_ONLY},
+                // https://github.com/OpenHFT/Chronicle-Wire/issues/665
+                //{WireType.YAML_ONLY},
                 {WireType.BINARY}
         });
     }
@@ -96,6 +102,18 @@ public class ReorderedTest extends WireTestCommon {
         assertEquals(outerClass2.toString().replace(',', '\n'), outerClass0.toString().replace(',', '\n'));
 
         bytes.releaseLast();
+    }
+
+    @Test
+    public void testWithSubsetFields() {
+        Bytes<?> bytes = Bytes.elasticByteBuffer();
+        Wire wire = wireType.apply(bytes);
+        wire.writeEventName(() -> "test1").collection(nestedReadSubsets, NestedReadSubset.class);
+
+        @NotNull StringBuilder sb = new StringBuilder();
+
+        assertEquals(nestedReadSubsets.toString().replace(',', '\n'), wire.readEventName(sb).collection(ArrayList::new, NestedReadSubset.class).toString().replace(',', '\n'));
+        assertEquals("test1", sb.toString());
     }
 
     @SuppressWarnings("rawtypes")


### PR DESCRIPTION
Add test for YAML method writer
Fix compatibility marshallable test
Fix nested maps test
Fix some reordering tests
Fix text binary wire test
Case insensitive field name matching to match TEXT behavior Fix type literal parsing
Fixed handling of sequences
Partially support scenario where not all fields are read Improve test coverage of tricky scenarios