### PR TITLE
Improve Javadoc for field info classes

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AbstractFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractFieldInfo.java
@@ -19,28 +19,28 @@ package net.openhft.chronicle.wire;
 
 import static net.openhft.chronicle.wire.WireType.TEXT;
 /**
- * The AbstractFieldInfo class serves as an abstract foundation for field information.
- * It implements the FieldInfo interface and provides basic implementations for some of the interface's methods.
- * This class contains the core properties of a field, including its name, type, and bracket type.
+ * Abstract foundation for {@link FieldInfo} implementations.  It stores the
+ * immutable characteristics of a field and supplies basic implementations of
+ * common methods.
  */
 @SuppressWarnings("rawtypes")
 public abstract class AbstractFieldInfo implements FieldInfo {
 
-    // The name of the field
+    /** name of the field this instance represents */
     protected final String name;
 
-    // The type of the field
+    /** declared type of the field */
     protected final Class<?> type;
 
-    // The bracket type associated with the field
+    /** how the field is represented on the wire */
     protected final BracketType bracketType;
 
     /**
-     * Constructs a new AbstractFieldInfo with the provided type, bracket type, and name.
+     * Create an instance describing the given field.
      *
-     * @param type         The class type of the field
-     * @param bracketType  The bracket type associated with the field
-     * @param name         The name of the field
+     * @param type        declared type of the field
+     * @param bracketType wire representation style
+     * @param name        name of the field
      */
     protected AbstractFieldInfo(Class<?> type, BracketType bracketType, String name) {
         this.type = type;
@@ -64,17 +64,26 @@ public abstract class AbstractFieldInfo implements FieldInfo {
     }
 
     @Override
+    /**
+     * Compute a hash code based on the field metadata.
+     */
     public int hashCode() {
         return HashWire.hash32(this);
     }
 
     @Override
+    /**
+     * Equality based on the YAML representation of the field info.
+     */
     public boolean equals(Object obj) {
         if (obj == null) return false;
         return (this == obj || Wires.isEquals(this, obj));
     }
 
     @Override
+    /**
+     * Return a YAML representation of this field info.
+     */
     public String toString() {
         return TEXT.asString(this);
     }

--- a/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
@@ -31,11 +31,24 @@ import java.util.stream.Collectors;
 import static net.openhft.chronicle.wire.WireMarshaller.WIRE_MARSHALLER_CL;
 
 /**
- * Represents an abstraction for the meta-information of a field within a class or interface.
- * Implementations should provide more specific details about the type, nature, and characteristics of the field.
+ * Represents an abstraction for the meta-information of a field within a class
+ * or interface.  Implementations provide details about the type, nature and
+ * characteristics of the field.  This metadata is used by components such as
+ * {@link WireMarshaller} to dynamically read and write values during
+ * serialisation.
  */
 public interface FieldInfo {
 
+    /**
+     * Create the appropriate {@code FieldInfo} implementation for the supplied
+     * field.
+     *
+     * @param name        the field name
+     * @param type        the field type
+     * @param bracketType how the value is represented on the wire
+     * @param field       the reflective {@link Field}
+     * @return a specialised {@code FieldInfo}
+     */
     static FieldInfo createForField(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
         // Choose the FieldInfo type based on the field's type.
         if (!type.isPrimitive()) {
@@ -54,11 +67,13 @@ public interface FieldInfo {
     }
 
     /**
-     * Looks up the meta-information of the fields associated with the provided class and returns
-     * a pair of information encapsulated in {@link Wires.FieldInfoPair}.
+     * Analyse the supplied class using reflection and produce a
+     * {@link Wires.FieldInfoPair} describing its marshallable fields.  The
+     * returned pair contains a list preserving the declared field order and a
+     * map for name based lookups.
      *
-     * @param aClass The class for which field info needs to be retrieved.
-     * @return A {@link Wires.FieldInfoPair} representing the field information of the class.
+     * @param aClass the class for which field info should be created
+     * @return metadata describing the marshallable fields of {@code aClass}
      */
     @NotNull
     static Wires.FieldInfoPair lookupClass(@NotNull Class<?> aClass) {
@@ -120,132 +135,121 @@ public interface FieldInfo {
     BracketType bracketType();
 
     /**
-     * Returns the value of the field represented by this {@code FieldInfo} object
-     * as an {@link Object}. The provided {@code object} is used as a target to
-     * extract the field from.
+     * Retrieve the field's value from the supplied instance.
      *
-     * @return the value of the field represented by this {@code FieldInfo} object
-     * as an {@link Object}.
+     * @param object the instance containing the field
+     * @return the value of the field, or {@code null} if it cannot be read
      */
     @Nullable
     Object get(Object object);
 
     /**
-     * Returns the value of the field represented by this {@code FieldInfo} object
-     * as a {@code long} primitive. The provided {@code object} is used as a target
-     * to extract the field from.
+     * Retrieve the field's {@code long} value from the given instance.
      *
-     * @return the value of the field represented by this {@code FieldInfo} object
-     * as a {@code long} primitive.
+     * @param object the instance containing the field
+     * @return the {@code long} value read, or a type specific default if not accessible
      */
     long getLong(Object object);
 
     /**
-     * Returns the value of the field represented by this {@code FieldInfo} object
-     * as an {@code int} primitive. The provided {@code object} is used as a target
-     * to extract the field from.
+     * Retrieve the field's {@code int} value from the given instance.
      *
-     * @return the value of the field represented by this {@code FieldInfo} object
-     * as an {@code int} primitive.
+     * @param object the instance containing the field
+     * @return the {@code int} value read, or a type specific default if not accessible
      */
     int getInt(Object object);
 
     /**
-     * Returns the value of the field represented by this {@code FieldInfo} object
-     * as a {@code char} primitive. The provided {@code object} is used as a target
-     * to extract the field from.
+     * Retrieve the field's {@code char} value from the given instance.
      *
-     * @return the value of the field represented by this {@code FieldInfo} object
-     * as a {@code char} primitive.
+     * @param object the instance containing the field
+     * @return the {@code char} value read, or a type specific default if not accessible
      */
     char getChar(Object object);
 
     /**
-     * Returns the value of the field represented by this {@code FieldInfo} object
-     * as a {@code double} primitive. The provided {@code object} is used as a target
-     * to extract the field from.
+     * Retrieve the field's {@code double} value from the given instance.
      *
-     * @return the value of the field represented by this {@code FieldInfo} object
-     * as a {@code double} primitive.
+     * @param object the instance containing the field
+     * @return the {@code double} value read, or a type specific default if not accessible
      */
     double getDouble(Object object);
 
     /**
-     * Sets the value of the field represented by this {@code FieldInfo} object
-     * to the provided {@code value}. The provided {@code object} is used as a
-     * target to the extract eh field from.
+     * Set the value of the field on the specified instance.
+     *
+     * @param object the instance to modify
+     * @param value  the new value for the field
+     * @throws IllegalArgumentException if the field cannot be written
      */
     void set(Object object, Object value) throws IllegalArgumentException;
 
     /**
-     * Sets the value of the field represented by this {@code FieldInfo} object
-     * to the provided {@code value}. The provided {@code object} is used as a
-     * target to the extract eh field from.
+     * Set the {@code char} value of the field on the specified instance.
+     *
+     * @param object the instance to modify
+     * @param value  the new value for the field
+     * @throws IllegalArgumentException if the field cannot be written
      */
     void set(Object object, char value) throws IllegalArgumentException;
 
     /**
-     * Sets the value of the field represented by this {@code FieldInfo} object
-     * to the provided {@code value}. The provided {@code object} is used as a
-     * target to the extract eh field from.
+     * Set the {@code int} value of the field on the specified instance.
+     *
+     * @param object the instance to modify
+     * @param value  the new value for the field
+     * @throws IllegalArgumentException if the field cannot be written
      */
     void set(Object object, int value) throws IllegalArgumentException;
 
     /**
-     * Sets the value of the field represented by this {@code FieldInfo} object
-     * to the provided {@code value} of type {@code long}. The provided {@code object} is used as a
-     * target from which the field is extracted.
+     * Set the {@code long} value of the field on the specified instance.
      *
-     * @param object The object containing the field to be set.
-     * @param value  The value to set the field to.
-     * @throws IllegalArgumentException if the specified object is not an instance of the class or
-     *                                  interface declaring the underlying field, or if an unwrapping
-     *                                  conversion fails.
+     * @param object the instance to modify
+     * @param value  the new value for the field
+     * @throws IllegalArgumentException if the field cannot be written
      */
     void set(Object object, long value) throws IllegalArgumentException;
 
     /**
-     * Sets the value of the field represented by this {@code FieldInfo} object
-     * to the provided {@code value} of type {@code double}. The provided {@code object} is used as a
-     * target from which the field is extracted.
+     * Set the {@code double} value of the field on the specified instance.
      *
-     * @param object The object containing the field to be set.
-     * @param value  The value to set the field to.
-     * @throws IllegalArgumentException if the specified object is not an instance of the class or
-     *                                  interface declaring the underlying field, or if an unwrapping
-     *                                  conversion fails.
+     * @param object the instance to modify
+     * @param value  the new value for the field
+     * @throws IllegalArgumentException if the field cannot be written
      */
     void set(Object object, double value) throws IllegalArgumentException;
 
     /**
-     * Retrieves the {@link Class} identifying the declared generic type of the
-     * field represented by this {@code FieldInfo} object at the provided {@code index}.
+     * Return the {@link Class} for the generic type parameter at the given
+     * {@code index}.  This is useful for fields declared with generics such as
+     * {@code List<String>} or {@code Map<K,V>}.
      *
-     * @param index The index of the generic type to be retrieved.
-     * @return a {@link Class} identifying the declared generic type of the field represented by
-     * this {@code FieldInfo} object at the provided {@code index}.
+     * @param index zero based index of the generic argument
+     * @return the {@link Class} of the generic type argument
      */
     Class<?> genericType(int index);
 
     /**
-     * Copies the value of the field represented by this {@code FieldInfo} object from
-     * the source object to the destination object. It's a shallow copy, so objects will be
-     * copied by reference.
+     * Copy the value of this field from {@code source} to {@code destination}.
+     * The copy is shallow so object references are transferred rather than
+     * cloned.
      *
-     * @param source      The object from which the field value is to be copied.
-     * @param destination The object to which the field value is to be copied.
+     * @param source      object to read from
+     * @param destination object to write to
      */
     default void copy(Object source, Object destination) {
         set(destination, get(source));
     }
 
     /**
-     * Compares the value of the field represented by this {@code FieldInfo} in both provided
-     * objects {@code a} and {@code b} and determines if they are equal.
+     * Compare the value of this field in two objects for equality.  Primitive
+     * types are compared with their natural operators while objects are compared
+     * using {@link java.util.Objects#deepEquals(Object, Object)}.
      *
-     * @param a First object to compare the field's value.
-     * @param b Second object to compare the field's value.
-     * @return {@code true} if the values are equal, {@code false} otherwise.
+     * @param a first instance
+     * @param b second instance
+     * @return {@code true} if the field values are considered equal
      */
     boolean isEqual(Object a, Object b);
 }

--- a/src/main/java/net/openhft/chronicle/wire/internal/VanillaFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/VanillaFieldInfo.java
@@ -30,18 +30,36 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Objects;
 
+/**
+ * Standard {@link FieldInfo} implementation based on Java reflection.  This
+ * class forms part of Chronicle Wire's internal marshalling mechanics and is
+ * used when no specialised unsafe version is available.
+ */
 @SuppressWarnings("rawtypes")
 public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
 
+    /** declaring class of the field */
     private final Class<?> parent;
+    /** reflective handle to the field, re-acquired after deserialisation */
     private transient Field field;
 
+    /**
+     * Construct using the given reflective {@link Field}.
+     *
+     * @param name        field name
+     * @param type        field type
+     * @param bracketType wire representation
+     * @param field       reflective handle to the field
+     */
     public VanillaFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
         super(type, bracketType, name);
         parent = field.getDeclaringClass();
         this.field = field;
     }
 
+    /**
+     * Read the value using reflection.
+     */
     @Nullable
     @Override
     public Object get(Object object) {
@@ -140,6 +158,10 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         }
     }
 
+    /**
+     * Lazily obtain the reflective {@link Field}.  When deserialised the
+     * transient field is null and is looked up again from the declaring class.
+     */
     public Field getField() throws NoSuchFieldException {
         if (field == null) {
             field = parent.getDeclaredField(name);
@@ -148,6 +170,9 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         return field;
     }
 
+    /**
+     * Resolve the {@link Class} of the generic parameter at {@code index}.
+     */
     @Override
     public Class<?> genericType(int index) {
         ParameterizedType genericType = (ParameterizedType) field.getGenericType();
@@ -155,6 +180,9 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         return (Class) type;
     }
 
+    /**
+     * Compare field values in two objects for equality.
+     */
     @Override
     public boolean isEqual(Object a, Object b) {
         if (type.isPrimitive()) {

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/CharFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/CharFieldInfo.java
@@ -26,9 +26,8 @@ import org.jetbrains.annotations.NotNull;
 import java.lang.reflect.Field;
 
 /**
- * Represents field information for character fields, extending the generic field information capabilities
- * provided by {@link UnsafeFieldInfo}. It offers direct memory access functionality to get and set
- * character values in objects, leveraging unsafe operations for performance.
+ * FieldInfo implementation for {@code char} fields using {@link UnsafeMemory}
+ * for high performance direct access.
  */
 public final class CharFieldInfo extends UnsafeFieldInfo {
 
@@ -44,6 +43,9 @@ public final class CharFieldInfo extends UnsafeFieldInfo {
         super(name, type, bracketType, field);
     }
 
+    /**
+     * Read the {@code char} value directly using an unsafe memory read.
+     */
     @Override
     public char getChar(Object object) {
         try {
@@ -54,6 +56,9 @@ public final class CharFieldInfo extends UnsafeFieldInfo {
         }
     }
 
+    /**
+     * Write a {@code char} value using an unsafe memory write.
+     */
     @Override
     public void set(Object object, char value) throws IllegalArgumentException {
         try {
@@ -63,11 +68,17 @@ public final class CharFieldInfo extends UnsafeFieldInfo {
         }
     }
 
+    /**
+     * Compare two {@code char} values for equality.
+     */
     @Override
     public boolean isEqual(Object a, Object b) {
         return getChar(a) == getChar(b);
     }
 
+    /**
+     * Copy the {@code char} value from {@code source} to {@code destination}.
+     */
     @Override
     public void copy(Object source, Object destination) {
         set(destination, getChar(source));

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/DoubleFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/DoubleFieldInfo.java
@@ -26,9 +26,8 @@ import org.jetbrains.annotations.NotNull;
 import java.lang.reflect.Field;
 
 /**
- * Represents field information for double fields, extending the generic field information capabilities
- * provided by {@link UnsafeFieldInfo}. It offers direct memory access functionality to get and set
- * double values in objects, leveraging unsafe operations for enhanced performance.
+ * {@link FieldInfo} specialised for {@code double} values accessed via
+ * {@link UnsafeMemory}.
  */
 public final class DoubleFieldInfo extends UnsafeFieldInfo {
 
@@ -44,6 +43,9 @@ public final class DoubleFieldInfo extends UnsafeFieldInfo {
         super(name, type, bracketType, field);
     }
 
+    /**
+     * Read the {@code double} value directly from memory.
+     */
     @Override
     public double getDouble(Object object) {
         try {
@@ -54,6 +56,9 @@ public final class DoubleFieldInfo extends UnsafeFieldInfo {
         }
     }
 
+    /**
+     * Write a {@code double} value using an unsafe memory write.
+     */
     @Override
     public void set(Object object, double value) throws IllegalArgumentException {
         try {
@@ -63,11 +68,17 @@ public final class DoubleFieldInfo extends UnsafeFieldInfo {
         }
     }
 
+    /**
+     * Compare two {@code double} values for equality.
+     */
     @Override
     public boolean isEqual(Object a, Object b) {
         return getDouble(a) == getDouble(b);
     }
 
+    /**
+     * Copy the {@code double} value from {@code source} to {@code destination}.
+     */
     @Override
     public void copy(Object source, Object destination) {
         set(destination, getDouble(source));

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/IntFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/IntFieldInfo.java
@@ -26,9 +26,8 @@ import org.jetbrains.annotations.NotNull;
 import java.lang.reflect.Field;
 
 /**
- * Represents field information for integer fields, extending the generic field information capabilities
- * provided by {@link UnsafeFieldInfo}. It offers direct memory access functionality to get and set
- * integer values in objects, leveraging unsafe operations for enhanced performance.
+ * {@link FieldInfo} specialised for {@code int} values accessed via
+ * {@link UnsafeMemory}.
  */
 public final class IntFieldInfo extends UnsafeFieldInfo {
 
@@ -44,6 +43,9 @@ public final class IntFieldInfo extends UnsafeFieldInfo {
         super(name, type, bracketType, field);
     }
 
+    /**
+     * Read the {@code int} value directly from memory.
+     */
     @Override
     public int getInt(Object object) {
         try {
@@ -54,6 +56,9 @@ public final class IntFieldInfo extends UnsafeFieldInfo {
         }
     }
 
+    /**
+     * Write an {@code int} value using an unsafe memory write.
+     */
     @Override
     public void set(Object object, int value) throws IllegalArgumentException {
         try {
@@ -63,11 +68,17 @@ public final class IntFieldInfo extends UnsafeFieldInfo {
         }
     }
 
+    /**
+     * Compare two {@code int} values for equality.
+     */
     @Override
     public boolean isEqual(Object a, Object b) {
         return getInt(a) == getInt(b);
     }
 
+    /**
+     * Copy the {@code int} value from {@code source} to {@code destination}.
+     */
     @Override
     public void copy(Object source, Object destination) {
         set(destination, getInt(source));

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/LongFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/LongFieldInfo.java
@@ -26,9 +26,8 @@ import org.jetbrains.annotations.NotNull;
 import java.lang.reflect.Field;
 
 /**
- * Represents field information for long fields, extending the generic field information capabilities
- * provided by {@link UnsafeFieldInfo}. This class offers direct memory access functionality to get and set
- * long values in objects, leveraging unsafe operations for performance enhancement.
+ * {@link FieldInfo} specialised for {@code long} values accessed via
+ * {@link UnsafeMemory}.
  */
 public final class LongFieldInfo extends UnsafeFieldInfo {
 
@@ -44,6 +43,9 @@ public final class LongFieldInfo extends UnsafeFieldInfo {
         super(name, type, bracketType, field);
     }
 
+    /**
+     * Read the {@code long} value directly from memory.
+     */
     @Override
     public long getLong(Object object) {
         try {
@@ -54,6 +56,9 @@ public final class LongFieldInfo extends UnsafeFieldInfo {
         }
     }
 
+    /**
+     * Write a {@code long} value using an unsafe memory write.
+     */
     @Override
     public void set(Object object, long value) throws IllegalArgumentException {
         try {
@@ -63,11 +68,17 @@ public final class LongFieldInfo extends UnsafeFieldInfo {
         }
     }
 
+    /**
+     * Compare two {@code long} values for equality.
+     */
     @Override
     public boolean isEqual(Object a, Object b) {
         return getLong(a) == getLong(b);
     }
 
+    /**
+     * Copy the {@code long} value from {@code source} to {@code destination}.
+     */
     @Override
     public void copy(Object source, Object destination) {
         set(destination, getLong(source));

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/ObjectFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/ObjectFieldInfo.java
@@ -29,9 +29,8 @@ import java.lang.reflect.Field;
 import java.util.Objects;
 
 /**
- * Represents field information for object fields, extending the generic field information capabilities
- * provided by {@link UnsafeFieldInfo}. This class offers direct memory access functionality to get and set
- * object values in objects, leveraging unsafe operations for performance enhancement.
+ * {@link FieldInfo} implementation for object references using
+ * {@link UnsafeMemory} for fast access.
  */
 public final class ObjectFieldInfo extends UnsafeFieldInfo {
 
@@ -47,6 +46,9 @@ public final class ObjectFieldInfo extends UnsafeFieldInfo {
         super(name, type, bracketType, field);
     }
 
+    /**
+     * Obtain the field value using an unsafe memory read.
+     */
     @Override
     public @Nullable Object get(Object object) {
         try {
@@ -57,6 +59,9 @@ public final class ObjectFieldInfo extends UnsafeFieldInfo {
         }
     }
 
+    /**
+     * Set the field to {@code value} using an unsafe memory write.
+     */
     @Override
     public void set(Object object, Object value) throws IllegalArgumentException {
         Object value2 = ObjectUtils.convertTo(type, value);
@@ -67,11 +72,17 @@ public final class ObjectFieldInfo extends UnsafeFieldInfo {
         }
     }
 
+    /**
+     * Compare two object values using {@link Objects#deepEquals(Object, Object)}.
+     */
     @Override
     public boolean isEqual(Object a, Object b) {
         return Objects.deepEquals(get(a), get(b));
     }
 
+    /**
+     * Copy the reference from {@code source} to {@code destination}.
+     */
     @Override
     public void copy(Object source, Object destination) {
         set(destination, get(source));

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/UnsafeFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/UnsafeFieldInfo.java
@@ -25,12 +25,16 @@ import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Field;
 
+/**
+ * Base class for field accessors that use {@link UnsafeMemory} to read and
+ * write values via raw memory offsets.  Intended for internal use only.
+ */
 @SuppressWarnings("deprecation" /* The parent class will either be moved to internal or cease to exist in x.26 */)
 class UnsafeFieldInfo extends VanillaFieldInfo {
-    // Offset value to indicate that it hasn't been set yet.
+    /** value indicating that the offset has not yet been determined */
     private static final long UNSET_OFFSET = Long.MAX_VALUE;
 
-    // Offset in memory where the value for this field can be found.
+    /** memory offset of the field within its declaring class */
     private transient long offset = UNSET_OFFSET;
 
     /**


### PR DESCRIPTION
## Summary
- expand docs for FieldInfo and related implementations
- clarify AbstractFieldInfo responsibilities
- document reflection-based VanillaFieldInfo
- document unsafe field info helpers for primitives and objects

## Also
-   Clarified the purpose of the `FieldInfo` interface and documented its factory method and other behaviors
    
-   Expanded class-level documentation and field descriptions in `AbstractFieldInfo`
    
-   Documented the reflection-based `VanillaFieldInfo` implementation and its helper methods
    
-   Added explanations for `UnsafeFieldInfo` and its subclasses providing direct memory access for primitive and object fields