### PR TITLE
Improve Javadoc for context wrappers

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/NoDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/NoDocumentContext.java
@@ -16,58 +16,84 @@
 package net.openhft.chronicle.wire;
 
 /**
- * An enumeration implementation of the {@link DocumentContext} interface.
- * This context represents a non-existent or uninitialized document context,
- * hence all its methods return default or null values.
+ * An enumeration implementation of {@link DocumentContext} representing an
+ * absent or uninitialised document. All methods return neutral values.
  *
- * <p>This can be useful as a sentinel value or placeholder to avoid null checks in code
- * that works with document contexts. Using `NoDocumentContext.INSTANCE` denotes
- * a guaranteed uninitialized state for a document context.
+ * <p>This is useful as a sentinel to avoid {@code null} checks in code that
+ * works with document contexts. Using {@code NoDocumentContext.INSTANCE}
+ * denotes a guaranteed uninitialised state.
  */
 public enum NoDocumentContext implements DocumentContext {
-    /** The singleton instance of the NoDocumentContext */
+    /** The singleton instance of the {@code NoDocumentContext}. */
     INSTANCE;
 
+    /**
+     * Returns {@code false} as this context has no metadata section.
+     */
     @Override
     public boolean isMetaData() {
         return false;
     }
 
+    /**
+     * Always returns {@code false} because no document is present.
+     */
     @Override
     public boolean isPresent() {
         return false;
     }
 
+    /**
+     * Always returns {@code false} as this is not a data document.
+     */
     @Override
     public boolean isData() {
         return false;
     }
 
+    /**
+     * Returns {@code null} because there is no associated {@link Wire}.
+     */
     @Override
     public Wire wire() {
         return null;
     }
 
+    /**
+     * Returns {@code -1} to indicate the absence of a source identifier.
+     */
     @Override
     public int sourceId() {
         return -1;
     }
 
+    /**
+     * Returns {@link Long#MIN_VALUE} as no index exists.
+     */
     @Override
     public long index() {
         return Long.MIN_VALUE;
     }
 
+    /**
+     * Always returns {@code false}; there is nothing to complete.
+     */
     @Override
     public boolean isNotComplete() {
         return false;
     }
 
+    /**
+     * Does nothing as there is no underlying resource to close.
+     */
     @Override
     public void close() {
         // Do nothing
     }
 
+    /**
+     * Resets the context by invoking {@link #close()}.
+     */
     @Override
     public void reset() {
         close();

--- a/src/main/java/net/openhft/chronicle/wire/WrappedDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/WrappedDocumentContext.java
@@ -19,9 +19,8 @@ import net.openhft.chronicle.core.io.IORuntimeException;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * This is the WrappedDocumentContext class which implements the DocumentContext interface.
- * The purpose of this class is to wrap another DocumentContext and delegate the behavior to the wrapped instance.
- * This can be used as a base for any specialized versions of DocumentContext which need to extend the default behavior.
+ * Wraps another {@link DocumentContext} and delegates all operations to it.
+ * Sub-classes extend this base to add specialised behaviour.
  */
 public abstract class WrappedDocumentContext implements DocumentContext {
 
@@ -38,67 +37,88 @@ public abstract class WrappedDocumentContext implements DocumentContext {
     }
 
     /**
-     * Getter method to retrieve the wrapped DocumentContext instance.
-     *
-     * @return The wrapped DocumentContext instance.
+     * Returns the currently wrapped {@link DocumentContext}.
      */
     public DocumentContext dc() {
         return dc;
     }
 
     /**
-     * Setter method to update the wrapped DocumentContext instance.
-     * This method is designed to follow the builder pattern, returning the current instance for chained calls.
-     *
-     * @param dc The new DocumentContext instance to be wrapped.
-     * @return The current instance of WrappedDocumentContext.
+     * Sets or replaces the {@link DocumentContext} being wrapped and returns this instance.
      */
     public WrappedDocumentContext dc(DocumentContext dc) {
         this.dc = dc;
         return this;
     }
 
+    /**
+     * Delegates to {@link DocumentContext#isMetaData()} on the wrapped instance.
+     */
     @Override
     public boolean isMetaData() {
         return dc.isMetaData();
     }
 
+    /**
+     * Delegates to {@link DocumentContext#isPresent()} on the wrapped instance.
+     */
     @Override
     public boolean isPresent() {
         return dc.isPresent();
     }
 
+    /**
+     * Delegates to {@link DocumentContext#wire()} on the wrapped instance.
+     */
     @Nullable
     @Override
     public Wire wire() {
         return dc.wire();
     }
 
+    /**
+     * Delegates to {@link DocumentContext#isNotComplete()} on the wrapped instance.
+     */
     @Override
     public boolean isNotComplete() {
         return dc.isNotComplete();
     }
 
+    /**
+     * Delegates to {@link DocumentContext#close()} on the wrapped instance.
+     */
     @Override
     public void close() {
         dc.close();
     }
 
+    /**
+     * Delegates to {@link DocumentContext#sourceId()} on the wrapped instance.
+     */
     @Override
     public int sourceId() {
         return dc.sourceId();
     }
 
+    /**
+     * Delegates to {@link DocumentContext#index()} on the wrapped instance.
+     */
     @Override
     public long index() throws IORuntimeException {
         return dc.index();
     }
 
+    /**
+     * Delegates to {@link DocumentContext#isData()} on the wrapped instance.
+     */
     @Override
     public boolean isData() {
         return dc.isData();
     }
 
+    /**
+     * Delegates to {@link DocumentContext#rollbackOnClose()} on the wrapped instance.
+     */
     @Override
     public void rollbackOnClose() {
         dc.rollbackOnClose();


### PR DESCRIPTION
## Summary
- clarify WrappedDocumentContext purpose and delegated methods
- detail default return values in NoDocumentContext

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*