### PR TITLE
Allow suppression of CNFE for interface fields

### DIFF
--- a/src/test/java/net/openhft/chronicle/wire/marshallable/CNFREOnMissingClassTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/CNFREOnMissingClassTest.java
@@ -133,10 +133,10 @@ public class CNFREOnMissingClassTest extends WireTestCommon {
     }
 
     /**
-     * Tests if ClassNotFoundRuntimeException is correctly thrown for an interface field with no fallback,
-     * when the class for the interface is missing.
+     * Tests if ClassNotFoundRuntimeException is suppressed for an interface field with no fallback,
+     * when the class for the interface is missing, and Wires CNFE property is set to false.
      */
-    @Test(expected = ClassNotFoundRuntimeException.class)
+    @Test
     public void throwClassNotFoundRuntimeExceptionOnMissingClassForInterfaceFieldNoFallback() {
         testInterfaceFieldTest0(false, false, null);
     }


### PR DESCRIPTION
When class.not.found.for.missing.class.alias is set to false, no CNFE should be thrown for an interface field set to a missing class name. This allows the user to optionally suppress CNFE behaviour.