### PR TITLE
Improve wire API javadocs

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AbstractAnyWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractAnyWire.java
@@ -28,17 +28,16 @@ import org.jetbrains.annotations.Nullable;
 import java.util.function.Supplier;
 
 /**
- * An abstract representation of a wire type that could be either {@code TextWire} or {@code BinaryWire}.
- * This class provides a generic foundation for wire types that could shift between the two mentioned types
- * based on the underlying acquisition logic.
- *
- * @author Rob Austin.
+ * Base class for wires that determine whether they are text or binary on demand.
  */
 @SuppressWarnings("rawtypes")
 public abstract class AbstractAnyWire extends AbstractWire implements Wire {
 
+    /**
+     * Strategy for lazily acquiring the concrete wire implementation.
+     */
     @NotNull
-    protected final WireAcquisition wireAcquisition;  // Responsible for acquiring the actual wire type (TextWire or BinaryWire).
+    protected final WireAcquisition wireAcquisition;
 
     /**
      * Constructs a new instance of {@code AbstractAnyWire} using the specified bytes and wire acquisition strategy.
@@ -52,10 +51,7 @@ public abstract class AbstractAnyWire extends AbstractWire implements Wire {
     }
 
     /**
-     * Retrieves the underlying wire, which could be either {@code TextWire} or {@code BinaryWire},
-     * based on the acquisition strategy.
-     *
-     * @return The underlying wire type.
+     * Returns the lazily acquired underlying wire, creating it if necessary.
      */
     @Nullable
     public Wire underlyingWire() {
@@ -63,9 +59,7 @@ public abstract class AbstractAnyWire extends AbstractWire implements Wire {
     }
 
     /**
-     * Provides a supplier that indicates the type of the underlying wire.
-     *
-     * @return A supplier yielding the {@code WireType}.
+     * Supplies the {@link WireType} of the underlying wire.
      */
     @NotNull
     public Supplier<WireType> underlyingType() {
@@ -146,6 +140,9 @@ public abstract class AbstractAnyWire extends AbstractWire implements Wire {
         return wireAcquisition.acquireWire().newIntArrayReference();
     }
 
+    /**
+     * Ensures the underlying wire has been created.
+     */
     void checkWire() {
         wireAcquisition.acquireWire();
     }
@@ -224,37 +221,29 @@ public abstract class AbstractAnyWire extends AbstractWire implements Wire {
     }
 
     /**
-     * Represents an interface defining the strategy for acquiring and interacting with the underlying wire types.
+     * Strategy for discovering or creating the actual wire implementation.
      */
     interface WireAcquisition {
 
         /**
-         * Provides a supplier indicating the type of the underlying wire, which could be either {@code TextWire} or {@code BinaryWire}.
-         *
-         * @return A supplier yielding the {@code WireType}.
+         * Returns a supplier describing the underlying {@link WireType}.
          */
         @NotNull
         Supplier<WireType> underlyingType();
 
         /**
-         * Retrieves the actual wire type which could be either {@code TextWire} or {@code BinaryWire}.
-         *
-         * @return The acquired wire type.
+         * Acquires the actual underlying wire instance.
          */
         @Nullable
         Wire acquireWire();
 
         /**
-         * Sets the class lookup mechanism for this wire acquisition.
-         *
-         * @param classLookup The class lookup mechanism to set.
+         * Sets the class lookup to use when creating the underlying wire.
          */
         void classLookup(ClassLookup classLookup);
 
         /**
-         * Retrieves the class lookup mechanism associated with this wire acquisition.
-         *
-         * @return The class lookup mechanism.
+         * Returns the class lookup associated with this acquisition.
          */
         @Nullable
         ClassLookup classLookup();

--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -46,10 +46,15 @@ import static net.openhft.chronicle.wire.Wires.*;
  */
 public abstract class AbstractWire implements Wire, InternalWire {
 
-    // Default padding configuration loaded from the system properties.
+    /**
+     * Default padding configuration taken from the {@code wire.usePadding}
+     * system property.
+     */
     public static final boolean DEFAULT_USE_PADDING = Jvm.getBoolean("wire.usePadding", false);
 
-    // Message used when a header is detected inside another header.
+    /**
+     * Error text used when a header is detected within another header.
+     */
     private static final String INSIDE_HEADER_MESSAGE = "you cant put a header inside a header, check that " +
             "you have not nested the documents. If you are using Chronicle-Queue please " +
             "ensure that you have a unique instance of the Appender per thread, in " +
@@ -59,21 +64,44 @@ public abstract class AbstractWire implements Wire, InternalWire {
         WireInternal.addAliases();
     }
 
-    // The underlying bytes representation used by the Wire.
+    /**
+     * Underlying byte storage.
+     */
     @NotNull
     protected final Bytes<?> bytes;
+    /**
+     * True if 8-bit encoding is permitted.
+     */
     protected final boolean use8bit;
+    /**
+     * Lookup used when resolving class aliases.
+     */
     protected ClassLookup classLookup = ClassAliasPool.CLASS_ALIASES;
+    /**
+     * Optional parent object for nested marshallables.
+     */
     protected Object parent;
+    /**
+     * Consumer invoked when comments are parsed.
+     */
     protected Consumer<CharSequence> commentListener = IgnoringConsumer.IGNORING_CONSUMER;
+    /** Pausing strategy for blocking operations. */
     private Pauser pauser;
+    /** Lazily created pauser used with timeouts. */
     private TimingPauser timedParser;
+    /** Last header number written. */
     private long headerNumber = Long.MIN_VALUE;
+    /** Controls whether NOT_COMPLETE messages are visible. */
     private boolean notCompleteIsNotPresent;
+    /** Lazy wrapper for Java ObjectOutput. */
     private ObjectOutput objectOutput;
+    /** Lazy wrapper for Java ObjectInput. */
     private ObjectInput objectInput;
+    /** True while inside a header. */
     private boolean insideHeader;
+    /** Optional checker for header numbers. */
     private HeadNumberChecker headNumberChecker;
+    /** Whether padding is currently enabled. */
     private boolean usePadding = DEFAULT_USE_PADDING;
 
     /**
@@ -102,9 +130,7 @@ public abstract class AbstractWire implements Wire, InternalWire {
     }
 
     /**
-     * Acquires or initializes a timed parser.
-     *
-     * @return The current instance of TimingPauser.
+     * Lazily creates a {@link TimingPauser} used when waiting for data.
      */
     @NotNull
     private TimingPauser acquireTimedParser() {
@@ -114,9 +140,7 @@ public abstract class AbstractWire implements Wire, InternalWire {
     }
 
     /**
-     * Checks if the current Wire is inside a header.
-     *
-     * @return True if inside a header, false otherwise.
+     * Returns {@code true} if a write header has been entered but not yet updated.
      */
     public boolean isInsideHeader() {
         return this.insideHeader;
@@ -254,8 +278,10 @@ public abstract class AbstractWire implements Wire, InternalWire {
         }
     }
 
+    /**
+     * Adjusts the read position for header alignment when padding is enabled.
+     */
     private void alignForRead(Bytes<?> bytes) {
-        // move the read position
         bytes.readPositionForHeader(usePadding);
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/Wire.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wire.java
@@ -23,10 +23,8 @@ import org.jetbrains.annotations.NotNull;
 import java.io.IOException;
 
 /**
- * Defines the standard interface for sequentially writing to and reading from a Bytes stream.
- * Implementations of this interface should ensure single-threaded access and avoid method chaining.
- *
- * <p>This interface combines the capabilities of both {@link WireIn} and {@link WireOut} interfaces.
+ * Primary interface for reading from and writing to a {@link Bytes} stream.
+ * Combines the {@link WireIn} and {@link WireOut} contracts.
  */
 @SingleThreaded
 @DontChain
@@ -41,10 +39,7 @@ public interface Wire extends WireIn, WireOut {
     }
 
     /**
-     * Set the header number for the Wire. Concrete implementations should ensure they provide the expected behavior for this method.
-     *
-     * @param headerNumber The header number to be set.
-     * @return The current Wire instance, often for method chaining.
+     * {@inheritDoc}
      */
     @Override
     @NotNull

--- a/src/main/java/net/openhft/chronicle/wire/WireCommon.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireCommon.java
@@ -24,33 +24,38 @@ import net.openhft.chronicle.threads.Pauser;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * Common configuration and factory methods shared by all wire types.
+ * These allow a wire to control class resolution, pausing behaviour and
+ * creation of low-latency value objects.
+ */
 public interface WireCommon {
 
     /**
-     * Sets the {@link ClassLookup} implementation to be used for class lookup.
+     * Sets the {@link ClassLookup} used to resolve class names during
+     * deserialisation. This comes into play when type aliases or numeric
+     * identifiers are read from the wire.
      *
-     * @param classLookup implementation to be used for class lookup.
+     * @param classLookup strategy for resolving class names
      */
     void classLookup(ClassLookup classLookup);
 
     /**
-     * Returns the current {@link ClassLookup} implementation being used for class lookup.
-     *
-     * @return the current {@link ClassLookup} implementation being used for class lookup
+     * Returns the {@link ClassLookup} currently in use for resolving class
+     * names during deserialisation.
      */
     ClassLookup classLookup();
 
     /**
-     * Sets the {@link Pauser} implementation to be used for blocking operations.
+     * Sets the {@link Pauser} controlling how read operations wait for data.
+     * Typical implementations yield or park the thread when the wire is empty.
      *
-     * @param pauser implementation to be used for blocking operations.
+     * @param pauser policy for blocking behaviour
      */
     void pauser(Pauser pauser);
 
     /**
-     * Returns the current {@link Pauser} implementation being used for blocking operations.
-     *
-     * @return the current {@link Pauser} implementation being used for blocking operations
+     * Returns the {@link Pauser} used to manage blocking behaviour.
      */
     Pauser pauser();
 
@@ -63,35 +68,27 @@ public interface WireCommon {
     Bytes<?> bytes();
 
     /**
-     * Returns the bytes() but only for comment.
-     *
-     * @return the bytes() but only for comment
+     * Returns the underlying {@link Bytes} for use in diagnostics. Implementati
+     * ons can attach textual comments to these bytes when producing hex dumps so
+     * that the main data stream is unaffected.
      */
     HexDumpBytesDescription<?> bytesComment();
 
     /**
-     * Creates and returns a new {@link IntValue}. The {@link IntValue} implementation that is
-     * returned depends on the wire implementation.
-     *
-     * @return a new {@link IntValue}.
+     * Creates an integer value bound to this wire. The concrete return type
+     * depends on whether the wire is text or binary.
      */
     @NotNull
     IntValue newIntReference();
 
     /**
-     * Creates and returns a new {@link LongValue}. The {@link LongValue} implementation that is
-     * returned depends on the wire implementation.
-     *
-     * @return a new {@link LongValue}
+     * Creates a long value bound to this wire.
      */
     @NotNull
     LongValue newLongReference();
 
     /**
-     * Creates and returns a new {@link TwoLongValue}. The {@link TwoLongValue} implementation that
-     * is returned depends on the wire implementation.
-     *
-     * @return a new {@link TwoLongValue}
+     * Creates two long values stored directly in the wire.
      */
     @NotNull
     default TwoLongValue newTwoLongReference() {
@@ -99,41 +96,31 @@ public interface WireCommon {
     }
 
     /**
-     * Creates and returns a new {@link LongArrayValues}. The {@link LongArrayValues} implementation that
-     * is returned depends on the wire implementation.
-     *
-     * @return a new {@link LongArrayValues}
+     * Creates an array of long values mapped to the wire for low latency updates.
      */
     @NotNull
     LongArrayValues newLongArrayReference();
 
     /**
-     * Creates and returns a new {@link IntArrayValues}. The {@link IntArrayValues} implementation that
-     * is returned depends on the wire implementation.
-     *
-     * @return a new {@link IntArrayValues}
+     * Creates an array of int values mapped to the wire for low latency updates.
      */
     @NotNull
     IntArrayValues newIntArrayReference();
 
     /**
-     * Resets the state of the underlying {@link Bytes} stored by the wire.
+     * Clears the wire and resets the underlying {@link Bytes} positions.
      */
     void clear();
 
     /**
-     * Returns the wire parent object. If the parent was not assigned, {@code null} is
-     * returned instead.
-     *
-     * @return the wire parent object or {@code null} if none was assigned.
+     * Returns the wire parent object used for nested marshallable structures.
+     * May be {@code null} if no parent has been set.
      */
     @Nullable
     Object parent();
 
     /**
-     * Assigns the wire parent object for later retrieval.
-     *
-     * @param parent to set, or null if there isn't one.
+     * Assigns a parent object for later retrieval.
      */
     void parent(Object parent);
 
@@ -150,40 +137,48 @@ public interface WireCommon {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Sets the header sequence number. This is typically used by queue
+     * implementations to track message order.
+     */
     @NotNull
     WireOut headerNumber(long headerNumber);
 
+    /**
+     * Returns the current header sequence number.
+     */
     long headerNumber();
 
+    /**
+     * Enables or disables padding for alignment purposes.
+     */
     void usePadding(boolean usePadding);
 
+    /**
+     * Returns whether padding is enabled.
+     */
     boolean usePadding();
 
     /**
-     * Creates and returns a new {@link BooleanValue}. The {@link BooleanValue} implementation that is
-     * returned depends on the wire implementation.
-     *
-     * @return a new {@link BooleanValue}.
+     * Creates a boolean value mapped directly to the underlying bytes.
      */
     @NotNull
     BooleanValue newBooleanReference();
 
     /**
-     * Should this wire write the object as a Marshallable or BytesMarshallable
-     *
-     * @return use Marshallable
+     * Returns {@code true} if the given object should write its type
+     * information into the wire (see {@code SelfDescribingMarshallable}).
      */
     boolean useSelfDescribingMessage(@NotNull CommonMarshallable object);
 
     /**
-     * Determine whether direct access to the underlying byte() makes sense or should it be treated as text
-     *
-     * @return Is this a binary protocol
+     * Returns {@code true} if this wire uses a binary format rather than text.
      */
     boolean isBinary();
 
     /**
-     * Reset the state of the wire
+     * Resets the wire to its initial state, clearing positions and internal
+     * buffers.
      */
     void reset();
 }

--- a/src/main/java/net/openhft/chronicle/wire/WireIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireIn.java
@@ -36,16 +36,8 @@ import java.util.function.Consumer;
 public interface WireIn extends WireCommon, MarshallableIn {
 
     /**
-     * Reads all available entries and populates the provided map with these entries.
-     * Each entry in the wire source is read as a key-value pair where the key is of type {@code K} and the value is of type {@code V}.
-     *
-     * @param <K>     The type of keys in the map.
-     * @param <V>     The type of values in the map.
-     * @param kClass  The class type of the key.
-     * @param vClass  The class type of the value.
-     * @param map     The map to populate with read entries.
-     * @return The populated map.
-     * @throws InvalidMarshallableException If there's an error in the marshalling process.
+     * Reads the remainder of the current document as a map.
+     * Keys and values are converted using the provided classes.
      */
     @NotNull
     default <K, V> Map<K, V> readAllAsMap(Class<K> kClass, @NotNull Class<V> vClass, @NotNull Map<K, V> map) throws InvalidMarshallableException {
@@ -62,35 +54,24 @@ public interface WireIn extends WireCommon, MarshallableIn {
     }
 
     /**
-     * Copies the content from the current WireIn source to the provided WireOut destination.
-     *
-     * @param wire The WireOut instance where the content will be copied to.
-     * @throws InvalidMarshallableException If there's an error in the marshalling process.
+     * Copies the remaining readable content of this wire to the given output.
      */
     void copyTo(@NotNull WireOut wire) throws InvalidMarshallableException;
 
     /**
-     * Reads the next field if present, or returns an empty string if not present.
-     *
-     * @return The value of the next field, encapsulated in a {@link ValueIn} instance.
+     * Reads the next field name and prepares to read its value.
      */
     @NotNull
     ValueIn read();
 
     /**
-     * Reads the next field if present. The field should match the provided {@link WireKey}.
-     *
-     * @param key The WireKey that should match the next field.
-     * @return The value of the matched field, encapsulated in a {@link ValueIn} instance.
+     * Reads the field with the given key, skipping other fields if necessary.
      */
     @NotNull
     ValueIn read(@NotNull WireKey key);
 
     /**
-     * Reads the next field based on the provided field name.
-     *
-     * @param fieldName The name of the field to read.
-     * @return The value of the specified field, encapsulated in a {@link ValueIn} instance.
+     * Reads the field with the given name.
      */
     @NotNull
     default ValueIn read(String fieldName) {
@@ -98,9 +79,8 @@ public interface WireIn extends WireCommon, MarshallableIn {
     }
 
     /**
-     * Reads the next event number. If no number is present, returns Long.MIN_VALUE.
-     *
-     * @return The next event number or Long.MIN_VALUE if no number is present.
+     * Reads the numeric event identifier used by some binary wires.
+     * Returns {@code Long.MIN_VALUE} if no number is present.
      */
     long readEventNumber();
 
@@ -129,11 +109,7 @@ public interface WireIn extends WireCommon, MarshallableIn {
     }
 
     /**
-     * Reads a specific field based on the provided field name.
-     * If the field is not present, it returns an empty string.
-     *
-     * @param name The name of the field to read.
-     * @return The value of the specified field, encapsulated in a {@link ValueIn} instance.
+     * Reads a field matching the supplied name.
      */
     @NotNull
     ValueIn read(@NotNull StringBuilder name);
@@ -158,17 +134,12 @@ public interface WireIn extends WireCommon, MarshallableIn {
     ValueIn getValueIn();
 
     /**
-     * Returns the ObjectInput associated with this WireIn for serialization operations.
-     *
-     * @return the ObjectInput instance.
+     * Provides a standard {@link ObjectInput} view over this wire.
      */
     ObjectInput objectInput();
 
     /**
-     * Reads a comment from the Wire data and appends it to the provided StringBuilder.
-     *
-     * @param sb StringBuilder to which the comment will be appended.
-     * @return the WireIn instance for method chaining.
+     * Reads a comment from the wire into the given buffer.
      */
     @NotNull
     WireIn readComment(@NotNull StringBuilder sb);
@@ -287,9 +258,7 @@ public interface WireIn extends WireCommon, MarshallableIn {
     void consumePadding();
 
     /**
-     * Sets a listener that gets notified whenever a comment is encountered during reading.
-     *
-     * @param commentListener The consumer that handles and processes the comments.
+     * Registers a consumer to receive comments encountered while parsing.
      */
     void commentListener(Consumer<CharSequence> commentListener);
 

--- a/src/main/java/net/openhft/chronicle/wire/WireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireOut.java
@@ -31,19 +31,15 @@ import java.util.concurrent.TimeUnit;
 @DontChain
 public interface WireOut extends WireCommon, MarshallableOut {
     /**
-     * Writes an empty field marker to the stream.
-     *
-     * @return An interface to further define the output for the written value.
+     * Writes a field marker with no name. For sequence items the returned
+     * {@link ValueOut} is used to write the value.
      */
     @NotNull
     ValueOut write();
 
     /**
-     * Writes a key to the stream. For RAW types, the label will be in text.
-     * This can be read using readEventName().
-     *
-     * @param key The key to write to the stream.
-     * @return An interface to further define the output for the written value.
+     * Writes an event key to the stream. RAW wires emit it in text so that
+     * {@link WireIn#readEventName(StringBuilder)} can later match it.
      */
     @NotNull
     default ValueOut writeEventName(WireKey key) {
@@ -51,22 +47,15 @@ public interface WireOut extends WireCommon, MarshallableOut {
     }
 
     /**
-     * Writes a CharSequence key to the stream.
-     *
-     * @param key The CharSequence key to write to the stream.
-     * @return An interface to further define the output for the written value.
+     * Writes an event key from arbitrary text.
      */
     default ValueOut writeEventName(CharSequence key) {
         return write(key);
     }
 
     /**
-     * Writes an event to the stream based on the type and event key.
-     *
-     * @param expectedType The expected type of the event to write.
-     * @param eventKey The key of the event.
-     * @return An interface to further define the output for the written value.
-     * @throws InvalidMarshallableException if there's an error marshalling the event.
+     * Writes an event key whose type is not a simple {@link WireKey}.
+     * The {@code expectedType} hints how the key should be serialised.
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
     default ValueOut writeEvent(Class<?> expectedType, Object eventKey) throws InvalidMarshallableException {
@@ -81,42 +70,27 @@ public interface WireOut extends WireCommon, MarshallableOut {
     }
 
     /**
-     * Writes an event identifier to the stream.
-     *
-     * @param methodId The ID of the method representing the event.
-     * @return An interface to further define the output for the written value.
+     * Writes a numeric event identifier for binary wires.
      */
     default ValueOut writeEventId(int methodId) {
         return write(new MethodWireKey(null, methodId));
     }
 
     /**
-     * Writes an event identifier with a name to the stream.
-     *
-     * @param name The name of the event.
-     * @param methodId The ID of the method representing the event.
-     * @return An interface to further define the output for the written value.
+     * Writes a numeric identifier along with a textual name for debugging.
      */
     default ValueOut writeEventId(String name, int methodId) {
         return write(new MethodWireKey(name, methodId));
     }
 
     /**
-     * Writes a WireKey to the stream. This method is typically used for
-     * wires that support fields with structured keys.
-     *
-     * @param key The WireKey to write to the stream.
-     * @return An interface to further define the output for the written value.
+     * Writes a structured key then returns a {@link ValueOut} for the value.
      */
     @NotNull
     ValueOut write(WireKey key);
 
     /**
-     * Writes a CharSequence key to the stream. This provides flexibility
-     * to write non-standard keys to the wire.
-     *
-     * @param key The CharSequence key to write to the stream.
-     * @return An interface to further define the output for the written value.
+     * Writes an arbitrary textual key.
      */
     ValueOut write(CharSequence key);
 
@@ -130,37 +104,24 @@ public interface WireOut extends WireCommon, MarshallableOut {
     ValueOut getValueOut();
 
     /**
-     * Get the ObjectOutput associated with this WireOut.
-     *
-     * @return The ObjectOutput associated with this WireOut.
+     * Returns a standard {@link ObjectOutput} view over this wire.
      */
     ObjectOutput objectOutput();
 
     /**
-     * Writes a comment to the wire. Comments may be useful for debugging
-     * or providing context within the wire stream.
-     *
-     * @param s The comment to be written to the stream.
-     * @return This WireOut instance for method chaining.
+     * Writes a comment for diagnostic dumps only.
      */
     @NotNull
     WireOut writeComment(CharSequence s);
 
     /**
-     * Adds padding to the wire. This is particularly useful for aligning data.
-     *
-     * @param paddingToAdd The amount of padding to add.
-     * @return This WireOut instance for method chaining.
+     * Inserts padding bytes, typically for alignment.
      */
     @NotNull
     WireOut addPadding(int paddingToAdd);
 
     /**
-     * Ensures that the wire's output aligns with cache boundaries. If the current write position
-     * is close to the end of a cache line, this method will pad the wire such that a subsequent
-     * 4-byte integer won't span across cache lines, optimizing cache performance.
-     *
-     * @return This WireOut instance for method chaining.
+     * Pads the output so the next four bytes do not straddle a cache line.
      */
     @NotNull
     default WireOut padToCacheAlign() {
@@ -177,12 +138,7 @@ public interface WireOut extends WireCommon, MarshallableOut {
     }
 
     /**
-     * Aligns the write position to the provided alignment boundary, taking into account
-     * the specified offset (plus). Padding will be added as necessary.
-     *
-     * @param alignment The alignment boundary.
-     * @param plus Additional offset to the write position.
-     * @return This WireOut instance for method chaining.
+     * Aligns the write position to {@code alignment} bytes from the optional offset.
      */
     @NotNull
     default WireOut writeAlignTo(int alignment, int plus) {


### PR DESCRIPTION
## Summary
- expand descriptions in `WireCommon`
- clarify behaviour in `WireIn` and `WireOut`
- shorten top-level `Wire` docs
- document key fields and helpers in `AbstractWire` and `AbstractAnyWire`

## Testing
- `mvn -q verify` *(fails: command not found)*