### PR TITLE
use Wire instead of AbstractWire impl. class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
                         <configuration>
                             <referenceVersion>2.26ea0</referenceVersion>
                             <artifactsURI>https://teamcity.chronicle.software/repository/download</artifactsURI>
-                            <binaryCompatibilityPercentageRequired>100.0</binaryCompatibilityPercentageRequired>
+                            <binaryCompatibilityPercentageRequired>98.4</binaryCompatibilityPercentageRequired>
                             <extraOptions>
                                 <extraOption>
                                     <name>skip-internal-packages</name>

--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -29,6 +29,7 @@ import net.openhft.chronicle.core.pool.ClassLookup;
 import net.openhft.chronicle.core.util.IgnoresEverything;
 import net.openhft.chronicle.threads.Pauser;
 import net.openhft.chronicle.threads.TimingPauser;
+import net.openhft.chronicle.wire.domestic.InternalWire;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.ObjectInput;
@@ -45,7 +46,7 @@ import static net.openhft.chronicle.wire.Wires.*;
  * Represents the AbstractWire class which serves as a base for all Wire implementations.
  * This class provides fundamental shared behaviors, configurations, and initializations for Wire types.
  */
-public abstract class AbstractWire implements Wire {
+public abstract class AbstractWire implements Wire, InternalWire {
 
     // Default padding configuration loaded from the system properties.
     public static final boolean DEFAULT_USE_PADDING = Jvm.getBoolean("wire.usePadding", false);
@@ -642,6 +643,7 @@ public abstract class AbstractWire implements Wire {
     /**
      * used by write bytes when doing a rollback
      */
+    @Override
     public void forceNotInsideHeader() {
         insideHeader = false;
     }

--- a/src/main/java/net/openhft/chronicle/wire/BinaryReadDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryReadDocumentContext.java
@@ -39,7 +39,7 @@ public class BinaryReadDocumentContext implements ReadDocumentContext {
     public long start = -1;
     public long lastStart = -1;
     @Nullable
-    protected AbstractWire wire;
+    protected Wire wire;
     protected boolean present;
     protected boolean notComplete;
     protected long readPosition;
@@ -65,7 +65,7 @@ public class BinaryReadDocumentContext implements ReadDocumentContext {
      * @param ensureFullRead Flag to determine if full reading is required.
      */
     public BinaryReadDocumentContext(@Nullable Wire wire, boolean ensureFullRead) {
-        this.wire = (AbstractWire) wire;
+        this.wire = wire;
         this.ensureFullRead = ensureFullRead;
     }
 
@@ -113,7 +113,7 @@ public class BinaryReadDocumentContext implements ReadDocumentContext {
      * @param wire0 The delta wire to read from.
      * @param start The starting position for the full read.
      */
-    private static void fullReadForDeltaWire(AbstractWire wire0, long start) {
+    private static void fullReadForDeltaWire(Wire wire0, long start) {
         long readPosition1 = wire0.bytes().readPosition();
         try {
             // we have to read back from the start, as close may have been called in
@@ -152,7 +152,7 @@ public class BinaryReadDocumentContext implements ReadDocumentContext {
         long readLimit0 = this.readLimit;
         long readPosition0 = this.readPosition;
 
-        AbstractWire wire0 = this.wire;
+        Wire wire0 = this.wire;
         if (present && ensureFullRead && start >= 0 && wire0 != null && wire0.hasMore()) {
             fullReadForDeltaWire(wire0, start);
         }

--- a/src/main/java/net/openhft/chronicle/wire/JSONWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/JSONWire.java
@@ -776,7 +776,7 @@ public class JSONWire extends TextWire {
     class JSONReadDocumentContext extends TextReadDocumentContext {
         private int first;
 
-        public JSONReadDocumentContext(@Nullable AbstractWire wire) {
+        public JSONReadDocumentContext(@Nullable Wire wire) {
             super(wire);
         }
 

--- a/src/main/java/net/openhft/chronicle/wire/TextReadDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextReadDocumentContext.java
@@ -36,7 +36,7 @@ public class TextReadDocumentContext implements ReadDocumentContext {
 
     // The wire instance this context operates on
     @Nullable
-    protected AbstractWire wire;
+    protected Wire wire;
 
     // Indicators for the state of the document
     protected boolean present, notComplete;
@@ -58,7 +58,7 @@ public class TextReadDocumentContext implements ReadDocumentContext {
      *
      * @param wire The wire instance to be used by this context. Can be null.
      */
-    public TextReadDocumentContext(@Nullable AbstractWire wire) {
+    public TextReadDocumentContext(@Nullable Wire wire) {
         this.wire = wire;
     }
 
@@ -132,8 +132,8 @@ public class TextReadDocumentContext implements ReadDocumentContext {
         long readLimit = this.readLimit;
         long readPosition = this.readPosition;
 
-        AbstractWire wire0 = this.wire;
-        Bytes<?> bytes = wire0.bytes;
+        Wire wire0 = this.wire;
+        Bytes<?> bytes = wire0.bytes();
         bytes.readLimit(readLimit);
 
         if (rollback) {

--- a/src/main/java/net/openhft/chronicle/wire/Wires.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wires.java
@@ -303,9 +303,9 @@ public enum Wires {
             try {
                 // Write the computed header to the temporary bytes
                 tempBytes.writeOrderedInt(header);
-                final AbstractWire wire2 = ((BinaryReadDocumentContext) dc).wire;
+                final Wire wire2 = ((BinaryReadDocumentContext) dc).wire;
                 // Copy data from the original wire to the temporary bytes
-                tempBytes.write(wire2.bytes, 0, wire2.bytes.readLimit());
+                tempBytes.write(wire2.bytes(), 0, wire2.bytes().readLimit());
 
                 // Derive the wire type and apply it to the temporary bytes
                 final WireType wireType = WireType.valueOf(wire);

--- a/src/main/java/net/openhft/chronicle/wire/domestic/InternalWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/domestic/InternalWire.java
@@ -1,0 +1,5 @@
+package net.openhft.chronicle.wire.domestic;
+
+public interface InternalWire {
+    void forceNotInsideHeader();
+}


### PR DESCRIPTION
Breaks binary compatibility but means that we don't have to depend on AbstractWire impl. in CQ