### PR TITLE
Reproduce segfault from EFX build

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -1058,7 +1058,7 @@ public class WireMarshaller<T> {
             super(field, isLeaf);
             asMarshallable = Jvm.findAnnotation(field, AsMarshallable.class);
             type = field.getType();
-            resettable = !DynamicEnum.class.isAssignableFrom(type);
+            resettable = !DynamicEnum.class.isAssignableFrom(type) && Marshallable.class.isAssignableFrom(type);
         }
 
         @Override

--- a/src/test/java/net/openhft/chronicle/wire/WireResetTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireResetTest.java
@@ -22,6 +22,7 @@ import net.openhft.chronicle.core.io.AbstractCloseable;
 import net.openhft.chronicle.core.io.Closeable;
 import org.junit.Test;
 
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -97,6 +98,16 @@ public class WireResetTest extends WireTestCommon {
 
     }
 
+    /**
+     * Reproduction of <a href="https://github.com/OpenHFT/Chronicle-Wire/issues/745">this issue</a>
+     */
+    @Test
+    public void canDeepResetOnDtosContainingLocalDates() {
+        Event e = new Event();
+        e.someDate = LocalDate.now();
+        e.reset();
+    }
+
     public static class Event extends SelfDescribingMarshallable implements Closeable {
 
         private boolean isClosed;
@@ -104,6 +115,7 @@ public class WireResetTest extends WireTestCommon {
         Identifier identifier = new Identifier();
         Collection<Identifier> ids = new LinkedList<>();
         String payload;
+        LocalDate someDate;
 
         @Override
         public void close() {


### PR DESCRIPTION
This is a minimal reproduction of the issue with the EFX build

I don't know what the intention was here, but it seems wrong to traverse into object fields and attempt to recursively reset their fields?

i.e. if I have a DTO with a LocalDate field I probably want that set to null when I reset, not set to a husk of a LocalDate instance (which is immutable and shouldn't be modified) with year=0, month=0 and day=0

Perhaps `ObjectFieldAccess.isResettable()` should only return true for fields that implement `Marshallable`?

It feels like this is way too broad