### PR TITLE
Backport add config loader to 2.25

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/utils/ConfigLoader.java
+++ b/src/main/java/net/openhft/chronicle/wire/utils/ConfigLoader.java
@@ -1,0 +1,63 @@
+package net.openhft.chronicle.wire.utils;
+
+import net.openhft.chronicle.core.io.IOTools;
+import net.openhft.chronicle.wire.TextWire;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+import static net.openhft.chronicle.bytes.util.PropertyReplacer.replaceTokensWithProperties;
+
+/**
+ * Utility class for loading configuration files in YAML format. The class provides methods to load configuration
+ * files in YAML format from the classpath and convert them to Java objects. The class will replace
+ * tokens in the format {@code ${property}} within strings with System properties or supplied properties.
+ * <p>
+ * Files must be in YAML format that conform to WireType.TEXT. For example:
+ * <pre>{@code
+ *   !SimpleConfig {
+ *      name: "some name",
+ *      value: 10,
+ *   }
+ * }</pre>
+ * <p>
+ * The class must be fully qualified or added to the {@link net.openhft.chronicle.core.pool.ClassAliasPool} to
+ * enable the conversion.
+ * <pre>
+ * {@code ClassAliasPool.CLASS_ALIASES.addAlias(SimpleConfig.class);}
+ * </pre>
+ */
+public enum ConfigLoader {
+    ; // none
+
+    public static String loadFile(Class<?> classLoader, String filename) throws IOException {
+        return new String(IOTools.readFile(classLoader, filename), StandardCharsets.UTF_8);
+    }
+
+    public static <T> T loadFromFile(String filename) throws IOException {
+        return loadFromFile(ConfigLoader.class, filename);
+    }
+
+    public static <T> T loadFromFile(Class<?> classLoader, String filename) throws IOException {
+        return load(loadFile(classLoader, filename));
+    }
+
+    public static <T> T loadFromFile(String filename, Properties properties) throws IOException {
+        return loadFromFile(ConfigLoader.class, filename, properties);
+    }
+
+    public static <T> T loadFromFile(Class<?> classLoader, String filename, Properties properties) throws IOException {
+        return loadWithProperties(loadFile(classLoader, filename), properties);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T load(String fileAsString) {
+        return  (T) TextWire.from(replaceTokensWithProperties(fileAsString)).readObject();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T loadWithProperties(String fileAsString, Properties properties) {
+        return (T) TextWire.from(replaceTokensWithProperties(fileAsString, properties)).readObject();
+    }
+}

--- a/src/test/java/net/openhft/chronicle/wire/utils/ConfigLoaderTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/utils/ConfigLoaderTest.java
@@ -1,0 +1,59 @@
+package net.openhft.chronicle.wire.utils;
+
+import net.openhft.chronicle.core.pool.ClassAliasPool;
+import net.openhft.chronicle.wire.AbstractMarshallableCfg;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ConfigLoaderTest {
+    static {
+        ClassAliasPool.CLASS_ALIASES.addAlias(SimpleConfig.class);
+    }
+
+    @Test
+    void testLoadFromFile() throws IOException {
+
+        SimpleConfig config = ConfigLoader.loadFromFile("utils/simple-config.yaml");
+        assertEquals("some name", config.name());
+        assertEquals(10, config.value());
+    }
+
+    @Test
+    void testLoadFromFileWithProperties() throws IOException {
+        Properties properties = new Properties();
+        properties.put("config-name", "some name");
+        SimpleConfig config = ConfigLoader.loadFromFile("utils/simple-config-properties.yaml", properties);
+        assertEquals("some name", config.name());
+        assertEquals(10, config.value());
+    }
+
+    static class SimpleConfig extends AbstractMarshallableCfg {
+        private String name;
+        private int value;
+
+        @SuppressWarnings("unused")
+        public SimpleConfig() {
+        }
+
+        public String name() {
+            return name;
+        }
+
+        public int value() {
+            return value;
+        }
+
+        public void name(String name) {
+            this.name = name;
+        }
+
+        public void value(int value) {
+            this.value = value;
+        }
+    }
+
+}

--- a/src/test/resources/utils/simple-config-properties.yaml
+++ b/src/test/resources/utils/simple-config-properties.yaml
@@ -1,0 +1,4 @@
+!SimpleConfig {
+    name: ${config-name},
+    value: 10,
+}

--- a/src/test/resources/utils/simple-config.yaml
+++ b/src/test/resources/utils/simple-config.yaml
@@ -1,0 +1,4 @@
+!SimpleConfig {
+    name: "some name",
+    value: 10,
+}


### PR DESCRIPTION
Add ConfigLoader as a common way to load yaml based configuration files. closes #911