### PR TITLE
Improve Javadocs for core wire APIs

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AbstractAnyWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractAnyWire.java
@@ -30,17 +30,18 @@ import org.jetbrains.annotations.Nullable;
 import java.util.function.Supplier;
 
 /**
- * An abstract representation of a wire type that could be either {@code TextWire} or {@code BinaryWire}.
- * This class provides a generic foundation for wire types that could shift between the two mentioned types
- * based on the underlying acquisition logic.
- *
- * @author Rob Austin.
+ * Base class for wires where the concrete format is determined lazily.  The
+ * underlying bytes are inspected on first use and a {@link Wire} implementation
+ * such as {@link TextWire} or {@link BinaryWire} is acquired via a
+ * {@link WireAcquisition} strategy.
  */
 @SuppressWarnings("rawtypes")
 public abstract class AbstractAnyWire extends AbstractWire implements Wire {
 
+    /** Strategy object responsible for lazily obtaining the real {@link Wire}
+     * implementation backed by the underlying bytes. */
     @NotNull
-    protected final WireAcquisition wireAcquisition;  // Responsible for acquiring the actual wire type (TextWire or BinaryWire).
+    protected final WireAcquisition wireAcquisition;
 
     /**
      * Constructs a new instance of {@code AbstractAnyWire} using the specified bytes and wire acquisition strategy.
@@ -54,10 +55,8 @@ public abstract class AbstractAnyWire extends AbstractWire implements Wire {
     }
 
     /**
-     * Retrieves the underlying wire, which could be either {@code TextWire} or {@code BinaryWire},
-     * based on the acquisition strategy.
-     *
-     * @return The underlying wire type.
+     * Returns the lazily acquired underlying {@link Wire}.  The first call will
+     * inspect the bytes and choose the appropriate wire implementation.
      */
     @Nullable
     public Wire underlyingWire() {
@@ -65,9 +64,8 @@ public abstract class AbstractAnyWire extends AbstractWire implements Wire {
     }
 
     /**
-     * Provides a supplier that indicates the type of the underlying wire.
-     *
-     * @return A supplier yielding the {@code WireType}.
+     * Returns a supplier indicating the {@link WireType} of the underlying
+     * implementation once acquired.
      */
     @NotNull
     public Supplier<WireType> underlyingType() {
@@ -148,6 +146,10 @@ public abstract class AbstractAnyWire extends AbstractWire implements Wire {
         return wireAcquisition.acquireWire().newIntArrayReference();
     }
 
+    /**
+     * Ensures the underlying wire has been acquired.  Invoked before delegating
+     * operations to the real wire implementation.
+     */
     void checkWire() {
         wireAcquisition.acquireWire();
     }

--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -48,16 +48,25 @@ import static net.openhft.chronicle.wire.Wires.*;
  */
 public abstract class AbstractWire implements Wire, InternalWire {
 
-    // Default padding configuration loaded from the system properties.
+    /**
+     * Default padding configuration loaded from the system property
+     * {@code wire.usePadding}. Padding can be used to align messages on cache
+     * line boundaries.
+     */
     public static final boolean DEFAULT_USE_PADDING = Jvm.getBoolean("wire.usePadding", false);
 
-    // Message used when a header is detected inside another header.
+    /**
+     * Error message issued when a header is detected inside another header,
+     * usually indicating nested document contexts.
+     */
     private static final String INSIDE_HEADER_MESSAGE = "you cant put a header inside a header, check that " +
             "you have not nested the documents. If you are using Chronicle-Queue please " +
             "ensure that you have a unique instance of the Appender per thread, in " +
             "other-words you can not share appenders across threads.";
 
     static {
+        // populate the global class alias pool with common aliases before any
+        // wires are constructed
         WireInternal.addAliases();
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/MarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableOut.java
@@ -41,10 +41,9 @@ import java.util.stream.Stream;
 public interface MarshallableOut extends DocumentWritten, RollbackIfNotCompleteNotifier {
 
     /**
-     * Creates and returns a new instance of {@link MarshallableOutBuilder} initialized with the provided URL.
-     *
-     * @param url The URL which will dictate the specific type of {@code MarshallableOut} to create.
-     * @return A new instance of {@code MarshallableOutBuilder}.
+     * Returns a builder whose implementation is chosen based on the scheme of
+     * the provided {@link URL}.  For example {@code file:} may create a queue
+     * appender while {@code http:} might create a network writer.
      */
     static MarshallableOutBuilder builder(URL url) {
         return new MarshallableOutBuilder(url);
@@ -89,8 +88,8 @@ public interface MarshallableOut extends DocumentWritten, RollbackIfNotCompleteN
     DocumentContext acquireWritingDocument(boolean metaData) throws UnrecoverableTimeoutException;
 
     /**
-     * @return true if this output is configured to expect the history of the message to be written
-     * to.
+     * Indicates whether history information (source id, index) should be
+     * appended with each message for tracing and debugging purposes.
      */
     default boolean recordHistory() {
         return false;

--- a/src/main/java/net/openhft/chronicle/wire/ReadAnyWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/ReadAnyWire.java
@@ -28,9 +28,9 @@ import org.jetbrains.annotations.Nullable;
 import java.util.function.Supplier;
 
 /**
- * Represents a wire type that can be either {@code TextWire} or {@code BinaryWire}.
- * The specific wire type is determined dynamically based on the provided bytes.
- * This class provides flexibility in reading from wires that could be in either format.
+ * Wire implementation that inspects the first bytes of the input to decide
+ * whether it is text, binary or fieldless binary.  Primarily used for reading
+ * where the wire type is not known ahead of time.
  */
 public class ReadAnyWire extends AbstractAnyWire implements Wire {
 
@@ -83,15 +83,18 @@ public class ReadAnyWire extends AbstractAnyWire implements Wire {
 
     @NotNull
     @Override
+    /**
+     * Returns the raw {@link Bytes} backing this wire.  Calling this forces the
+     * underlying wire type to be determined if it hasn't already.
+     */
     public Bytes<?> bytes() {
         checkWire();
         return bytes;
     }
 
     /**
-     * Represents a mechanism to acquire the correct wire type based on provided bytes.
-     * This class is responsible for dynamically determining whether the bytes
-     * correspond to a {@code TextWire} or a {@code BinaryWire}.
+     * Acquisition strategy used by {@link ReadAnyWire}.  It peeks at the initial
+     * bytes to decide which concrete wire to instantiate.
      */
     static class ReadAnyWireAcquisition implements WireAcquisition {
         private final Bytes<?> bytes;
@@ -129,6 +132,12 @@ public class ReadAnyWire extends AbstractAnyWire implements Wire {
 
         @Override
         @Nullable
+        /**
+         * Lazily determines the wire type by inspecting the first few bytes. If
+         * all high bits of the first eight bytes are clear it assumes text; if
+         * the first byte is a field code it chooses fieldless binary otherwise
+         * {@link WireType#BINARY}.
+         */
         public Wire acquireWire() {
             if (wire != null)
                 return wire;

--- a/src/main/java/net/openhft/chronicle/wire/SourceContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/SourceContext.java
@@ -20,10 +20,9 @@ package net.openhft.chronicle.wire;
 import net.openhft.chronicle.core.io.IORuntimeException;
 
 /**
- * This is the SourceContext interface.
- * It defines methods to interact with the underlying source context, particularly in terms of accessing its source ID
- * and the last read index. Implementations of this interface are expected to handle source contexts which could be used
- * in various scenarios like I/O operations, data streaming, or context management.
+ * Provides access to metadata about the source of a message, typically used by
+ * queue tailers or network receivers.  A {@link DocumentContext} implements
+ * this interface so consumers can obtain the source id and last read index.
  */
 public interface SourceContext {
 

--- a/src/main/java/net/openhft/chronicle/wire/Wire.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wire.java
@@ -25,10 +25,10 @@ import org.jetbrains.annotations.NotNull;
 import java.io.IOException;
 
 /**
- * Defines the standard interface for sequentially writing to and reading from a Bytes stream.
- * Implementations of this interface should ensure single-threaded access and avoid method chaining.
- *
- * <p>This interface combines the capabilities of both {@link WireIn} and {@link WireOut} interfaces.
+ * Top level interface for bidirectional wire implementations.  It combines the
+ * functionality of {@link WireIn} and {@link WireOut} and represents the most
+ * common entry point for using Chronicle Wire.  All operations are expected to
+ * be single threaded on a given instance.
  */
 @SingleThreaded
 @DontChain
@@ -43,10 +43,8 @@ public interface Wire extends WireIn, WireOut {
     }
 
     /**
-     * Set the header number for the Wire. Concrete implementations should ensure they provide the expected behavior for this method.
-     *
-     * @param headerNumber The header number to be set.
-     * @return The current Wire instance, often for method chaining.
+     * Sets the sequence number used when writing headers.  Queue and TCP
+     * protocols typically increment this value for each new document.
      */
     @Override
     @NotNull

--- a/src/main/java/net/openhft/chronicle/wire/WireCommon.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireCommon.java
@@ -26,33 +26,48 @@ import net.openhft.chronicle.threads.Pauser;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Common functionality shared by all {@link Wire} implementations.
+ * <p>
+ * This interface groups configuration options and utility factory methods that
+ * are required by both {@link WireIn} and {@link WireOut}. Implementations
+ * use these methods to control how marshalling is performed, how waiting or
+ * back pressure is handled and to create value references bound to the
+ * underlying wire format.
+ */
 public interface WireCommon {
 
     /**
-     * Sets the {@link ClassLookup} implementation to be used for class lookup.
+     * Sets the {@link ClassLookup} used to resolve class names during
+     * deserialization.  This is particularly important when type information is
+     * written as a textual alias or when reading a {@code class} field from the
+     * wire.
      *
-     * @param classLookup implementation to be used for class lookup.
+     * @param classLookup strategy used for class resolution
      */
     void classLookup(ClassLookup classLookup);
 
     /**
-     * Returns the current {@link ClassLookup} implementation being used for class lookup.
+     * Returns the current {@link ClassLookup} used for resolving class names
+     * while reading objects from the wire.
      *
-     * @return the current {@link ClassLookup} implementation being used for class lookup
+     * @return the {@link ClassLookup} in use
      */
     ClassLookup classLookup();
 
     /**
-     * Sets the {@link Pauser} implementation to be used for blocking operations.
+     * Sets the {@link Pauser} implementation.  A {@code Pauser} defines the
+     * strategy used by blocking operations to wait for data (for example,
+     * busy-spin, yield or park).
      *
-     * @param pauser implementation to be used for blocking operations.
+     * @param pauser strategy for blocking/waiting operations
      */
     void pauser(Pauser pauser);
 
     /**
-     * Returns the current {@link Pauser} implementation being used for blocking operations.
+     * Returns the {@link Pauser} used when blocking for more data or capacity.
      *
-     * @return the current {@link Pauser} implementation being used for blocking operations
+     * @return the pauser strategy
      */
     Pauser pauser();
 
@@ -65,35 +80,32 @@ public interface WireCommon {
     Bytes<?> bytes();
 
     /**
-     * Returns the bytes() but only for comment.
-     *
-     * @return the bytes() but only for comment
+     * Returns the underlying bytes when generating debug output such as hex
+     * dumps.  Comments written via {@link ValueOut#comment(CharSequence)} are
+     * directed here so the primary data stream is unaffected.
      */
     HexDumpBytesDescription<?> bytesComment();
 
     /**
-     * Creates and returns a new {@link IntValue}. The {@link IntValue} implementation that is
-     * returned depends on the wire implementation.
-     *
-     * @return a new {@link IntValue}.
+     * Creates a direct {@link IntValue} bound to this wire.  The concrete
+     * implementation (binary or text) depends on the underlying wire type and
+     * allows low latency access to an integer field stored within the wire.
      */
     @NotNull
     IntValue newIntReference();
 
     /**
-     * Creates and returns a new {@link LongValue}. The {@link LongValue} implementation that is
-     * returned depends on the wire implementation.
-     *
-     * @return a new {@link LongValue}
+     * Creates a direct {@link LongValue} bound to this wire.  As with
+     * {@link #newIntReference()}, the actual implementation is wire specific and
+     * provides direct access to a long field within the wire data.
      */
     @NotNull
     LongValue newLongReference();
 
     /**
-     * Creates and returns a new {@link TwoLongValue}. The {@link TwoLongValue} implementation that
-     * is returned depends on the wire implementation.
-     *
-     * @return a new {@link TwoLongValue}
+     * Creates a new {@link TwoLongValue} reference.  The returned instance gives
+     * low level access to two consecutive long values stored in the wire.
+     * Concrete implementation is wire specific.
      */
     @NotNull
     default TwoLongValue newTwoLongReference() {
@@ -101,48 +113,48 @@ public interface WireCommon {
     }
 
     /**
-     * Creates and returns a new {@link LongArrayValues}. The {@link LongArrayValues} implementation that
-     * is returned depends on the wire implementation.
-     *
-     * @return a new {@link LongArrayValues}
+     * Creates an array view over long values stored in the wire.  Useful for
+     * accessing memory-mapped arrays directly without additional copying.
      */
     @NotNull
     LongArrayValues newLongArrayReference();
 
     /**
-     * Creates and returns a new {@link IntArrayValues}. The {@link IntArrayValues} implementation that
-     * is returned depends on the wire implementation.
-     *
-     * @return a new {@link IntArrayValues}
+     * Creates an array view over integer values stored in the wire.  The
+     * concrete implementation depends on the wire type.
      */
     @NotNull
     IntArrayValues newIntArrayReference();
 
     /**
-     * Resets the state of the underlying {@link Bytes} stored by the wire.
+     * Clears the underlying {@link Bytes} and resets any internal state held by
+     * the wire implementation.
      */
     void clear();
 
     /**
-     * Returns the wire parent object. If the parent was not assigned, {@code null} is
-     * returned instead.
+     * Returns the parent object associated with this wire.  This is typically
+     * used for nested marshallable objects to access their containing object.
      *
-     * @return the wire parent object or {@code null} if none was assigned.
+     * @return the parent object or {@code null} if none was set
      */
     @Nullable
     Object parent();
 
     /**
-     * Assigns the wire parent object for later retrieval.
+     * Assigns a parent object which may later be retrieved via
+     * {@link #parent()}.  This allows wires to maintain a hierarchy of
+     * marshallable objects if required.
      *
-     * @param parent to set, or null if there isn't one.
+     * @param parent the parent object or {@code null}
      */
     void parent(Object parent);
 
     /**
-     * If a message is marked as NOT_COMPLETE is it still present.
+     * Whether a message flagged as {@link Wires#NOT_COMPLETE} should still be
+     * treated as visible when reading.
      *
-     * @return true if NOT_COMPLETE messages can be seen, false if they cannot.
+     * @return {@code true} if incomplete messages appear as absent
      */
     default boolean notCompleteIsNotPresent() {
         return true;
@@ -157,35 +169,42 @@ public interface WireCommon {
 
     long headerNumber();
 
+    /**
+     * Enables or disables padding around messages.  Padding can be used to
+     * align messages on cache-line boundaries to improve performance.
+     */
     void usePadding(boolean usePadding);
 
+    /**
+     * @return {@code true} if padding is enabled for read and write operations
+     */
     boolean usePadding();
 
     /**
-     * Creates and returns a new {@link BooleanValue}. The {@link BooleanValue} implementation that is
-     * returned depends on the wire implementation.
-     *
-     * @return a new {@link BooleanValue}.
+     * Creates a {@link BooleanValue} bound to this wire for direct manipulation
+     * of an on-wire boolean value.
      */
     @NotNull
     BooleanValue newBooleanReference();
 
     /**
-     * Should this wire write the object as a Marshallable or BytesMarshallable
+     * Determines whether the provided object should write its own class type
+     * when being marshalled.  Implementations may choose to omit the type if it
+     * can be inferred from context.
      *
-     * @return use Marshallable
+     * @return {@code true} if the object should use a self describing message
      */
     boolean useSelfDescribingMessage(@NotNull CommonMarshallable object);
 
     /**
-     * Determine whether direct access to the underlying byte() makes sense or should it be treated as text
-     *
-     * @return Is this a binary protocol
+     * Determines whether the underlying wire format is binary.  Binary wires are
+     * optimised for speed and size whereas text wires favour readability.
      */
     boolean isBinary();
 
     /**
-     * Reset the state of the wire
+     * Reset any internal read/write positions or temporary state held by the
+     * wire.
      */
     void reset();
 }

--- a/src/main/java/net/openhft/chronicle/wire/WireIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireIn.java
@@ -32,22 +32,27 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 /**
- * Defines the standard interface for reading sequentially from a Bytes stream.
+ * Defines the standard interface for reading sequentially from a {@link
+ * net.openhft.chronicle.bytes.Bytes} stream.  Concrete implementations know how
+ * to parse a specific wire format (text, binary, field-less binary, etc.) but
+ * present a consistent API to clients.  Typical usage is to obtain a
+ * {@link DocumentContext} via {@link #readingDocument()} and read fields via the
+ * {@code read()} or {@code readEventName()} methods.
  */
 @DontChain
 public interface WireIn extends WireCommon, MarshallableIn {
 
     /**
-     * Reads all available entries and populates the provided map with these entries.
-     * Each entry in the wire source is read as a key-value pair where the key is of type {@code K} and the value is of type {@code V}.
+     * Convenience method to consume the remainder of the current document as a
+     * map.  Each key/value pair is read in sequence until no more data is
+     * available.
      *
-     * @param <K>     The type of keys in the map.
-     * @param <V>     The type of values in the map.
-     * @param kClass  The class type of the key.
-     * @param vClass  The class type of the value.
-     * @param map     The map to populate with read entries.
-     * @return The populated map.
-     * @throws InvalidMarshallableException If there's an error in the marshalling process.
+     * @param <K>    key type
+     * @param <V>    value type
+     * @param kClass class of the key
+     * @param vClass class of the value
+     * @param map    destination map to populate
+     * @return the populated {@code map}
      */
     @NotNull
     default <K, V> Map<K, V> readAllAsMap(Class<K> kClass, @NotNull Class<V> vClass, @NotNull Map<K, V> map) throws InvalidMarshallableException {
@@ -64,35 +69,31 @@ public interface WireIn extends WireCommon, MarshallableIn {
     }
 
     /**
-     * Copies the content from the current WireIn source to the provided WireOut destination.
-     *
-     * @param wire The WireOut instance where the content will be copied to.
-     * @throws InvalidMarshallableException If there's an error in the marshalling process.
+     * Writes the remaining readable data from this wire into another
+     * {@link WireOut}.  This is a utility method used when reserializing a
+     * document or forwarding it to another destination.
      */
     void copyTo(@NotNull WireOut wire) throws InvalidMarshallableException;
 
     /**
-     * Reads the next field if present, or returns an empty string if not present.
+     * Begins reading the next field or sequence element.  For text formats this
+     * also consumes the field name if present.  Binary formats may simply return
+     * the next value.
      *
-     * @return The value of the next field, encapsulated in a {@link ValueIn} instance.
+     * @return {@link ValueIn} used to read the value
      */
     @NotNull
     ValueIn read();
 
     /**
-     * Reads the next field if present. The field should match the provided {@link WireKey}.
-     *
-     * @param key The WireKey that should match the next field.
-     * @return The value of the matched field, encapsulated in a {@link ValueIn} instance.
+     * Reads the field identified by {@code key}.  Fields that do not match may
+     * be skipped internally until the requested key is found.
      */
     @NotNull
     ValueIn read(@NotNull WireKey key);
 
     /**
-     * Reads the next field based on the provided field name.
-     *
-     * @param fieldName The name of the field to read.
-     * @return The value of the specified field, encapsulated in a {@link ValueIn} instance.
+     * Convenience overload of {@link #read(WireKey)} using a simple field name.
      */
     @NotNull
     default ValueIn read(String fieldName) {
@@ -100,20 +101,16 @@ public interface WireIn extends WireCommon, MarshallableIn {
     }
 
     /**
-     * Reads the next event number. If no number is present, returns Long.MIN_VALUE.
-     *
-     * @return The next event number or Long.MIN_VALUE if no number is present.
+     * Reads a numeric identifier for the next event.  Binary wires sometimes
+     * encode events as integers rather than textual names.  If no such identifier
+     * is present {@code Long.MIN_VALUE} is returned.
      */
     long readEventNumber();
 
     /**
-     * Reads a field or string, ensuring the value is always read.
-     * This method is specifically designed to ensure reading even for formats that might
-     * potentially omit the field, such as RAW.
-     *
-     * @param name The StringBuilder that holds the name of the field or string.
-     * @return The value of the field or string, encapsulated in a {@link ValueIn} instance.
-     * @throws IORuntimeException If the bytes fail to be parsed.
+     * Reads the event or field name into {@code name} and returns a
+     * {@link ValueIn} for its value.  This method always consumes a value even if
+     * the underlying format does not explicitly encode the name (e.g. RAW).
      */
     @NotNull
     default ValueIn readEventName(@NotNull StringBuilder name) {
@@ -182,22 +179,16 @@ public interface WireIn extends WireCommon, MarshallableIn {
     void clear();
 
     /**
-     * This consumes any padding before checking if readRemaining() &gt; 0 <p> NOTE: This method
-     * only works inside a document. Call it just before a document and it won't know not to read
-     * the read in case there is padding.
-     *
-     * @return if there is more data to be read in this document.
+     * Indicates whether more fields/events remain in the current document.  Any
+     * trailing padding bytes are consumed before the check is made.
      */
     default boolean hasMore() {
         return isNotEmptyAfterPadding();
     }
 
     /**
-     * This consumes any padding before checking if readRemaining() &gt; 0 <p> NOTE: This method
-     * only works inside a document. Call it just before a document and it won't know not to read
-     * the read in case there is padding.
-     *
-     * @return if there is more data to be read in this document.
+     * Helper used by {@link #hasMore()} which consumes any alignment padding and
+     * then checks if unread bytes remain in this document.
      */
     default boolean isNotEmptyAfterPadding() {
         consumePadding();
@@ -289,29 +280,27 @@ public interface WireIn extends WireCommon, MarshallableIn {
     void consumePadding();
 
     /**
-     * Sets a listener that gets notified whenever a comment is encountered during reading.
-     *
-     * @param commentListener The consumer that handles and processes the comments.
+     * Registers a consumer to receive any comments encountered while parsing the
+     * wire.  Comments are primarily used for debugging or additional metadata and
+     * are not part of the logical data model.
      */
     void commentListener(Consumer<CharSequence> commentListener);
 
     /**
-     * Consume a header if one is available.
+     * Consume a header if one is available.  This is typically used by queue or
+     * networking layers to determine whether a complete message is ready to be
+     * read.
      *
-     * @return true, if a message can be read between readPosition and readLimit, else false if no
-     * header is ready.
-     * @throws EOFException if the end of wire marker is reached.
+     * @return {@code true} if a data header was consumed
      */
     default boolean readDataHeader() throws EOFException {
         return readDataHeader(false) == HeaderType.DATA;
     }
 
     /**
-     * Attempts to read a header for data or metadata, based on the provided parameter.
-     *
-     * @param includeMetaData If true, metadata headers are included in the read attempt.
-     * @return The type of header that was read.
-     * @throws EOFException if an end-of-file marker is encountered.
+     * Low level method used to read the next message header.  The returned
+     * {@link HeaderType} indicates whether the message is data, metadata or the
+     * end-of-stream marker.
      */
     @NotNull
     HeaderType readDataHeader(boolean includeMetaData) throws EOFException;
@@ -346,9 +335,8 @@ public interface WireIn extends WireCommon, MarshallableIn {
     void readMetaDataHeader();
 
     /**
-     * Peeks at the content in the current WireIn instance and returns it as a YAML string.
-     *
-     * @return A String containing a YAML representation of the peeked content.
+     * Returns a YAML representation of the remaining bytes without advancing the
+     * read position.  Useful for logging and diagnostics.
      */
     String readingPeekYaml();
 

--- a/src/main/java/net/openhft/chronicle/wire/WireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireOut.java
@@ -28,24 +28,26 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Defines the standard interface for sequential writing to a Bytes stream.
+ * Defines the standard interface for sequential writing to a
+ * {@link net.openhft.chronicle.bytes.Bytes} stream.  Implementations know how
+ * to encode data in a particular wire format while presenting a common API.
+ * Typically a user obtains a {@link DocumentContext} via
+ * {@link #writingDocument()} and then writes fields using the {@code write}
+ * methods.
  */
 @DontChain
 public interface WireOut extends WireCommon, MarshallableOut {
     /**
-     * Writes an empty field marker to the stream.
-     *
-     * @return An interface to further define the output for the written value.
+     * Begins writing a value without an explicit field name.  This is typically
+     * used for sequence elements.
      */
     @NotNull
     ValueOut write();
 
     /**
-     * Writes a key to the stream. For RAW types, the label will be in text.
-     * This can be read using readEventName().
-     *
-     * @param key The key to write to the stream.
-     * @return An interface to further define the output for the written value.
+     * Writes a field/event name using a {@link WireKey}.  For RAW wires the key
+     * is output in text form so that it can be read back with
+     * {@link WireIn#readEventName(StringBuilder)}.
      */
     @NotNull
     default ValueOut writeEventName(WireKey key) {
@@ -53,10 +55,7 @@ public interface WireOut extends WireCommon, MarshallableOut {
     }
 
     /**
-     * Writes a CharSequence key to the stream.
-     *
-     * @param key The CharSequence key to write to the stream.
-     * @return An interface to further define the output for the written value.
+     * Writes an event or field name as a {@link CharSequence}.
      */
     default ValueOut writeEventName(CharSequence key) {
         return write(key);
@@ -120,6 +119,10 @@ public interface WireOut extends WireCommon, MarshallableOut {
      * @param key The CharSequence key to write to the stream.
      * @return An interface to further define the output for the written value.
      */
+    /**
+     * Writes a field/event name supplied as a raw character sequence and
+     * returns a {@link ValueOut} to write its value.
+     */
     ValueOut write(CharSequence key);
 
     /**
@@ -149,10 +152,8 @@ public interface WireOut extends WireCommon, MarshallableOut {
     WireOut writeComment(CharSequence s);
 
     /**
-     * Adds padding to the wire. This is particularly useful for aligning data.
-     *
-     * @param paddingToAdd The amount of padding to add.
-     * @return This WireOut instance for method chaining.
+     * Adds explicit padding bytes to the output.  Padding is most often used for
+     * alignment when appending to shared memory or files.
      */
     @NotNull
     WireOut addPadding(int paddingToAdd);


### PR DESCRIPTION
## Summary
- expand explanations in `WireCommon` and clarify factory methods
- enhance descriptions for `WireIn` and `WireOut` operations
- document use of sequence headers in `Wire`
- add detailed comments in `AbstractWire` and subclasses
- clarify builder behaviour in `MarshallableOut`
- improve `SourceContext` notes

## Also
-   Clarified that `WireCommon` centralizes configuration and reference creation used across all wire implementations
    
-   Documented the lazy inspection approach for determining the underlying wire type in `ReadAnyWire` and its acquisition strategy
    
-   Explained in `SourceContext` that consumers such as `DocumentContext` provide source IDs and indexes for tracking messages