### PR TITLE
Added exploratory fix for MarshallingJSONStringTest

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -1670,6 +1670,8 @@ public class TextWire extends YamlWireOut<TextWire> {
                 // Reset the consumption flag and reading position
                 this.consumeAny = false;
                 bytes.readPosition(start);
+                // @TODO - use ScopedResource<StringBuilder> for consistency throughout YamlWireOut - https://github.com/OpenHFT/Chronicle-Wire/issues/879
+                sb.setLength(0);
             }
         }
 

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/MarshallingJSONStringTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/MarshallingJSONStringTest.java
@@ -1,0 +1,43 @@
+package net.openhft.chronicle.wire.marshallable;
+
+import net.openhft.chronicle.core.io.IORuntimeException;
+import net.openhft.chronicle.core.io.InvalidMarshallableException;
+import net.openhft.chronicle.wire.Marshallable;
+import net.openhft.chronicle.wire.WireIn;
+import net.openhft.chronicle.wire.WireOut;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+
+public class MarshallingJSONStringTest implements Marshallable {
+
+    private String configAsJSON;
+
+    @Override
+    public void writeMarshallable(@NotNull final WireOut wire) throws InvalidMarshallableException {
+        wire.write("config").text(configAsJSON);
+    }
+
+    @Override
+    public void readMarshallable(@NotNull final WireIn wire) throws IORuntimeException, InvalidMarshallableException {
+        configAsJSON = wire.read("config").text();
+    }
+
+    @Test
+    public void testNoPrefixAddedToJson() {
+
+        String configJson = "!net.openhft.chronicle.wire.marshallable.MarshallingJSONStringTest {\n" +
+                "  config: {\n" +
+                "    \"username\": \"sampleApp\",\n" +
+                "    \"password\": \"samplePassword\",\n" +
+                "    \"publishPort\": 4021,\n" +
+                "    \"subscribePort\": 4024,\n" +
+                "  }\n" +
+                "}";
+
+        MarshallingJSONStringTest read = Marshallable.fromString(configJson);
+        assertFalse(read.configAsJSON.startsWith("4024"));
+    }
+
+}

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/MarshallingJSONStringTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/MarshallingJSONStringTest.java
@@ -8,6 +8,7 @@ import net.openhft.chronicle.wire.WireOut;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 public class MarshallingJSONStringTest implements Marshallable {
@@ -35,9 +36,15 @@ public class MarshallingJSONStringTest implements Marshallable {
                 "    \"subscribePort\": 4024,\n" +
                 "  }\n" +
                 "}";
+        String expectedJson = "{\n" +
+        "    \"username\": \"sampleApp\",\n" +
+                "    \"password\": \"samplePassword\",\n" +
+                "    \"publishPort\": 4021,\n" +
+                "    \"subscribePort\": 4024,\n" +
+                "  }";
 
         MarshallingJSONStringTest read = Marshallable.fromString(configJson);
-        assertFalse(read.configAsJSON.startsWith("4024"));
+        assertEquals(expectedJson, read.configAsJSON);
     }
 
 }


### PR DESCRIPTION
StringBuffer length is now reset at end of readLength, clearing StringBuffer.