### PR TITLE
Added test demonstrating sb not clearing after TextWire#readLength

### DIFF
--- a/src/test/java/net/openhft/chronicle/wire/marshallable/MarshallingJSONStringTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/MarshallingJSONStringTest.java
@@ -1,0 +1,43 @@
+package net.openhft.chronicle.wire.marshallable;
+
+import net.openhft.chronicle.core.io.IORuntimeException;
+import net.openhft.chronicle.core.io.InvalidMarshallableException;
+import net.openhft.chronicle.wire.Marshallable;
+import net.openhft.chronicle.wire.WireIn;
+import net.openhft.chronicle.wire.WireOut;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+
+public class MarshallingJSONStringTest implements Marshallable {
+
+    private String configAsJSON;
+
+    @Override
+    public void writeMarshallable(@NotNull final WireOut wire) throws InvalidMarshallableException {
+        wire.write("config").text(configAsJSON);
+    }
+
+    @Override
+    public void readMarshallable(@NotNull final WireIn wire) throws IORuntimeException, InvalidMarshallableException {
+        configAsJSON = wire.read("config").text();
+    }
+
+    @Test
+    public void testNoPrefixAddedToJson() {
+
+        String configJson = "!net.openhft.chronicle.wire.marshallable.MarshallingJSONStringTest {\n" +
+                "  config: {\n" +
+                "    \"username\": \"sampleApp\",\n" +
+                "    \"password\": \"samplePassword\",\n" +
+                "    \"publishPort\": 4021,\n" +
+                "    \"subscribePort\": 4024,\n" +
+                "  }\n" +
+                "}";
+
+        MarshallingJSONStringTest read = Marshallable.fromString(configJson);
+        assertFalse(read.configAsJSON.startsWith("4024"));
+    }
+
+}


### PR DESCRIPTION
It appears that TextWire#readLength (called as part of converting a ValueIn to text) has a side effect of leaving the string buffer set to the last read value, and that value is then prepended to the converted text.