### PR TITLE
add service id into the event holder

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
@@ -90,6 +90,7 @@ public class GenerateMethodReader {
     private boolean methodFilterPresent;
     private boolean isSourceCodeGenerated;
     private boolean hasChainedCalls;
+    private String serviceName;
 
     public GenerateMethodReader(WireType wireType, MethodReaderInterceptorReturns interceptor, Object[] metaDataHandler, Object... instances) {
         this.wireType = wireType;
@@ -97,6 +98,10 @@ public class GenerateMethodReader {
         this.metaDataHandler = metaDataHandler;
         this.instances = instances;
         this.generatedClassName = generatedClassName0();
+    }
+
+    public void serviceName(String serviceName) {
+        this.serviceName = serviceName;
     }
 
     private static String signature(Method m, Class type) {
@@ -559,7 +564,7 @@ public class GenerateMethodReader {
                     (GeneratingMethodReaderInterceptorReturns) interceptor : null;
 
             if (generatingInterceptor != null) {
-                final String codeBefore = generatingInterceptor.codeBeforeCall(m, instanceFieldName, args);
+                final String codeBefore = generatingInterceptor.codeBeforeCall(m, instanceFieldName, args, serviceName);
 
                 if (codeBefore != null)
                     res.append(codeBefore).append("\n");

--- a/src/main/java/net/openhft/chronicle/wire/GeneratingMethodReaderInterceptorReturns.java
+++ b/src/main/java/net/openhft/chronicle/wire/GeneratingMethodReaderInterceptorReturns.java
@@ -32,7 +32,7 @@ import java.lang.reflect.Method;
  *
  * <p>Simple example that allows to skip call of method "foo" in case its second argument is null:
  * <pre>{@code
- *     public String codeBeforeCall(Method m, String objectName, String[] argumentNames) {
+ *     public String codeBeforeCall(Method m, String objectName, String[] argumentNames, String serviceName) {
  *         if (m.getName().equals("foo"))
  *             return "if (" + argumentNames[1] + " != null) {";
  *         else
@@ -64,16 +64,31 @@ public interface GeneratingMethodReaderInterceptorReturns extends MethodReaderIn
     String generatorId();
 
     /**
-     * @param m Calling method.
-     * @param objectName Object instance name.
+     * @param m             Calling method.
+     * @param objectName    Object instance name.
      * @param argumentNames Call argument names.
      * @return Source code to add before the method call.
+     * @deprecated use codeBeforeCall(java.lang.reflect.Method, java.lang.String, java.lang.String[], java.lang.String)
      */
-    String codeBeforeCall(Method m, String objectName, String[] argumentNames);
+    @Deprecated
+    default String codeBeforeCall(Method m, String objectName, String[] argumentNames) {
+        return codeBeforeCall(m, objectName, argumentNames, "");
+    }
 
     /**
-     * @param m Calling method.
-     * @param objectName Object instance name.
+     * @param m             Calling method.
+     * @param objectName    Object instance name.
+     * @param argumentNames Call argument names.
+     * @param serviceName   the name of the service
+     * @return Source code to add before the method call.
+     */
+    default String codeBeforeCall(Method m, String objectName, String[] argumentNames, String serviceName) {
+        return codeBeforeCall(m, objectName, argumentNames);
+    }
+
+    /**
+     * @param m             Calling method.
+     * @param objectName    Object instance name.
      * @param argumentNames Call argument names.
      * @return Source code to add after the method call.
      */

--- a/src/main/java/net/openhft/chronicle/wire/VanillaMethodReaderBuilder.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMethodReaderBuilder.java
@@ -49,6 +49,17 @@ public class VanillaMethodReaderBuilder implements MethodReaderBuilder {
 
     private boolean scanning = false;
 
+    public String serviceName() {
+        return serviceName;
+    }
+
+    public VanillaMethodReaderBuilder serviceName(String serviceName) {
+        this.serviceName = serviceName;
+        return this;
+    }
+
+    private String serviceName ="";
+
     public VanillaMethodReaderBuilder(MarshallableIn in) {
         this.in = in;
     }
@@ -121,6 +132,7 @@ public class VanillaMethodReaderBuilder implements MethodReaderBuilder {
 
     /**
      * When enabled, readOne() will skip over meta data and unknown events to find at least one event.
+     *
      * @param scanning whether to read events until it finds a known one.
      * @return this
      */
@@ -135,6 +147,7 @@ public class VanillaMethodReaderBuilder implements MethodReaderBuilder {
             return null;
 
         GenerateMethodReader generateMethodReader = new GenerateMethodReader(wireType, methodReaderInterceptorReturns, metaDataHandler, impls);
+        generateMethodReader.serviceName(serviceName);
 
         String fullClassName = generateMethodReader.packageName() + "." + generateMethodReader.generatedClassName();
 

--- a/src/test/java/net/openhft/chronicle/wire/MethodReaderInterceptorReturnsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MethodReaderInterceptorReturnsTest.java
@@ -276,6 +276,12 @@ public class MethodReaderInterceptorReturnsTest extends WireTestCommon {
 
         @Override
         public String codeBeforeCall(Method m, String objectName, String[] argumentNames) {
+            return null;
+        }
+
+
+        @Override
+        public String codeBeforeCall(Method m, String objectName, String[] argumentNames, String serviceName) {
             if (m.getName().equals("oneArg")) {
                 return String.format("if (%s == 2)\n" +
                         "break;\n", argumentNames[0]);
@@ -310,8 +316,9 @@ public class MethodReaderInterceptorReturnsTest extends WireTestCommon {
             return "skipping";
         }
 
+
         @Override
-        public String codeBeforeCall(Method m, String objectName, String[] argumentNames) {
+        public String codeBeforeCall(Method m, String objectName, String[] argumentNames, String serviceName) {
             if (m.getName().equals("twoArgs"))
                 return "if (" + argumentNames[0] + " != null) {";
             else


### PR DESCRIPTION
see issue -  https://github.com/ChronicleEnterprise/Chronicle-Services/issues/515 relates to - https://github.com/ChronicleEnterprise/Chronicle-Services/pull/516/files

Sometimes, when running multiple services in the same event loop, we want to get the currently executed service name from some generic code (e.g. for logging purposes).