### PR TITLE
Improve DocumentContext Javadocs

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/BinaryReadDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryReadDocumentContext.java
@@ -29,13 +29,14 @@ import org.jetbrains.annotations.Nullable;
 import static net.openhft.chronicle.wire.Wires.lengthOf;
 
 /**
- * This is the BinaryReadDocumentContext class which implements the ReadDocumentContext interface.
- * It provides an implementation tailored for reading from binary document contexts and ensures
- * full read capability if required.
+ * {@link ReadDocumentContext} implementation for length prefixed binary
+ * messages.
  */
 public class BinaryReadDocumentContext implements ReadDocumentContext {
 
+    /** Start position of the current document. */
     public long start = -1;
+    /** Last document start position, used for diagnostics. */
     public long lastStart = -1;
     @Nullable
     protected Wire wire;
@@ -47,21 +48,16 @@ public class BinaryReadDocumentContext implements ReadDocumentContext {
     protected boolean rollback;
 
     /**
-     * Constructor that initializes the BinaryReadDocumentContext using the provided wire.
-     * It also determines if a full read should be ensured based on the wire type.
+     * Create a new context for the supplied wire.
      *
-     * @param wire The wire used for reading the document.
+     * @param wire wire to read from, may be {@code null}
      */
     public BinaryReadDocumentContext(@Nullable Wire wire) {
         this.wire = wire;
     }
 
     /**
-     * Constructor that initializes the BinaryReadDocumentContext using the provided wire and
-     * a flag to determine if a full read should be ensured.
-     *
-     * @param wire           The wire used for reading the document.
-     * @param ensureFullRead Flag to determine if full reading is required.
+     * @deprecated delta wire support removed
      */
     @Deprecated(/* to be removed in x.29 */)
     public BinaryReadDocumentContext(@Nullable Wire wire, boolean ensureFullRead) {
@@ -106,6 +102,9 @@ public class BinaryReadDocumentContext implements ReadDocumentContext {
 
     static final ScopedResourcePool<StringBuilder> SBP = StringBuilderPool.createThreadLocal(1);
 
+    /**
+     * Restore the read position/limit unless a rollback was requested.
+     */
     @Override
     public void close() {
         if (rollbackIfNeeded())
@@ -135,10 +134,10 @@ public class BinaryReadDocumentContext implements ReadDocumentContext {
     }
 
     /**
-     * Rolls back the document context to its state before opening, if the rollback marker is set.
-     * Resets relevant attributes and updates the read position and limit accordingly.
+     * Roll back to the {@link #start} position if {@link #rollbackOnClose()} was
+     * called.
      *
-     * @return {@code true} if the context was rolled back, {@code false} otherwise.
+     * @return {@code true} if a rollback occurred
      */
     protected boolean rollbackIfNeeded() {
         if (rollback) {
@@ -153,6 +152,9 @@ public class BinaryReadDocumentContext implements ReadDocumentContext {
         return false;
     }
 
+    /**
+     * Read the length prefix and prepare the next document for reading.
+     */
     @Override
     public void start() {
         rollback = false;
@@ -215,16 +217,17 @@ public class BinaryReadDocumentContext implements ReadDocumentContext {
     }
 
     /**
-     * Sets the start position of the document context and updates the last start position.
-     * This is useful to keep track of the beginning position for reading purposes.
-     *
-     * @param start The new starting position to set.
+     * Record the starting position of the current document.
      */
     public void setStart(long start) {
         this.start = start;
         this.lastStart = start;
     }
 
+    /**
+     * Dump the current document as text via
+     * {@link Wires#fromSizePrefixedBlobs(DocumentContext)}.
+     */
     @Override
     public String toString() {
         return Wires.fromSizePrefixedBlobs(this);

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWriteDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWriteDocumentContext.java
@@ -24,24 +24,21 @@ import org.jetbrains.annotations.NotNull;
 import static net.openhft.chronicle.wire.Wires.toIntU30;
 
 /**
- * A context used for writing documents in a binary format.
- * This class provides facilities to start, query, and manage the state of binary
- * documents that are currently being written. The binary format uses headers to
- * denote metadata, data length, and completion status.
+ * {@link WriteDocumentContext} for binary length prefixed messages.
  */
 public class BinaryWriteDocumentContext implements WriteDocumentContext {
 
-    // The wire instance used for the binary writing process
+    /** Wire the document is written to. */
     protected Wire wire;
     protected long position = 0;
     protected int tmpHeader;
-    // Count of how many times the start() method was invoked
+    /** Nesting depth of {@link #start(boolean)} calls. */
     protected int count = 0;
-    // Bit representing whether meta data is present
+    /** Bit mask for metadata in the header. */
     private int metaDataBit;
-    // Flag to indicate if the document write is complete
+    /** True while the document is still open. */
     private volatile boolean notComplete;
-    // Flag to check if the current element is chained
+    /** Part of a chained write. */
     private boolean chainedElement;
     private boolean rollback;
 
@@ -55,10 +52,7 @@ public class BinaryWriteDocumentContext implements WriteDocumentContext {
     }
 
     /**
-     * Initializes the context for starting a new binary write.
-     * This will setup necessary headers and markers to facilitate the write.
-     *
-     * @param metaData A flag indicating whether the write includes metadata.
+     * Begin writing a new binary document by writing a placeholder header.
      */
     public void start(boolean metaData) {
         count++;
@@ -79,6 +73,10 @@ public class BinaryWriteDocumentContext implements WriteDocumentContext {
         chainedElement = false;
     }
 
+    /**
+     * Returns {@code true} if no data beyond the 4 byte header has been
+     * written.
+     */
     @Override
     public boolean isEmpty() {
         return notComplete && wire().bytes().writePosition() == position + 4;
@@ -89,6 +87,10 @@ public class BinaryWriteDocumentContext implements WriteDocumentContext {
         return metaDataBit != 0;
     }
 
+    /**
+     * Finalise the header with the actual length unless this context was rolled
+     * back.
+     */
     @Override
     public void close() {
         if (chainedElement)
@@ -119,6 +121,9 @@ public class BinaryWriteDocumentContext implements WriteDocumentContext {
         wire().getValueOut().resetBetweenDocuments();
     }
 
+    /**
+     * Roll back the current document if it has not been completed yet.
+     */
     @Override
     public void rollbackIfNotComplete() {
         if (!notComplete) return;
@@ -128,11 +133,17 @@ public class BinaryWriteDocumentContext implements WriteDocumentContext {
         close();
     }
 
+    /**
+     * Mark the document for rollback when {@link #close()} is invoked.
+     */
     @Override
     public void rollbackOnClose() {
         rollback = true;
     }
 
+    /**
+     * Reset all state so the context may be reused.
+     */
     @Override
     public void reset() {
         chainedElement = false;
@@ -173,9 +184,7 @@ public class BinaryWriteDocumentContext implements WriteDocumentContext {
     }
 
     /**
-     * Retrieves the current position in the wire where the document starts.
-     *
-     * @return The position in the wire where the current document starts.
+     * Position where the header for the current document was written.
      */
     protected long position() {
         return position;

--- a/src/main/java/net/openhft/chronicle/wire/DocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/DocumentContext.java
@@ -23,89 +23,106 @@ import org.jetbrains.annotations.Nullable;
 import java.io.Closeable;
 
 /**
- * Represents a context that governs the interactions and state management for a document.
- * It provides methods to interrogate and manipulate the state of the associated document,
- * ensuring consistent and safe operations. This interface offers checks for metadata,
- * presence, and completion status of the document, as well as operations to manage the context's
- * lifecycle such as open, close, and reset.
+ * Represents a context for interacting with a single "document" (message) on a
+ * {@link Wire}.  A document can either be data or metadata and may be in a
+ * partially written state until {@link #close()} is invoked.
  * <p>
- * Implementations must ensure proper handling of resources and consistency of the document state.
+ * Implementations manage the lifecycle of the document and typically should be
+ * used in a try-with-resources block:
+ *
+ * <pre>{@code
+ *   try (DocumentContext dc = wire.writingDocument()) {
+ *       // write fields
+ *   }
+ * }</pre>
+ *
+ * Closing the context finalises or rolls back the document depending on the
+ * implementation.  The interface exposes flags to query whether the document is
+ * metadata, present and/or complete.
  */
 public interface DocumentContext extends Closeable, SourceContext {
+    /**
+     * A no-op implementation useful as a default or for testing.  All method
+     * calls on this instance are ignored.
+     */
     DocumentContext NOOP = Mocker.ignored(DocumentContext.class);
 
     /**
-     * Checks it the {@code DocumentContext} is metadata. If it is, {@code true} is
-     * returned, otherwise {@code false}.
+     * Indicates whether this document represents metadata as opposed to regular
+     * user data.  Metadata documents are typically used for control messages or
+     * headers within a wire.
      *
-     * @return true if the entry is metadata
+     * @return {@code true} if the document is metadata
      */
     boolean isMetaData();
 
     /**
-     * Checks if the {@code DocumentContext} is present. If it is, {@code true} is returned,
-     * otherwise {@code false}.
+     * For a reading context this returns {@code true} if a document was found
+     * and is available for reading.  For a writing context it is usually
+     * {@code true} while the context is open.
      *
-     * @return true if the entry is present
+     * @return {@code true} if the document is available
      */
     boolean isPresent();
 
     /**
-     * Determines if the {@code DocumentContext} is in an open state.
-     * This method essentially checks the inverse of the completion status of the context.
-     *
-     * @return {@code true} if the context is open (i.e., the NOT_COMPLETE flag is set),
-     * {@code false} otherwise.
+     * Convenience method returning {@code true} if the document is present and
+     * not metadata.  Equivalent to {@code isPresent() && !isMetaData()}.
      */
     default boolean isData() {
         return isPresent() && !isMetaData();
     }
 
     /**
-     * Returns the {@link Wire} associated with the {@code Document}. It is possible that
-     * {@code null} is returned, depending on the implementation.
-     *
-     * @return the {@link Wire} associated with the {@code Document}.
+     * Returns the {@link Wire} this document is read from or written to.  May be
+     * {@code null} for specialised implementations.
      */
     @Nullable
     Wire wire();
 
     /**
-     * @return whether the NOT_COMPLETE flag has been set.
+     * Indicates whether the {@code NOT_COMPLETE} flag is currently set on the
+     * document.  For writers this means the document length has not yet been
+     * finalised.
      */
     boolean isNotComplete();
 
+    /**
+     * Convenience synonym for {@link #isNotComplete()}.
+     */
     default boolean isOpen() {
         return isNotComplete();
     }
 
     /**
-     * Invoked to signal an error condition in the current context.
-     * This ensures that upon closing the context, any changes made during its lifecycle
-     * are rolled back rather than committing a potentially erroneous state.
+     * Invoked to signal an error condition in the current context so that when
+     * {@link #close()} is called the document is rolled back instead of
+     * committed.  Typically used in a {@code catch} block while writing.
      */
     default void rollbackOnClose() {
     }
 
     /**
-     * Call this if any incomplete message should be rolled back at this point, it it wasn't complete by now.
+     * Explicitly roll back the current document if it is still marked as
+     * {@link #isNotComplete() not complete}.  Some implementations may throw
+     * {@link UnsupportedOperationException} if rollback is not supported.
      */
     default void rollbackIfNotComplete() {
         throw new UnsupportedOperationException(getClass().getName());
     }
 
     /**
-     * Closes the {@code DocumentContext} and releases any held resources.
-     * It is crucial to ensure that this method is invoked after the context's operations are completed
-     * to prevent any potential resource leaks or data corruption.
+     * Close the context and finalise the document.  Always call this method,
+     * ideally via try-with-resources, to ensure resources are released and any
+     * length prefixes are written.
      */
     @Override
     void close();
 
     /**
-     * Cleans up the {@code DocumentContext} by invoking the close method, then discarding
-     * any lingering state associated with it. This provides a way to ensure the context
-     * is in a fresh state and free of any residual data or settings.
+     * Reset the context to its initial state after closing.  Implementations may
+     * reuse instances so this clears any internal state ready for another
+     * document.
      */
     void reset();
 }

--- a/src/main/java/net/openhft/chronicle/wire/DocumentContextHolder.java
+++ b/src/main/java/net/openhft/chronicle/wire/DocumentContextHolder.java
@@ -22,9 +22,8 @@ import net.openhft.chronicle.core.io.IORuntimeException;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * This is the DocumentContextHolder class which implements both {@link DocumentContext}
- * and {@link WriteDocumentContext}. It acts as a wrapper or a delegate around an instance of
- * {@link DocumentContext}, providing methods to interact with the encapsulated context.
+ * Wrapper around another {@link DocumentContext}.  Useful when behaviour needs
+ * to be decorated or intercepted.
  */
 public class DocumentContextHolder implements DocumentContext, WriteDocumentContext {
 
@@ -70,6 +69,10 @@ public class DocumentContextHolder implements DocumentContext, WriteDocumentCont
         this.dc = dc;
     }
 
+    /**
+     * Delegate closing to the wrapped context and clear the reference once the
+     * document is complete.
+     */
     @Override
     public void close() {
         DocumentContext documentContext = this.dc;
@@ -80,6 +83,9 @@ public class DocumentContextHolder implements DocumentContext, WriteDocumentCont
             dc = null;
     }
 
+    /**
+     * Reset the wrapped context and clear the reference.
+     */
     @Override
     public void reset() {
         DocumentContext documentContext = this.dc;

--- a/src/main/java/net/openhft/chronicle/wire/DocumentWritten.java
+++ b/src/main/java/net/openhft/chronicle/wire/DocumentWritten.java
@@ -19,10 +19,9 @@
 package net.openhft.chronicle.wire;
 
 /**
- * Represents an entity that supports writing documents. The interface provides methods
- * to initiate and manage the context in which documents are written. It is crucial
- * to manage the lifecycle of the {@link DocumentContext} correctly, either by using
- * try-with-resources or explicitly invoking the close() method.
+ * Factory for obtaining {@link DocumentContext}s used when writing documents to
+ * a wire.  The returned context must always be closed to finalise or roll back
+ * the document.
  */
 public interface DocumentWritten {
     /**

--- a/src/main/java/net/openhft/chronicle/wire/NoDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/NoDocumentContext.java
@@ -18,59 +18,63 @@
 package net.openhft.chronicle.wire;
 
 /**
- * An enumeration implementation of the {@link DocumentContext} interface.
- * This context represents a non-existent or uninitialized document context,
- * hence all its methods return default or null values.
- *
- * <p>This can be useful as a sentinel value or placeholder to avoid null checks in code
- * that works with document contexts. Using `NoDocumentContext.INSTANCE` denotes
- * a guaranteed uninitialized state for a document context.
+ * {@link DocumentContext} implementation that represents the absence of a
+ * document.  All methods return default values.
  */
 public enum NoDocumentContext implements DocumentContext {
-    /** The singleton instance of the NoDocumentContext */
+    /** Singleton instance. */
     INSTANCE;
 
     @Override
+    /** Always {@code false}. */
     public boolean isMetaData() {
         return false;
     }
 
     @Override
+    /** Always {@code false}. */
     public boolean isPresent() {
         return false;
     }
 
     @Override
+    /** Always {@code false}. */
     public boolean isData() {
         return false;
     }
 
     @Override
+    /** Always {@code null}. */
     public Wire wire() {
         return null;
     }
 
     @Override
+    /** Always {@code -1}. */
     public int sourceId() {
         return -1;
     }
 
     @Override
+    /** Always {@link Long#MIN_VALUE}. */
     public long index() {
         return Long.MIN_VALUE;
     }
 
     @Override
+    /** Always {@code false}. */
     public boolean isNotComplete() {
         return false;
     }
 
     @Override
+    /** No-op. */
     public void close() {
         // Do nothing
     }
 
     @Override
+    /** No-op. */
     public void reset() {
         close();
     }

--- a/src/main/java/net/openhft/chronicle/wire/ReadDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/ReadDocumentContext.java
@@ -18,29 +18,26 @@
 package net.openhft.chronicle.wire;
 
 /**
- * Represents a context for reading documents. This interface extends {@code DocumentContext}
- * and provides methods to manipulate the reading limits and positions within a document.
+ * A {@link DocumentContext} specialised for reading.  Implementations detect
+ * the next document boundary and expose the document's bytes via
+ * {@link #wire()}.
  */
 public interface ReadDocumentContext extends DocumentContext {
 
     /**
-     * Initiates the start of reading within the context.
+     * Locate and prepare the next document in the underlying {@link Wire}.  On
+     * return {@link #isPresent()} indicates if a document was found.
      */
     void start();
 
     /**
-     * Sets the read limit for this {@code ReadDocumentContext}.
-     * This defines the boundary or endpoint within the document up to which reading should occur.
-     *
-     * @param readLimit The long value representing the read limit.
+     * Restore the read limit of the underlying bytes when closing.  Generally
+     * used by the implementation rather than user code.
      */
     void closeReadLimit(long readLimit);
 
     /**
-     * Sets the read position for this {@code ReadDocumentContext}.
-     * This defines the starting point within the document from which reading should begin.
-     *
-     * @param readPosition The long value representing the read position.
+     * Restore the read position of the underlying bytes on close.
      */
     void closeReadPosition(long readPosition);
 }

--- a/src/main/java/net/openhft/chronicle/wire/TextReadDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextReadDocumentContext.java
@@ -24,14 +24,15 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 
 /**
- * This class represents the context for reading a document in textual format.
- * It provides methods and utilities for understanding the structure and boundaries
- * of the document within a given wire format.
+ * {@link ReadDocumentContext} implementation for textual wire formats such as
+ * YAML.  It recognises document separators ("---" and "...") and exposes the
+ * current document via the underlying {@link Wire}.
  */
 public class TextReadDocumentContext implements ReadDocumentContext {
 
-    // Byte sequences for start and end of the document
+    /** BytesStore representing the start of a document ('---'). */
     public static final BytesStore<?, ?> SOD_SEP = BytesStore.from("---");
+    /** BytesStore representing the end of a document ('...'). */
     public static final BytesStore<?, ?> EOD_SEP = BytesStore.from("...");
 
     // The wire instance this context operates on
@@ -63,10 +64,9 @@ public class TextReadDocumentContext implements ReadDocumentContext {
     }
 
     /**
-     * Consumes the bytes until the end of the message is encountered.
-     * Skips bytes that do not denote the end of the document.
-     *
-     * @param bytes The bytes to be consumed.
+     * Advance the supplied {@link Bytes} to the end of the current text message
+     * looking for a document separator ({@link #SOD_SEP} or {@link #EOD_SEP})
+     * followed by whitespace.
      */
     public static void consumeToEndOfMessage(Bytes<?> bytes) {
         while (bytes.readRemaining() > 0) {
@@ -80,11 +80,8 @@ public class TextReadDocumentContext implements ReadDocumentContext {
     }
 
     /**
-     * Checks if the current position in the bytes denotes the end of a message.
-     * This is done by checking if the bytes start with either the start or end document separator.
-     *
-     * @param bytes The bytes to be checked.
-     * @return True if it's the end of a message; false otherwise.
+     * Test whether the bytes at the current position denote the end of a text
+     * message ("---" or "...") followed by whitespace.
      */
     public static boolean isEndOfMessage(Bytes<?> bytes) {
         return (bytes.startsWith(SOD_SEP) || bytes.startsWith(EOD_SEP))
@@ -92,10 +89,8 @@ public class TextReadDocumentContext implements ReadDocumentContext {
     }
 
     /**
-     * Determines if the byte at a specific position (offset by 3 from current) is a whitespace.
-     *
-     * @param bytes The bytes to be checked.
-     * @return True if the byte is whitespace; false otherwise.
+     * Returns {@code true} if the byte three positions after the current read
+     * position is a whitespace character.
      */
     protected static boolean isWhiteSpaceAt(Bytes<?> bytes) {
         return bytes.peekUnsignedByte(bytes.readPosition() + 3) <= ' ';
@@ -127,6 +122,10 @@ public class TextReadDocumentContext implements ReadDocumentContext {
         return wire;
     }
 
+    /**
+     * Restore the original read position/limit and skip the trailing document
+     * separator if present.
+     */
     @Override
     public void close() {
         long readLimit = this.readLimit;
@@ -168,6 +167,11 @@ public class TextReadDocumentContext implements ReadDocumentContext {
         rollback = false;
     }
 
+    /**
+     * Locate the next text document, set {@link #isPresent()} accordingly and
+     * adjust {@link Bytes#readLimit(long)} so only this document is visible for
+     * reading.
+     */
     @Override
     public void start() {
         wire.getValueIn().resetState();
@@ -197,10 +201,8 @@ public class TextReadDocumentContext implements ReadDocumentContext {
     }
 
     /**
-     * Skips the document separator sequence (3 bytes) in the given bytes.
-     * It also resets the state of the wire's value input and consumes any padding present.
-     *
-     * @param bytes The bytes in which the separator sequence should be skipped.
+     * Skip the 3-byte document separator in the supplied bytes and consume any
+     * following padding.
      */
     protected void skipSep(Bytes<?> bytes) {
         // Skip 3 bytes (length of the separator sequence)
@@ -233,6 +235,10 @@ public class TextReadDocumentContext implements ReadDocumentContext {
         return notComplete;
     }
 
+    /**
+     * Delegates to {@code Objects.toString(wire)} so the underlying wire's
+     * textual representation is returned.
+     */
     @Override
     public String toString() {
         return Objects.toString(wire);

--- a/src/main/java/net/openhft/chronicle/wire/TextWriteDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWriteDocumentContext.java
@@ -22,34 +22,30 @@ import net.openhft.chronicle.bytes.BytesUtil;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Provides a concrete implementation of the {@link WriteDocumentContext} for text-based wire representations.
- * This class manages and tracks the state of the document being written and contains functionalities
- * for starting a new write transaction in the document.
- * <p>
- * While writing, it can be ensured that meta-data is correctly specified, and the position of the write
- * operation is recorded.
+ * {@link WriteDocumentContext} for text based wires such as YAML.  It writes
+ * document separators and tracks whether the document has been completed.
  */
 public class TextWriteDocumentContext implements WriteDocumentContext {
 
-    // The wire used for writing.
+    /** Wire used for output. */
     protected Wire wire;
 
-    // Flag to check if the current data being written is meta-data.
+    /** Whether the document is metadata. */
     private boolean metaData;
 
-    // Indicates if the write operation is completed.
+    /** True while the document is still open. */
     private volatile boolean notComplete;
 
-    // Maintains the count of start operations.
+    /** Nesting count for {@link #start(boolean)} calls. */
     protected int count = 0;
 
-    // Indicates if the current element is chained to the previous one.
+    /** Whether this document is part of a chained write sequence. */
     private boolean chainedElement;
 
-    // Indicates if the current write operation should be rolled back.
+    /** If true the document will be rolled back on close. */
     private boolean rollback;
 
-    // Maintains the current position of the write operation.
+    /** Position where the document started. */
     protected long position;
 
     /**
@@ -62,11 +58,9 @@ public class TextWriteDocumentContext implements WriteDocumentContext {
     }
 
     /**
-     * Starts a new write transaction in the document. If a transaction is already in progress,
-     * this method ensures the meta-data flag is consistent. It also sets the write position
-     * and other state flags to their initial values.
-     *
-     * @param metaData Indicates if the data being written is meta-data
+     * Begin writing a new text document.  Nested calls are allowed but only the
+     * outermost call performs the initialisation.  The starting write position
+     * is recorded so that the document can be rolled back if required.
      */
     public void start(boolean metaData) {
         count++;
@@ -83,6 +77,10 @@ public class TextWriteDocumentContext implements WriteDocumentContext {
         position = wire().bytes().writePosition();
     }
 
+    /**
+     * Returns {@code true} if no bytes have been written since the document was
+     * {@link #start(boolean) started}.
+     */
     @Override
     public boolean isEmpty() {
         return wire().bytes().writePosition() == position;
@@ -93,6 +91,10 @@ public class TextWriteDocumentContext implements WriteDocumentContext {
         return metaData;
     }
 
+    /**
+     * Finalise the document.  If the context is part of a chained call the
+     * close is ignored until the final call closes it.
+     */
     @Override
     public void close() {
         if (chainedElement)
@@ -119,6 +121,9 @@ public class TextWriteDocumentContext implements WriteDocumentContext {
         wire().getValueOut().resetBetweenDocuments();
     }
 
+    /**
+     * Roll back the document if it has not yet been completed.
+     */
     @Override
     public void rollbackIfNotComplete() {
         if (!notComplete) return;
@@ -128,11 +133,17 @@ public class TextWriteDocumentContext implements WriteDocumentContext {
         close();
     }
 
+    /**
+     * Mark the document for rollback when {@link #close()} is called.
+     */
     @Override
     public void rollbackOnClose() {
         rollback = true;
     }
 
+    /**
+     * Reset internal state so this context can be reused.
+     */
     @Override
     public void reset() {
         chainedElement = false;

--- a/src/main/java/net/openhft/chronicle/wire/WrappedDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/WrappedDocumentContext.java
@@ -21,9 +21,8 @@ import net.openhft.chronicle.core.io.IORuntimeException;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * This is the WrappedDocumentContext class which implements the DocumentContext interface.
- * The purpose of this class is to wrap another DocumentContext and delegate the behavior to the wrapped instance.
- * This can be used as a base for any specialized versions of DocumentContext which need to extend the default behavior.
+ * Base class for {@link DocumentContext} implementations that delegate to
+ * another context.
  */
 public abstract class WrappedDocumentContext implements DocumentContext {
 
@@ -40,20 +39,14 @@ public abstract class WrappedDocumentContext implements DocumentContext {
     }
 
     /**
-     * Getter method to retrieve the wrapped DocumentContext instance.
-     *
-     * @return The wrapped DocumentContext instance.
+     * Return the currently wrapped {@link DocumentContext}.
      */
     public DocumentContext dc() {
         return dc;
     }
 
     /**
-     * Setter method to update the wrapped DocumentContext instance.
-     * This method is designed to follow the builder pattern, returning the current instance for chained calls.
-     *
-     * @param dc The new DocumentContext instance to be wrapped.
-     * @return The current instance of WrappedDocumentContext.
+     * Replace the wrapped context.
      */
     public WrappedDocumentContext dc(DocumentContext dc) {
         this.dc = dc;

--- a/src/main/java/net/openhft/chronicle/wire/WriteDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/WriteDocumentContext.java
@@ -18,41 +18,34 @@
 package net.openhft.chronicle.wire;
 
 /**
- * This is the WriteDocumentContext interface extending DocumentContext.
- * It defines methods related to the writing context of a document.
- * The interface offers features to determine metadata status, check if elements are chained,
- * and discern if the document context is empty or not.
+ * A {@link DocumentContext} specialised for writing.  Implementations manage
+ * the process of starting a new document, writing data and finalising the
+ * length prefix when {@link #close()} is called.
  */
 public interface WriteDocumentContext extends DocumentContext {
 
     /**
-     * Initializes the writing context with a specific metadata status.
+     * Prepare this context to write a new document.  Called by the owning
+     * {@link MarshallableOut} before any data is written.
      *
-     * @param metaData A boolean value indicating if the context is metadata.
+     * @param metaData {@code true} if the document represents metadata
      */
     void start(boolean metaData);
 
     /**
-     * Returns {@code true} if this {@code WriteDocumentContext} is a
-     * chained element.
-     *
-     * @return {@code true} if this {@code WriteDocumentContext} is a
-     * chained element; otherwise, {@code false}.
+     * Whether this write is part of a chained sequence of method calls where
+     * the document is not finalised until the chain completes.
      */
     boolean chainedElement();
 
     /**
-     * Marks this {@code WriteDocumentContext} as a chained element.
-     *
-     * @param chainedElement A boolean value indicating if the context
-     * is a chained element.
+     * Mark this context as part of a chained write.
      */
     void chainedElement(boolean chainedElement);
 
     /**
-     * Checks if the writing context is empty.
-     *
-     * @return {@code true} if the context is empty; otherwise, {@code false}.
+     * Returns {@code true} if no actual data has been written since
+     * {@link #start(boolean)} was invoked.
      */
     boolean isEmpty();
 }


### PR DESCRIPTION
## Summary
- expand explanations in `DocumentContext` and related interfaces
- document start/end separators and behaviour in text contexts
- clarify binary document read/write lifecycles
- document wrapper and noop implementations

## Also
-   Clarified the purpose and lifecycle of document contexts, including usage patterns and the provided no-op implementation
    
-   Documented how write contexts start new documents and handle chained writes
    
-   Added descriptions of text document separators and the reading process in text contexts
    
-   Expanded explanations of closing binary write contexts to finalise length prefixes
    
-   Documented how wrapper contexts delegate operations and clear references on close