### PR TITLE
Improve document context Javadocs

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/DocumentContextHolder.java
+++ b/src/main/java/net/openhft/chronicle/wire/DocumentContextHolder.java
@@ -20,9 +20,9 @@ import net.openhft.chronicle.core.io.IORuntimeException;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * This is the DocumentContextHolder class which implements both {@link DocumentContext}
- * and {@link WriteDocumentContext}. It acts as a wrapper or a delegate around an instance of
- * {@link DocumentContext}, providing methods to interact with the encapsulated context.
+ * Wrapper around a {@link DocumentContext} implementing both {@link DocumentContext}
+ * and {@link WriteDocumentContext}. Useful when behaviour of the underlying context
+ * needs to be intercepted or extended without modifying it directly.
  */
 public class DocumentContextHolder implements DocumentContext, WriteDocumentContext {
 
@@ -51,23 +51,23 @@ public class DocumentContextHolder implements DocumentContext, WriteDocumentCont
     }
 
     /**
-     * Retrieves the encapsulated {@link DocumentContext} instance.
-     *
-     * @return The current {@link DocumentContext} instance.
+     * Returns the wrapped {@link DocumentContext}.
      */
     public DocumentContext documentContext() {
         return dc;
     }
 
     /**
-     * Sets the encapsulated {@link DocumentContext} instance to the provided value.
-     *
-     * @param dc The new {@link DocumentContext} to be set.
+     * Replaces the wrapped {@link DocumentContext}.
      */
     public void documentContext(DocumentContext dc) {
         this.dc = dc;
     }
 
+    /**
+     * Delegates to the wrapped context's {@code close} method. If that context
+     * reports completion afterwards the internal reference is cleared.
+     */
     @Override
     public void close() {
         DocumentContext documentContext = this.dc;
@@ -78,6 +78,9 @@ public class DocumentContextHolder implements DocumentContext, WriteDocumentCont
             dc = null;
     }
 
+    /**
+     * Resets the wrapped context and removes the reference to it.
+     */
     @Override
     public void reset() {
         DocumentContext documentContext = this.dc;
@@ -97,11 +100,7 @@ public class DocumentContextHolder implements DocumentContext, WriteDocumentCont
     }
 
     /**
-     * Determines if the DocumentContextHolder has been closed or not.
-     * This method checks if the encapsulated {@link DocumentContext} is {@code null}, indicating a closed state.
-     *
-     * @return {@code true} if the holder is closed (i.e., the internal {@link DocumentContext} is {@code null}),
-     * {@code false} otherwise.
+     * Returns {@code true} if there is no wrapped {@link DocumentContext}.
      */
     public boolean isClosed() {
         return dc == null;

--- a/src/main/java/net/openhft/chronicle/wire/DocumentWritten.java
+++ b/src/main/java/net/openhft/chronicle/wire/DocumentWritten.java
@@ -17,40 +17,38 @@
 package net.openhft.chronicle.wire;
 
 /**
- * Represents an entity that supports writing documents. The interface provides methods
- * to initiate and manage the context in which documents are written. It is crucial
- * to manage the lifecycle of the {@link DocumentContext} correctly, either by using
- * try-with-resources or explicitly invoking the close() method.
+ * Entry point for obtaining a {@link DocumentContext} used when writing a document.
+ * Implementations act as factories, returning contexts that must be closed to
+ * release any associated locks or buffers.
  */
 public interface DocumentWritten {
     /**
-     * Creates a new {@link DocumentContext} for writing a document.
-     * This context is designed for use within a try-with-resource block to ensure
-     * proper resource management.
+     * Starts a write operation.
+     * <p>
+     * Always close the returned context, preferably via try-with-resources,
+     * otherwise locks may be held.
      *
-     * @return A fresh {@link DocumentContext} for writing.
+     * @return a new {@link DocumentContext} for this write
      */
     DocumentContext writingDocument();
 
     /**
-     * Initiates a new {@link DocumentContext} for writing, with an option to include
-     * metadata. It is imperative to always invoke the close() method on the context
-     * after completing the write operation.
+     * Starts a write operation with optional metadata.
      *
-     * @param metaData A boolean indicating if metadata should be included during writing.
-     * @return A fresh {@link DocumentContext} tailored to the metadata preference.
-     * @throws UnrecoverableTimeoutException If the operation times out in an unrecoverable manner.
+     * @param metaData include metadata if {@code true}
+     * @return a new {@link DocumentContext} for this write
+     * @throws UnrecoverableTimeoutException if an unrecoverable timeout occurs
      */
     DocumentContext writingDocument(boolean metaData) throws UnrecoverableTimeoutException;
 
     /**
-     * Obtains a {@link DocumentContext} for writing. This method either initiates a new context
-     * or reuses an existing one. Depending on the use case, calling the close() method
-     * on the context might be optional.
+     * Obtains a {@link DocumentContext} for writing. Depending on the implementation
+     * this may be a fresh context or a reusable instance and closing may be optional
+     * for chained writes.
      *
-     * @param metaData A boolean indicating if metadata should be included during writing.
-     * @return An existing or new {@link DocumentContext} tailored to the metadata preference.
-     * @throws UnrecoverableTimeoutException If the operation times out in an unrecoverable manner.
+     * @param metaData include metadata if {@code true}
+     * @return a {@link DocumentContext} ready for use
+     * @throws UnrecoverableTimeoutException if an unrecoverable timeout occurs
      */
     DocumentContext acquireWritingDocument(boolean metaData) throws UnrecoverableTimeoutException;
 }


### PR DESCRIPTION
## Summary
- clarify DocumentWritten interface documentation
- expand DocumentContextHolder docs and explain its close/reset semantics

## Testing
- `mvn -q verify` *(fails: mvn not found)*