### PR TITLE
implement missing ValueIn#sequence override for Text&YamlWire

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -2186,23 +2186,18 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Handles the processing of a sequence, delegating to an overloaded version of itself.
+         * Handles the processing of a sequence.
          *
          * @param <T> The type of items in the lists.
          * @param list The main list that should be populated based on the buffer.
          * @param buffer A temporary buffer used for staging data.
          * @param bufferAdd A supplier function that can add items to the buffer.
-         * @param reader0 This seems to be an unused reader, possibly for future extensions.
+         * @param reader0 The reader that processes each item in the sequence.
          * @return Returns a boolean indicating success/failure or some other status.
          * @throws InvalidMarshallableException if there's an error during the sequence processing.
          */
-        public <T> boolean sequence(List<T> list, @NotNull List<T> buffer, Supplier<T> bufferAdd, Reader reader0) throws InvalidMarshallableException {
-            // Currently, this method delegates to an overloaded version of itself, ignoring the reader0 parameter.
-            return sequence(list, buffer, bufferAdd);
-        }
-
         @Override
-        public <T> boolean sequence(@NotNull List<T> list, @NotNull List<T> buffer, @NotNull Supplier<T> bufferAdd) throws InvalidMarshallableException {
+        public <T> boolean sequence(@NotNull List<T> list, @NotNull List<T> buffer, @NotNull Supplier<T> bufferAdd, Reader reader0) throws InvalidMarshallableException {
 
             list.clear();
             consumePadding();
@@ -2224,14 +2219,7 @@ public class TextWire extends YamlWireOut<TextWire> {
                 sequenceLimit = 1;
             }
 
-            while (hasNextSequenceItem()) {
-                int size = list.size();
-                if (buffer.size() <= size) buffer.add(bufferAdd.get());
-
-                final T t = buffer.get(size);
-                if (t instanceof Resettable) ((Resettable) t).reset();
-                list.add(object(t, (Class<T>) t.getClass()));
-            }
+            reader0.accept(this, list, buffer, bufferAdd);
 
             if (code == '[') {
                 consumePadding(1);

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -1759,17 +1759,12 @@ public class YamlWire extends YamlWireOut<YamlWire> {
          * @param list The list to populate with the sequence items.
          * @param buffer Temporary storage used during sequence processing.
          * @param bufferAdd Supplier function to add items to the buffer.
-         * @param reader0 Reader to process the tokens.
+         * @param reader0 The reader that processes each item in the sequence.
          * @return true if the sequence was successfully read, false otherwise.
          * @throws InvalidMarshallableException If there's a problem with marshalling.
          */
-        public <T> boolean sequence(List<T> list, @NotNull List<T> buffer, Supplier<T> bufferAdd, Reader reader0) throws InvalidMarshallableException {
-            // Delegate to the other `sequence` method without the reader.
-            return sequence(list, buffer, bufferAdd);
-        }
-
         @Override
-        public <T> boolean sequence(@NotNull List<T> list, @NotNull List<T> buffer, @NotNull Supplier<T> bufferAdd) throws InvalidMarshallableException {
+        public <T> boolean sequence(@NotNull List<T> list, @NotNull List<T> buffer, @NotNull Supplier<T> bufferAdd, Reader reader0) throws InvalidMarshallableException {
             consumePadding();
             if (isNull()) {
                 return false;
@@ -1779,12 +1774,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                 int minIndent = yt.secondTopContext().indent;
                 yt.next(Integer.MAX_VALUE);
 
-                while (hasNextSequenceItem()) {
-                    if (buffer.size() <= list.size())
-                        buffer.add(bufferAdd.get());
-                    Object using = buffer.get(list.size());
-                    list.add((T) valueIn.object(using, using.getClass()));
-                }
+                reader0.accept(this, list, buffer, bufferAdd);
 
                 if (yt.current() == YamlToken.NONE)
                     yt.next(minIndent);


### PR DESCRIPTION
for Yaml & TextWire 
```
    <T> boolean sequence(List<T> list, @NotNull List<T> buffer, Supplier<T> bufferAdd, Reader reader0) throws InvalidMarshallableException;
```
was not properly implemented - it's implementation instead uses the overload without the `Reader`. 

This PR removes the stubbed implementations and ensures that the `Reader` argument is used. It also removes the  `net.openhft.chronicle.wire.ValueIn#sequence(java.util.List<T>, java.util.List<T>, java.util.function.Supplier<T>)` overloads from the Text Wires as the default impl. interface already implements the correct behaviour.