### PR TITLE
Backported CNFRE on missing class changes

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -60,6 +60,7 @@ import static net.openhft.chronicle.core.util.ReadResolvable.readResolve;
 import static net.openhft.chronicle.wire.BinaryWire.AnyCodeMatch.ANY_CODE_MATCH;
 import static net.openhft.chronicle.wire.BinaryWireCode.*;
 import static net.openhft.chronicle.wire.Wires.GENERATE_TUPLES;
+import static net.openhft.chronicle.wire.Wires.THROW_CNFRE;
 
 /**
  * This Wire is a binary translation of TextWire which is a sub set of YAML.
@@ -3558,6 +3559,8 @@ public class BinaryWire extends AbstractWire implements Wire {
                 if (Wires.dtoInterface(tClass) && GENERATE_TUPLES) {
                     return Wires.tupleFor(tClass, sb.toString());
                 }
+                if (THROW_CNFRE)
+                    throw e;
                 Jvm.warn().on(getClass(), "Unknown class (" + sb + "), perhaps you need to define an alias", e);
                 return null;
             }

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -46,6 +46,8 @@ import java.util.regex.Pattern;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static net.openhft.chronicle.bytes.NativeBytes.nativeBytes;
 import static net.openhft.chronicle.wire.TextStopCharTesters.END_OF_TYPE;
+import static net.openhft.chronicle.wire.Wires.GENERATE_TUPLES;
+import static net.openhft.chronicle.wire.Wires.THROW_CNFRE;
 
 /**
  * YAML Based wire format
@@ -67,8 +69,6 @@ public class TextWire extends YamlWireOut<TextWire> {
     static final Supplier<StopCharsTester> STRICT_END_OF_TEXT_ESCAPING = TextStopCharsTesters.STRICT_END_OF_TEXT::escaping;
     static final Supplier<StopCharsTester> END_EVENT_NAME_ESCAPING = TextStopCharsTesters.END_EVENT_NAME::escaping;
     static final Bytes<?> META_DATA = Bytes.from("!!meta-data");
-    @Deprecated(/* for removal in x.26, make default true in x.25 */)
-    static final boolean IAE_ON_CNF = Jvm.getBoolean("class.not.found.for.missing.class.alias", false);
 
     static {
         IOTools.unmonitor(BINARY);
@@ -1857,9 +1857,10 @@ public class TextWire extends YamlWireOut<TextWire> {
                 try {
                     return classLookup().forName(stringBuilder);
                 } catch (ClassNotFoundRuntimeException e) {
+                    // Note: it's not possible to generate a Tuple without an interface implied.
+                    if (THROW_CNFRE)
+                        throw e;
                     String message = "Unable to find " + stringBuilder + " " + e.getCause();
-                    if (IAE_ON_CNF)
-                        throw new IllegalArgumentException(message);
                     Jvm.warn().on(getClass(), message);
                     return null;
                 }
@@ -1881,40 +1882,54 @@ public class TextWire extends YamlWireOut<TextWire> {
                 try {
                     return classLookup().forName(stringBuilder);
                 } catch (ClassNotFoundRuntimeException e) {
-                    if (tClass == null) {
-                        if (Wires.GENERATE_TUPLES) {
-                            return Wires.tupleFor(null, stringBuilder.toString());
-                        }
-                        String message = "Unable to load " + stringBuilder + ", is a class alias missing.";
-                        if (IAE_ON_CNF)
-                            throw new ClassNotFoundRuntimeException(new ClassNotFoundException(message));
-                        Jvm.warn().on(TextWire.class, message);
-                        return null;
-                    }
-
-                    final String className = tClass.getName();
-
-                    String[] split = REGX_PATTERN.split(stringBuilder);
-                    if (split[split.length - 1].equalsIgnoreCase(tClass.getSimpleName())) {
-                        try {
-
-                            return tClass.isInterface()
-                                    ? Wires.tupleFor(tClass, stringBuilder.toString())
-                                    : classLookup().forName(className);
-
-                        } catch (ClassNotFoundRuntimeException e1) {
-                            Jvm.warn().on(getClass(), "ClassNotFoundException class=" + className);
-                            return Wires.tupleFor(tClass, className);
-                        }
-
-                    } else if (tClass.getClassLoader() == null) {
-                        throw new ClassNotFoundRuntimeException(new ClassNotFoundException("Unable to find class " + stringBuilder));
-                    } else {
-                        return Wires.tupleFor(tClass, stringBuilder.toString());
-                    }
+                    Object o = handleCNFE(tClass, e, stringBuilder);
+                    if (o != null)
+                        return o;
                 }
             }
-            return Wires.dtoInterface(tClass) && Wires.GENERATE_TUPLES && ObjectUtils.implementationToUse(tClass) == tClass ? Wires.tupleFor(tClass, null) : null;
+            if (Wires.dtoInterface(tClass) && GENERATE_TUPLES && ObjectUtils.implementationToUse(tClass) == tClass)
+                return Wires.tupleFor(tClass, null);
+            return null;
+        }
+
+        @Nullable
+        private Object handleCNFE(Class tClass, ClassNotFoundRuntimeException e, StringBuilder stringBuilder) {
+            if (tClass == null) {
+                if (GENERATE_TUPLES) {
+                    return Wires.tupleFor(null, stringBuilder.toString());
+                }
+                String message = "Unable to load " + stringBuilder + ", is a class alias missing.";
+                if (THROW_CNFRE)
+                    throw new ClassNotFoundRuntimeException(new ClassNotFoundException(message));
+                Jvm.warn().on(TextWire.class, message);
+                return null;
+            }
+
+            final String className = tClass.getName();
+
+            String[] split = REGX_PATTERN.split(stringBuilder);
+            if (split[split.length - 1].equalsIgnoreCase(tClass.getSimpleName())) {
+                try {
+
+                    return tClass.isInterface()
+                            ? Wires.tupleFor(tClass, stringBuilder.toString())
+                            : classLookup().forName(className);
+
+                } catch (ClassNotFoundRuntimeException e1) {
+                    if (!THROW_CNFRE) {
+                        Jvm.warn().on(getClass(), "ClassNotFoundException class=" + className);
+                        return Wires.tupleFor(tClass, className);
+                    }
+                }
+
+            } else if (GENERATE_TUPLES && tClass.getClassLoader() != null) {
+                return Wires.tupleFor(tClass, stringBuilder.toString());
+            }
+
+            if (THROW_CNFRE || tClass.isInterface())
+                throw e;
+            Jvm.warn().on(TextWire.class, "Cannot find a class for " + stringBuilder + " are you missing an alias?");
+            return null;
         }
 
         @Override

--- a/src/main/java/net/openhft/chronicle/wire/Wires.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wires.java
@@ -32,6 +32,7 @@ import net.openhft.chronicle.core.pool.StringBuilderPool;
 import net.openhft.chronicle.core.scoped.ScopedResource;
 import net.openhft.chronicle.core.scoped.ScopedResourcePool;
 import net.openhft.chronicle.core.threads.ThreadLocalHelper;
+import net.openhft.chronicle.core.util.ClassNotFoundRuntimeException;
 import net.openhft.chronicle.core.util.CoreDynamicEnum;
 import net.openhft.chronicle.core.util.ObjectUtils;
 import net.openhft.chronicle.core.util.ReadResolvable;
@@ -78,6 +79,9 @@ public enum Wires {
     public static final Bytes<?> NO_BYTES = BytesStore.empty().bytesForRead();
     public static final int SPB_HEADER_SIZE = 4;
     public static final List<Function<Class, SerializationStrategy>> CLASS_STRATEGY_FUNCTIONS = new CopyOnWriteArrayList<>();
+
+    @Deprecated(/* for removal in x.26, make default true in x.25 */)
+    static boolean THROW_CNFRE = Jvm.getBoolean("class.not.found.for.missing.class.alias", false);
     static final ClassLocal<SerializationStrategy> CLASS_STRATEGY = ClassLocal.withInitial(c -> {
         for (@NotNull Function<Class, SerializationStrategy> func : CLASS_STRATEGY_FUNCTIONS) {
             final SerializationStrategy strategy = func.apply(c);
@@ -627,7 +631,7 @@ public enum Wires {
             return (E) WireInternal.throwable(in, false, (Throwable) using);
 
         if (using == null)
-            throw new IllegalStateException("failed to create instance of clazz=" + clazz + " is it aliased?");
+            throw new ClassNotFoundRuntimeException(new ClassNotFoundException("failed to create instance of clazz=" + clazz + " is it aliased?"));
 
         Object marshallable = in.marshallable(using, strategy);
         E e = readResolve(marshallable);

--- a/src/test/java/net/openhft/chronicle/wire/InvalidYamWithCommonMistakesTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/InvalidYamWithCommonMistakesTest.java
@@ -19,6 +19,7 @@
 package net.openhft.chronicle.wire;
 
 import net.openhft.chronicle.core.pool.ClassAliasPool;
+import net.openhft.chronicle.core.util.ClassNotFoundRuntimeException;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -69,7 +70,26 @@ public class InvalidYamWithCommonMistakesTest extends WireTestCommon {
 
     @Test
     public void testAssumeTheTypeMissingType() {
+        Wires.THROW_CNFRE = false;
+        Wires.GENERATE_TUPLES = false;
         expectException("Cannot find a class for Xyz are you missing an alias?");
+        final String cs = "!Xyz " +
+                "{\n" +
+                "  y: hello8\n" +
+                "}\n";
+        String s = Marshallable.fromString(Dto.class, cs).toString();
+        assertEquals("" +
+                "!net.openhft.chronicle.wire.InvalidYamWithCommonMistakesTest$Dto {\n" +
+                "  y: hello8,\n" +
+                "  x: !!null \"\"\n" +
+                "}\n", s);
+    }
+
+    @Test(expected = ClassNotFoundRuntimeException.class)
+    public void testAssumeTheTypeMissingTypeThrows() {
+        Wires.THROW_CNFRE = true;
+        Wires.GENERATE_TUPLES = false;
+
         final String cs = "!Xyz " +
                 "{\n" +
                 "  y: hello8\n" +

--- a/src/test/java/net/openhft/chronicle/wire/TextWireAgitatorTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TextWireAgitatorTest.java
@@ -29,9 +29,29 @@ import static org.junit.Assert.*;
 // Test created as a result of agitator tests i.e. random character changes
 public class TextWireAgitatorTest extends WireTestCommon {
 
-    @Test(expected = ClassNotFoundRuntimeException.class)
-    public void lowerCaseClass() {
+    @Test
+    public void lowerCaseClassTuple() {
+        Wires.THROW_CNFRE = false;
+        Wires.GENERATE_TUPLES = true;
+        Object o = Marshallable.fromString("!" + TextWireTest.MyDto.class.getName().toLowerCase() + " { }");
+        assertEquals("!net.openhft.chronicle.wire.textwiretest$mydto {\n" +
+                "}\n", o.toString());
+    }
+
+    @Test
+    public void lowerCaseClassWarn() {
+        expectException("Unable to load net.openhft.chronicle.wire.textwiretest$mydto, is a class alias missing");
+        Wires.THROW_CNFRE = false;
+        Wires.GENERATE_TUPLES = false;
         assertTrue(Marshallable.fromString("!" + TextWireTest.MyDto.class.getName().toLowerCase() + " { }") instanceof Map);
+    }
+
+    @Test(expected = ClassNotFoundRuntimeException.class)
+    public void lowerCaseClassThrows() {
+        Wires.THROW_CNFRE = true;
+        Wires.GENERATE_TUPLES = false;
+        Object o = Marshallable.fromString("!" + TextWireTest.MyDto.class.getName().toLowerCase() + " { }");
+        fail("" + o);
     }
 
     @Test(expected = IORuntimeException.class)

--- a/src/test/java/net/openhft/chronicle/wire/UnknownEnumTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/UnknownEnumTest.java
@@ -19,6 +19,7 @@
 package net.openhft.chronicle.wire;
 
 import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.core.util.ClassNotFoundRuntimeException;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
@@ -63,31 +64,24 @@ public class UnknownEnumTest extends WireTestCommon {
 
         assertThrows(IllegalArgumentException.class, () -> wire.read("value").asEnum(StrictYesNo.class));
     }
-   // private enum Temp {
-       // FIRST
-   // }
 
     /*
     Documents the behaviour of BinaryWire when an enum type is unknown
      */
     @Test
-    public void shouldConvertEnumValueToStringWhenTypeIsNotKnownInBinaryWire() throws Exception {
-
-        // generates the serialised form
-       // final Bytes<ByteBuffer> b = Bytes.allocateElasticOnHeap(128);
-       // final Wire w = WireType.BINARY.apply(b);
-//
-       // final Map<String, Temp> m = new HashMap<>();
-       // m.put("key", Temp.FIRST);
-       // w.write("event").marshallable(m);
-       // final ByteBuffer hb = b.underlyingObject();
-       // hb.limit((int) b.writePosition());
-       // while (hb.remaining() != 0) {
-           // System.out.print(" " + hb.get() + ",");
-       // }
-       // System.out.println();
-
+    public void shouldConvertEnumValueToStringWhenTypeIsNotKnownInBinaryWire() {
+        Wires.THROW_CNFRE = false;
         expectException("Unknown class (net.openhft.chronicle.wire.UnknownEnumTest$Temp), perhaps you need to define an alias");
+        final Bytes<ByteBuffer> bytes = Bytes.wrapForRead(ByteBuffer.wrap(SERIALISED_MAP_DATA));
+
+        final Wire wire = WireType.BINARY.apply(bytes);
+        final Map<String, Object> enumField = wire.read("event").marshallableAsMap(String.class, Object.class);
+        assertEquals("FIRST", enumField.get("key"));
+    }
+
+    @Test(expected = ClassNotFoundRuntimeException.class)
+    public void shouldConvertEnumValueToStringWhenTypeIsNotKnownInBinaryWireThrows() {
+        Wires.THROW_CNFRE = true;
         final Bytes<ByteBuffer> bytes = Bytes.wrapForRead(ByteBuffer.wrap(SERIALISED_MAP_DATA));
 
         final Wire wire = WireType.BINARY.apply(bytes);

--- a/src/test/java/net/openhft/chronicle/wire/WiresTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WiresTest.java
@@ -22,6 +22,7 @@ import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.bytes.BytesMarshallable;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.pool.ClassAliasPool;
+import net.openhft.chronicle.core.util.ClassNotFoundRuntimeException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -126,6 +127,7 @@ public class WiresTest extends WireTestCommon {
 
     @Test
     public void unknownType2() {
+        wiresThrowCNFRE(false);
         Wires.GENERATE_TUPLES = true;
 
         String text = "!FourValues {\n" +
@@ -154,7 +156,76 @@ public class WiresTest extends WireTestCommon {
                 "  big: 0.128,\n" +
                 "  also: extra\n" +
                 "}\n", tv.toString());
+    }
 
+    @Test(expected = ClassNotFoundRuntimeException.class)
+    public void unknownType2WarnThrows() {
+        wiresThrowCNFRE(false);
+        Wires.GENERATE_TUPLES = false;
+
+        String text = "!FourValues {\n" +
+                "  string: Hello,\n" +
+                "  num: 123,\n" +
+                "  big: 1E6,\n" +
+                "  also: extra\n" +
+                "}\n";
+        ThreeValues tv = Marshallable.fromString(ThreeValues.class, text);
+        assertEquals(text, tv.toString());
+        assertEquals("Hello", tv.string());
+        tv.string("Hello World");
+        assertEquals("Hello World", tv.string());
+
+        assertEquals(123, tv.num());
+        tv.num(1234);
+        assertEquals(1234, tv.num());
+
+        assertEquals(1e6, tv.big(), 0.0);
+        tv.big(0.128);
+        assertEquals(0.128, tv.big(), 0.0);
+
+        assertEquals("!FourValues {\n" +
+                "  string: Hello World,\n" +
+                "  num: !int 1234,\n" +
+                "  big: 0.128,\n" +
+                "  also: extra\n" +
+                "}\n", tv.toString());
+    }
+
+    @Test(expected = ClassNotFoundRuntimeException.class)
+    public void unknownType2Throws2() {
+        wiresThrowCNFRE(true);
+        Wires.GENERATE_TUPLES = false;
+
+        String text = "!FourValues {\n" +
+                "  string: Hello,\n" +
+                "  num: 123,\n" +
+                "  big: 1E6,\n" +
+                "  also: extra\n" +
+                "}\n";
+        ThreeValues tv = Marshallable.fromString(ThreeValues.class, text);
+        assertEquals(text, tv.toString());
+        assertEquals("Hello", tv.string());
+        tv.string("Hello World");
+        assertEquals("Hello World", tv.string());
+
+        assertEquals(123, tv.num());
+        tv.num(1234);
+        assertEquals(1234, tv.num());
+
+        assertEquals(1e6, tv.big(), 0.0);
+        tv.big(0.128);
+        assertEquals(0.128, tv.big(), 0.0);
+
+        assertEquals("!FourValues {\n" +
+                "  string: Hello World,\n" +
+                "  num: !int 1234,\n" +
+                "  big: 0.128,\n" +
+                "  also: extra\n" +
+                "}\n", tv.toString());
+    }
+
+    public static void wiresThrowCNFRE(boolean throwCnfre) {
+        Wires.THROW_CNFRE = throwCnfre;
     }
     @Test
     public void recordAsYaml() {

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/CNFREOnMissingClassTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/CNFREOnMissingClassTest.java
@@ -4,17 +4,15 @@ import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.pool.ClassAliasPool;
 import net.openhft.chronicle.core.util.ClassNotFoundRuntimeException;
-import net.openhft.chronicle.wire.AbstractMarshallableCfg;
-import net.openhft.chronicle.wire.Marshallable;
-import net.openhft.chronicle.wire.TextWire;
-import net.openhft.chronicle.wire.Wire;
+import net.openhft.chronicle.wire.*;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
 
-public class CNFREOnMissingClassTest {
+public class CNFREOnMissingClassTest extends WireTestCommon {
     @Test(expected = ClassNotFoundRuntimeException.class)
     public void throwIllegalArgumentExceptionOnMissingClassAlias() {
+        WiresTest.wiresThrowCNFRE(true);
         Wire wire = new TextWire(Bytes.from("" +
                 "a: !Aaa { hi: bye }"));
         Object object = wire.read("a").object();
@@ -29,10 +27,31 @@ public class CNFREOnMissingClassTest {
 
     @Test(expected = ClassNotFoundRuntimeException.class)
     public void throwClassNotFoundRuntimeExceptionOnMissingClassForField() {
+        WiresTest.wiresThrowCNFRE(true);
         ClassAliasPool.CLASS_ALIASES.addAlias(TwoFields.class);
         String simpleObject = "!TwoFields { name: \"henry\", fieldOne: !ThisClassDoesntExist { } }";
         String key = "class.not.found.for.missing.class.alias";
         Jvm.startup().on(CNFREOnMissingClassTest.class, "Value of " + key + ": " + Jvm.getBoolean(key));
         final TwoFields simple = Marshallable.fromString(simpleObject);
     }
+
+    static class UsesTwoFields extends AbstractMarshallableCfg {
+        private TwoFields bothFields;
+        private String name;
+    }
+
+    /**
+     * Failing to load a class for a field with a type of java.lang.Object causes the correct behaviour but in
+     * an unexpected code path (the check for a classloader at TextWire#typeOrPrefixObject - line 1913
+     */
+    @Test(expected = ClassNotFoundRuntimeException.class)
+    public void throwClassNotFoundRuntimeExceptionOnMissingClassForFieldNotObject() {
+        WiresTest.wiresThrowCNFRE(true);
+        ClassAliasPool.CLASS_ALIASES.addAlias(TwoFields.class, UsesTwoFields.class);
+        String key = "class.not.found.for.missing.class.alias";
+        String simpleObject = "!UsesTwoFields { name: \"henry\", bothFields: !ThisClassDoesntExist { } }";
+        Jvm.startup().on(CNFREOnMissingClassTest.class, "Value of " + key + ": " + Jvm.getBoolean(key));
+        final UsesTwoFields simple = Marshallable.fromString(simpleObject);
+    }
+
 }

--- a/src/test/java/net/openhft/chronicle/wire/method/VanillaMethodReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/VanillaMethodReaderTest.java
@@ -24,6 +24,7 @@ import net.openhft.chronicle.bytes.HexDumpBytes;
 import net.openhft.chronicle.bytes.MethodReader;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.Mocker;
+import net.openhft.chronicle.core.util.ClassNotFoundRuntimeException;
 import net.openhft.chronicle.wire.*;
 import org.jetbrains.annotations.NotNull;
 import org.junit.After;
@@ -221,7 +222,31 @@ public class VanillaMethodReaderTest extends WireTestCommon {
     }
 
     @Test
+    public void testNestedUnknownClassWarn() {
+        WiresTest.wiresThrowCNFRE(false);
+        Wires.GENERATE_TUPLES = false;
+
+        Wire wire2 = new TextWire(Bytes.allocateElasticOnHeap())
+                .useTextDocuments();
+        MRTListener writer2 = wire2.methodWriter(MRTListener.class);
+
+        String text = "" +
+                "unknown: {\n" +
+                "  u: !!null \"\"\n" +
+                "}\n" +
+                "...\n";
+        Wire wire = TextWire.from(text)
+                .useTextDocuments();
+        MethodReader reader = wire.methodReader(writer2);
+        checkReaderType(reader);
+        assertTrue(reader.readOne());
+        assertFalse(reader.readOne());
+        assertEquals(text, wire2.toString());
+    }
+
+    @Test
     public void testNestedUnknownClass() {
+        WiresTest.wiresThrowCNFRE(true);
         Wires.GENERATE_TUPLES = true;
 
         Wire wire2 = new TextWire(Bytes.allocateElasticOnHeap())
@@ -245,9 +270,72 @@ public class VanillaMethodReaderTest extends WireTestCommon {
         assertEquals(text, wire2.toString());
     }
 
+    @Test(expected = ClassNotFoundRuntimeException.class)
+    public void testUnknownClassCNFREInterface() {
+        WiresTest.wiresThrowCNFRE(false);
+        Wires.GENERATE_TUPLES = false;
+
+        Wire wire2 = new TextWire(Bytes.allocateElasticOnHeap())
+                .useTextDocuments();
+        MRTListener writer2 = wire2.methodWriter(MRTListener.class);
+
+        String text = "top: !UnknownClass {\n" +
+                "  one: 1,\n" +
+                "  two: 2.2,\n" +
+                "  three: words\n" +
+                "}\n" +
+                "...\n" +
+                "top: {\n" +
+                "  one: 11,\n" +
+                "  two: 22.2,\n" +
+                "  three: many words\n" +
+                "}\n" +
+                "...\n";
+        Wire wire = TextWire.from(text)
+                .useTextDocuments();
+        MethodReader reader = wire.methodReader(writer2);
+        checkReaderType(reader);
+        assertTrue(reader.readOne());
+        assertTrue(reader.readOne());
+        assertFalse(reader.readOne());
+        assertEquals(text, wire2.toString());
+    }
+
     @Test
-    public void testUnknownClass() {
+    public void testUnknownClassDoesntThrow() {
+        WiresTest.wiresThrowCNFRE(true);
         Wires.GENERATE_TUPLES = true;
+
+        Wire wire2 = new TextWire(Bytes.allocateElasticOnHeap())
+                .useTextDocuments();
+        MRTListener writer2 = wire2.methodWriter(MRTListener.class);
+
+        String text = "top: !UnknownClass {\n" +
+                "  one: 1,\n" +
+                "  two: 2.2,\n" +
+                "  three: words\n" +
+                "}\n" +
+                "...\n" +
+                "top: {\n" +
+                "  one: 11,\n" +
+                "  two: 22.2,\n" +
+                "  three: many words\n" +
+                "}\n" +
+                "...\n";
+        Wire wire = TextWire.from(text)
+                .useTextDocuments();
+        MethodReader reader = wire.methodReader(writer2);
+        checkReaderType(reader);
+        assertTrue(reader.readOne());
+        assertTrue(reader.readOne());
+        assertFalse(reader.readOne());
+        assertEquals(text, wire2.toString());
+    }
+
+    @Test(expected = ClassNotFoundRuntimeException.class)
+    public void testUnknownClassThrow() {
+        WiresTest.wiresThrowCNFRE(true);
+        Wires.GENERATE_TUPLES = false;
 
         Wire wire2 = new TextWire(Bytes.allocateElasticOnHeap())
                 .useTextDocuments();


### PR DESCRIPTION
Throw CNFRE on missing class when enabled, or if an interface is provided and tuples are off.