### PR TITLE
Improve ValueIn/Out Javadocs

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/DefaultValueIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/DefaultValueIn.java
@@ -39,23 +39,23 @@ import java.util.List;
 import java.util.UUID;
 import java.util.function.*;
 /**
- * This class provides the default implementation for the {@link ValueIn} interface. It's primarily designed
- * to handle default values, converting them into various formats such as text and bytes.
- * The default value is retrieved from an underlying {@link WireIn} source.
+ * Default implementation of {@link ValueIn} used when a field is absent on the wire.
+ * The value returned by the various read methods comes from {@link #defaultValue} which is
+ * populated by the {@link WireMarshaller} for missing fields.
  */
 @SuppressWarnings("rawtypes")
 public class DefaultValueIn implements ValueIn {
 
-    // The underlying WireIn source for fetching default values
+    /** Parent {@link WireIn} that this instance belongs to. */
     private final WireIn wireIn;
 
-    // The stored default value, fetched from the WireIn source
+    /** Value returned when the requested field is missing. */
     Object defaultValue;
 
     /**
-     * Constructs a new instance of DefaultValueIn with a given {@link WireIn} source.
+     * Constructs a {@code DefaultValueIn} associated with the given {@link WireIn}.
      *
-     * @param wireIn The WireIn source to fetch default values from.
+     * @param wireIn parent wire used when returning to the caller
      */
     DefaultValueIn(WireIn wireIn) {
         this.wireIn = wireIn;

--- a/src/main/java/net/openhft/chronicle/wire/ValueIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueIn.java
@@ -43,26 +43,31 @@ import java.util.function.*;
 import static net.openhft.chronicle.wire.SerializationStrategies.MARSHALLABLE;
 
 /**
- * Represents an interface for reading values in various formats from a serialized data source.
- * This interface is part of the Chronicle Wire library, which is designed for high-performance
- * serialization and deserialization of data. It provides methods to read data types like text,
- * binary, numeric, and temporal values, as well as support for more complex types like collections
- * and marshallable objects.
+ * Represents the value part of a key-value pair being read from a wire. After a field name
+ * (or event key) is processed via {@link WireIn#read()}, a {@code ValueIn} instance is used to
+ * deserialize the associated value. Implementations provide methods for reading primitive types,
+ * text, bytes and marshallable objects from the underlying wire format.
+ * <p>
+ * A {@code ValueIn} instance is typically used only once for a single field before obtaining the
+ * next one from {@link WireIn}.
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public interface ValueIn {
-    /** A constant consumer that does nothing when accepting a {@link ValueIn}. */
+    /**
+     * A {@link Consumer} for {@code ValueIn} instances that discards the value. Useful
+     * as a no-op placeholder when a value is intentionally ignored.
+     */
     Consumer<ValueIn> DISCARD = v -> {};
 
     // ---- Text / Strings section ----
 
     /**
-     * Reads text data and applies a given bi-consumer to the text data and the provided object.
+     * Reads the current field as text and supplies it to the provided bi-consumer.
      *
-     * @param t  The target object.
-     * @param ts The bi-consumer that accepts the target object and the read text.
-     * @param <T> Type of the target object.
-     * @return The current WireIn instance.
+     * @param t  target object passed back to {@code ts}
+     * @param ts consumer receiving {@code t} and the deserialized text
+     * @param <T> type of the target object
+     * @return parent {@link WireIn} for chaining
      */
     @NotNull
     default <T> WireIn text(T t, @NotNull BiConsumer<T, String> ts) {
@@ -72,10 +77,11 @@ public interface ValueIn {
     }
 
     /**
-     * Reads text data and appends it to the given StringBuilder. If the data is null, the StringBuilder is cleared.
+     * Reads the current value as text and appends it to the supplied {@link StringBuilder}.
+     * If the underlying value is {@code null}, the builder is cleared.
      *
-     * @param sb The StringBuilder to append the text data to.
-     * @return The current WireIn instance.
+     * @param sb destination for the text
+     * @return parent {@link WireIn} for chaining
      */
     @NotNull
     default WireIn text(@NotNull StringBuilder sb) {
@@ -85,9 +91,10 @@ public interface ValueIn {
     }
 
     /**
-     * Reads text data and returns the first character. If the data is null or empty, a null character is returned.
+     * Reads the value as text and returns its first character. If no text is present
+     * an {@code '\u0000'} character is returned.
      *
-     * @return The first character of the text data or '\u0000' if none.
+     * @return first character of the text value or {@code '\u0000'} if the value was null or empty
      */
     default char character() {
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
@@ -100,10 +107,11 @@ public interface ValueIn {
     }
 
     /**
-     * Reads text data into the provided Bytes object, which is then cleared.
+     * Reads the current value as text and writes it into the supplied {@link Bytes} instance.
+     * The target bytes are cleared before writing.
      *
-     * @param sdo The Bytes object to store the text data.
-     * @return The current WireIn instance.
+     * @param sdo destination for the text value
+     * @return parent {@link WireIn} for chaining
      */
     @NotNull
     default WireIn text(@NotNull Bytes<?> sdo) {
@@ -113,9 +121,9 @@ public interface ValueIn {
     }
 
     /**
-     * Reads and returns the text data.
+     * Reads and returns the current value as a {@link String}.
      *
-     * @return The text data or null.
+     * @return the text representation or {@code null} if the value on the wire was null
      */
     @Nullable
     String text();
@@ -130,10 +138,10 @@ public interface ValueIn {
     StringBuilder textTo(@NotNull StringBuilder sb);
 
     /**
-     * Reads text data into the provided Bytes object.
+     * Reads the value as text and appends it to the provided {@link Bytes} buffer.
      *
-     * @param bytes The Bytes object to store the text data.
-     * @return The Bytes object with the text data or null.
+     * @param bytes destination for the text
+     * @return the passed in {@link Bytes} populated with the text, or {@code null} if the wire value was null
      */
     @Nullable
     Bytes<?> textTo(@NotNull Bytes<?> bytes);
@@ -249,24 +257,21 @@ public interface ValueIn {
     }
 
     /**
-     * Provides the current WireIn instance.
-     *
-     * @return The current WireIn instance.
+     * Returns the parent {@link WireIn} from which this {@code ValueIn} was obtained.
      */
     @NotNull
     WireIn wireIn();
 
     /**
-     * Retrieves the length of the field in bytes, inclusive of any encoding and header character.
-     *
-     * @return The length of the field in bytes.
+     * Returns the length in bytes of the current value as represented on the wire,
+     * excluding the field name.
      */
     long readLength();
 
     /**
-     * Skips the current value while reading.
+     * Consumes and discards the current field's value, advancing the read position.
      *
-     * @return The current WireIn instance.
+     * @return parent {@link WireIn}
      */
     @NotNull
     WireIn skipValue();
@@ -430,16 +435,13 @@ public interface ValueIn {
     }
 
     /**
-     * Checks if there is another element to read in a sequence or collection.
-     *
-     * @return True if there is another element to read, false otherwise.
+     * Indicates whether more fields or items remain to be read in the current context.
+     * Typically used when iterating over a map or list structure.
      */
     boolean hasNext();
 
     /**
-     * Checks if there is another item in a sequence.
-     *
-     * @return True if there is another sequence item, false otherwise.
+     * Returns {@code true} if the current value represents a sequence and more items are available.
      */
     boolean hasNextSequenceItem();
 

--- a/src/main/java/net/openhft/chronicle/wire/ValueInStack.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueInStack.java
@@ -21,27 +21,27 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Represents a stack structure specifically designed to manage {@link ValueInState} instances.
- * The primary purpose of this class is to provide an organized way to manage and retrieve states
- * at different levels, and efficiently reuse them without constant instantiation.
+ * Package-private stack of {@link ValueInState} objects used by {@link ValueIn}
+ * implementations when parsing nested structures. States are recycled to minimise
+ * allocation.
  */
 class ValueInStack {
 
-    // A list to hold ValueInState instances that can be reused
+    /** Pool of {@link ValueInState} instances available for reuse. */
     final List<ValueInState> freeList = new ArrayList<>();
 
-    // Represents the current level of the stack
+    /** Current depth of the stack. */
     int level = 0;
 
     /**
-     * Constructs a new ValueInStack and adds the first ValueInState to the free list.
+     * Creates a new stack and pre-allocates a {@link ValueInState} for level {@code 0}.
      */
     public ValueInStack() {
         addOne();
     }
 
     /**
-     * Resets the current level to the initial state and clears the state of the first ValueInState.
+     * Resets to level {@code 0} and clears the root {@link ValueInState}.
      */
     public void reset() {
         level = 0;
@@ -49,7 +49,7 @@ class ValueInStack {
     }
 
     /**
-     * Increases the current level of the stack. If the free list has a state at this new level, it is reset.
+     * Pushes a new level onto the stack, reusing an existing {@link ValueInState} if available.
      */
     public void push() {
         level++;
@@ -59,9 +59,9 @@ class ValueInStack {
     }
 
     /**
-     * Decreases the current level of the stack. If the level would become negative, an exception is thrown.
+     * Pops the current level from the stack.
      *
-     * @throws IllegalStateException if trying to pop below the bottom of the stack.
+     * @throws IllegalStateException if the stack would underflow
      */
     public void pop() {
         if (level < 0)
@@ -70,9 +70,8 @@ class ValueInStack {
     }
 
     /**
-     * Retrieves the {@link ValueInState} at the current level. If none exists, new instances are added until one does.
-     *
-     * @return The ValueInState at the current stack level
+     * Returns the {@link ValueInState} for the current level, creating additional
+     * instances as necessary.
      */
     public ValueInState curr() {
         while (freeList.size() <= level)
@@ -81,7 +80,7 @@ class ValueInStack {
     }
 
     /**
-     * Adds a new {@link ValueInState} instance to the free list.
+     * Allocates and stores a new {@link ValueInState} in the pool.
      */
     private void addOne() {
         freeList.add(new ValueInState());

--- a/src/main/java/net/openhft/chronicle/wire/ValueInState.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueInState.java
@@ -20,26 +20,26 @@ package net.openhft.chronicle.wire;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Represents the state associated with a particular input value.
- * This class is primarily designed to manage unexpected inputs and the position of these unexpected values.
+ * Package-private helper used by {@link ValueIn} implementations to track parsing state.
+ * It records positions of any fields encountered out of order so they can be revisited later.
  */
 class ValueInState {
 
-    // A constant representing an empty array of long values
+    /** Shared empty array used to initialise {@link #unexpected}. */
     private static final long[] EMPTY_ARRAY = {};
 
-    // The saved position for the current state
+    /** Position in the wire to return to. */
     private long savedPosition;
 
-    // Size of the unexpected values
+    /** Number of unexpected field positions currently stored. */
     private int unexpectedSize;
 
-    // An array to hold unexpected values
+    /** Wire positions of fields encountered but not yet processed. */
     @NotNull
     private long[] unexpected = EMPTY_ARRAY;
 
     /**
-     * Resets the saved position and the unexpected values to their initial states.
+     * Clears the saved position and any recorded unexpected field positions.
      */
     public void reset() {
         savedPosition = 0;
@@ -47,9 +47,9 @@ class ValueInState {
     }
 
     /**
-     * Adds an unexpected position to the list of unexpected values.
+     * Records an unexpected field start position so it can be processed later.
      *
-     * @param position The unexpected position to be added
+     * @param position wire position of the unexpected field
      */
     public void addUnexpected(long position) {
         if (unexpectedSize >= unexpected.length) {
@@ -62,46 +62,39 @@ class ValueInState {
     }
 
     /**
-     * Sets the saved position for the current state.
+     * Sets the wire position to return to later.
      *
-     * @param savedPosition The position to be saved
+     * @param savedPosition position in the underlying wire
      */
     public void savedPosition(long savedPosition) {
         this.savedPosition = savedPosition;
     }
 
     /**
-     * Retrieves the saved position for the current state.
-     *
-     * @return The saved position
+     * Returns the currently saved wire position.
      */
     public long savedPosition() {
         return savedPosition;
     }
 
     /**
-     * Retrieves the number of unexpected positions stored.
-     *
-     * @return The size of unexpected positions
+     * Number of unexpected positions currently recorded.
      */
     public int unexpectedSize() {
         return unexpectedSize;
     }
 
     /**
-     * Retrieves a specific unexpected position based on its index.
-     *
-     * @param index The index of the unexpected position
-     * @return The unexpected position at the given index
+     * Returns the unexpected field position at the given index.
      */
     public long unexpected(int index) {
         return unexpected[index];
     }
 
     /**
-     * Removes an unexpected position from the list based on its index.
+     * Removes the unexpected position at the supplied index.
      *
-     * @param i The index of the unexpected position to be removed
+     * @param i index of the entry to remove
      */
     public void removeUnexpected(int i) {
         int length = unexpectedSize - i - 1;

--- a/src/main/java/net/openhft/chronicle/wire/ValueOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueOut.java
@@ -54,24 +54,25 @@ import java.util.stream.Stream;
 import static net.openhft.chronicle.wire.Wires.isScalar;
 
 /**
- * Defines an interface for writing out values after writing a field.
- * Implementations of this interface should provide methods to handle writing various data types.
+ * Responsible for writing the value component of a key-value pair to a wire. After a field name
+ * has been written using {@link WireOut#write(CharSequence)}, a {@code ValueOut} is obtained to
+ * serialise the corresponding value. Each instance is generally used to write one value only.
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public interface ValueOut {
 
     /**
-     * Thread local instance for MapMarshaller to support thread-safe marshalling operations.
+     * Thread-local {@link MapMarshaller} used for efficient, thread-safe map serialisation.
      */
     ThreadLocal<MapMarshaller> MM_TL = ThreadLocal.withInitial(MapMarshaller::new);
 
     /**
-     * Defines a threshold for small messages.
+     * Threshold size in bytes below which {@link #compress(String, Bytes)} may choose not to compress.
      */
     int SMALL_MESSAGE = 64;
 
     /**
-     * Represents a 64-character sequence of zeros.
+     * Utility string containing 64 zeros, used for formatting of binary representations.
      */
     String ZEROS_64 = "0000000000000000000000000000000000000000000000000000000000000000";
 


### PR DESCRIPTION
## Summary
- clarify purpose of ValueIn and ValueOut interfaces
- enhance Javadoc for default ValueIn implementation
- document internal ValueIn state helpers

## Also
-   Clarified that each `ValueIn` handles the value for a single field and added a discard consumer description
    
-   Documented string-handling methods in `ValueIn` for clearer semantics
    
-   Updated `ValueOut` to explain its role after a field name is written, and documented its constants
    
-   Enhanced `DefaultValueIn` to describe how default values are supplied when fields are missing
    
-   Added explanatory Javadoc to `ValueInState` and `ValueInStack` for managing unexpected fields and nested states