### PR TITLE
Clarify SourceContext Javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/SourceContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/SourceContext.java
@@ -18,29 +18,28 @@ package net.openhft.chronicle.wire;
 import net.openhft.chronicle.core.io.IORuntimeException;
 
 /**
- * This is the SourceContext interface.
- * It defines methods to interact with the underlying source context, particularly in terms of accessing its source ID
- * and the last read index. Implementations of this interface are expected to handle source contexts which could be used
- * in various scenarios like I/O operations, data streaming, or context management.
+ * SourceContext exposes the numeric source ID and position for a data source.
+ *
+ * Implementations may wrap a queue {@code DocumentContext}, a network event or
+ * another source of data.
  */
 public interface SourceContext {
 
     /**
-     * Retrieves the source ID associated with this context.
-     * A unique identifier that represents the source from which data or operations might be fetched or to which data
-     * might be written. If a valid source ID has not been established or isn't available, it defaults to returning -1.
+     * Unique identifier for the underlying source, or {@code -1} when none has
+     * been established.
      *
-     * @return The unique identifier for this source context, or -1 if not available.
+     * @return the source identifier or {@code -1}
      */
     int sourceId();
 
     /**
-     * Obtains the index of the last read operation from this source context.
-     * This is particularly useful to track the reading progress and can act as a checkpoint or reference point.
-     * Note: This method is specifically intended for read contexts and might not be relevant for other context types.
+     * Position in the source stream.
+     * For queue readers this is the last index read; other sources may define a
+     * different meaning.
      *
-     * @return The index corresponding to the last read operation.
-     * @throws IORuntimeException if any issue arises while fetching the index.
+     * @return the position in implementation-defined units
+     * @throws IORuntimeException if the position cannot be retrieved
      */
     long index() throws IORuntimeException;
 }


### PR DESCRIPTION
## Summary
- refresh Javadoc for `SourceContext`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*