### PR TITLE
Improve Javadoc for marshallable base classes

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AsMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/AsMarshallable.java
@@ -22,11 +22,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * This annotation indicates that the associated field or parameter should be treated as
- * a {@code Marshallable} type, implying it should be serialized or deserialized accordingly.
- * It can be applied to fields or method parameters to provide metadata about their marshalling behavior.
+ * Indicates that a field or parameter should be treated as a {@link Marshallable}.
+ * <p>
+ * Useful when the declared type is an interface but the value is known to be a
+ * concrete marshallable implementation. The annotation hints to the marshalling
+ * framework that the object should be serialised or deserialised as that concrete
+ * type rather than as a proxy of the interface.
  */
-@Retention(RetentionPolicy.RUNTIME)  // Indicates that this annotation should be retained at runtime.
-@Target({ElementType.FIELD, ElementType.PARAMETER})  // Specifies that this annotation can be applied to fields and method parameters.
+@Retention(RetentionPolicy.RUNTIME) // Annotation is visible at runtime
+@Target({ElementType.FIELD, ElementType.PARAMETER}) // Applicable to fields and parameters
 public @interface AsMarshallable {
 }

--- a/src/main/java/net/openhft/chronicle/wire/BytesInBinaryMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/BytesInBinaryMarshallable.java
@@ -16,18 +16,16 @@
 package net.openhft.chronicle.wire;
 
 /**
- * Represents an abstract base class for binary marshallables that primarily deal with bytes.
- * By default, this class does not use self-describing messages.
+ * Abstract base for marshallables that handle their own binary layout.
  * <p>
- * This class extends the {@link AbstractCommonMarshallable} to provide common functionalities
- * shared among marshallables.
+ * These objects are typically written and read as a block of bytes rather than
+ * through field-by-field wire operations. They do not embed type information
+ * when serialized via the standard wire mechanisms.
  */
 public abstract class BytesInBinaryMarshallable extends AbstractCommonMarshallable {
 
     /**
-     * Determines whether this marshallable uses self-describing messages.
-     *
-     * @return {@code false} indicating that this marshallable does not use self-describing messages by default.
+     * Returns {@code false} as binary marshallables omit explicit type metadata.
      */
     @Override
     public boolean usesSelfDescribingMessage() {

--- a/src/main/java/net/openhft/chronicle/wire/KeyedMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/KeyedMarshallable.java
@@ -18,13 +18,18 @@ package net.openhft.chronicle.wire;
 import net.openhft.chronicle.bytes.Bytes;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * A {@link Marshallable} that exposes a portion of its state as a key.
+ * Useful for map-like collections where objects are identified by part of their
+ * content.
+ */
 public interface KeyedMarshallable {
 
     /**
-     * Writes the key of the current instance into the provided {@code Bytes} object.
-     * This default implementation utilizes the {@code Wires.writeKey} method.
+     * Writes the key portion of this instance to the supplied bytes.
+     * The default implementation delegates to {@link Wires#writeKey(Object, Bytes)}.
      *
-     * @param bytes The {@code Bytes} object into which the key of the current instance is written.
+     * @param bytes destination buffer for the key
      */
     @SuppressWarnings("rawtypes")
     default void writeKey(@NotNull Bytes<?> bytes) {

--- a/src/main/java/net/openhft/chronicle/wire/SelfDescribingMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/SelfDescribingMarshallable.java
@@ -16,11 +16,17 @@
 package net.openhft.chronicle.wire;
 
 /**
- * Represents an abstraction of marshallable objects that are self-describing by default.
- * This class extends {@code AbstractCommonMarshallable} and ensures that instances
- * inherently use self-describing messages.
+ * Base class for marshallables that include their type information when written.
+ * <p>
+ * A self-describing marshallable writes its class name (and, for text wires,
+ * the field names) into the stream so that a reader can reconstruct the object
+ * without knowing its exact type.
  */
 public abstract class SelfDescribingMarshallable extends AbstractCommonMarshallable {
+
+    /**
+     * Always returns {@code true} as these marshallables emit type metadata.
+     */
     @Override
     public boolean usesSelfDescribingMessage() {
         return true;


### PR DESCRIPTION
## Summary
- clarify purpose of `SelfDescribingMarshallable`
- describe binary-focused behaviour in `BytesInBinaryMarshallable`
- explain how `KeyedMarshallable` writes its key
- expand `AsMarshallable` to note common use case

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*