### PR TITLE
JsonWire - Adds additional Double NaN test case

### DIFF
--- a/src/test/java/net/openhft/chronicle/wire/JSONNanTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/JSONNanTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 
 public class JSONNanTest extends WireTestCommon {
 
-    // Test to verify that a Dto object with Double.NaN as its value gets written as null in JSON format
+    // Test to verify that a Dto object with Double.NaN as its value gets written as quoted "NaN" in JSON format
     @Test
     public void writeNaNs() {
         // Allocate a new elastic byte buffer
@@ -41,7 +41,7 @@ public class JSONNanTest extends WireTestCommon {
             // Write the Dto object to the wire
             wire.write().marshallable(value);
 
-            // Assert that the wire content represents the NaN as null
+            // Assert that the wire content represents the Double.NaN as quoted "NaN" in JSON format
             Assert.assertEquals("\"\":{\"value\":0.0,\"value1\":\"NaN\",\"value2\":0,\"field\":\"text\"}", wire.toString());
         } finally {
             // Release the byte buffer resources
@@ -51,7 +51,7 @@ public class JSONNanTest extends WireTestCommon {
 
     // Test to verify that reading a JSON formatted null into a Dto object sets its value to Double.NaN
     @Test
-    public void readNaNs() {
+    public void readJSONNullToDoubleNaN() {
         Bytes<?> b = Bytes.from("\"\":{\"value\":null,\"value1\": null, \"value2\":\n0 ,\"field\": \"text\"}");
         Wire wire = WireType.JSON.apply(b);
         Dto value = wire.read().object(Dto.class);
@@ -60,7 +60,7 @@ public class JSONNanTest extends WireTestCommon {
 
     // Test to verify that a leading space before the JSON formatted null is handled correctly
     @Test
-    public void readNaNWithFieldNext() {
+    public void readJSONNullWithLeadingSpaceToDoubleNaN() {
         Bytes<?> b = Bytes.from("\"\":{\"value\": null , \"field\" : \"text\" , \"value1\": 1\n,\n\"value2\": \"1\" \n}");
         Wire wire = WireType.JSON.apply(b);
         Dto value = wire.read().object(Dto.class);
@@ -68,6 +68,16 @@ public class JSONNanTest extends WireTestCommon {
         Assert.assertEquals("text", value.field);
         Assert.assertEquals(1.0, value.value1, 0.01);
         Assert.assertEquals(1L, value.value2);
+    }
+
+    // Test to verify that reading a JSON formatted quoted "NaN" into a Dto object sets its value to Double.NaN
+    @Test
+    public void readJSONQuotedNaNToNaN() {
+        Bytes<?> b = Bytes.from("\"\":{\"value\":\"NaN\",\"value1\": \"NaN\" , \"value2\":\n0 ,\"field\": \"text\"}");
+        Wire wire = WireType.JSON.apply(b);
+        Dto value = wire.read().object(Dto.class);
+        Assert.assertTrue(Double.isNaN(value.value));
+        Assert.assertTrue(Double.isNaN(value.value1));
     }
 
     // Class Dto extending SelfDescribingMarshallable with a single double field


### PR DESCRIPTION
Adds additional test case to test that JSON quoted "NaN" parses to Double.NaN correctly

[Related PR](https://github.com/OpenHFT/Chronicle-Wire/pull/983)

[Issue](https://github.com/OpenHFT/Chronicle-Wire/issues/982)