### PR TITLE
Turn off deep resetting altogether

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -1064,7 +1064,7 @@ public class WireMarshaller<T> {
             super(field, isLeaf);
             asMarshallable = Jvm.findAnnotation(field, AsMarshallable.class);
             type = field.getType();
-            resettable = !DynamicEnum.class.isAssignableFrom(type) && Marshallable.class.isAssignableFrom(type);
+            resettable = false;
         }
 
         @Override

--- a/src/test/java/net/openhft/chronicle/wire/WireResetTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireResetTest.java
@@ -20,6 +20,7 @@ package net.openhft.chronicle.wire;
 
 import net.openhft.chronicle.core.io.AbstractCloseable;
 import net.openhft.chronicle.core.io.Closeable;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.time.LocalDate;
@@ -52,6 +53,7 @@ public class WireResetTest extends WireTestCommon {
         }
     }
 
+    @Ignore("https://github.com/OpenHFT/Chronicle-Wire/issues/745")
     @Test
     //https://github.com/OpenHFT/Chronicle-Wire/issues/732
     public void testDeepReset() {


### PR DESCRIPTION
Even doing it just for Marshallable classes is problematic, it triggered lots of problems with EFX config loading for some reason