### PR TITLE
DRAFT: Replace literal 4 with header constant or Integer.BYTES

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -244,7 +244,7 @@ public abstract class AbstractWire implements Wire {
     @Override
     public void readFirstHeader() throws StreamCorruptedException {
         int header;
-        if (bytes.realCapacity() >= 4) {
+        if (bytes.realCapacity() >= SPB_HEADER_SIZE) {
             header = bytes.readVolatileInt(0L);
             if (!isReady(header))
                 throw new StreamCorruptedException("Not ready header is found");
@@ -265,7 +265,7 @@ public abstract class AbstractWire implements Wire {
             boolean hasAtLeast4 = false;
             for (; ; ) {
 
-                if (hasAtLeast4 || bytes.realCapacity() >= 4) {
+                if (hasAtLeast4 || bytes.realCapacity() >= SPB_HEADER_SIZE) {
                     hasAtLeast4 = true;
                     header = bytes.readVolatileInt(0L);
                     if (isReady(header))
@@ -329,7 +329,7 @@ public abstract class AbstractWire implements Wire {
         // the reason we add padding is so that a message gets sent ( this is, mostly for queue as
         // it cant handle a zero len message )
         long pos = bytes.writePosition();
-        if (pos == position + 4) {
+        if (pos == position + SPB_HEADER_SIZE) {
             addPadding(1);
             pos = bytes.writePosition();
         }
@@ -348,7 +348,7 @@ public abstract class AbstractWire implements Wire {
                 bytesStore.writeByte(pos + i, 0);
         }
 
-        final long value = pos - position - 4;
+        final long value = pos - position - SPB_HEADER_SIZE;
         int header = (int) value;
         if (metaData) header |= META_DATA;
         // shouldn't happen due to padding above.
@@ -382,9 +382,9 @@ public abstract class AbstractWire implements Wire {
 
     private boolean checkNoDataAfterEnd(long pos) {
         // can't do this check without jumping back.
-        if (!bytes.inside(pos, 4L))
+        if (!bytes.inside(pos, SPB_HEADER_SIZE))
             return true;
-        if (pos <= bytes.writeLimit() - 4) {
+        if (pos <= bytes.writeLimit() - SPB_HEADER_SIZE) {
             final int value = bytes.bytesStore().readVolatileInt(pos);
             if (value != 0) {
                 String text;

--- a/src/main/java/net/openhft/chronicle/wire/BinaryReadDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryReadDocumentContext.java
@@ -24,6 +24,7 @@ import net.openhft.chronicle.core.pool.StringBuilderPool;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static net.openhft.chronicle.wire.Wires.SPB_HEADER_SIZE;
 import static net.openhft.chronicle.wire.Wires.lengthOf;
 
 public class BinaryReadDocumentContext implements ReadDocumentContext {
@@ -86,7 +87,7 @@ public class BinaryReadDocumentContext implements ReadDocumentContext {
             // we have to read back from the start, as close may have been called in
             // the middle of reading a value
             wire0.bytes().readPosition(start);
-            wire0.bytes().readSkip(4);
+            wire0.bytes().readSkip(SPB_HEADER_SIZE);
             while (wire0.hasMore()) {
                 final long remaining = wire0.bytes().readRemaining();
                 final ValueIn read = wire0.read();
@@ -169,7 +170,7 @@ public class BinaryReadDocumentContext implements ReadDocumentContext {
         setStart(bytes.readPosition());
 
         present = false;
-        if (bytes.readRemaining() < 4) {
+        if (bytes.readRemaining() < SPB_HEADER_SIZE) {
             notComplete = false;
             return;
         }
@@ -183,12 +184,12 @@ public class BinaryReadDocumentContext implements ReadDocumentContext {
             return;
         }
 
-        bytes.readSkip(4);
+        bytes.readSkip(SPB_HEADER_SIZE);
 
         final int len = lengthOf(header);
 
         if (len > bytes.readRemaining()) {
-            bytes.readSkip(-4);
+            bytes.readSkip(-SPB_HEADER_SIZE);
             return;
         }
 

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWriteDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWriteDocumentContext.java
@@ -22,6 +22,7 @@ import net.openhft.chronicle.bytes.HexDumpBytes;
 import net.openhft.chronicle.core.Jvm;
 import org.jetbrains.annotations.NotNull;
 
+import static net.openhft.chronicle.wire.Wires.SPB_HEADER_SIZE;
 import static net.openhft.chronicle.wire.Wires.toIntU30;
 
 public class BinaryWriteDocumentContext implements WriteDocumentContext {
@@ -56,7 +57,7 @@ public class BinaryWriteDocumentContext implements WriteDocumentContext {
 
     @Override
     public boolean isEmpty() {
-        return notComplete && wire().bytes().writePosition() == position + 4;
+        return notComplete && wire().bytes().writePosition() == position + SPB_HEADER_SIZE;
     }
 
     @Override
@@ -93,7 +94,7 @@ public class BinaryWriteDocumentContext implements WriteDocumentContext {
         long position1 = bytes.writePosition();
 //        if (position1 < position)
 //            System.out.println("Message truncated from " + position + " to " + position1);
-        long length0 = position1 - position - 4;
+        long length0 = position1 - position - SPB_HEADER_SIZE;
         if (length0 > Integer.MAX_VALUE && bytes instanceof HexDumpBytes)
             length0 = (int) length0;
         int length = metaDataBit | toIntU30(length0, "Document length %,d out of 30-bit int range.");

--- a/src/main/java/net/openhft/chronicle/wire/JSONWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/JSONWire.java
@@ -40,6 +40,7 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import static net.openhft.chronicle.bytes.NativeBytes.nativeBytes;
+import static net.openhft.chronicle.wire.Wires.SPB_HEADER_SIZE;
 
 /**
  * JSON wire format
@@ -139,7 +140,7 @@ public class JSONWire extends TextWire {
 
                 long l = bytes.readLimit();
                 try {
-                    bytes.readLimit(bytes.readPosition() + 4);
+                    bytes.readLimit(bytes.readPosition() + SPB_HEADER_SIZE);
                     isNull = "null".contentEquals(bytes);
                 } finally {
                     bytes.readLimit(l);
@@ -742,7 +743,7 @@ public class JSONWire extends TextWire {
             consumePadding();
 
             if (peekStringIgnoreCase("null")) {
-                bytes.readSkip(4);
+                bytes.readSkip(Integer.BYTES);
                 // Skip to the next token, consuming any padding and/or a comma
                 consumePadding(1);
 

--- a/src/main/java/net/openhft/chronicle/wire/RawWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/RawWire.java
@@ -45,6 +45,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.*;
 
+import static net.openhft.chronicle.wire.Wires.SPB_HEADER_SIZE;
+
 /**
  * This format writes just the data, without meta data.
  */
@@ -585,7 +587,7 @@ public class RawWire extends AbstractWire implements Wire {
         @Override
         public WireOut int32forBinding(int value, @NotNull IntValue intValue) {
             int32forBinding(value);
-            ((BinaryIntReference) intValue).bytesStore(bytes, bytes.writePosition() - 4, 4);
+            ((BinaryIntReference) intValue).bytesStore(bytes, bytes.writePosition() - Integer.BYTES, Integer.BYTES);
             return RawWire.this;
         }
 
@@ -613,7 +615,7 @@ public class RawWire extends AbstractWire implements Wire {
 
             writer.accept(t, this);
 
-            bytes.writeOrderedInt(position, Maths.toInt32(bytes.lengthWritten(position) - 4, "Document length %,d out of 32-bit int range."));
+            bytes.writeOrderedInt(position, Maths.toInt32(bytes.lengthWritten(position) - Integer.BYTES, "Document length %,d out of 32-bit int range."));
             return RawWire.this;
         }
 
@@ -625,7 +627,7 @@ public class RawWire extends AbstractWire implements Wire {
 
             writer.accept(t, kls, this);
 
-            bytes.writeOrderedInt(position, Maths.toInt32(bytes.lengthWritten(position) - 4, "Document length %,d out of 32-bit int range."));
+            bytes.writeOrderedInt(position, Maths.toInt32(bytes.lengthWritten(position) - Integer.BYTES, "Document length %,d out of 32-bit int range."));
             return RawWire.this;
         }
 
@@ -637,7 +639,7 @@ public class RawWire extends AbstractWire implements Wire {
 
             object.writeMarshallable(RawWire.this);
 
-            int length = Maths.toInt32(bytes.lengthWritten(position) - 4, "Document length %,d out of 32-bit int range.");
+            int length = Maths.toInt32(bytes.lengthWritten(position) - Integer.BYTES, "Document length %,d out of 32-bit int range.");
             bytes.writeOrderedInt(position, length);
             return RawWire.this;
         }
@@ -650,7 +652,7 @@ public class RawWire extends AbstractWire implements Wire {
 
             writeSerializable(object);
 
-            int length = Maths.toInt32(bytes.lengthWritten(position) - 4, "Document length %,d out of 32-bit int range.");
+            int length = Maths.toInt32(bytes.lengthWritten(position) - SPB_HEADER_SIZE, "Document length %,d out of 32-bit int range.");
             bytes.writeOrderedInt(position, length);
             return RawWire.this;
         }

--- a/src/main/java/net/openhft/chronicle/wire/ReadAnyWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/ReadAnyWire.java
@@ -121,7 +121,7 @@ public class ReadAnyWire extends AbstractAnyWire implements Wire {
                 return wire;
             if (bytes.readRemaining() >= 8) {
                 int firstBytes = bytes.readInt(bytes.readPosition()) |
-                        bytes.readInt(bytes.readPosition() + 4);
+                        bytes.readInt(bytes.readPosition() + Integer.BYTES);
                 firstBytes |= firstBytes >> 16;
                 firstBytes |= firstBytes >> 8;
 

--- a/src/main/java/net/openhft/chronicle/wire/SelfDescribingTriviallyCopyable.java
+++ b/src/main/java/net/openhft/chronicle/wire/SelfDescribingTriviallyCopyable.java
@@ -53,7 +53,7 @@ public abstract class SelfDescribingTriviallyCopyable extends SelfDescribingMars
         int ints0 = (description0 >>> 16) & 0xFF;
         int shorts0 = (description0 >>> 8) & 0x7F;
         int bytes0 = description0 & 0xFF;
-        int length = longs0 * 8 + ints0 * 4 + shorts0 * 2 + bytes0;
+        int length = longs0 * 8 + ints0 * Integer.BYTES + shorts0 * 2 + bytes0;
         if (Integer.bitCount(description0) % 2 == 0 || length > in.readRemaining())
             throw new IllegalStateException("Invalid description: " + Integer.toHexString(description0) + ", length: " + length + ", remaining: " + in.readRemaining());
 
@@ -74,7 +74,7 @@ public abstract class SelfDescribingTriviallyCopyable extends SelfDescribingMars
                 value = in.readInt();
             if (i < ints) {
                 MEMORY.writeInt(this, offset, value);
-                offset += 4;
+                offset += Integer.BYTES;
             }
         }
         int shorts = ($description() >>> 8) & 0x7F; // max 127

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -45,6 +45,7 @@ import java.util.regex.Pattern;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static net.openhft.chronicle.bytes.NativeBytes.nativeBytes;
 import static net.openhft.chronicle.wire.TextStopCharTesters.END_OF_TYPE;
+import static net.openhft.chronicle.wire.Wires.SPB_HEADER_SIZE;
 
 /**
  * YAML Based wire format
@@ -595,7 +596,7 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     protected void consumeDocumentStart() {
-        if (bytes.readRemaining() > 4) {
+        if (bytes.readRemaining() > SPB_HEADER_SIZE) {
             long pos = bytes.readPosition();
             if (bytes.readByte(pos) == '-' && bytes.readByte(pos + 1) == '-' && bytes.readByte(pos + 2) == '-') {
                 bytes.readSkip(3);

--- a/src/main/java/net/openhft/chronicle/wire/WireDumper.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireDumper.java
@@ -22,6 +22,8 @@ import net.openhft.chronicle.bytes.BytesUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static net.openhft.chronicle.wire.Wires.SPB_HEADER_SIZE;
+
 @SuppressWarnings("rawtypes")
 public class WireDumper {
     @NotNull
@@ -82,7 +84,7 @@ public class WireDumper {
             bytes.readLimit(limit2);
 
             long missing = position + length - limit2;
-            while (bytes.readRemaining() >= 4) {
+            while (bytes.readRemaining() >= SPB_HEADER_SIZE) {
                 if (dumpOne(sb, bytes2, abbrev))
                     break;
 
@@ -208,7 +210,7 @@ public class WireDumper {
             sb.append('\n');
         if (wireIn.usePadding())
             len0 = (len0 + 3) & ~3;
-        this.bytes.readPosition(Math.min(this.bytes.readLimit(), start + 4 + len0));
+        this.bytes.readPosition(Math.min(this.bytes.readLimit(), start + SPB_HEADER_SIZE + len0));
         return false;
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/WireInternal.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireInternal.java
@@ -40,6 +40,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static net.openhft.chronicle.core.pool.ClassAliasPool.CLASS_ALIASES;
+import static net.openhft.chronicle.wire.Wires.SPB_HEADER_SIZE;
 import static net.openhft.chronicle.wire.Wires.toIntU30;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
@@ -141,7 +142,7 @@ public enum WireInternal {
         int length;
         if (bytes instanceof HexDumpBytes) {
             // Todo: this looks suspicious. Why cast to int individually rather than use long arithmetics?
-            length = metaDataBit | toIntU30((int) position1 - (int) position - 4, "Document length %,d out of 30-bit int range.");
+            length = metaDataBit | toIntU30((int) position1 - (int) position - SPB_HEADER_SIZE, "Document length %,d out of 30-bit int range.");
         } else {
             length = metaDataBit | toIntU30(position1 - position - 4L, "Document length %,d out of 30-bit int range.");
         }
@@ -177,12 +178,12 @@ public enum WireInternal {
         boolean read = false;
         while (true) {
             bytes.readPositionForHeader(wireIn.usePadding());
-            if (bytes.readRemaining() < 4) break;
+            if (bytes.readRemaining() < SPB_HEADER_SIZE) break;
             long position = bytes.readPosition();
             int header = bytes.readVolatileInt(position);
             if (!isKnownLength(header))
                 return read;
-            bytes.readSkip(4);
+            bytes.readSkip(SPB_HEADER_SIZE);
 
             final int len = Wires.lengthOf(header);
             if (Wires.isData(header)) {

--- a/src/main/java/net/openhft/chronicle/wire/Wires.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wires.java
@@ -218,7 +218,7 @@ public enum Wires {
                 assert wireType != null;
                 Wire tempWire = wireType.apply(tempBytes);
 
-                return WireDumper.of(tempWire).asString(0, length + 4);
+                return WireDumper.of(tempWire).asString(0, length + SPB_HEADER_SIZE);
 
             } finally {
                 tempBytes.releaseLast();
@@ -229,14 +229,14 @@ public enum Wires {
                 if (start != -1)
                     headerPosition = start;
                 else
-                    headerPosition = bytes.readPosition() - 4;
+                    headerPosition = bytes.readPosition() - SPB_HEADER_SIZE;
             } else
-                headerPosition = bytes.readPosition() - 4;
+                headerPosition = bytes.readPosition() - SPB_HEADER_SIZE;
 
             length = Wires.lengthOf(bytes.readInt(headerPosition));
         }
 
-        return WireDumper.of(wire).asString(headerPosition, length + 4);
+        return WireDumper.of(wire).asString(headerPosition, length + SPB_HEADER_SIZE);
     }
 
     public static String fromSizePrefixedBlobs(@NotNull WireIn wireIn) {

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -45,6 +45,7 @@ import java.util.*;
 import java.util.function.*;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static net.openhft.chronicle.wire.Wires.SPB_HEADER_SIZE;
 
 /**
  * YAML Based wire format
@@ -729,7 +730,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     protected void consumeDocumentStart() {
-        if (bytes.readRemaining() > 4) {
+        if (bytes.readRemaining() > SPB_HEADER_SIZE) {
             long pos = bytes.readPosition();
             if (bytes.readByte(pos) == '-' && bytes.readByte(pos + 1) == '-' && bytes.readByte(pos + 2) == '-')
                 bytes.readSkip(3);

--- a/src/main/java/net/openhft/chronicle/wire/channel/impl/TCPChronicleChannel.java
+++ b/src/main/java/net/openhft/chronicle/wire/channel/impl/TCPChronicleChannel.java
@@ -39,6 +39,7 @@ import java.util.function.Function;
 import static java.util.Objects.requireNonNull;
 import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
 import static net.openhft.chronicle.core.io.ClosedIORuntimeException.newIORuntimeException;
+import static net.openhft.chronicle.wire.Wires.SPB_HEADER_SIZE;
 
 public class TCPChronicleChannel extends AbstractCloseable implements InternalChronicleChannel {
     // tune for message sizes up to this
@@ -226,7 +227,7 @@ public class TCPChronicleChannel extends AbstractCloseable implements InternalCh
                 throw new InvalidProtocolException("Dump\n" + bytes.toHexString());
             }
         }
-        assert bytes.readRemaining() < 4 || validateHeader(header);
+        assert bytes.readRemaining() < SPB_HEADER_SIZE || validateHeader(header);
         if (DUMP_YAML)
             System.out.println("in - " + Integer.toUnsignedString(header, 16) + "\n" + Wires.fromSizePrefixedBlobs(in));
         return in.readingDocument();


### PR DESCRIPTION
Nick, this is a draft PR to begin replacing literal 4's with either the header constant or Integer.BYTES. In some cases it is a little unclear whether the header constant should be used. Let me know your thoughts.