### PR TITLE
Improve javadoc for marshallable interfaces

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/ReadMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/ReadMarshallable.java
@@ -22,45 +22,47 @@ import net.openhft.chronicle.core.io.InvalidMarshallableException;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * This interface represents objects that can be reloaded from a stream by reusing an existing instance.
- * Instead of creating a new object every time the data is read from a stream, instances implementing
- * this interface can update their state based on the stream content, thereby potentially improving performance
- * and reducing garbage.
+ * Represents objects that can reload their state from a wire by reusing the
+ * current instance.  This avoids allocating a new object each time data is
+ * read and can reduce garbage collection in performance-critical code.
  * <p>
- * For objects which need to deserialize final fields, consider using the {@link Demarshallable} interface.
- *
- * <p>
- * Example usage might involve reading an object's state from a file or network stream
- * without allocating a new object on each read operation.
+ * For objects which need to deserialize final fields, consider using the
+ * {@link Demarshallable} interface instead.
  */
 @FunctionalInterface
 @DontChain
 public interface ReadMarshallable extends CommonMarshallable {
 
-    // An instance of ReadMarshallable that doesn't perform any action when reading.
+    /**
+     * A no-operation {@code ReadMarshallable} that consumes and discards
+     * the input from the wire.  Useful as a placeholder or when unwanted
+     * data should be skipped.
+     */
     ReadMarshallable DISCARD = w -> {};
 
     /**
-     * Reads the object's state from the given wire input.
-     * Implementations should update the current instance's state based on the content of the wire.
+     * Read data from the wire and apply it to this instance.
+     * Implementations must parse the input and update their fields
+     * accordingly.
      *
-     * @param wire The wire input from which the object's state should be read.
-     *
-     * @throws IORuntimeException If there's an error reading from the wire.
-     * @throws InvalidMarshallableException If the data in the wire is not as expected or invalid.
+     * @param wire the wire to read from
+     * @throws IORuntimeException         if an I/O error occurs
+     * @throws InvalidMarshallableException if the data is invalid for this type
      */
-    void readMarshallable(@NotNull WireIn wire) throws IORuntimeException, InvalidMarshallableException;
+    void readMarshallable(@NotNull WireIn wire)
+            throws IORuntimeException, InvalidMarshallableException;
 
     /**
-     * Handles unexpected fields encountered during the deserialization process.
-     * Default behavior is to skip the unexpected value. Override this method if a different behavior is required.
+     * Handles an unexpected field during deserialization.  The default
+     * implementation skips the value.
      *
-     * @param event   The event or field identifier that was unexpected.
-     * @param valueIn The value associated with the unexpected field.
-     *
-     * @throws InvalidMarshallableException If the unexpected field cannot be processed.
+     * @param event   the identifier of the field, typically a String or
+     *                {@code WireKey}
+     * @param valueIn the unexpected value
+     * @throws InvalidMarshallableException if the field cannot be processed
      */
-    default void unexpectedField(Object event, ValueIn valueIn) throws InvalidMarshallableException {
+    default void unexpectedField(Object event, ValueIn valueIn)
+            throws InvalidMarshallableException {
         valueIn.skipValue();
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/WriteMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/WriteMarshallable.java
@@ -22,53 +22,53 @@ import net.openhft.chronicle.core.io.InvalidMarshallableException;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Represents a marshallable entity capable of writing its state to a given wire format.
- * Implementations of this interface can describe their serialization logic by defining
- * the {@link #writeMarshallable(WireOut)} method.
- * <p>
- * This interface is annotated with {@code @FunctionalInterface}, indicating that it is
- * intended to be used primarily for lambda expressions and method references.
- * Furthermore, the {@code @DontChain} annotation highlights that implementations should
- * not be chained for certain operations.
+ * Represents an entity that can write its state to a wire.  It is a
+ * {@code @FunctionalInterface} and is commonly used by DTOs or other
+ * objects that need lightweight serialisation.  The interface extends
+ * {@link WriteValue} and {@link CommonMarshallable}.
  */
 @FunctionalInterface
 @DontChain
 public interface WriteMarshallable extends WriteValue, CommonMarshallable {
 
     /**
-     * Represents an empty marshallable entity that performs no actions
-     * when its {@code writeMarshallable} method is invoked.
+     * A no-operation {@code WriteMarshallable} that writes nothing to the
+     * wire.  Useful as a placeholder.
      */
     WriteMarshallable EMPTY = wire -> {
         // nothing
     };
 
     /**
-     * Write the current state of the marshallable entity to the provided wire.
+     * Write this object's state to the supplied wire.
+     * Implementations should read their fields and serialise them to the
+     * given output.
      *
-     * @param wire The wire format to write to.
-     * @throws InvalidMarshallableException if any serialization error occurs.
+     * @param wire the wire to write to
+     * @throws InvalidMarshallableException if serialization fails
      */
-    void writeMarshallable(@NotNull WireOut wire) throws InvalidMarshallableException;
+    void writeMarshallable(@NotNull WireOut wire)
+            throws InvalidMarshallableException;
 
     /**
-     * Writes the current state of the marshallable entity as a value
-     * to the provided output.
+     * Serialises this object as a value.  The default implementation
+     * simply delegates to {@code out.marshallable(this)}.
      *
-     * @param out The output to write to.
-     * @throws InvalidMarshallableException if any serialization error occurs.
+     * @param out the output to write to
+     * @throws InvalidMarshallableException if any error occurs
      */
     @Override
-    default void writeValue(@NotNull ValueOut out) throws InvalidMarshallableException {
+    default void writeValue(@NotNull ValueOut out)
+            throws InvalidMarshallableException {
         out.marshallable(this);
     }
 
     /**
-     * Provides an assumed length in bytes for the serialized form of this entity.
-     * This is useful for pre-allocating resources or optimizing serialization
-     * and deserialization processes.
+     * Returns the length prefix to use when serialising this object.  It is
+     * mainly relevant for binary wire formats that prefix marshallable
+     * objects with their length.  See {@link BinaryLengthLength} for details.
      *
-     * @return The binary length length indicating the size in bytes.
+     * @return the assumed length prefix
      */
     default BinaryLengthLength binaryLengthLength() {
         return BinaryLengthLength.LENGTH_32BIT;


### PR DESCRIPTION
## Summary
- update `ReadMarshallable` docs to explain object reuse
- clarify behaviour of `DISCARD` constant
- refine method docs for `readMarshallable` and `unexpectedField`
- streamline `WriteMarshallable` description and constant docs
- expand method docs and binary length explanation

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*