### PR TITLE
Fix maxParseLength

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/LongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/LongConverter.java
@@ -56,7 +56,7 @@ public interface LongConverter {
      * @return The maximum length a string can have to represent a long value.
      */
     static int maxParseLength(int based) {
-        return (int) Math.ceil(64 / log(based) * log(2));
+        return (int) Math.floor(64 / log(based) * log(2));
     }
 
     /**


### PR DESCRIPTION
Unless the base is incidentally a power of 2 whose exponent is a divisor of 64, the number returned is greater than the real allowed size by 1.

Using floor fixes this.