### PR TITLE
Added the the service name to the message history

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/MessageHistory.java
+++ b/src/main/java/net/openhft/chronicle/wire/MessageHistory.java
@@ -150,10 +150,10 @@ public interface MessageHistory extends Marshallable {
     boolean isDirty();
 
     /**
-     * @return the name of the service that last wrote the message history
+     * @return the name of the service that last wrote the message history, or empty string if not set.
      */
     default CharSequence serviceName() {
-        return null;
+        return "";
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/MessageHistory.java
+++ b/src/main/java/net/openhft/chronicle/wire/MessageHistory.java
@@ -148,4 +148,17 @@ public interface MessageHistory extends Marshallable {
      * {@link Marshallable#writeMarshallable(net.openhft.chronicle.wire.WireOut)}
      */
     boolean isDirty();
+
+    /**
+     * @return the name of the service that last wrote the message history
+     */
+    default CharSequence serviceName() {
+        return null;
+    }
+
+    /**
+     * sets the name of the current service
+     */
+    default void serviceName(long serviceName) {
+    }
 }

--- a/src/main/java/net/openhft/chronicle/wire/VanillaMessageHistory.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMessageHistory.java
@@ -23,6 +23,7 @@ import net.openhft.chronicle.core.OS;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.io.InvalidMarshallableException;
 import net.openhft.chronicle.wire.converter.NanoTime;
+import net.openhft.chronicle.wire.converter.ShortText;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -81,6 +82,16 @@ public class VanillaMessageHistory extends SelfDescribingMarshallable implements
 
     // Flag to decide if source details should be added or not
     private boolean addSourceDetails = false;
+
+
+    // the name of the service that was used to write the message history
+    @ShortText
+    private long serviceName;
+
+    // the name of our-service that we use to read the history message
+    // this name will be used in the next write
+    @ShortText
+    private transient long ourServiceName;
 
     /**
      * Returns the thread-local instance of {@link MessageHistory}.
@@ -242,12 +253,14 @@ public class VanillaMessageHistory extends SelfDescribingMarshallable implements
 
     @Override
     public void writeMarshallable(@NotNull WireOut wire) {
+        serviceName = ourServiceName;
         if (useBytesMarshallable && wire.isBinary()) {
             wire.bytes().writeUnsignedByte(BinaryWireCode.HISTORY_MESSAGE);
             writeMarshallable(wire.bytes());
         } else {
             wire.write("sources").sequence(this, acceptSourcesConsumer);
             wire.write("timings").sequence(this, acceptTimingsConsumer);
+            wire.write("serviceName").int64(serviceName);
         }
         dirty = false;
     }
@@ -264,6 +277,7 @@ public class VanillaMessageHistory extends SelfDescribingMarshallable implements
         } else {
             readMarshallable0(bytes);
         }
+        serviceName = bytes.readRemaining() >= 8 ? bytes.readLong() : 0;
         assert !addSourceDetails : "Bytes marshalling does not yet support addSourceDetails";
     }
 
@@ -304,6 +318,7 @@ public class VanillaMessageHistory extends SelfDescribingMarshallable implements
 
     @Override
     public void writeMarshallable(@NotNull BytesOut<?> b) {
+        serviceName = ourServiceName;
         if (b.canWriteDirect(MAX_LENGTH)) {
             writeMarshallableDirect(b);
         } else {
@@ -331,6 +346,8 @@ public class VanillaMessageHistory extends SelfDescribingMarshallable implements
         }
         memory.writeLong(addr, nanoTime()); // add time for this output
         addr += 8;
+        memory.writeLong(addr, serviceName); // add time for this output
+        addr += 8;
         b.writeSkip(addr - start);
     }
 
@@ -349,6 +366,7 @@ public class VanillaMessageHistory extends SelfDescribingMarshallable implements
             bytes.writeLong(timingsArray[i]);
         }
         bytes.writeLong(nanoTime()); // add time for this output
+        bytes.writeLong(serviceName);
         dirty = false;
     }
 
@@ -364,8 +382,8 @@ public class VanillaMessageHistory extends SelfDescribingMarshallable implements
     /**
      * Writes the sources information of the provided message history to the output.
      *
-     * @param t    Message history instance with the source's data.
-     * @param out  Output to write the sources data to.
+     * @param t   Message history instance with the source's data.
+     * @param out Output to write the sources data to.
      */
     private void acceptSources(VanillaMessageHistory t, ValueOut out) {
         HexDumpBytesDescription<?> b = bytesComment(out);
@@ -381,8 +399,8 @@ public class VanillaMessageHistory extends SelfDescribingMarshallable implements
     /**
      * Writes the timings information of the provided message history to the output.
      *
-     * @param t    Message history instance with the timing's data.
-     * @param out  Output to write the timings data to.
+     * @param t   Message history instance with the timing's data.
+     * @param out Output to write the timings data to.
      */
     private void acceptTimings(VanillaMessageHistory t, ValueOut out) {
         HexDumpBytesDescription<?> b = bytesComment(out);
@@ -522,5 +540,15 @@ public class VanillaMessageHistory extends SelfDescribingMarshallable implements
 
     public void historyWallClock(boolean historyWallClock) {
         this.historyWallClock = historyWallClock;
+    }
+
+    @Override
+    public CharSequence serviceName() {
+        return ShortText.INSTANCE.asString(serviceName); // this will create GC, please don't call it ! too often.
+    }
+
+    @Override
+    public void serviceName(long serviceName) {
+        this.ourServiceName = serviceName;
     }
 }

--- a/src/test/java/net/openhft/chronicle/wire/MessageHistoryTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MessageHistoryTest.java
@@ -154,7 +154,7 @@ public class MessageHistoryTest extends WireTestCommon {
             bw.writeEventName(MethodReader.HISTORY).marshallable(history);
             assertEquals("" +
                             "b9 07 68 69 73 74 6f 72 79                      # history: (event)\n" +
-                            "81 4b 00                                        # SetTimeMessageHistory\n" +
+                            "81 59 00                                        # SetTimeMessageHistory\n" +
                             "c7 73 6f 75 72 63 65 73                         # sources:\n" +
                             "82 16 00 00 00                                  # sequence\n" +
                             "                                                # source id & index\n" +
@@ -167,7 +167,9 @@ public class MessageHistoryTest extends WireTestCommon {
                             "a7 00 00 64 a7 b3 b6 e0 0d                      # 1000000000000000000\n" +
                             "                                                # timing in nanos\n" +
                             "a7 10 27 64 a7 b3 b6 e0 0d                      # 1000000000000010000\n" +
-                            "a7 64 0c 2c b5 03 6e 00 00                      # 120962203520100\n",
+                            "a7 64 0c 2c b5 03 6e 00 00                      # 120962203520100\n" +
+                            "cb 73 65 72 76 69 63 65 4e 61 6d 65             # serviceName:\n" +
+                            "a1 00                                           # 0\n",
                     bw.bytes().toHexString());
 
             // Release the bytes from the wire.
@@ -183,11 +185,11 @@ public class MessageHistoryTest extends WireTestCommon {
             bw2.writeEventName(MethodReader.HISTORY).marshallable(history);
             assertEquals("" +
                             "b9 07 68 69 73 74 6f 72 79                      # history: (event)\n" +
-                            "81 33 00 86                                     # SetTimeMessageHistory\n" +
+                            "81 3b 00 86                                     # SetTimeMessageHistory\n" +
                             "02 01 00 00 00 02 00 00 00 ff 00 00 00 00 00 00 # sources\n" +
                             "00 ff 0f 00 00 00 00 00 00 03 00 00 64 a7 b3 b6 # timings\n" +
                             "e0 0d 10 27 64 a7 b3 b6 e0 0d 64 0c 2c b5 03 6e\n" +
-                            "00 00\n",
+                            "00 00 00 00 00 00 00 00 00 00\n",
                     bw2.bytes().toHexString());
             bw2.bytes().releaseLast();
 
@@ -235,7 +237,7 @@ public class MessageHistoryTest extends WireTestCommon {
 
             assertEquals("" +
                             "b9 07 68 69 73 74 6f 72 79                      # history: (event)\n" +
-                            "81 34 00                                        # SetTimeMessageHistory\n" +
+                            "81 42 00                                        # SetTimeMessageHistory\n" +
                             "c7 73 6f 75 72 63 65 73                         # sources:\n" +
                             "82 0b 00 00 00                                  # sequence\n" +
                             "                                                # source id & index\n" +
@@ -246,11 +248,14 @@ public class MessageHistoryTest extends WireTestCommon {
                             "a5 57 04                                        # 1111\n" +
                             "                                                # timing in nanos\n" +
                             "a5 ae 08                                        # 2222\n" +
-                            "a7 64 0c 2c b5 03 6e 00 00 ba 80 00             # 120962203520100\n" +
-                            "81 27 00 86                                     # SetTimeMessageHistory\n" +
+                            "a7 64 0c 2c b5 03 6e 00 00                      # 120962203520100\n" +
+                            "cb 73 65 72 76 69 63 65 4e 61 6d 65             # serviceName:\n" +
+                            "a1 00 ba 80 00                                  # 0\n" +
+                            "81 2f 00 86                                     # SetTimeMessageHistory\n" +
                             "01 01 00 00 00 02 00 00 00 00 00 00 00          # sources\n" +
                             "03 57 04 00 00 00 00 00 00 ae 08 00 00 00 00 00 # timings\n" +
-                            "00 64 0c 2c b5 03 6e 00 00\n",
+                            "00 64 0c 2c b5 03 6e 00 00 00 00 00 00 00 00 00\n" +
+                            "00\n",
                     bytes.toHexString());
 
             // Add additional timing to the original history.
@@ -288,7 +293,7 @@ public class MessageHistoryTest extends WireTestCommon {
                 MessageHistory.writeHistory(dc);
             }
 
-            assertEquals("00000000 57 00 00 00 b9 07 68 69  73 74 6f 72 79 81 4b 00 W·····hi story·K·",
+            assertEquals("00000000 65 00 00 00 b9 07 68 69  73 74 6f 72 79 81 59 00 e·····hi story·Y·",
                     bytes.toHexString().split("\n")[0]);
         }
     }
@@ -328,7 +333,8 @@ public class MessageHistoryTest extends WireTestCommon {
                 "    11111111,\n" +
                 "    22222222,\n" +
                 "    120962203520100\n" +
-                "  ]\n" +
+                "  ],\n" +
+                "  serviceName: 0\n" +
                 "}\n", wire2.toString());
         VanillaMessageHistory vmh2 = new VanillaMessageHistory();
         vmh2.addSourceDetails(false);
@@ -350,7 +356,7 @@ public class MessageHistoryTest extends WireTestCommon {
                 MessageHistory.writeHistory(dc);
             }
 
-            assertEquals("00000000 39 00 00 00 ba 80 00 81  33 00 86 02 01 00 00 00 9······· 3·······",
+            assertEquals("00000000 41 00 00 00 ba 80 00 81  3b 00 86 02 01 00 00 00 A······· ;·······",
                     bytes.toHexString().split("\n")[0]);
 
             final SetTimeMessageHistory history2 = new SetTimeMessageHistory();
@@ -362,7 +368,7 @@ public class MessageHistoryTest extends WireTestCommon {
                 MessageHistory.writeHistory(dc);
             }
 
-            assertEquals("00000000 39 00 00 00 ba 80 00 81  33 00 86 02 01 00 00 00 9······· 3·······",
+            assertEquals("00000000 41 00 00 00 ba 80 00 81  3b 00 86 02 01 00 00 00 A······· ;·······",
                     bytes.toHexString().split("\n")[0]);
 
         } finally {

--- a/src/test/java/net/openhft/chronicle/wire/VanillaMessageHistoryTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/VanillaMessageHistoryTest.java
@@ -55,7 +55,7 @@ public class VanillaMessageHistoryTest extends net.openhft.chronicle.wire.WireTe
         assertEquals("" +
                         "c3 76 6d 68                                     # vmh:\n" +
                         "b6 03 56 4d 48                                  # VMH\n" +
-                        "81 33 00                                        # VanillaMessageHistory\n" +
+                        "81 41 00                                        # VanillaMessageHistory\n" +
                         "c7 73 6f 75 72 63 65 73                         # sources:\n" +
                         "82 0b 00 00 00                                  # sequence\n" +
                         "                                                # source id & index\n" +
@@ -64,7 +64,9 @@ public class VanillaMessageHistoryTest extends net.openhft.chronicle.wire.WireTe
                         "82 0e 00 00 00                                  # sequence\n" +
                         "                                                # timing in nanos\n" +
                         "a6 7c f4 b8 00                                  # 12121212\n" +
-                        "a7 timestamp\n",
+                        "a7 timestamp\n" +
+                        "cb 73 65 72 76 69 63 65 4e 61 6d 65             # serviceName:\n" +
+                        "a1 00                                           # 0\n",
                 wire.bytes().toHexString().replaceAll("\na7.*\n", "\na7 timestamp\n"));
 
         // Create two new VanillaMessageHistory objects for comparison


### PR DESCRIPTION
Tools like service- links don't work if two or more severs write to the same queue, because they are unable to determine from which services the message originated, this enriches the history message to include the service name.

see 

wire - https://github.com/OpenHFT/Chronicle-Wire/issues/922