### PR TITLE
Improve Javadoc for serialization utilities

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/ScalarStrategy.java
+++ b/src/main/java/net/openhft/chronicle/wire/ScalarStrategy.java
@@ -26,15 +26,17 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**
- * Implements the {@link SerializationStrategy} for scalar data types.
- * This strategy is designed for simple types and provides mechanisms for reading
- * them using provided functions.
+ * Implementation of {@link SerializationStrategy} for simple scalar values.  It
+ * is typically used for primitive wrappers or other types that appear in the
+ * wire as single values without any surrounding structure
+ * ({@link BracketType#NONE}).
  *
  * @param <E> The type of the scalar value that this strategy handles.
  */
 class ScalarStrategy<E> implements SerializationStrategy {
+    /** Function used to read the value from a {@link ValueIn}. */
     final BiFunction<? super E, ValueIn, E> read;
-    // The class type of the scalar value
+    /** The scalar value type. */
     private final Class<E> type;
 
     /**
@@ -83,13 +85,18 @@ class ScalarStrategy<E> implements SerializationStrategy {
     @NotNull
     @Override
     public BracketType bracketType() {
+        // scalar values are typically written without any brackets
         return BracketType.NONE;
     }
 
+    /**
+     * Creates a new instance of the scalar type when no existing object is
+     * supplied to {@link #readUsing}. Utilises {@link ObjectUtils#newInstance(Class)}.
+     */
     @SuppressWarnings("rawtypes")
     @NotNull
     @Override
-    public <T> T newInstanceOrNull(Class<T>type) {
+    public <T> T newInstanceOrNull(Class<T> type) {
         return Jvm.uncheckedCast(ObjectUtils.newInstance(this.type));
     }
 
@@ -101,6 +108,10 @@ class ScalarStrategy<E> implements SerializationStrategy {
     @SuppressWarnings("unchecked")
     @Nullable
     @Override
+    /**
+     * Reads the scalar value using the configured {@link #read} function.
+     * Returns {@code null} if {@link ValueIn#isNull()}.
+     */
     public <T> T readUsing(Class<?> clazz, T using, @NotNull ValueIn in, BracketType bracketType) {
         if (in.isNull())
             return null;
@@ -110,6 +121,9 @@ class ScalarStrategy<E> implements SerializationStrategy {
 
     @NotNull
     @Override
+    /**
+     * @return a textual representation including the scalar type name.
+     */
     public String toString() {
         return "ScalarStrategy<" + type.getName() + ">";
     }

--- a/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
+++ b/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
@@ -41,8 +41,10 @@ import java.util.*;
 import static net.openhft.chronicle.wire.BracketType.UNKNOWN;
 
 /**
- * Enumerates the available serialization strategies, each implementing the {@link SerializationStrategy} interface.
- * These strategies cater to different serialization requirements and support specific object types.
+ * Enumerates the available serialization strategies, each implementing the
+ * {@link SerializationStrategy} interface.  These built-in strategies cover a
+ * range of common Java types and provide the default behaviour used by the wire
+ * layer when no explicit strategy is supplied.
  */
 @SuppressWarnings({"rawtypes", "unchecked", "deprecation"})
 public enum SerializationStrategies implements SerializationStrategy {
@@ -96,8 +98,9 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy that supports any object type.
-     * This strategy infers the object type during deserialization.
+     * A general purpose strategy that can deserialize any object.  The
+     * concrete type is inferred from the wire and, once determined, the call is
+     * delegated to the appropriate strategy (often {@link #ANY_NESTED}).
      */
     ANY_OBJECT {
         /**
@@ -136,8 +139,9 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy that supports any scalar value.
-     * Scalar values are typically primitive types or their boxed equivalents.
+     * A strategy for scalar values such as primitives or boxed primitives.  In
+     * wire formats these values are typically written without enclosing map or
+     * sequence brackets.
      */
     ANY_SCALAR {
         /**
@@ -175,7 +179,8 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy specifically designed for handling enumerations (enums).
+     * Strategy for standard Java {@link Enum} types.  Values are typically
+     * serialised using their {@link Enum#name()} representation.
      */
     ENUM {
         /**
@@ -213,10 +218,10 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy designed for handling dynamic enumerations (enums).
-     * Dynamic enums are enums whose values can be altered or enhanced at runtime.
-     * This strategy incorporates custom handling to ensure proper deserialization
-     * of dynamic enums from the input source.
+     * Strategy for {@link DynamicEnum} values whose set of constants may be
+     * extended at runtime.  The {@link #readUsing} method understands both a
+     * simple textual name and a map based representation when the enum also
+     * implements {@link ReadMarshallable}.
      */
     DYNAMIC_ENUM {
 
@@ -293,10 +298,9 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy designed for handling nested objects.
-     * This strategy reads nested objects without explicitly knowing
-     * their exact type, treating them as generic objects and performing
-     * a generic deserialization.
+     * Strategy for nested objects when their exact class is not known at compile
+     * time.  Objects are treated generically and deserialized as map-like
+     * structures.
      */
     ANY_NESTED {
 
@@ -341,9 +345,9 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy specifically designed for handling
-     * {@link Demarshallable} objects. {@link Demarshallable} represents
-     * an object that can be deserialized from a wire format.
+     * Strategy for {@link Demarshallable} objects.  During reading a
+     * {@link DemarshallableWrapper} is created which later resolves to the
+     * actual instance via its {@link ReadResolvable#readResolve()} method.
      */
     DEMARSHALLABLE {
 
@@ -392,11 +396,10 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling objects that implement the
-     * {@link java.io.Serializable} interface. This strategy checks if the object
-     * is also an instance of {@link Externalizable}, and if so, uses the
-     * {@link #EXTERNALIZABLE} strategy. Otherwise, it defaults to the
-     * {@link #ANY_OBJECT} strategy.
+     * Strategy for objects implementing {@link Serializable}.  If the object is
+     * also {@link Externalizable} it delegates to {@link #EXTERNALIZABLE};
+     * otherwise the object is treated as a normal bean and the type is inferred
+     * in the same manner as {@link #ANY_OBJECT}.
      */
     SERIALIZABLE {
 
@@ -428,9 +431,10 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy specifically designed for handling
-     * {@link Externalizable} objects. Externalizable objects provide their
-     * own custom serialization mechanism that this strategy leverages.
+     * Strategy for {@link Externalizable} objects which use the standard
+     * Java {@code Externalizable} hooks.  During reading the object's
+     * {@link java.io.Externalizable#readExternal(java.io.ObjectInput)} method is
+     * invoked via an {@link java.io.ObjectInput} facade over the wire data.
      */
     EXTERNALIZABLE {
 
@@ -476,9 +480,8 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling objects that implement the
-     * {@link java.util.Map} interface. This strategy deserializes a sequence
-     * of key-value pairs into a Map instance.
+     * Strategy for {@link Map} types.  Key/value pairs are read from the wire
+     * until no more entries are present and are placed into the target map.
      */
     MAP {
 
@@ -536,9 +539,8 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling objects that implement the
-     * {@link java.util.Set} interface. This strategy deserializes a sequence
-     * of items into a Set instance.
+     * Strategy for {@link Set} implementations.  Items are read from the
+     * sequence one by one and added to the target set.
      */
     SET {
 
@@ -603,9 +605,9 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling objects that implement the
-     * {@link java.util.List} interface. This strategy deserializes a sequence
-     * of items into a List instance.
+     * Strategy for {@link List} implementations.  Items are read sequentially
+     * and placed into the list; existing elements are reused where possible and
+     * the list is trimmed or expanded to match the input size.
      */
     LIST {
 
@@ -675,8 +677,9 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling arrays. This strategy deserializes
-     * a sequence of items into an array instance.
+     * Strategy for object arrays.  Items are read into a temporary list and then
+     * converted to an array.  When the target {@code using} object is an
+     * {@link ArrayWrapper}, its component type guides the conversion.
      */
     ARRAY {
 
@@ -747,9 +750,9 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling primitive arrays. This strategy
-     * deserializes a sequence of items into an array instance, dynamically
-     * resizing the array as required during deserialization.
+     * Strategy for arrays of primitive types.  Elements are read into a
+     * {@link PrimArrayWrapper} which grows as needed and is trimmed to the
+     * correct length once reading completes.
      */
     PRIM_ARRAY {
 
@@ -854,8 +857,10 @@ public enum SerializationStrategies implements SerializationStrategy {
     }
 
     /**
-     * A wrapper class for arrays which provides a mechanism for deserialization
-     * by resolving the actual array when being read from a serialized source.
+     * Wrapper used during deserialization of arrays.  It implements
+     * {@link ReadResolvable} so that when read back via
+     * {@link ValueIn#object(Class)} the {@link #readResolve()} method returns the
+     * real array instance.
      */
     static class ArrayWrapper implements ReadResolvable<Object[]> {
 
@@ -893,12 +898,9 @@ public enum SerializationStrategies implements SerializationStrategy {
     }
 
     /**
-     * The following classes are wrappers that facilitate deserialization processes for
-     * specific types of objects. They implement the ReadResolvable interface to define
-     * the deserialization mechanism.
-     * <p>
-     * A wrapper class for primitive arrays which provides a mechanism for deserialization
-     * by resolving the actual array when being read from a serialized source.
+     * Wrapper used for primitive arrays during deserialization.  It grows as data
+     * arrives and its {@link #readResolve()} method exposes the final primitive
+     * array to the caller.
      */
     static class PrimArrayWrapper implements ReadResolvable<Object> {
 
@@ -936,8 +938,9 @@ public enum SerializationStrategies implements SerializationStrategy {
     }
 
     /**
-     * A wrapper class for Demarshallable objects which provides a mechanism for deserialization
-     * by resolving the actual Demarshallable object when being read from a serialized source.
+     * Wrapper used when reading {@link Demarshallable} objects.  The wrapper is
+     * returned during the initial read and later resolves to the actual object
+     * via {@link #readResolve()}.
      */
     static class DemarshallableWrapper implements ReadResolvable<Demarshallable> {
 

--- a/src/main/java/net/openhft/chronicle/wire/SerializationStrategy.java
+++ b/src/main/java/net/openhft/chronicle/wire/SerializationStrategy.java
@@ -23,19 +23,29 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents a strategy for serializing and deserializing objects of type {@code T}.
- * Implementations of this interface define methods for reading, instantiating,
- * and providing metadata about the serialized format.
+ * <p>
+ * Each implementation typically targets a particular Java type (for example
+ * {@link Enum enums}, {@link java.util.List lists} or {@link Marshallable} objects)
+ * and defines how instances of that type are converted to and from a wire
+ * representation.  See {@link SerializationStrategies} for the common built-in
+ * strategies.
  */
 public interface SerializationStrategy {
 
     /**
      * Reads an object of type {@code T} from the provided input source and populates
-     * the given 'using' object, if not null. The method uses the given {@link BracketType}
-     * to aid in the deserialization.
+     * the given {@code using} instance if one is supplied.  The {@code clazz}
+     * parameter describes the expected type.  It may be a super type of the
+     * actual object being read if the concrete type can be inferred from the
+     * wire data.  If {@code using} is {@code null}, the implementation may call
+     * {@link #newInstanceOrNull(Class)} to obtain a new instance.  The provided
+     * {@link BracketType} hints at the structural representation (map, sequence
+     * or none) of the value being read.
      *
-     * @param clazz The class type to be deserialized.
-     * @param using An optional object of type {@code T} that can be populated with the read data.
-     *              If null, a new object will be created or an exception might be thrown depending on implementation.
+     * @param clazz       the expected class of the object to read.  May be {@code null}
+     *                    if the type is to be inferred by the strategy.
+     * @param using       an optional existing instance to populate.  If {@code null}
+     *                    the strategy may create a new instance.
      * @param in The input source containing serialized data.
      * @param bracketType The type of bracket used in the serialized format.
      * @return The populated or newly created object of type {@code T}.
@@ -45,28 +55,30 @@ public interface SerializationStrategy {
     <T> T readUsing(Class<?> clazz, T using, ValueIn in, BracketType bracketType) throws InvalidMarshallableException;
 
     /**
-     * Constructs and returns a new instance of the provided {@code type}
-     * as a reference. If the instance cannot be constructed for any reason,
-     * {@code null} is returned.
+     * Constructs and returns a new instance of the provided {@code type}.  This
+     * method is used by the deserialization process when no existing instance is
+     * supplied via the {@code using} parameter of {@link #readUsing}.  If a new
+     * instance cannot be constructed (for example the type is an interface or
+     * abstract class) {@code null} is returned.
      *
-     * @param type The class type for which a new instance is required.
-     * @return A new instance of the provided {@code type} or {@code null} if instantiation is not possible.
+     * @param type The class for which a new instance is required.
+     * @return a new instance or {@code null} if instantiation is not possible.
      */
     @Nullable
     <T> T newInstanceOrNull(Class<T> type);
 
     /**
-     * Returns the class type of objects this serialization strategy is designed to handle.
-     *
-     * @return The class type of objects this strategy can serialize and deserialize.
+     * Returns the primary Java {@link Class} that this strategy serializes and
+     * deserializes.  This may be a concrete class, an interface or a more
+     * generic type such as {@link Object}.
      */
     Class<?> type();
 
     /**
-     * Provides the bracket type used in the serialized format, which might
-     * give hints or constraints on how the data is structured.
-     *
-     * @return the {@link BracketType} used by this serialization strategy.
+     * Returns the {@link BracketType} associated with this strategy.  This
+     * describes the structural form expected when reading or writing a value –
+     * for example {@link BracketType#MAP} for objects, {@link BracketType#SEQ}
+     * for collections or {@link BracketType#NONE} for scalar values.
      */
     @NotNull
     BracketType bracketType();

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -44,27 +44,33 @@ import java.util.stream.Stream;
 import static net.openhft.chronicle.core.UnsafeMemory.*;
 
 /**
- * The WireMarshaller class is responsible for marshalling and unmarshalling of objects of type T.
- * This class provides an efficient mechanism for serialization/deserialization using wire protocols.
- * It utilizes field accessors to read and write values directly to and from the fields of the object.
+ * Responsible for marshalling and unmarshalling objects of type {@code T} using
+ * the Chronicle Wire framework.  Instances of this class are typically cached
+ * per target class (see {@link #WIRE_MARSHALLER_CL}) and use reflection only at
+ * construction time to discover the fields.  Subsequent reads and writes use
+ * optimised {@link FieldAccess} objects for performance.
  *
  * @param <T> The type of the object to be marshalled/unmarshalled.
  */
 @SuppressWarnings({"rawtypes", "unchecked", "deprecation"})
 public class WireMarshaller<T> {
+    /** Parameter types for a potential {@code unexpectedField(Object, ValueIn)} method. */
     private static final Class[] UNEXPECTED_FIELDS_PARAMETER_TYPES = {Object.class, ValueIn.class};
+    /** Empty field array used when a class has no marshallable fields. */
     private static final FieldAccess[] NO_FIELDS = {};
+    /** Reflection accessor for {@link Class#isRecord()} on Java&nbsp;14+. */
     private static Method isRecord;
+    /** Accessors for all marshallable fields of {@code T}. */
     @NotNull
     final FieldAccess[] fields;
 
-    // Map for quick field look-up based on their names.
+    /** Map for quick field look-up based on field name. */
     final TreeMap<CharSequence, FieldAccess> fieldMap = new TreeMap<>(WireMarshaller::compare);
 
-    // Flag to determine if this marshaller is for a leaf class.
+    /** Indicates whether {@code T} is considered a leaf object in the object graph. */
     private final boolean isLeaf;
 
-    // Default value for the type T.
+    /** Pre-created default instance used for comparison and defaulting missing fields. */
     @Nullable
     private final T defaultValue;
 
@@ -78,18 +84,22 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Constructs a new instance of the WireMarshaller with the specified parameters.
+     * Protected constructor.  Use {@link #of(Class)} or
+     * {@link #WIRE_MARSHALLER_CL} to obtain instances in normal use.
      *
      * @param tClass  The class of the object to be marshalled.
-     * @param fields  An array of field accessors that provide access to the fields of the object.
+     * @param fields  An array of field accessors for the class.
      * @param isLeaf  Indicates if the marshaller is for a leaf class.
      */
     protected WireMarshaller(@NotNull Class<T> tClass, @NotNull FieldAccess[] fields, boolean isLeaf) {
         this(fields, isLeaf, defaultValueForType(tClass));
     }
 
-    // A class-local storage for caching WireMarshallers for different types.
-    // Depending on the type of class, it either creates a marshaller for exceptions or a generic one.
+    /**
+     * Cache of {@link WireMarshaller} instances keyed by class.  When first
+     * accessed the appropriate marshaller is created – specialised for
+     * {@link Throwable} subclasses or generic otherwise.
+     */
     public static final ClassLocal<WireMarshaller> WIRE_MARSHALLER_CL = ClassLocal.withInitial
             (tClass ->
                     Throwable.class.isAssignableFrom(tClass)
@@ -97,6 +107,7 @@ public class WireMarshaller<T> {
                             : WireMarshaller.of(tClass)
             );
 
+    /** Internal constructor used by the factory methods. */
     WireMarshaller(@NotNull FieldAccess[] fields, boolean isLeaf, @Nullable T defaultValue) {
         this.fields = fields;
         this.isLeaf = isLeaf;
@@ -231,6 +242,10 @@ public class WireMarshaller<T> {
         }
     }
 
+    /**
+     * Creates a default instance for the given type if possible.  Used for
+     * delta encoding and for populating missing fields during read.
+     */
     static <T> T defaultValueForType(@NotNull Class<T> tClass) {
 //        tClass = ObjectUtils.implementationToUse(tClass);
         if (ObjectUtils.isConcreteClass(tClass)
@@ -432,9 +447,9 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Writes the values of the fields from the provided object (DTO) to the output. Before writing,
-     * the object is validated. The method also supports optional copying of the values
-     * from the source object to a previous instance.
+     * Writes all fields of {@code t} to the {@code out}.  If {@code copy} is
+     * {@code true} the written values are also copied into the {@link #defaultValue}
+     * instance so that subsequent delta writes can compare against it.
      *
      * @param t    Object whose field values are to be written.
      * @param out  Output destination where the field values are written to.
@@ -475,12 +490,9 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Reads and populates the DTO based on the provided order.
-     *
-     * @param t         Target object to populate with read values.
-     * @param in        Input source from which values are read.
-     * @param overwrite Flag indicating whether to overwrite the existing value in the target object.
-     * @throws InvalidMarshallableException If there is an error during marshalling.
+     * Reads the fields in the order they are defined in the DTO class.
+     * If a field is not present in the input and {@code overwrite} is true the
+     * value from {@link #defaultValue} is applied.
      */
     public void readMarshallableDTOOrder(T t, @NotNull WireIn in, boolean overwrite) throws InvalidMarshallableException {
         try {
@@ -495,12 +507,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Reads and populates the DTO based on the input's order.
-     *
-     * @param t         Target object to populate with read values.
-     * @param in        Input source from which values are read.
-     * @param overwrite Flag indicating whether to overwrite the existing value in the target object.
-     * @throws InvalidMarshallableException If there is an error during marshalling.
+     * Reads fields in the order they appear in the input wire.  If a field is
+     * missing and {@code overwrite} is true the value from {@link #defaultValue}
+     * is applied after reading all input fields. Unknown fields are skipped or
+     * delegated to {@link ReadMarshallable#unexpectedField(Object, ValueIn)} if
+     * implemented by {@code t}.
      */
     public void readMarshallableInputOrder(T t, @NotNull WireIn in, boolean overwrite) throws InvalidMarshallableException {
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshallerForUnexpectedFields.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshallerForUnexpectedFields.java
@@ -23,15 +23,19 @@ import net.openhft.chronicle.core.scoped.ScopedResource;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * This class extends the WireMarshaller and provides the ability to handle unexpected fields.
- * It maps fields by their name (both in their original form and lower-cased) for easy access.
- * It overrides the method to read marshallable objects and provides specialized logic to
- * handle unexpected fields that might be present in the data source.
+ * Extension of {@link WireMarshaller} that can delegate unknown fields to the
+ * target object's {@link ReadMarshallable#unexpectedField(Object, ValueIn)}
+ * method. Field names are stored in a {@link CharSequenceObjectMap} for quick
+ * case-insensitive lookup.
  */
 public class WireMarshallerForUnexpectedFields<T> extends WireMarshaller<T> {
-    // Map for storing fields based on their names.
+    /** Map for storing fields by name (original and lower case). */
     final CharSequenceObjectMap<FieldAccess> fieldMap;
 
+    /**
+     * Creates a marshaller capable of reporting unexpected fields to the target
+     * object.
+     */
     public WireMarshallerForUnexpectedFields(@NotNull FieldAccess[] fields, boolean isLeaf, T defaultValue) {
         super(fields, isLeaf, defaultValue);
         fieldMap = new CharSequenceObjectMap<>(fields.length * 3);
@@ -41,6 +45,11 @@ public class WireMarshallerForUnexpectedFields<T> extends WireMarshaller<T> {
         }
     }
 
+    /**
+     * Overrides the normal deserialization to invoke
+     * {@link ReadMarshallable#unexpectedField(Object, ValueIn)} when an input
+     * field name does not match any known field.
+     */
     @Override
     public void readMarshallable(T t, @NotNull WireIn in, boolean overwrite) throws InvalidMarshallableException {
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {


### PR DESCRIPTION
## Summary
-   Enhanced overall description and method explanations in `SerializationStrategy` for better clarity on how strategies infer and handle types
    
-   Documented specific behaviors of strategy constants such as `ENUM` and `MAP` in `SerializationStrategies`
    
-   Expanded class and method Javadoc in `ScalarStrategy` including notes on bracket usage and instance creation
    
-   Updated `WireMarshaller` fields and constructors with detailed comments and added a summary of default value handling
    
-   Added explanations in `WireMarshallerForUnexpectedFields` about unexpected field handling and constructor purpose