### PR TITLE
Optimise length check BinaryWire.text(CharSequence) #848

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -1499,8 +1499,8 @@ public class BinaryWire extends AbstractWire implements Wire {
             } else {
                 if (bytes.retainedHexDumpDescription())
                     bytes.writeHexDumpDescription(s);
-                long utflen = AppendableUtil.findUtf8Length(s);
-                if (utflen < 0x20) {
+                long utflen;
+                if (s.length() < 0x20 && (utflen = AppendableUtil.findUtf8Length(s)) < 0x20) {
                     bytes.writeUnsignedByte((int) (STRING_0 + utflen)).appendUtf8(s);
                 } else {
                     writeCode(STRING_ANY);


### PR DESCRIPTION
Fixes #848 