### PR TITLE
Improve Javadocs for YAML text wire

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/Quotes.java
+++ b/src/main/java/net/openhft/chronicle/wire/Quotes.java
@@ -18,9 +18,8 @@
 package net.openhft.chronicle.wire;
 
 /**
- * Enumerates the types of quotation marks.
- * This enum represents the most common quotation marks: none, single, and double.
- * Each enumeration value is associated with its corresponding character representation.
+ * Enumerates the types of quotation marks used by
+ * {@link net.openhft.chronicle.wire.YamlWireOut} when writing strings.
  */
 enum Quotes {
 

--- a/src/main/java/net/openhft/chronicle/wire/TextStopCharTesters.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextStopCharTesters.java
@@ -47,6 +47,7 @@ enum TextStopCharTesters implements StopCharTester {
             return ch >= eowLength || eow.get(ch);
         }
     },
+    /** Stops at common YAML end-of-text characters such as quotes, commas or newlines. */
     END_OF_TEXT {
         @Override
         public boolean isStopChar(int ch) throws IllegalStateException {

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -49,43 +49,68 @@ import static net.openhft.chronicle.wire.TextStopCharTesters.END_OF_TYPE;
 import static net.openhft.chronicle.wire.Wires.*;
 
 /**
- * A representation of the YAML-based wire format. `TextWire` provides functionalities
- * for reading and writing objects in a YAML-based format, and encapsulates various characteristics
- * of the YAML text format.
+ * A representation of Chronicle's text based wire format.  It reads and writes a
+ * YAML inspired dialect and is commonly used for human readable configurations or
+ * when interoperability with YAML tools is required.
  *
- * <p>This class utilizes bit sets, thread locals, and regular expressions to efficiently handle
- * the YAML formatting nuances.
+ * <p>The implementation is heavily optimised for performance and makes extensive
+ * use of {@link BitSet}, {@link ThreadLocal} caches and regular expressions when
+ * parsing or emitting text.  While compatible with YAML in most cases, it is not
+ * a full YAML 1.2 implementation and favours speed over supporting every edge
+ * case of the specification.</p>
  *
- * <p><b>Important:</b> Some configurations and methods in this class are marked as deprecated
- * and are slated for removal in future versions, suggesting that its behavior might evolve in future releases.
+ * <p><b>Note:</b> A number of fields and methods are deprecated and may be removed
+ * in a future release.</p>
  */
 @SuppressWarnings({"rawtypes", "unchecked", "this-escape"})
 public class TextWire extends YamlWireOut<TextWire> {
 
-    // Constants representing specific textual constructs in YAML.
+    /** YAML tag used when serialising raw binary data. */
     public static final BytesStore<?, ?> BINARY = BytesStore.from("!!binary");
+
+    /** Prefix used for a type declaration, e.g. <code>!type Foo</code>. */
     public static final @NotNull Bytes<byte[]> TYPE_STR = Bytes.from("type ");
+
+    /**
+     * Tag employed internally to represent a sequence of maps. It is not part
+     * of the standard YAML specification.
+     */
     static final String SEQ_MAP = "!seqmap";
 
-    // A set of characters considered as "end characters" in this wire format.
+    /**
+     * Characters which terminate an unquoted text token when parsing.  The set
+     * is initialised in a static block.
+     */
     static final BitSet END_CHARS = new BitSet();
 
     // Thread locals for stop char testers that might need escaping in specific contexts.
     // They are weakly referenced to avoid potential memory leaks in multithreaded environments.
-    static final ThreadLocal<WeakReference<StopCharTester>> ESCAPED_QUOTES = new ThreadLocal<>();//ThreadLocal.withInitial(StopCharTesters.QUOTES::escaping);
-    static final ThreadLocal<WeakReference<StopCharTester>> ESCAPED_SINGLE_QUOTES = new ThreadLocal<>();//ThreadLocal.withInitial(() -> StopCharTesters.SINGLE_QUOTES.escaping());
-    static final ThreadLocal<WeakReference<StopCharTester>> ESCAPED_END_OF_TEXT = new ThreadLocal<>();// ThreadLocal.withInitial(() -> TextStopCharsTesters.END_OF_TEXT.escaping());
-    static final ThreadLocal<WeakReference<StopCharsTester>> STRICT_ESCAPED_END_OF_TEXT = new ThreadLocal<>();// ThreadLocal.withInitial(() -> TextStopCharsTesters.END_OF_TEXT.escaping());
+    /** Cached tester for quoted strings. */
+    static final ThreadLocal<WeakReference<StopCharTester>> ESCAPED_QUOTES = new ThreadLocal<>();
+
+    /** Cached tester for single quoted strings. */
+    static final ThreadLocal<WeakReference<StopCharTester>> ESCAPED_SINGLE_QUOTES = new ThreadLocal<>();
+
+    /** Cached tester that honours YAML escaping rules when reading text. */
+    static final ThreadLocal<WeakReference<StopCharTester>> ESCAPED_END_OF_TEXT = new ThreadLocal<>();
+
+    /** Strict variant used when parsing event names. */
+    static final ThreadLocal<WeakReference<StopCharsTester>> STRICT_ESCAPED_END_OF_TEXT = new ThreadLocal<>();
     static final Pattern REGX_PATTERN = Pattern.compile("\\.|\\$");
 
     // Suppliers for various stop char testers.
     static final Supplier<StopCharTester> QUOTES_ESCAPING = StopCharTesters.QUOTES::escaping;
     static final Supplier<StopCharTester> SINGLE_QUOTES_ESCAPING = StopCharTesters.SINGLE_QUOTES::escaping;
+    /** Supplier for the standard end of text tester. */
     static final Supplier<StopCharTester> END_OF_TEXT_ESCAPING = TextStopCharTesters.END_OF_TEXT::escaping;
+
+    /** Supplier for a stricter variant used while parsing field names. */
     static final Supplier<StopCharsTester> STRICT_END_OF_TEXT_ESCAPING = TextStopCharsTesters.STRICT_END_OF_TEXT::escaping;
+
+    /** Supplier used when reading event names. */
     static final Supplier<StopCharsTester> END_EVENT_NAME_ESCAPING = TextStopCharsTesters.END_EVENT_NAME::escaping;
 
-    // Metadata representation in bytes.
+    /** Byte sequence used when writing or detecting the <code>!!meta-data</code> tag. */
     static final Bytes<?> META_DATA = Bytes.from("!!meta-data");
 
     static {
@@ -99,62 +124,62 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Input value parser specifically for text-based wire format.
+     * Primary {@link ValueIn} instance used to deserialize values from this
+     * wire.  Subclasses may override {@link #createValueIn()} to supply a
+     * specialised implementation.
      */
     protected final TextValueIn valueIn = createValueIn();
 
     /**
-     * Represents the start of the current line being processed in the wire format.
+     * Byte offset marking the start of the line currently being parsed.  Used
+     * for indentation calculations.
      */
     protected long lineStart = 0;
 
     /**
-     * Default value input utility.
+     * Helper {@link ValueIn} returned when a requested field is missing.
      */
     private DefaultValueIn defaultValueIn;
 
-    /**
-     * Context for writing documents in the wire format.
-     */
+    /** Current document writing context. */
     protected WriteDocumentContext writeContext;
 
-    /**
-     * Context for reading documents from the wire format.
-     */
+    /** Current document reading context. */
     protected ReadDocumentContext readContext;
 
     /**
-     * Flag to determine if strict parsing rules are applied.
+     * If set, parsing is less tolerant of deviations from the expected
+     * format.  Disabled by default.
      */
     private boolean strict = false;
 
     /**
-     * Constructor to initialize the `TextWire` with a specific bytes representation
-     * and a flag to determine if 8-bit encoding is to be used.
+     * Creates a new instance backed by the provided bytes.
      *
-     * @param bytes   Bytes representation.
-     * @param use8bit Flag to determine if 8-bit encoding is to be used.
+     * @param bytes   underlying data buffer
+     * @param use8bit if {@code true} strings are written using ISO-8859-1 rather
+     *                than UTF‑8
      */
     public TextWire(@NotNull Bytes<?> bytes, boolean use8bit) {
         super(bytes, use8bit);
     }
 
     /**
-     * Constructor that initializes the `TextWire` with bytes representation
-     * with default 8-bit encoding turned off.
+     * Creates a new instance using UTF‑8 by default.
      *
-     * @param bytes Bytes representation.
+     * @param bytes buffer to wrap
      */
     public TextWire(@NotNull Bytes<?> bytes) {
         this(bytes, false);
     }
 
     /**
-     * Factory method to create a `TextWire` from a file.
+     * Create a new {@code TextWire} initialised with the contents of the given
+     * file.
      *
-     * @param name Name of the file.
-     * @return A new instance of `TextWire`.
-     * @throws IOException if any I/O error occurs.
+     * @param name path to the file to read
+     * @return a new instance populated with the file contents
+     * @throws IOException if the file cannot be read
      */
     @NotNull
     public static TextWire fromFile(String name) throws IOException {
@@ -162,10 +187,10 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Factory method to create a `TextWire` from a string representation.
+     * Parse a text string to create a new instance.
      *
-     * @param text String representation of the wire format.
-     * @return A new instance of `TextWire`.
+     * @param text YAML text
+     * @return newly created instance
      */
     @NotNull
     public static TextWire from(@NotNull String text) {
@@ -173,10 +198,8 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Converts any wire format into a text representation.
-     *
-     * @param wire The wire format to be converted.
-     * @return The text representation of the wire format.
+     * Utility that converts any given {@link Wire} into its textual
+     * representation.  Useful for logging or debugging.
      */
     public static String asText(@NotNull Wire wire) {
         NativeBytes<Void> bytes = nativeBytes();
@@ -195,12 +218,11 @@ public class TextWire extends YamlWireOut<TextWire> {
 
     // https://yaml.org/spec/1.2.2/#escaped-characters
     /**
-     * Processes and unescapes the provided {@link CharSequence} containing escaped sequences.
-     * For instance, "\\n" is converted to a newline character, "\\t" to a tab, etc.
-     * This method modifies the given sequence directly and adjusts its length if needed.
-     *
-     * @param sb A {@link CharSequence} that is also an {@link Appendable}, containing potentially escaped sequences.
-     *           This sequence will be modified directly.
+     * Unescapes YAML escape sequences in {@code sb} in-place. Examples such as
+     * <code>\n</code> or <code>\t</code> are converted to their character
+     * equivalents. The implementation follows the
+     * <a href="https://yaml.org/spec/1.2.2/#escaped-characters">YAML&nbsp;1.2
+     * specification</a>.
      */
     public static <ACS extends Appendable & CharSequence> void unescape(@NotNull ACS sb) {
         int end = 0;
@@ -277,11 +299,8 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Acquires a {@link StopCharTester} instance related to escaping single quotes.
-     * This method utilizes thread-local storage to ensure that the returned instance is thread-safe.
-     *
-     * @return A {@link StopCharTester} instance specifically designed for escaping single quotes,
-     *         or null if such an instance could not be acquired.
+     * Returns a thread local instance used when parsing text within single
+     * quotes.  The tester is reset on each call to avoid additional allocations.
      */
     @Nullable
     static StopCharTester getEscapingSingleQuotes() {
@@ -293,12 +312,12 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Loads an Object from a file
+     * Convenience method to deserialize an object from a YAML file.
      *
-     * @param filename the file-path containing the object
-     * @param <T>      the type of the object to load
-     * @return an instance of the object created from the data in the file
-     * @throws IOException if the file can not be found or read
+     * @param filename path to the YAML file
+     * @param <T>      expected object type
+     * @return deserialized object instance
+     * @throws IOException if the file cannot be read
      */
     public static <T> T load(String filename) throws IOException, InvalidMarshallableException {
         return (T) TextWire.fromFile(filename).readObject();

--- a/src/main/java/net/openhft/chronicle/wire/YamlKeys.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlKeys.java
@@ -28,12 +28,13 @@ import java.util.Arrays;
  * varying numbers of offsets without a significant overhead in space.
  */
 public class YamlKeys {
+    /** Shared empty array used when no offsets are stored. */
     private static final long[] NO_OFFSETS = {};
 
-    // The current number of offsets stored
+    /** Number of valid entries currently in {@link #offsets}. */
     int count = 0;
 
-    // The dynamic array of offsets
+    /** Array of byte offsets for keys.  Grows as required. */
     long[] offsets = NO_OFFSETS;
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/YamlLogging.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlLogging.java
@@ -185,18 +185,21 @@ public enum YamlLogging {
      * The levels include OFF (no logging), DEBUG_ONLY (logs only when in debug mode), and ON (always logs).
      */
     public enum YamlLoggingLevel {
+        /** Logging is disabled. */
         OFF {
             @Override
             public boolean isSet() {
                 return false;
             }
         },
+        /** Logging is enabled only when {@link Jvm#isDebug()} is {@code true}. */
         DEBUG_ONLY {
             @Override
             public boolean isSet() {
                 return Jvm.isDebug();
             }
         },
+        /** Logging is always enabled. */
         ON {
             @Override
             public boolean isSet() {

--- a/src/main/java/net/openhft/chronicle/wire/YamlToken.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlToken.java
@@ -23,28 +23,61 @@ package net.openhft.chronicle.wire;
  * for tasks such as parsing or tokenization of YAML documents.
  */
 public enum YamlToken {
+    /** No token present. */
     NONE,
+
+    /** A comment line beginning with '#'. */
     COMMENT,
+
+    /** A YAML tag such as <code>!type</code>. */
     TAG,
+
+    /** A YAML directive starting with '%'. */
     DIRECTIVE,
+
+    /** End of a document marker (<code>...</code>). */
     DOCUMENT_END(),
-    /** Represents the end of the directives in a YAML document. */
+
+    /** Marker for the end of the directives section (<code>---</code>). */
     DIRECTIVES_END(DOCUMENT_END),
+
+    /** A key within a mapping. */
     MAPPING_KEY(NONE),
+
+    /** End of a mapping (<code>}</code>). */
     MAPPING_END(),
-    /** Represents the start of a key-value mapping in a YAML document. */
+
+    /** Start of a mapping (<code>{</code>). */
     MAPPING_START(MAPPING_END),
+
+    /** End of a sequence (<code>]</code>). */
     SEQUENCE_END(),
+
+    /** Entry within a sequence. */
     SEQUENCE_ENTRY,
-    /** Represents the start of a sequence in a YAML document. */
+
+    /** Start of a sequence (<code>[</code> or '-'). */
     SEQUENCE_START(SEQUENCE_END),
+
+    /** Scalar text value. */
     TEXT,
+
+    /** Literal block (<code>|</code> or <code>></code>). */
     LITERAL,
+
+    /** Anchor (e.g. <code>&amp;id</code>). */
     ANCHOR,
+
+    /** Alias referencing an anchor (e.g. <code>*id</code>). */
     ALIAS,
+
+    /** Reserved indicator. */
     RESERVED,
+
+    /** End of the YAML stream. */
     STREAM_END,
-    /** Represents the start of a YAML document stream. */
+
+    /** Start of the YAML stream. */
     STREAM_START(STREAM_END);
 
     /** The corresponding end token for certain start tokens. */

--- a/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
@@ -32,10 +32,10 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * A tokenizer for YAML documents. The YamlTokeniser class is responsible for
- * converting a raw YAML input into individual tokens, each representing
- * a distinct construct or symbol in YAML. This class is integral to
- * processes such as parsing or tokenization of YAML documents.
+ * A tokenizer for YAML documents. It converts a raw character stream into a
+ * sequence of {@link YamlToken tokens} which are then consumed by
+ * {@link YamlWire}.  The class is optimised for speed and reuses internal
+ * buffers to minimise allocations.
  */
 @SuppressWarnings({"this-escape","deprecation"})
 public class YamlTokeniser {

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -47,39 +47,46 @@ import java.util.function.*;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 /**
- * Represents a YAML-based wire format designed for efficient parsing and serialization of data.
- * The YamlWire class extends YamlWireOut and utilizes a custom tokenizer to convert YAML tokens into byte sequences.
- * It provides utility methods to read from and write to both byte buffers and files.
+ * Wire implementation that aims to follow the YAML&nbsp;1.2 specification more
+ * closely than {@link TextWire}.  It uses {@link YamlTokeniser} for parsing and
+ * supports anchors, aliases and other YAML features.  This comes at the cost of
+ * being slightly stricter and slower than the lighter weight {@code TextWire}.
  */
 @SuppressWarnings({"rawtypes", "unchecked", "this-escape"})
 public class YamlWire extends YamlWireOut<YamlWire> {
 
-    // YAML-specific tag constants for representing special constructs.
+    /** Tag representing a sequence of maps used internally. */
     static final String SEQ_MAP = "!seqmap";
+
+    /** YAML tag for binary data. */
     static final String BINARY_TAG = "!binary";
+
+    /** Tag used for pre-encoded data blocks. */
     static final String DATA_TAG = "!data";
+
+    /** YAML null tag. */
     static final String NULL_TAG = "!null";
 
     //for (char ch : "?%&*@`0123456789+- ',#:{}[]|>!\\".toCharArray())
-    // Internal helper for reading text-based values.
+    /** Value reader used to deserialize YAML scalars and structures. */
     private final TextValueIn valueIn = createValueIn();
 
-    // Custom tokenizer for parsing YAML tokens.
+    /** Tokeniser driving the parsing process. */
     private final YamlTokeniser yt;
 
-    // Map to store reusable content anchors defined in the YAML.
+    /** Storage for objects defined via YAML anchors. */
     private final Map<String, Object> anchorValues = new HashMap<>();
 
-    // Provides default values for reading.
+    /** {@link ValueIn} returned when a field is missing. */
     private DefaultValueIn defaultValueIn;
 
-    // Context for writing out YAML documents.
+    /** Document writing context. */
     private WriteDocumentContext writeContext;
 
-    // Context for reading in YAML documents.
+    /** Document reading context. */
     private ReadDocumentContext readContext;
 
-    // Instance for re-reading or re-parsing scenarios.
+    /** Helper used for revisiting skipped fields. */
     private YamlWire rereadWire;
 
     /**
@@ -128,11 +135,9 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Converts the content of a given {@link Wire} object into its string representation.
-     *
-     * @param wire The {@link Wire} object whose content needs to be converted to string.
-     * @return The string representation of the wire's content.
-     * @throws InvalidMarshallableException If the given wire's content cannot be marshalled.
+     * Convenience helper that copies the supplied {@link Wire} into a temporary
+     * {@code YamlWire} and returns the textual form.  Useful when debugging a
+     * wire of a different type.
      */
     public static String asText(@NotNull Wire wire) throws InvalidMarshallableException {
         long pos = wire.bytes().readPosition();

--- a/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
@@ -49,27 +49,43 @@ import java.util.function.BiConsumer;
 import static net.openhft.chronicle.bytes.BytesStore.empty;
 
 /**
- * Provides functionality for writing data in a YAML-based wire format.
- * This class encapsulates methods and attributes to handle data serialization into YAML format.
+ * Abstract base class for wires that serialise data using a YAML like
+ * representation.  It manages indentation, separators and string escaping while
+ * delegating the actual value formatting to {@link YamlValueOut}.
  *
- * @param <T> The type that extends YamlWireOut
+ * @param <T> concrete subclass type
  */
 @SuppressWarnings({"rawtypes", "unchecked", "this-escape", "deprecation"})
 public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire {
     @Deprecated(/* to remove in x.28 */)
     private static final boolean APPEND_0 = Jvm.getBoolean("bytes.append.0", true);
 
+    /** Prefix written before a type name when emitting typed objects. */
     public static final BytesStore<?, ?> TYPE = BytesStore.from("!type ");
+
+    /** Representation of a YAML null value. */
     static final String NULL = "!null \"\"";
+
+    /** Characters which require quoting when appearing at the start of a string. */
     static final BitSet STARTS_QUOTE_CHARS = new BitSet();
+
+    /** Characters which force double quoting within a string. */
     static final BitSet QUOTE_CHARS = new BitSet();
+    /** Separator used between elements when rendering a sequence inline. */
     static final BytesStore<?, ?> COMMA_SPACE = BytesStore.from(", ");
+
+    /** Separator used when an element is followed by a newline. */
     static final BytesStore<?, ?> COMMA_NEW_LINE = BytesStore.from(",\n");
+
+    /** New line bytes. */
     static final BytesStore<?, ?> NEW_LINE = BytesStore.from("\n");
-    static final BytesStore<?, ?> EMPTY_AFTER_COMMENT = BytesStore.wrap(new byte[0]); // not the same as EMPTY, so we can check this value.
+
+    /** Marker inserted when a comment occupies an otherwise empty line. */
+    static final BytesStore<?, ?> EMPTY_AFTER_COMMENT = BytesStore.wrap(new byte[0]);
     static final BytesStore<?, ?> EMPTY = BytesStore.from("");
     static final BytesStore<?, ?> SPACE = BytesStore.from(" ");
     static final BytesStore<?, ?> END_FIELD = NEW_LINE;
+    /** Lookup table for writing hexadecimal escapes. */
     static final char[] HEXADECIMAL = "0123456789ABCDEF".toCharArray();
 
     // Static initializer block to configure quote characters for the YAML writer
@@ -505,30 +521,31 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * This internal class represents an output value in the YAML format. It provides functionalities related
-     * to appending separators, handling whitespace, and maintaining indentation among others.
+     * Implementation of {@link ValueOut} used by YAML based wires.  It keeps
+     * track of indentation and chooses appropriate separators (comma or newline)
+     * based on whether the value being written is a scalar or a complex block.
      */
     class YamlValueOut implements ValueOut, CommentAnnotationNotifier {
         protected boolean hasCommentAnnotation = false;
 
-        // The current indentation level for the value.
+        /** Current indentation level (in spaces). */
         protected int indentation = 0;
 
-        // A list of separators to be used when writing the value.
+        /** Stack of separators for nested structures. */
         @NotNull
         protected List<BytesStore> seps = new ArrayList<>(4);
 
-        // The current separator being used.
+        /** Separator to insert before the next value. */
         @NotNull
         protected BytesStore<?, ?> sep = BytesStore.empty();
 
-        // Flag indicating if the value is a leaf node (i.e., doesn't have child elements).
+        /** If true the current value is a scalar and separators are commas. */
         protected boolean leaf = false;
 
-        // Flag indicating if default values should be dropped from the output.
+        /** Whether default values should be omitted when marshalling. */
         protected boolean dropDefault = false;
 
-        // The name of the event associated with this value (if any).
+        /** Field name cached when {@link #dropDefault} is active. */
         @Nullable
         private String eventName;
 


### PR DESCRIPTION
## Summary
- document TextWire internals and static helpers
- clarify behaviour of YamlWire and its constants
- expand comments in YamlWireOut
- document logging levels in YamlLogging
- add comments for YAML helper classes and enums

## Testing
- `mvn -q test` *(fails: `mvn` not found)*