### PR TITLE
Improve Javadoc for marshalling core classes

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AbstractCommonMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractCommonMarshallable.java
@@ -21,21 +21,27 @@ import net.openhft.chronicle.bytes.BytesMarshallable;
 import net.openhft.chronicle.core.io.ValidatableUtil;
 
 /**
- * This uses bytes marshallable, non self describing messages by default.
- * use {@link SelfDescribingMarshallable} or {@link BytesInBinaryMarshallable} instead
+ * Base class providing common {@link Marshallable} implementations.  It writes
+ * and reads using the raw {@link net.openhft.chronicle.bytes.BytesMarshallable}
+ * format and is therefore not self-describing.  Subclasses that require type
+ * information should extend {@link SelfDescribingMarshallable} or, if dealing
+ * directly with binary bytes, {@link BytesInBinaryMarshallable}.
  */
 abstract class AbstractCommonMarshallable implements Marshallable, BytesMarshallable {
     @Override
+    /** Delegates to {@link Marshallable#$equals(WriteMarshallable, Object)} based on the serialised form. */
     public boolean equals(Object o) {
         return Marshallable.$equals(this, o);
     }
 
     @Override
+    /** Delegates to {@link Marshallable#$hashCode(WriteMarshallable)}. */
     public int hashCode() {
         return Marshallable.$hashCode(this);
     }
 
     @Override
+    /** Serialises this object to text for debugging. Validation is disabled to allow partial objects to be printed. */
     public String toString() {
         // this allows even invalid DTOs to be written to dump on a best effort basis.
         ValidatableUtil.startValidateDisabled();

--- a/src/main/java/net/openhft/chronicle/wire/AbstractMarshallableCfg.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractMarshallableCfg.java
@@ -23,24 +23,16 @@ import net.openhft.chronicle.core.io.InvalidMarshallableException;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * An abstract class that represents a configuration Data Transfer Object (DTO) capable of marshalling.
- * This base class offers default implementations for reading and writing configurations through {@code WireMarshaller}.
- * Derived configuration DTOs can benefit from merging default configurations with specific configurations to enhance flexibility.
+ * Base class for configuration beans that are {@link Marshallable}.  When
+ * reading, fields not present in the input remain unchanged so a previously
+ * applied default configuration can be retained.  When writing, only fields that
+ * differ from a supplied default are emitted.
  */
 public abstract class AbstractMarshallableCfg extends SelfDescribingMarshallable {
 
     /**
-     * Reads the state of this configuration object from the given wire input.
-     * It uses the {@link WireMarshaller} corresponding to the class of the current object
-     * to perform the reading.
-     * <p>
-     * Configuration merging is supported; absent values in the wire input retain their
-     * existing state. To ensure the use of default values for any unset attributes,
-     * consider invoking {@code reset()} before this method.
-     *
-     * @param wire Wire input source for reading the configuration.
-     * @throws IORuntimeException             If there's an IO-related exception during reading.
-     * @throws InvalidMarshallableException   If a marshalling error occurs.
+     * Read configuration values from {@code wire}.  Fields not present in the
+     * input are left unchanged so defaults can be merged in.
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
@@ -54,14 +46,8 @@ public abstract class AbstractMarshallableCfg extends SelfDescribingMarshallable
     }
 
     /**
-     * Writes the state of this configuration object to the given wire output.
-     * It uses the {@link WireMarshaller} corresponding to the class of the current object
-     * to perform the writing.
-     * <p>
-     * For brevity, only fields differing from default values are written.
-     *
-     * @param wire Wire output target for writing the configuration.
-     * @throws InvalidMarshallableException If a marshalling error occurs.
+     * Write only those fields that differ from the default configuration to
+     * {@code wire}.
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
@@ -75,12 +61,8 @@ public abstract class AbstractMarshallableCfg extends SelfDescribingMarshallable
     }
 
     /**
-     * Handles the presence of unexpected fields during the reading process.
-     * A warning is logged with details of the unexpected field.
-     *
-     * @param event   The name or identifier of the unexpected field.
-     * @param valueIn The value associated with the unexpected field.
-     * @throws InvalidMarshallableException If there's an error during the processing.
+     * Log and skip any field encountered in the wire that is not defined in this
+     * configuration object.
      */
     @Override
     public void unexpectedField(Object event, ValueIn valueIn) throws InvalidMarshallableException {

--- a/src/main/java/net/openhft/chronicle/wire/AsMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/AsMarshallable.java
@@ -24,9 +24,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation indicates that the associated field or parameter should be treated as
- * a {@code Marshallable} type, implying it should be serialized or deserialized accordingly.
- * It can be applied to fields or method parameters to provide metadata about their marshalling behavior.
+ * Annotation used to hint that a field or parameter should be marshalled as a
+ * {@link Marshallable} even if its declared type is more generic (e.g. an
+ * interface).  It is typically employed when the runtime type implements
+ * {@code Marshallable} but the declared type does not.
  */
 @Retention(RetentionPolicy.RUNTIME)  // Indicates that this annotation should be retained at runtime.
 @Target({ElementType.FIELD, ElementType.PARAMETER})  // Specifies that this annotation can be applied to fields and method parameters.

--- a/src/main/java/net/openhft/chronicle/wire/BytesInBinaryMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/BytesInBinaryMarshallable.java
@@ -18,18 +18,14 @@
 package net.openhft.chronicle.wire;
 
 /**
- * Represents an abstract base class for binary marshallables that primarily deal with bytes.
- * By default, this class does not use self-describing messages.
- * <p>
- * This class extends the {@link AbstractCommonMarshallable} to provide common functionalities
- * shared among marshallables.
+ * Abstract base for marshallables that read and write directly to
+ * {@link net.openhft.chronicle.bytes.Bytes} using a fixed binary layout.  These
+ * objects do not include type information when serialized.
  */
 public abstract class BytesInBinaryMarshallable extends AbstractCommonMarshallable {
 
     /**
-     * Determines whether this marshallable uses self-describing messages.
-     *
-     * @return {@code false} indicating that this marshallable does not use self-describing messages by default.
+     * Returns {@code false} as binary marshallables omit type information by default.
      */
     @Override
     public boolean usesSelfDescribingMessage() {

--- a/src/main/java/net/openhft/chronicle/wire/Demarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/Demarshallable.java
@@ -25,18 +25,19 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
 /**
- * Represents a contract for objects that are designed for deserialization, with an expectation
- * that a new, potentially immutable object is instantiated during each deserialization process.
- * <p>
- * Unlike the `ReadMarshallable` pattern, the `Demarshallable` interface mandates that
- * implementing classes provide a constructor taking a `WireIn` instance to enable deserialization.
- * This approach ensures a clear mechanism to obtain a new object instance from the serialized data.
- * The interface also provides a utility to instantiate objects of implementing classes using the
- * appropriate constructor.
+ * Contract for classes that are created afresh from a {@link WireIn} rather than
+ * having an existing instance reused.  This is particularly suited to immutable
+ * objects.  Implementations must provide a constructor taking a {@code WireIn}
+ * which is used by {@link #newInstance(Class, WireIn)} to create and populate a
+ * new instance.
  */
 public interface Demarshallable {
 
-    // Holds a cache for constructors of Demarshallable implementing classes, optimized for retrieval performance.
+    /**
+     * Cache of constructors taking a single {@link WireIn} argument for each
+     * {@code Demarshallable} implementation.  Using a {@link ClassValue}
+     * avoids repeated reflective lookups when creating new instances.
+     */
     ClassValue<Constructor<Demarshallable>> DEMARSHALLABLES = new ClassValue<Constructor<Demarshallable>>() {
         @NotNull
         @Override
@@ -57,13 +58,8 @@ public interface Demarshallable {
     };
 
     /**
-     * Provides a utility method to create a new instance of a class that implements the `Demarshallable` interface.
-     * This method relies on the appropriate constructor from the cached constructors for efficient instantiation.
-     *
-     * @param clazz   The class type to be instantiated.
-     * @param wireIn  The `WireIn` parameter to be passed to the constructor for deserialization.
-     * @param <T>     The type of the object to be returned, which should implement `Demarshallable`.
-     * @return        A new instance of the specified class type.
+     * Utility method that uses the cached constructor to create a new instance
+     * of {@code clazz} and immediately populates it from {@code wireIn}.
      */
     @SuppressWarnings("unchecked")
     @NotNull

--- a/src/main/java/net/openhft/chronicle/wire/DynamicEnum.java
+++ b/src/main/java/net/openhft/chronicle/wire/DynamicEnum.java
@@ -24,23 +24,19 @@ import net.openhft.chronicle.core.util.CoreDynamicEnum;
 import java.util.List;
 
 /**
- * Represents a dynamic enumeration which can either be a traditional {@code Enum} or a class
- * possessing a {@code String name} field. The interface extends both {@link CoreDynamicEnum} and
- * {@link Marshallable}, facilitating serialization and specific dynamic enumeration operations.
+ * <b>Deprecated:</b> scheduled for removal in x.28.
+ * <p>
+ * Represents an enumeration whose values may be extended at runtime.  The
+ * underlying type may be a traditional {@code enum} or any class with a
+ * {@code String name} field.
  */
 @SuppressWarnings({"deprecation", "rawtypes", "unchecked"})
 @Deprecated(/* to be removed in x.28 */)
 public interface DynamicEnum extends CoreDynamicEnum, Marshallable {
 
     /**
-     * Refreshes the cached instance of a {@code DynamicEnum} based on the given template.
-     * This ensures that every deserialization of the enum value from its {@code name()} method
-     * is up-to-date with the most recent information.
-     * <p>
-     * Leveraging this method to update the cached enum details is essential for maintaining
-     * data consistency, especially during frequent deserialization operations.
-     *
-     * @param e The {@code DynamicEnum} template used to refresh the cached version.
+     * Refresh an enum instance held in the internal {@link EnumCache} using the
+     * supplied template {@code e}.
      */
     static <E extends DynamicEnum> void updateEnum(E e) {
         // Retrieve the enum cache corresponding to the class of the provided template
@@ -59,7 +55,7 @@ public interface DynamicEnum extends CoreDynamicEnum, Marshallable {
     }
 
     /**
-     * Not resettable, treat as immutable.
+     * Dynamic enums are treated as immutable and therefore cannot be reset.
      */
     default void reset() {
         throw new UnsupportedOperationException();

--- a/src/main/java/net/openhft/chronicle/wire/KeyedMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/KeyedMarshallable.java
@@ -20,13 +20,16 @@ package net.openhft.chronicle.wire;
 import net.openhft.chronicle.bytes.Bytes;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Marker interface for {@link Marshallable} objects that expose a distinct key
+ * portion used for indexing or map lookups.
+ */
 public interface KeyedMarshallable {
 
     /**
-     * Writes the key of the current instance into the provided {@code Bytes} object.
-     * This default implementation utilizes the {@code Wires.writeKey} method.
-     *
-     * @param bytes The {@code Bytes} object into which the key of the current instance is written.
+     * Write the key portion of this object to {@code bytes}.  The default
+     * implementation delegates to {@link Wires#writeKey(Object, Bytes)} which
+     * typically serializes the first field or fields designated as the key.
      */
     @SuppressWarnings("rawtypes")
     default void writeKey(@NotNull Bytes<?> bytes) {

--- a/src/main/java/net/openhft/chronicle/wire/Marshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/Marshallable.java
@@ -37,23 +37,25 @@ import static net.openhft.chronicle.wire.WireMarshaller.WIRE_MARSHALLER_CL;
 import static net.openhft.chronicle.wire.WireType.TEXT;
 
 /**
- * Represents a data structure that supports both reading from and writing to marshallable
- * formats. Implementations of this interface can be converted to and from serialized forms,
- * making it suitable for storage, transmission, or other forms of data exchange.
+ * Primary interface for objects that can be written to and read from a {@link Wire}.
  * <p>
- * This interface also provides a set of static utility methods to aid in the manipulation
- * and interpretation of marshallable data, allowing for data comparison, hashing,
- * and serialization to and from string and file representations.
+ * Implementations are typically simple data transfer objects or state holders that need to
+ * be persisted or transmitted.  It combines the capabilities of
+ * {@link WriteMarshallable} and {@link ReadMarshallable} and also extends
+ * {@link net.openhft.chronicle.core.io.Resettable} so that instances can be recycled.
+ * <p>
+ * A number of convenience static methods are supplied for converting to and from textual
+ * representations and for reflective style field access.
  */
 @DontChain
 public interface Marshallable extends WriteMarshallable, ReadMarshallable, Resettable {
 
     /**
-     * Compares a given {@code WriteMarshallable} object with another object for equality.
-     *
-     * @param $this The reference {@code WriteMarshallable} object.
-     * @param o The object to compare with.
-     * @return {@code true} if both objects are equal, {@code false} otherwise.
+     * Compare two {@link WriteMarshallable} instances for equality.
+     * <p>
+     * The comparison is performed on their serialized form via
+     * {@link Wires#isEquals(Object, Object)} after verifying the other object is
+     * also a {@code WriteMarshallable}.
      */
     static boolean $equals(@NotNull WriteMarshallable $this, Object o) {
         return o instanceof WriteMarshallable &&
@@ -61,30 +63,24 @@ public interface Marshallable extends WriteMarshallable, ReadMarshallable, Reset
     }
 
     /**
-     * Generates a 32-bit hash code for a given {@code WriteMarshallable} object.
-     *
-     * @param $this The reference {@code WriteMarshallable} object.
-     * @return The 32-bit hash code.
+     * Generate a 32‑bit hash code for the provided marshallable using
+     * {@link HashWire#hash32(WriteMarshallable)}.
      */
     static int $hashCode(WriteMarshallable $this) {
         return HashWire.hash32($this);
     }
 
     /**
-     * Converts a given {@code WriteMarshallable} object into its string representation.
-     *
-     * @param $this The reference {@code WriteMarshallable} object.
-     * @return A string representation of the object.
+     * Convert the marshallable to a textual representation – typically YAML via
+     * {@link WireType#TEXT}.
      */
     static String $toString(WriteMarshallable $this) {
         return TEXT.asString($this);
     }
 
     /**
-     * Converts a {@code CharSequence} into its corresponding marshallable representation.
-     *
-     * @param cs The character sequence to convert.
-     * @return The corresponding marshallable object, or {@code null} if the conversion is not possible.
+     * Parse a textual representation (assumed {@link WireType#TEXT}) into a new
+     * instance of the appropriate type.
      */
     @Nullable
     static <T> T fromString(@NotNull CharSequence cs) throws InvalidMarshallableException {
@@ -92,12 +88,8 @@ public interface Marshallable extends WriteMarshallable, ReadMarshallable, Reset
     }
 
     /**
-     * Converts a {@code CharSequence} into its corresponding marshallable representation,
-     * expecting a specific type as the result.
-     *
-     * @param tClass The expected class of the resulting object.
-     * @param cs The character sequence to convert.
-     * @return The corresponding marshallable object of type {@code T}, or {@code null} if the conversion is not possible.
+     * Parse a textual representation (assumed {@link WireType#TEXT}) into an
+     * instance of {@code tClass}.
      */
     @Nullable
     static <T> T fromString(@NotNull Class<T> tClass, @NotNull CharSequence cs) throws InvalidMarshallableException {
@@ -105,12 +97,8 @@ public interface Marshallable extends WriteMarshallable, ReadMarshallable, Reset
     }
 
     /**
-     * Reads a file, either from the current working directory or the classpath, and interprets its
-     * content as a marshallable object. The method supports various file formats and relies on
-     * the underlying marshallable parsing logic to interpret the content.
-     *
-     * @param filename The name or path of the file to read.
-     * @return The marshallable object interpreted from the file content.
+     * Read a file (from the working directory or classpath) and deserialize its
+     * textual content (typically YAML) into a marshallable instance.
      */
     @NotNull
     static <T> T fromFile(String filename) throws IOException, InvalidMarshallableException {
@@ -118,10 +106,8 @@ public interface Marshallable extends WriteMarshallable, ReadMarshallable, Reset
     }
 
     /**
-     * Converts the content from an {@code InputStream} into its corresponding marshallable representation.
-     *
-     * @param is The input stream containing the content to convert.
-     * @return The corresponding marshallable object, or {@code null} if the conversion is not possible.
+     * Deserialize the entire contents of an {@link InputStream} using the default
+     * textual format.
      */
     static <T> T fromString(@NotNull InputStream is) throws InvalidMarshallableException {
         Scanner s = new Scanner(is).useDelimiter("\\A");
@@ -129,12 +115,8 @@ public interface Marshallable extends WriteMarshallable, ReadMarshallable, Reset
     }
 
     /**
-     * Reads a file, either from the current working directory or the classpath, and interprets its
-     * content as a marshallable object of a specific type.
-     *
-     * @param expectedType The expected type of the resulting object.
-     * @param filename The name or path of the file to read.
-     * @return The marshallable object interpreted from the file content.
+     * Read a file and deserialize it into an instance of {@code expectedType}
+     * assuming a textual wire format.
      */
     @Nullable
     static <T> T fromFile(@NotNull Class<T> expectedType, String filename) throws IOException, InvalidMarshallableException {
@@ -142,10 +124,8 @@ public interface Marshallable extends WriteMarshallable, ReadMarshallable, Reset
     }
 
     /**
-     * Streams the content of a file as marshallable objects.
-     *
-     * @param filename The name or path of the file to read.
-     * @return A stream of marshallable objects.
+     * Stream all documents contained in the given file, deserializing each using
+     * the default textual format.
      */
     @NotNull
     static <T> Stream<T> streamFromFile(String filename) throws IOException {
@@ -153,11 +133,7 @@ public interface Marshallable extends WriteMarshallable, ReadMarshallable, Reset
     }
 
     /**
-     * Streams the content of a file as marshallable objects of a specific type.
-     *
-     * @param expectedType The expected type of the resulting objects in the stream.
-     * @param filename The name or path of the file to read.
-     * @return A stream of marshallable objects of type {@code T}.
+     * Stream all documents in the file as instances of {@code expectedType}.
      */
     @Nullable
     static <T> Stream<T> streamFromFile(@NotNull Class<T> expectedType, String filename) throws IOException {
@@ -165,12 +141,8 @@ public interface Marshallable extends WriteMarshallable, ReadMarshallable, Reset
     }
 
     /**
-     * Retrieves the value of a specific field from the current marshallable object, expecting
-     * a certain type for the field's value.
-     *
-     * @param name The name of the field.
-     * @param tClass The expected class/type of the field's value.
-     * @return The value of the specified field.
+     * Convenience method providing reflective-style access to a field value via
+     * {@link Wires#getField(Object, String, Class)}.
      */
     @Nullable
     default <T> T getField(String name, Class<T> tClass) throws NoSuchFieldException {
@@ -178,45 +150,31 @@ public interface Marshallable extends WriteMarshallable, ReadMarshallable, Reset
     }
 
     /**
-     * Sets the value of a specific field in the current marshallable object.
-     *
-     * @param name The name of the field.
-     * @param value The new value for the specified field.
+     * Set a field value reflectively using {@link Wires#setField(Object, String, Object)}.
      */
     default void setField(String name, Object value) throws NoSuchFieldException {
         Wires.setField(this, name, value);
     }
 
     /**
-     * Retrieves the long value of a specific field from the current marshallable object.
-     *
-     * @param name The name of the field.
-     * @return The long value of the specified field.
+     * Shortcut to read a {@code long} field via {@link Wires#getLongField(Object, String)}.
      */
     default long getLongField(String name) throws NoSuchFieldException {
         return Wires.getLongField(this, name);
     }
 
     /**
-     * Sets the long value of a specific field in the current marshallable object.
-     *
-     * @param name The name of the field.
-     * @param value The new long value for the specified field.
+     * Shortcut to write a {@code long} field via {@link Wires#setLongField(Object, String, long)}.
      */
     default void setLongField(String name, long value) throws NoSuchFieldException {
         Wires.setLongField(this, name, value);
     }
 
     /**
-     * Reads the state of the Marshallable object from the given wire input. The method
-     * obtains a WireMarshaller specific to the class of the current object and delegates
-     * the reading process to that marshaller.
-     * <p>
-     * The default implementation will use a default value for each field not present
-     *
-     * @param wire The wire input source.
-     * @throws IORuntimeException           If an IO error occurs during the read operation.
-     * @throws InvalidMarshallableException If there's an error during marshalling.
+     * Read this object from {@code wire} using the
+     * {@link WireMarshaller} associated with its class.  Subclasses rarely need
+     * to override this unless they perform custom deserialization that cannot be
+     * expressed via field marshalling.
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
@@ -229,14 +187,9 @@ public interface Marshallable extends WriteMarshallable, ReadMarshallable, Reset
     }
 
     /**
-     * Writes the state of the Marshallable object to the given wire output. The method
-     * obtains a WireMarshaller specific to the class of the current object and delegates
-     * the writing process to that marshaller.
-     * <p>
-     * The default implementation will write all values even if they are a default value. c.f. readMarshallable
-     *
-     * @param wire The wire output destination.
-     * @throws InvalidMarshallableException If there's an error during marshalling.
+     * Write this object to {@code wire} using the
+     * {@link WireMarshaller} associated with its class.  Subclasses should only
+     * override if they require bespoke serialization logic.
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
@@ -249,9 +202,9 @@ public interface Marshallable extends WriteMarshallable, ReadMarshallable, Reset
     }
 
     /**
-     * Creates a deep copy of the current marshallable object.
-     *
-     * @return The deep copy of the current object.
+     * Create a deep copy by serialising this object to an in-memory binary wire
+     * and deserialising it back into a new instance of the same class.  Enum
+     * instances are returned as is.
      */
     @SuppressWarnings("unchecked")
     @NotNull
@@ -260,23 +213,18 @@ public interface Marshallable extends WriteMarshallable, ReadMarshallable, Reset
     }
 
     /**
-     * Copy fields from this to dest by marshalling out and then in. Allows copying of fields by name
-     * even if there is no type relationship between this and dest
-     *
-     * @param dest destination
-     * @return t
-     * @param <T> destination type
+     * Copy fields from this instance to {@code dest} by marshalling to a wire
+     * and then reading into the destination.  Fields are matched by name so the
+     * two objects do not need to share a type hierarchy.
      */
     default <T extends Marshallable> T copyTo(@NotNull T dest) throws InvalidMarshallableException {
         return Wires.copyTo(this, dest);
     }
 
     /**
-     * Merges the current marshallable object into a map, using a specified function to determine the key.
-     *
-     * @param map The map to merge into.
-     * @param getKey The function to determine the key for the current object in the map.
-     * @return The merged marshallable object in the map.
+     * Merge this object into {@code map}.  If an entry with the same key (as
+     * provided by {@code getKey}) exists, its fields are updated using
+     * {@link #copyTo(Marshallable)}; otherwise this instance is put into the map.
      */
     default <K, T extends Marshallable> T mergeToMap(@NotNull Map<K, T> map, @NotNull Function<T, K> getKey) {
         @NotNull @SuppressWarnings("unchecked")
@@ -286,9 +234,8 @@ public interface Marshallable extends WriteMarshallable, ReadMarshallable, Reset
     }
 
     /**
-     * Retrieves the list of field information for the current class.
-     *
-     * @return A list of field information objects.
+     * Return metadata describing the fields of this class as calculated by
+     * {@link WireMarshaller}.  Useful for reflective operations.
      */
     @NotNull
     default List<FieldInfo> $fieldInfos() {
@@ -296,25 +243,23 @@ public interface Marshallable extends WriteMarshallable, ReadMarshallable, Reset
     }
 
     /**
-     * Retrieves a map of field information for the current class, with field names as keys.
-     *
-     * @return A map with field names as keys and field information objects as values.
+     * As {@link #$fieldInfos()} but returned as a map keyed by field name.
      */
     default @NotNull Map<String, FieldInfo> $fieldInfoMap() {
         return Wires.fieldInfoMap(getClass());
     }
 
     /**
-     * Returns the alias name for the current class, if available.
-     *
-     * @return The alias name for the current class or the canonical name if no alias exists.
+     * Returns the alias for this class as registered with
+     * {@link net.openhft.chronicle.core.pool.ClassAliasPool#CLASS_ALIASES} or
+     * falls back to the canonical class name.
      */
     default String className() {
         return ClassAliasPool.CLASS_ALIASES.nameFor(getClass());
     }
 
     /**
-     * Resets the current marshallable object to its initial state.
+     * Reset this object to its default state via {@link Wires#reset(Object)}.
      */
     default void reset() {
         Wires.reset(this);

--- a/src/main/java/net/openhft/chronicle/wire/MarshallableIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableIn.java
@@ -30,25 +30,21 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * This interface provides methods for reading marshallable objects. It defines the contract for any
- * entity that is capable of reading marshalled data. The interface incorporates default methods for
- * various reading operations to offer flexibility and extensibility to implementors.
- * <p>
- * Note: This interface assumes that you are familiar with the concept of marshallable objects,
- * which are objects that can be marshalled (converted to byte streams) and unmarshalled
- * (converted back to objects).
+ * Abstraction for any source from which {@link DocumentContext}s can be read
+ * (for example a queue tailer or network connection).
  */
 @FunctionalInterface
 public interface MarshallableIn {
 
-    // Size configuration for internal use
+    /**
+     * Maximum length of text that will be {@linkplain String#intern() interned}
+     * when read via {@link #readText()}.
+     */
     int MARSHALLABLE_IN_INTERN_SIZE = Integer.getInteger("marshallableIn.intern.size", 128);
 
     /**
-     * Provides a {@code DocumentContext} that can be used to read data from a source. The specific
-     * source and the means of reading are determined by the concrete implementation.
-     *
-     * @return A {@code DocumentContext} appropriate for reading from the underlying source.
+     * Open a {@link DocumentContext} for reading the next message.  Always use
+     * in a try-with-resources block so the context is closed correctly.
      */
     @NotNull
     DocumentContext readingDocument();

--- a/src/main/java/net/openhft/chronicle/wire/ReadMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/ReadMarshallable.java
@@ -24,22 +24,20 @@ import net.openhft.chronicle.core.io.InvalidMarshallableException;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * This interface represents objects that can be reloaded from a stream by reusing an existing instance.
- * Instead of creating a new object every time the data is read from a stream, instances implementing
- * this interface can update their state based on the stream content, thereby potentially improving performance
- * and reducing garbage.
- * <p>
- * For objects which need to deserialize final fields, consider using the {@link Demarshallable} interface.
- *
- * <p>
- * Example usage might involve reading an object's state from a file or network stream
- * without allocating a new object on each read operation.
+ * Interface for objects that read their state from a {@link Wire} into an
+ * existing instance.  Reusing the same object instance can dramatically reduce
+ * allocation rates in performance critical code.  For immutable objects or
+ * those that require a fresh instance on each load see {@link Demarshallable}.
  */
 @FunctionalInterface
 @DontChain
 public interface ReadMarshallable extends CommonMarshallable {
 
-    // An instance of ReadMarshallable that doesn't perform any action when reading.
+    /**
+     * A no-op instance that simply consumes and discards input.  Useful as a
+     * placeholder when a {@code ReadMarshallable} is required but the data is
+     * intentionally ignored.
+     */
     ReadMarshallable DISCARD = w -> {};
 
     /**
@@ -54,13 +52,12 @@ public interface ReadMarshallable extends CommonMarshallable {
     void readMarshallable(@NotNull WireIn wire) throws IORuntimeException, InvalidMarshallableException;
 
     /**
-     * Handles unexpected fields encountered during the deserialization process.
-     * Default behavior is to skip the unexpected value. Override this method if a different behavior is required.
+     * Called when a field name is encountered that this object does not expect.
+     * The default implementation simply skips the value but subclasses may
+     * override to perform validation or error handling.
      *
-     * @param event   The event or field identifier that was unexpected.
-     * @param valueIn The value associated with the unexpected field.
-     *
-     * @throws InvalidMarshallableException If the unexpected field cannot be processed.
+     * @param event   typically the field name that was not recognised
+     * @param valueIn the value to skip or process
      */
     default void unexpectedField(Object event, ValueIn valueIn) throws InvalidMarshallableException {
         valueIn.skipValue();

--- a/src/main/java/net/openhft/chronicle/wire/SelfDescribingMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/SelfDescribingMarshallable.java
@@ -18,9 +18,9 @@
 package net.openhft.chronicle.wire;
 
 /**
- * Represents an abstraction of marshallable objects that are self-describing by default.
- * This class extends {@code AbstractCommonMarshallable} and ensures that instances
- * inherently use self-describing messages.
+ * Base class for marshallable objects that write their type information when
+ * serialized.  This allows them to be deserialized without prior knowledge of
+ * the exact class.
  */
 public abstract class SelfDescribingMarshallable extends AbstractCommonMarshallable {
     @Override

--- a/src/main/java/net/openhft/chronicle/wire/SelfDescribingTriviallyCopyable.java
+++ b/src/main/java/net/openhft/chronicle/wire/SelfDescribingTriviallyCopyable.java
@@ -29,39 +29,39 @@ import java.nio.BufferUnderflowException;
 import static net.openhft.chronicle.core.UnsafeMemory.MEMORY;
 
 /**
- * Represents a self-describing object that is trivially copyable, extending the functionality of {@link SelfDescribingMarshallable}.
- * The class provides mechanisms to efficiently manage the internal data layout of an instance based on various data types
- * such as longs, ints, shorts, and bytes. The layout is determined using a description integer.
+ * Self-describing marshallable that can be copied by simple memory operations.
+ * The binary layout of the object is encoded by {@link #$description()} which
+ * specifies how many primitive values of each type it contains.
  */
 @SuppressWarnings("this-escape")
 public abstract class SelfDescribingTriviallyCopyable extends SelfDescribingMarshallable {
 
-    // Contains the description of the data layout.
+    /**
+     * Integer encoding of the field layout.  Initialised from {@link #$description()} and
+     * written/read as part of the object header.
+     */
     @FieldGroup("header")
     transient int description = $description();
 
     /**
-     * Fetches the description of the current data layout.
-     *
-     * @return An integer description of the layout.
+     * @return integer encoding the number of longs, ints, shorts and bytes in
+     * this object's layout.
      */
     protected abstract int $description();
 
-    /**
-     * Determines the starting offset for the data.
-     *
-     * @return The start offset.
-     */
+    /** start offset of the trivially copyable region. */
     protected abstract int $start();
 
-    /**
-     * Fetches the total length of the data based on its layout.
-     *
-     * @return The total data length.
-     */
+    /** total length in bytes of the trivially copyable region. */
     protected abstract int $length();
 
     @Override
+    /**
+     * Read the binary state of this object from {@code bytes}.  If the layout
+     * description in the input matches {@link #$description()}, a fast unsafe
+     * memory copy is used, otherwise {@link #carefulCopy(BytesIn, int)} handles
+     * any schema differences field by field.
+     */
     public void readMarshallable(BytesIn<?> bytes) throws IORuntimeException, BufferUnderflowException, IllegalStateException {
         int description0 = bytes.readInt();
         if (description0 != $description())
@@ -71,13 +71,9 @@ public abstract class SelfDescribingTriviallyCopyable extends SelfDescribingMars
     }
 
     /**
-     * Performs a controlled copy of data from an input source based on the given description.
-     * The method will read data of various sizes (long, int, short, byte) based on the description
-     * and will copy this data to the current instance's memory.
-     *
-     * @param in          The input source from which data will be read.
-     * @param description0 The description integer specifying the layout of the data in the input source.
-     * @throws IllegalStateException if the description is invalid or does not match the input's content.
+     * Copy fields from {@code in} into this object honouring both the source
+     * description ({@code description0}) and this object's own
+     * {@link #$description()} so that layout changes are tolerated.
      */
     private void carefulCopy(BytesIn<?> in, int description0) {
         // Start offset for copying data
@@ -146,6 +142,7 @@ public abstract class SelfDescribingTriviallyCopyable extends SelfDescribingMars
     }
 
     @Override
+    /** Write out the layout description followed by the raw memory block. */
     public void writeMarshallable(BytesOut<?> bytes) throws IllegalStateException, BufferOverflowException, BufferUnderflowException, ArithmeticException {
         bytes.writeInt($description());
         bytes.unsafeWriteObject(this, $start(), $length());

--- a/src/main/java/net/openhft/chronicle/wire/WriteMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/WriteMarshallable.java
@@ -24,41 +24,30 @@ import net.openhft.chronicle.core.io.InvalidMarshallableException;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Represents a marshallable entity capable of writing its state to a given wire format.
- * Implementations of this interface can describe their serialization logic by defining
- * the {@link #writeMarshallable(WireOut)} method.
- * <p>
- * This interface is annotated with {@code @FunctionalInterface}, indicating that it is
- * intended to be used primarily for lambda expressions and method references.
- * Furthermore, the {@code @DontChain} annotation highlights that implementations should
- * not be chained for certain operations.
+ * Functional interface for objects that can write their state to a
+ * {@link WireOut}.  Often used by DTOs or other objects that need to be
+ * serialized.
  */
 @FunctionalInterface
 @DontChain
 public interface WriteMarshallable extends WriteValue, CommonMarshallable {
 
     /**
-     * Represents an empty marshallable entity that performs no actions
-     * when its {@code writeMarshallable} method is invoked.
+     * A no-op instance that writes nothing.  Useful as a placeholder
+     * implementation of {@code WriteMarshallable}.
      */
     WriteMarshallable EMPTY = wire -> {
         // nothing
     };
 
     /**
-     * Write the current state of the marshallable entity to the provided wire.
-     *
-     * @param wire The wire format to write to.
-     * @throws InvalidMarshallableException if any serialization error occurs.
+     * Write this object's state to {@code wire}.  Implementations should read
+     * their own fields and emit them via the provided {@link WireOut}.
      */
     void writeMarshallable(@NotNull WireOut wire) throws InvalidMarshallableException;
 
     /**
-     * Writes the current state of the marshallable entity as a value
-     * to the provided output.
-     *
-     * @param out The output to write to.
-     * @throws InvalidMarshallableException if any serialization error occurs.
+     * Default implementation that simply calls {@code out.marshallable(this)}.
      */
     @Override
     default void writeValue(@NotNull ValueOut out) throws InvalidMarshallableException {
@@ -66,11 +55,8 @@ public interface WriteMarshallable extends WriteValue, CommonMarshallable {
     }
 
     /**
-     * Provides an assumed length in bytes for the serialized form of this entity.
-     * This is useful for pre-allocating resources or optimizing serialization
-     * and deserialization processes.
-     *
-     * @return The binary length length indicating the size in bytes.
+     * Hint about the length prefix used when this object is written in binary
+     * form.  Defaults to {@link BinaryLengthLength#LENGTH_32BIT}.
      */
     default BinaryLengthLength binaryLengthLength() {
         return BinaryLengthLength.LENGTH_32BIT;


### PR DESCRIPTION
## Summary
-   Expanded the overview for `Marshallable` to clarify its role as the main interface combining read and write capabilities while supporting object recycling
    
-   Documented the placeholder nature of `WriteMarshallable.EMPTY` and explained how implementations should output their fields to `WireOut`
    
-   Explained how configuration beans merge defaults in `AbstractMarshallableCfg` and skip undefined fields during reading
    
-   Clarified self‑describing objects and trivially copyable layouts for binary efficiency
    
-   Marked `DynamicEnum` as deprecated and described how `updateEnum` refreshes cached values