### PR TITLE
Remove old check.thread.safety property

### DIFF
--- a/demo/system.properties
+++ b/demo/system.properties
@@ -19,7 +19,6 @@
 # Tracing if resources are closed/released correctly.
 jvm.resource.tracing=true
 disable.resource.warning=true
-check.thread.safety=true
 # for profiling
 jvm.safepoint.enabled=false
 wire.generate.v2=false

--- a/marshallingperf/system.properties
+++ b/marshallingperf/system.properties
@@ -18,7 +18,6 @@
 
 # Tracing if resources are closed/released correctly.
 jvm.resource.tracing=false
-check.thread.safety=false
 # for profiling
 jvm.safepoint.enabled=false
 wire.generate.v2=false

--- a/microbenchmarks/system.properties
+++ b/microbenchmarks/system.properties
@@ -18,7 +18,6 @@
 
 # Tracing if resources are closed/released correctly.
 jvm.resource.tracing=false
-check.thread.safety=false
 # for profiling
 jvm.safepoint.enabled=false
 # reduce logging of the announcer

--- a/src/test/java/net/openhft/chronicle/wire/TriviallyCopyableJLBH.java
+++ b/src/test/java/net/openhft/chronicle/wire/TriviallyCopyableJLBH.java
@@ -51,7 +51,6 @@ public class TriviallyCopyableJLBH implements JLBHTask {
         CLASS_ALIASES.addAlias(House.class, "House2");
         System.setProperty("disable.thread.safety", "true");
         System.setProperty("jvm.resource.tracing", "false");
-        System.setProperty("check.thread.safety", "false");
     }
 
     public interface BaseHouse {

--- a/system.properties
+++ b/system.properties
@@ -19,7 +19,6 @@
 # Tracing if resources are closed/released correctly.
 jvm.resource.tracing=true
 disable.resource.warning=true
-check.thread.safety=true
 disable.discard.warning=false
 # for profiling
 jvm.safepoint.enabled=false


### PR DESCRIPTION
The check.thread.saftety property has not been used for a while. Removing references to it.