### PR TITLE
Added a @ShortText specifically designed to encode short strings.

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/Base85LongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/Base85LongConverter.java
@@ -18,35 +18,41 @@
 package net.openhft.chronicle.wire;
 
 /**
- * Provides a Base85 encoding scheme for converting long values into a string representation.
+ * Provides a Base85 encoding scheme, converting long values to a string representation.
+ * NOTE: This is intended for encoding numbers into text so that small non-negative numbers produce short strings.
+ * Notably, leading zero are truncated. In particular, 0 is encoded as an empty string.
+ * <p>
+ * If you need to encode text as a long value, refer to {@link ShortTextLongConverter}.
  * <p>
  * Base85 is a binary-to-text encoding scheme that represents binary data in an ASCII string format.
- * It uses a set of 85 characters to represent the data, which can result in a more compact
+ * It uses a set of 85 printable characters to represent the data, which can result in a more compact
  * representation compared to Base64, especially for larger data sizes.
- * </p>
- *
  * <p>
  * This implementation uses a custom character set that includes punctuation, numbers,
  * uppercase letters, lowercase letters, and special characters, ensuring a wider range of
  * encoded values.
- * </p>
  *
  * @see AbstractLongConverter
+ * @see ShortTextLongConverter
  */
 public class Base85LongConverter extends AbstractLongConverter {
 
     /**
-     * Maximum length of the parsed string.
+     * Defines the maximum length of strings that can be parsed by this converter.
+     * The value is set to 10, considering the encoding efficiency of Base85.
      */
     public static final int MAX_LENGTH = 10;
 
     /**
-     * Shared instance of Base85LongConverter for ease of use.
+     * Provides a readily available instance of Base85LongConverter for ease of use.
+     * This shared instance simplifies the usage pattern by avoiding repeated instantiation.
      */
     public static final Base85LongConverter INSTANCE = new Base85LongConverter();
 
     /**
-     * Custom set of characters used for the Base85 encoding.
+     * Specifies the custom character set used for Base85 encoding in this implementation.
+     * The character set includes a mix of digits, uppercase and lowercase letters, punctuation,
+     * and special symbols, enabling a broad range of encoded outputs.
      */
     private static final String CHARS = "" +
             "0123456789" +
@@ -57,7 +63,7 @@ public class Base85LongConverter extends AbstractLongConverter {
 
     /**
      * Private constructor to prevent external instantiation.
-     * Initializes the converter with the custom Base85 character set.
+     * Initializes the converter with the defined custom Base85 character set.
      */
     private Base85LongConverter() {
         super(CHARS);
@@ -74,13 +80,13 @@ public class Base85LongConverter extends AbstractLongConverter {
     }
 
     /**
-     * Specifies that not all characters are safe for the given {@code wireOut}.
+     * Indicates whether all characters in the custom Base85 character set are safe for the given output context.
+     * In this implementation, not all characters are considered safe.
      *
-     * @param wireOut the output for which the safety of characters is checked.
-     * @return always returns {@code false} indicating not all characters are safe.
+     * @return always {@code false}, denoting that not all characters are safe for all contexts.
      */
     @Override
-    public boolean allSafeChars(WireOut wireOut) {
+    public boolean allSafeChars() {
         return false;
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/LongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/LongConverter.java
@@ -149,7 +149,19 @@ public interface LongConverter {
      * @param wireOut The WireOut instance to check.
      * @return {@code true} if no characters need escaping or additional quoting for YAML, {@code false} otherwise.
      */
+    @Deprecated(/* to be removed in x.27 */)
     default boolean allSafeChars(WireOut wireOut) {
+        return allSafeChars();
+    }
+
+    /**
+     * Checks if the characters used are "safe",
+     * meaning they don't require additional quoting or escaping, especially in contexts
+     * like YAML serialization.
+     *
+     * @return {@code true} if no characters need escaping or additional quoting for JSON or YAML, {@code false} otherwise.
+     */
+    default boolean allSafeChars() {
         return true;
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/ShortTextLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/ShortTextLongConverter.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2016-2020 chronicle.software
+ *
+ *       https://chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.openhft.chronicle.wire;
+
+/**
+ * Implements a Base 85 encoding scheme specifically designed for converting short text strings into long values.
+ * <p>
+ * The ShortTextLongConverter is optimized for encoding text strings of up to 10 characters. It efficiently handles
+ * leading spaces by truncating them, similar to how {@link Base85LongConverter} truncates leading zeros. This feature
+ * is particularly useful in scenarios where text padding can be ignored.
+ * <p>
+ * This class employs a set of 85 characters, resulting in a more compact representation compared to traditional Base64 encoding,
+ * especially for larger data sizes. The custom character set includes a mix of punctuation, numbers, uppercase and lowercase letters,
+ * and special characters. This extensive character set ensures a wide range of possible encoded values, enhancing the versatility
+ * of the encoding process.
+ *
+ * @see AbstractLongConverter
+ * @see Base85LongConverter
+ */
+public class ShortTextLongConverter extends AbstractLongConverter {
+
+    /**
+     * Defines the maximum length of text strings that can be parsed by this converter.
+     * The value is set to 10 to optimize for short text strings, making this converter
+     * ideal for concise text encoding.
+     */
+    public static final int MAX_LENGTH = 10;
+
+    /**
+     * Provides a readily available instance of ShortTextLongConverter for ease of use.
+     * This shared instance allows for convenient access to the converter functionality
+     * without the need for repeated instantiations.
+     */
+    public static final ShortTextLongConverter INSTANCE = new ShortTextLongConverter();
+
+    /**
+     * Specifies the custom character set used for the Base85 encoding in this implementation.
+     * The character set is thoughtfully chosen to include a diverse range of symbols, letters,
+     * and digits, facilitating a robust and flexible encoding process.
+     */
+    private static final String CHARS = " " +
+            "123456789" +
+            ":;<=>?@" +
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ_" +
+            "abcdefghijklmnopqrstuvwxyz" +
+            "\"#$%&'()*+,-./0";
+
+    /**
+     * Private constructor to prevent external instantiation.
+     * Initializes the converter with the specified custom Base85 character set.
+     */
+    private ShortTextLongConverter() {
+        super(CHARS);
+    }
+
+    /**
+     * Returns the maximum number of characters that can be parsed.
+     *
+     * @return the maximum length for the parsed string
+     */
+    @Override
+    public int maxParseLength() {
+        return MAX_LENGTH;
+    }
+
+    /**
+     * Specifies that not all characters are safe for the given {@code wireOut}.
+     *
+     * @return always {@code false}, indicating that caution is required as not all characters are safe for all contexts.
+     */
+    @Override
+    public boolean allSafeChars() {
+        return false;
+    }
+}

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -604,10 +604,23 @@ public class WireMarshaller<T> {
                     longConverter.append(sb, aLong);
                     if (!write.isBinary() && sb.length() == 0)
                         write.text("");
-                    else
+                    else if (longConverter.allSafeChars() || noUnsafeChars(sb))
                         write.rawText(sb);
+                    else
+                        write.text(sb);
                 }
             }
+        }
+
+        private boolean noUnsafeChars(StringBuilder sb) {
+            int index = sb.length() - 1;
+            if (sb.charAt(0) == ' ' || sb.charAt(index) == ' ')
+                return false;
+            for (int i = 0; i < sb.length(); i++) {
+                if (":'\"#,".indexOf(sb.charAt(i)) >= 0)
+                    return false;
+            }
+            return true;
         }
 
         /**
@@ -1017,7 +1030,7 @@ public class WireMarshaller<T> {
          * Where possible, existing data structures should be preserved without reallocation to avoid garbage.
          *
          * @param defaultObject A reference unmodified instance of this class.
-         * @param o Object to reset the value in.
+         * @param o             Object to reset the value in.
          */
         protected void setDefaultValue(Object defaultObject, Object o) throws IllegalAccessException {
             copy(defaultObject, o);

--- a/src/main/java/net/openhft/chronicle/wire/converter/ShortText.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/ShortText.java
@@ -18,9 +18,9 @@
 
 package net.openhft.chronicle.wire.converter;
 
-import net.openhft.chronicle.wire.Base85LongConverter;
 import net.openhft.chronicle.wire.LongConversion;
 import net.openhft.chronicle.wire.LongConverter;
+import net.openhft.chronicle.wire.ShortTextLongConverter;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -29,11 +29,10 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation to indicate that a given field or parameter, represented as a long value,
- * should be treated as a string containing 0 to 10 characters in Base85 format.
+ * should be treated as a string containing 0 to 10 characters in Base85 format. This truncated leading spaces, but preserves leading zero c.f. {@link Base85}
  * <p>
- * Base85, also known as Ascii85, is a binary-to-ASCII encoding scheme optimized for
- * encoding binary data in a compact ASCII string format. It's particularly useful for
- * transporting binary data over text-based protocols where binary formats are not supported.
+ * Base85, also known as Ascii85, is a binary-to-ASCII encoding scheme that provides
+ * an efficient way to encode binary data for transport over text-based protocols.
  * </p>
  * <p>
  * When this annotation is applied to a field or parameter, it provides a hint about the expected format
@@ -43,27 +42,28 @@ import java.lang.annotation.Target;
  * The provided {@link #INSTANCE} is a default converter that can be used for operations relevant to the Base85 format.
  * </p>
  *
- * <b>Example:</b>
+ * <b>Usage Example:</b>
  * <pre>
  * {@code
- * @Base85
- * private long encodedData;
+ * @ShortText
+ * private long encodedText;
  * }
  * </pre>
  *
  * @see LongConverter
- * @see Base85LongConverter
+ * @see Base85
+ * @see ShortTextLongConverter
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.PARAMETER})
-@LongConversion(Base85.class)
-public @interface Base85 {
+@LongConversion(ShortText.class)
+public @interface ShortText {
 
     /**
-     * An instance of {@link Base85LongConverter} specifically configured for Base85 conversions.
-     * This converter uses a character set defined by the {@link Base85LongConverter} to represent Base85 encoded data.
+     * An instance of {@link ShortTextLongConverter} specifically configured for Base85 conversions.
+     * This converter uses a character set defined by the {@link ShortTextLongConverter} to represent Base85 encoded data.
      *
-     * @return the Base85 long converter instance.
+     * @return the specialized Base85 long converter instance for ShortText.
      */
-    LongConverter INSTANCE = Base85LongConverter.INSTANCE;
+    LongConverter INSTANCE = ShortTextLongConverter.INSTANCE;
 }

--- a/src/test/java/net/openhft/chronicle/wire/ShortTextLongConverterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ShortTextLongConverterTest.java
@@ -21,37 +21,41 @@ package net.openhft.chronicle.wire;
 import net.openhft.chronicle.bytes.Bytes;
 import org.junit.Test;
 
-import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
-public class Base85LongConverterTest extends WireTestCommon {
+public class ShortTextLongConverterTest extends WireTestCommon {
 
     private static final CharSequence TEST_STRING = "world";
 
     @Test
     public void parseLeadingZero() {
-        LongConverter c = Base85LongConverter.INSTANCE;
-        assertEquals(0L, c.parse("0"));
-        assertEquals(0L, c.parse("00"));
-        assertEquals(0L, c.parse("000"));
-        assertEquals(0L, c.parse("0000"));
-        assertEquals(0L, c.parse("00000"));
-        assertEquals(0L, c.parse("000000"));
-        assertEquals(0L, c.parse("0000000"));
-        assertEquals(0L, c.parse("00000000"));
-        assertEquals(0L, c.parse("000000000"));
-        assertEquals(0L, c.parse("0000000000"));
+        LongConverter c = ShortTextLongConverter.INSTANCE;
+        assertEquals(0L, c.parse(""));
+        assertEquals(0L, c.parse(" "));
+        assertEquals(0L, c.parse("  "));
+        assertEquals(84L, c.parse("0"));
+        assertEquals(84L, c.parse(" 0"));
+        assertEquals(7224, c.parse("00"));
+        assertEquals(7224, c.parse("  00"));
+        assertEquals(614124, c.parse("000"));
+        assertEquals(52200624, c.parse("0000"));
+        assertEquals(4437053124L, c.parse("00000"));
+        assertEquals(377149515624L, c.parse("000000"));
+        assertEquals(32057708828124L, c.parse("0000000"));
+        assertEquals(2724905250390624L, c.parse("00000000"));
+        assertEquals(231616946283203124L, c.parse("000000000"));
+        assertEquals(1240696360362714008L, c.parse("0000000000"));
         assertThrows(IllegalArgumentException.class, () -> c.parse("00000000000"));
         assertEquals("", c.asString(0L));
     }
 
     @Test
     public void parse() {
-        LongConverter c = Base85LongConverter.INSTANCE;
+        LongConverter c = ShortTextLongConverter.INSTANCE;
         // System.out.println(c.asString(-1L));
         for (String s : ",a,ab,abc,abcd,ab.de,123=56,1234567,12345678,zzzzzzzzz,+ko2&)z.0".split(",")) {
             long v = c.parse(s);
@@ -63,7 +67,7 @@ public class Base85LongConverterTest extends WireTestCommon {
 
     @Test
     public void asString() {
-        LongConverter c = Base85LongConverter.INSTANCE;
+        LongConverter c = ShortTextLongConverter.INSTANCE;
         IntStream.range(0, 10_000_000)
                 .parallel()
                 .mapToLong(i -> ThreadLocalRandom.current().nextLong())
@@ -77,7 +81,7 @@ public class Base85LongConverterTest extends WireTestCommon {
     public void testAppend() {
         final Bytes<?> b = Bytes.elasticByteBuffer();
         try {
-            final Base85LongConverter idLongConverter = Base85LongConverter.INSTANCE;
+            final LongConverter idLongConverter = ShortTextLongConverter.INSTANCE;
             final long helloWorld = idLongConverter.parse(TEST_STRING);
             idLongConverter.append(b, helloWorld);
             assertEquals(TEST_STRING, b.toString());
@@ -90,7 +94,7 @@ public class Base85LongConverterTest extends WireTestCommon {
     public void testAppendWithExistingData() {
         final Bytes<?> b = Bytes.elasticByteBuffer().append("hello");
         try {
-            final Base85LongConverter idLongConverter = Base85LongConverter.INSTANCE;
+            final LongConverter idLongConverter = ShortTextLongConverter.INSTANCE;
             final long helloWorld = idLongConverter.parse(TEST_STRING);
             idLongConverter.append(b, helloWorld);
             assertEquals("hello" + TEST_STRING, b.toString());
@@ -112,7 +116,7 @@ public class Base85LongConverterTest extends WireTestCommon {
     }
 
     private void allSafeChars(Wire wire) {
-        final Base85LongConverter converter = Base85LongConverter.INSTANCE;
+        final LongConverter converter = ShortTextLongConverter.INSTANCE;
         for (long i = 0; i <= 85 * 85; i++) {
             wire.clear();
             wire.write("a").writeLong(converter, i);

--- a/src/test/java/net/openhft/chronicle/wire/examples/Person.java
+++ b/src/test/java/net/openhft/chronicle/wire/examples/Person.java
@@ -1,14 +1,14 @@
 package net.openhft.chronicle.wire.examples;
 
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
-import net.openhft.chronicle.wire.converter.Base85;
 import net.openhft.chronicle.wire.converter.NanoTime;
+import net.openhft.chronicle.wire.converter.ShortText;
 
 public class Person extends SelfDescribingMarshallable {
     private String name;
     @NanoTime
     private long timestampNS;
-    @Base85
+    @ShortText
     private long userName;
 
     public String name() {

--- a/src/test/java/net/openhft/chronicle/wire/examples/PersonWireMain.java
+++ b/src/test/java/net/openhft/chronicle/wire/examples/PersonWireMain.java
@@ -4,7 +4,7 @@ import net.openhft.chronicle.bytes.MethodReader;
 import net.openhft.chronicle.core.pool.ClassAliasPool;
 import net.openhft.chronicle.wire.Marshallable;
 import net.openhft.chronicle.wire.Wire;
-import net.openhft.chronicle.wire.converter.Base85;
+import net.openhft.chronicle.wire.converter.ShortText;
 
 import static net.openhft.chronicle.core.time.SystemTimeProvider.CLOCK;
 
@@ -16,7 +16,7 @@ public class PersonWireMain {
         Person p1 = new Person()
                 .name("George Ball")
                 .timestampNS(CLOCK.currentTimeNanos())
-                .userName(Base85.INSTANCE.parse("georgeb"));
+                .userName(ShortText.INSTANCE.parse("georgeb"));
         System.out.println("p1: " + p1);
 
         Wire yWire = Wire.newYamlWireOnHeap();
@@ -41,7 +41,7 @@ public class PersonWireMain {
         personOps.addPerson(new Person()
                 .name("Bob Singh")
                 .timestampNS(CLOCK.currentTimeNanos())
-                .userName(Base85.INSTANCE.parse("bobs")));
+                .userName(ShortText.INSTANCE.parse("bobs")));
 
         System.out.println(yWire);
 

--- a/src/test/java/net/openhft/chronicle/wire/utils/dto/AbstractEvent.java
+++ b/src/test/java/net/openhft/chronicle/wire/utils/dto/AbstractEvent.java
@@ -5,13 +5,13 @@
 package net.openhft.chronicle.wire.utils.dto;
 
 import net.openhft.chronicle.wire.*;
-import net.openhft.chronicle.wire.converter.Base85;
 import net.openhft.chronicle.wire.converter.NanoTime;
+import net.openhft.chronicle.wire.converter.ShortText;
 
 public class AbstractEvent<E extends AbstractEvent<E>> extends SelfDescribingMarshallable {
-    @Base85
+    @ShortText
     private long sender;
-    @Base85
+    @ShortText
     private long target;
     // client sending time
     @NanoTime

--- a/src/test/java/net/openhft/chronicle/wire/utils/dto/CancelOrderRequest.java
+++ b/src/test/java/net/openhft/chronicle/wire/utils/dto/CancelOrderRequest.java
@@ -4,11 +4,11 @@
 
 package net.openhft.chronicle.wire.utils.dto;
 
-import net.openhft.chronicle.wire.converter.Base85;
+import net.openhft.chronicle.wire.converter.ShortText;
 
 public class CancelOrderRequest extends AbstractEvent<CancelOrderRequest> {
     private static final int MASHALLABLE_VERSION = 1;
-    @Base85
+    @ShortText
     private long symbol;
     private String clOrdID = "";
 

--- a/src/test/java/net/openhft/chronicle/wire/utils/dto/ExecutionReport.java
+++ b/src/test/java/net/openhft/chronicle/wire/utils/dto/ExecutionReport.java
@@ -4,12 +4,12 @@
 
 package net.openhft.chronicle.wire.utils.dto;
 
-import net.openhft.chronicle.wire.converter.Base85;
 import net.openhft.chronicle.wire.converter.NanoTime;
+import net.openhft.chronicle.wire.converter.ShortText;
 
 public class ExecutionReport extends AbstractEvent<ExecutionReport> {
     private static final int MASHALLABLE_VERSION = 1;
-    @Base85
+    @ShortText
     private long symbol;
     @NanoTime
     private long transactTime;

--- a/src/test/java/net/openhft/chronicle/wire/utils/dto/NewOrderSingle.java
+++ b/src/test/java/net/openhft/chronicle/wire/utils/dto/NewOrderSingle.java
@@ -4,12 +4,12 @@
 
 package net.openhft.chronicle.wire.utils.dto;
 
-import net.openhft.chronicle.wire.converter.Base85;
 import net.openhft.chronicle.wire.converter.NanoTime;
+import net.openhft.chronicle.wire.converter.ShortText;
 
 public class NewOrderSingle extends AbstractEvent<NewOrderSingle> {
     private static final int MASHALLABLE_VERSION = 1;
-    @Base85
+    @ShortText
     private long symbol;
     @NanoTime
     private long transactTime;

--- a/src/test/java/net/openhft/chronicle/wire/utils/dto/OrderCancelReject.java
+++ b/src/test/java/net/openhft/chronicle/wire/utils/dto/OrderCancelReject.java
@@ -4,11 +4,11 @@
 
 package net.openhft.chronicle.wire.utils.dto;
 
-import net.openhft.chronicle.wire.converter.Base85;
+import net.openhft.chronicle.wire.converter.ShortText;
 
 public class OrderCancelReject extends AbstractEvent<OrderCancelReject> {
     private static final int MASHALLABLE_VERSION = 1;
-    @Base85
+    @ShortText
     private long symbol;
     private String clOrdID = "";
     private String reason = "";

--- a/src/test/java/run/chronicle/account/AccountsTest.java
+++ b/src/test/java/run/chronicle/account/AccountsTest.java
@@ -21,7 +21,7 @@ package run.chronicle.account;
 import net.openhft.chronicle.core.time.SetTimeProvider;
 import net.openhft.chronicle.core.time.SystemTimeProvider;
 import net.openhft.chronicle.wire.WireTestCommon;
-import net.openhft.chronicle.wire.converter.Base85;
+import net.openhft.chronicle.wire.converter.ShortText;
 import net.openhft.chronicle.wire.utils.YamlAgitator;
 import net.openhft.chronicle.wire.utils.YamlTester;
 import net.openhft.chronicle.wire.utils.YamlTesterParametersBuilder;
@@ -44,7 +44,7 @@ public class AccountsTest extends WireTestCommon {
             "account/mixed",
             "account/waterfall"
     };
-    static final long VAULT = Base85.INSTANCE.parse("vault");
+    static final long VAULT = ShortText.INSTANCE.parse("vault");
 
     final String name;
     final YamlTester tester;

--- a/src/test/java/run/chronicle/account/dto/AbstractEvent.java
+++ b/src/test/java/run/chronicle/account/dto/AbstractEvent.java
@@ -21,13 +21,13 @@ package run.chronicle.account.dto;
 import net.openhft.chronicle.core.io.InvalidMarshallableException;
 import net.openhft.chronicle.core.io.Validatable;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
-import net.openhft.chronicle.wire.converter.Base85;
 import net.openhft.chronicle.wire.converter.NanoTime;
+import net.openhft.chronicle.wire.converter.ShortText;
 
 public class AbstractEvent<E extends AbstractEvent<E>> extends SelfDescribingMarshallable implements Validatable {
-    @Base85
+    @ShortText
     private long sender;
-    @Base85
+    @ShortText
     private long target;
     // time sent
     @NanoTime

--- a/src/test/java/run/chronicle/account/dto/AccountStatus.java
+++ b/src/test/java/run/chronicle/account/dto/AccountStatus.java
@@ -19,12 +19,12 @@
 package run.chronicle.account.dto;
 
 import net.openhft.chronicle.core.io.InvalidMarshallableException;
-import net.openhft.chronicle.wire.converter.Base85;
+import net.openhft.chronicle.wire.converter.ShortText;
 
 public class AccountStatus extends AbstractEvent<AccountStatus> {
     private String name;
     private long account;
-    @Base85
+    @ShortText
     private int currency;
     private double amount;
 

--- a/src/test/java/run/chronicle/account/dto/AccountStatusFailedTest.java
+++ b/src/test/java/run/chronicle/account/dto/AccountStatusFailedTest.java
@@ -1,7 +1,7 @@
 package run.chronicle.account.dto;
 
 import net.openhft.chronicle.wire.Marshallable;
-import net.openhft.chronicle.wire.converter.Base85;
+import net.openhft.chronicle.wire.converter.ShortText;
 import org.junit.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -26,8 +26,8 @@ public class AccountStatusFailedTest {
                 "  },\n" +
                 "  reason: reasons\n" +
                 "}");
-        assertEquals("sender", Base85.INSTANCE.asString(asf.sender()));
-        assertEquals("target", Base85.INSTANCE.asString(asf.target()));
+        assertEquals("sender", ShortText.INSTANCE.asString(asf.sender()));
+        assertEquals("target", ShortText.INSTANCE.asString(asf.target()));
         assertEquals("reasons", asf.reason());
         assertEquals(getAccountStatus(), asf.accountStatus());
     }

--- a/src/test/java/run/chronicle/account/dto/AccountStatusOKTest.java
+++ b/src/test/java/run/chronicle/account/dto/AccountStatusOKTest.java
@@ -1,7 +1,7 @@
 package run.chronicle.account.dto;
 
 import net.openhft.chronicle.wire.Marshallable;
-import net.openhft.chronicle.wire.converter.Base85;
+import net.openhft.chronicle.wire.converter.ShortText;
 import org.junit.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,8 +25,8 @@ public class AccountStatusOKTest {
                 "    amount: 1.0" +
                 "  }\n" +
                 "}");
-        assertEquals("sender", Base85.INSTANCE.asString(asf.sender()));
-        assertEquals("target", Base85.INSTANCE.asString(asf.target()));
+        assertEquals("sender", ShortText.INSTANCE.asString(asf.sender()));
+        assertEquals("target", ShortText.INSTANCE.asString(asf.target()));
         assertEquals(getAccountStatus(), asf.accountStatus());
     }
 

--- a/src/test/java/run/chronicle/account/dto/AccountStatusTest.java
+++ b/src/test/java/run/chronicle/account/dto/AccountStatusTest.java
@@ -1,7 +1,7 @@
 package run.chronicle.account.dto;
 
-import net.openhft.chronicle.wire.converter.Base85;
 import net.openhft.chronicle.wire.converter.NanoTime;
+import net.openhft.chronicle.wire.converter.ShortText;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -24,12 +24,12 @@ public class AccountStatusTest {
 
     static AccountStatus getAccountStatus() {
         return new AccountStatus()
-                .sender(Base85.INSTANCE.parse("sender"))
-                .target(Base85.INSTANCE.parse("target"))
+                .sender(ShortText.INSTANCE.parse("sender"))
+                .target(ShortText.INSTANCE.parse("target"))
                 .sendingTime(NanoTime.INSTANCE.parse("2001/02/03T04:05:06.007008009"))
                 .amount(1)
                 .account(2)
-                .currency((int) Base85.INSTANCE.parse("CURR"))
+                .currency((int) ShortText.INSTANCE.parse("CURR"))
                 .name("name");
     }
 }

--- a/src/test/java/run/chronicle/account/dto/Transfer.java
+++ b/src/test/java/run/chronicle/account/dto/Transfer.java
@@ -20,11 +20,11 @@ package run.chronicle.account.dto;
 
 import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.core.io.InvalidMarshallableException;
-import net.openhft.chronicle.wire.converter.Base85;
+import net.openhft.chronicle.wire.converter.ShortText;
 
 public class Transfer extends AbstractEvent<Transfer> {
     private long from, to;
-    @Base85
+    @ShortText
     private int currency;
     private double amount;
     private Bytes reference = Bytes.allocateElasticOnHeap();

--- a/src/test/java/run/chronicle/account/dto/TransferFailedTest.java
+++ b/src/test/java/run/chronicle/account/dto/TransferFailedTest.java
@@ -1,8 +1,8 @@
 package run.chronicle.account.dto;
 
 import net.openhft.chronicle.wire.Marshallable;
-import net.openhft.chronicle.wire.converter.Base85;
 import net.openhft.chronicle.wire.converter.NanoTime;
+import net.openhft.chronicle.wire.converter.ShortText;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -31,8 +31,8 @@ public class TransferFailedTest {
     public void testToString() {
         assertEquals(EXPECTED,
                 new TransferFailed()
-                        .target(Base85.INSTANCE.parse("sender"))
-                        .sender(Base85.INSTANCE.parse("target"))
+                        .target(ShortText.INSTANCE.parse("sender"))
+                        .sender(ShortText.INSTANCE.parse("target"))
                         .sendingTime(NanoTime.INSTANCE.parse("2001/02/03T04:05:06.777888999"))
                         .reason("reasons")
                         .transfer(TransferTest.getTransfer())

--- a/src/test/java/run/chronicle/account/dto/TransferOKTest.java
+++ b/src/test/java/run/chronicle/account/dto/TransferOKTest.java
@@ -1,8 +1,8 @@
 package run.chronicle.account.dto;
 
 import net.openhft.chronicle.wire.Marshallable;
-import net.openhft.chronicle.wire.converter.Base85;
 import net.openhft.chronicle.wire.converter.NanoTime;
+import net.openhft.chronicle.wire.converter.ShortText;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -31,8 +31,8 @@ public class TransferOKTest {
     public void testToString() {
         assertEquals(EXPECTED,
                 new TransferOK()
-                        .target(Base85.INSTANCE.parse("sender"))
-                        .sender(Base85.INSTANCE.parse("target"))
+                        .target(ShortText.INSTANCE.parse("sender"))
+                        .sender(ShortText.INSTANCE.parse("target"))
                         .sendingTime(NanoTime.INSTANCE.parse("2001/02/03T04:05:06.777888999"))
                         .transfer(getTransfer())
                         .toString());

--- a/src/test/java/run/chronicle/account/dto/TransferTest.java
+++ b/src/test/java/run/chronicle/account/dto/TransferTest.java
@@ -1,8 +1,8 @@
 package run.chronicle.account.dto;
 
 import net.openhft.chronicle.bytes.Bytes;
-import net.openhft.chronicle.wire.converter.Base85;
 import net.openhft.chronicle.wire.converter.NanoTime;
+import net.openhft.chronicle.wire.converter.ShortText;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -10,11 +10,11 @@ import static org.junit.Assert.assertEquals;
 public class TransferTest {
     static Transfer getTransfer() {
         return new Transfer()
-                .sender(Base85.INSTANCE.parse("sender"))
-                .target(Base85.INSTANCE.parse("target"))
+                .sender(ShortText.INSTANCE.parse("sender"))
+                .target(ShortText.INSTANCE.parse("target"))
                 .sendingTime(NanoTime.INSTANCE.parse("2001/02/03T04:05:06.007008009"))
                 .amount(1)
-                .currency((int) Base85.INSTANCE.parse("CURR"))
+                .currency((int) ShortText.INSTANCE.parse("CURR"))
                 .from(12345)
                 .to(67890)
                 .reference(Bytes.from("reference"));


### PR DESCRIPTION
`@Base85` is designed for encoding numbers as short strings.
This is designed to encode short strings including leading zeros as long.

Closes https://github.com/OpenHFT/Chronicle-Wire/issues/649