### PR TITLE
Suppress CNFE for interface classes when field is set to false

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -36,6 +36,7 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.ref.WeakReference;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.nio.BufferUnderflowException;
 import java.time.LocalDate;
@@ -3205,7 +3206,7 @@ public class TextWire extends AbstractWire implements Wire {
             }
             if (Wires.dtoInterface(tClass) && GENERATE_TUPLES && ObjectUtils.implementationToUse(tClass) == tClass)
                 return Wires.tupleFor(tClass, null);
-            return null;
+            return tClass == null || Modifier.isAbstract(tClass.getModifiers()) ? null : tClass;
         }
 
         @Nullable

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -3242,7 +3242,7 @@ public class TextWire extends AbstractWire implements Wire {
                 return Wires.tupleFor(tClass, stringBuilder.toString());
             }
 
-            if (THROW_CNFRE || tClass.isInterface())
+            if (THROW_CNFRE)
                 throw e;
             Jvm.warn().on(TextWire.class, "Cannot find a class for " + stringBuilder + " are you missing an alias?");
             return null;

--- a/src/main/java/net/openhft/chronicle/wire/Wires.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wires.java
@@ -592,6 +592,7 @@ public enum Wires {
 
     @Nullable
     public static <E> E object0(ValueIn in, @Nullable E using, @Nullable Class clazz) {
+        final Class class0 = clazz;
         if (using instanceof AbstractMarshallableCfg)
             ((AbstractMarshallableCfg) using).reset();
 
@@ -643,7 +644,9 @@ public enum Wires {
 
         switch (brackets) {
             case MAP:
-                return objectMap(in, using, clazz, strategy);
+                E objectMap = objectMap(in, using, clazz, strategy);
+                // was the object created just to consume data
+                return class0 == null || class0.isInstance(objectMap) ? objectMap : null;
 
             case SEQ:
                 return objectSequence(in, using, clazz, strategy);

--- a/src/test/java/net/openhft/chronicle/wire/WireTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireTestCommon.java
@@ -103,7 +103,7 @@ public class WireTestCommon {
         if (Jvm.hasException(exceptions)) {
             final String msg = exceptions.size() + " exceptions were detected: " +
                     exceptions.keySet().stream()
-                            .map(ek -> "" + ek.throwable)
+                            .map(ek -> ek.throwable == null ? ek.message : "" + ek.throwable)
                             .collect(Collectors.joining(", "));
             Jvm.dumpException(exceptions);
             Jvm.resetExceptionHandlers();

--- a/src/test/java/net/openhft/chronicle/wire/WiresTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WiresTest.java
@@ -159,8 +159,10 @@ public class WiresTest extends WireTestCommon {
                 "}\n", tv.toString());
     }
 
-    @Test(expected = ClassNotFoundRuntimeException.class)
+    @Test
     public void unknownType2WarnThrows() {
+        expectException("Cannot find a class for FourValues are you missing an alias?");
+
         wiresThrowCNFRE(false);
         Wires.GENERATE_TUPLES = false;
 
@@ -171,24 +173,33 @@ public class WiresTest extends WireTestCommon {
                 "  also: extra\n" +
                 "}\n";
         ThreeValues tv = Marshallable.fromString(ThreeValues.class, text);
-        assertEquals(text, tv.toString());
-        assertEquals("Hello", tv.string());
-        tv.string("Hello World");
-        assertEquals("Hello World", tv.string());
+        assertNull(tv);
+    }
 
-        assertEquals(123, tv.num());
-        tv.num(1234);
-        assertEquals(1234, tv.num());
 
-        assertEquals(1e6, tv.big(), 0.0);
-        tv.big(0.128);
-        assertEquals(0.128, tv.big(), 0.0);
+    @Test
+    public void unknownType3WarnThrows() {
+        expectException("Cannot find a class for FourValues are you missing an alias?");
+        expectException("Found this$0, in class net.openhft.chronicle.wire.WiresTest$ThreeValuesPOJO which will be ignored!");
+        wiresThrowCNFRE(false);
+        Wires.GENERATE_TUPLES = false;
 
-        assertEquals("!FourValues {\n" +
-                "  string: Hello World,\n" +
-                "  num: !int 1234,\n" +
-                "  big: 0.128,\n" +
+        String text = "!FourValues {\n" +
+                "  string: Hello,\n" +
+                "  num: 123,\n" +
+                "  big: 1E6,\n" +
                 "  also: extra\n" +
+                "}\n";
+        ThreeValuesPOJO tv = Marshallable.fromString(ThreeValuesPOJO.class, text);
+        assertEquals("Hello", tv.string);
+        assertEquals(123, tv.num);
+        assertEquals(1e6, tv.big, 0.0);
+
+        ClassAliasPool.CLASS_ALIASES.addAlias(ThreeValuesPOJO.class);
+        assertEquals("!ThreeValuesPOJO {\n" +
+                "  string: Hello,\n" +
+                "  num: 123,\n" +
+                "  big: 1E6\n" +
                 "}\n", tv.toString());
     }
 
@@ -302,6 +313,12 @@ public class WiresTest extends WireTestCommon {
         ThreeValues big(double d);
 
         double big();
+    }
+
+    class ThreeValuesPOJO extends SelfDescribingMarshallable{
+        String string;
+        int num;
+        double big;
     }
 
     private static final class BytesContainer {

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/CNFREOnMissingClassTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/CNFREOnMissingClassTest.java
@@ -140,8 +140,6 @@ public class CNFREOnMissingClassTest extends WireTestCommon {
     public void throwClassNotFoundRuntimeExceptionOnMissingClassForInterfaceFieldNoFallback() {
         // expect the warnings that will occur due to class not being found
         expectException("Cannot find a class for ThisListenerClassDoesntExist");
-        expectException("Unable to load ThisListenerClassDoesntExist");
-        expectException("Unable to parse field: engineListener");
         testInterfaceFieldTest0(false, false, "!UsesInterfaceField {\n" +
                 "  name: henry\n" +
                 "}\n");

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/CNFREOnMissingClassTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/CNFREOnMissingClassTest.java
@@ -136,9 +136,15 @@ public class CNFREOnMissingClassTest extends WireTestCommon {
      * Tests if ClassNotFoundRuntimeException is correctly thrown for an interface field with no fallback,
      * when the class for the interface is missing.
      */
-    @Test(expected = ClassNotFoundRuntimeException.class)
+    @Test
     public void throwClassNotFoundRuntimeExceptionOnMissingClassForInterfaceFieldNoFallback() {
-        testInterfaceFieldTest0(false, false, null);
+        // expect the warnings that will occur due to class not being found
+        expectException("Cannot find a class for ThisListenerClassDoesntExist");
+        expectException("Unable to load ThisListenerClassDoesntExist");
+        expectException("Unable to parse field: engineListener");
+        testInterfaceFieldTest0(false, false, "!UsesInterfaceField {\n" +
+                "  name: henry\n" +
+                "}\n");
     }
 
 

--- a/src/test/java/net/openhft/chronicle/wire/method/VanillaMethodReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/VanillaMethodReaderTest.java
@@ -269,8 +269,9 @@ public class VanillaMethodReaderTest extends WireTestCommon {
         assertEquals(text, wire2.toString());
     }
 
-    @Test(expected = ClassNotFoundRuntimeException.class)
-    public void testUnknownClassCNFREInterface() {
+    @Test
+    public void testUnknownClassNoCNFREInterface() {
+        expectException("Cannot find a class for UnknownClass are you missing an alias?");
         WiresTest.wiresThrowCNFRE(false);
         Wires.GENERATE_TUPLES = false;
 
@@ -297,7 +298,11 @@ public class VanillaMethodReaderTest extends WireTestCommon {
         assertTrue(reader.readOne());
         assertTrue(reader.readOne());
         assertFalse(reader.readOne());
-        assertEquals(text, wire2.toString());
+        assertEquals("" +
+                "top: !!null \"\"\n" +
+                "...\n" +
+                "top: !!null \"\"\n" +
+                "...\n", wire2.toString());
     }
 
     @Test


### PR DESCRIPTION
IIn this proposed change, CNFE is not thrown automatically for an interface field, allowing warnings and silent failure.

Modified throwClassNotFoundRuntimeExceptionOnMissingClassForInterfaceFieldNoFallback to not expect exception.