### PR TITLE
Improve Javadoc for configuration and copyable classes

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AbstractMarshallableCfg.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractMarshallableCfg.java
@@ -21,24 +21,24 @@ import net.openhft.chronicle.core.io.InvalidMarshallableException;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * An abstract class that represents a configuration Data Transfer Object (DTO) capable of marshalling.
- * This base class offers default implementations for reading and writing configurations through {@code WireMarshaller}.
- * Derived configuration DTOs can benefit from merging default configurations with specific configurations to enhance flexibility.
+ * Abstract base for configuration DTOs that are {@link Marshallable}.
+ * <p>
+ * The provided implementations of {@link #readMarshallable(WireIn)} and
+ * {@link #writeMarshallable(WireOut)} support merging with defaults. When
+ * reading, fields missing from the input leave their current values unchanged
+ * (which may have been initialised by {@link #reset()}). When writing, only
+ * fields that differ from the defaults (as supplied to the
+ * {@link WireMarshaller}) tend to be emitted.
  */
 public abstract class AbstractMarshallableCfg extends SelfDescribingMarshallable {
 
     /**
-     * Reads the state of this configuration object from the given wire input.
-     * It uses the {@link WireMarshaller} corresponding to the class of the current object
-     * to perform the reading.
-     * <p>
-     * Configuration merging is supported; absent values in the wire input retain their
-     * existing state. To ensure the use of default values for any unset attributes,
-     * consider invoking {@code reset()} before this method.
+     * Reads this configuration from the supplied wire without overwriting fields
+     * absent from the input.
      *
-     * @param wire Wire input source for reading the configuration.
-     * @throws IORuntimeException             If there's an IO-related exception during reading.
-     * @throws InvalidMarshallableException   If a marshalling error occurs.
+     * @param wire source of configuration data
+     * @throws IORuntimeException           on IO issues
+     * @throws InvalidMarshallableException if marshalling fails
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
@@ -52,14 +52,11 @@ public abstract class AbstractMarshallableCfg extends SelfDescribingMarshallable
     }
 
     /**
-     * Writes the state of this configuration object to the given wire output.
-     * It uses the {@link WireMarshaller} corresponding to the class of the current object
-     * to perform the writing.
-     * <p>
-     * For brevity, only fields differing from default values are written.
+     * Writes this configuration to the wire, omitting fields that match the
+     * default instance known to the {@link WireMarshaller}.
      *
-     * @param wire Wire output target for writing the configuration.
-     * @throws InvalidMarshallableException If a marshalling error occurs.
+     * @param wire destination for the configuration
+     * @throws InvalidMarshallableException if marshalling fails
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
@@ -73,12 +70,11 @@ public abstract class AbstractMarshallableCfg extends SelfDescribingMarshallable
     }
 
     /**
-     * Handles the presence of unexpected fields during the reading process.
-     * A warning is logged with details of the unexpected field.
+     * Logs and skips fields that are not defined in this configuration.
      *
-     * @param event   The name or identifier of the unexpected field.
-     * @param valueIn The value associated with the unexpected field.
-     * @throws InvalidMarshallableException If there's an error during the processing.
+     * @param event   field name encountered
+     * @param valueIn value of that field
+     * @throws InvalidMarshallableException if processing fails
      */
     @Override
     public void unexpectedField(Object event, ValueIn valueIn) throws InvalidMarshallableException {

--- a/src/main/java/net/openhft/chronicle/wire/SelfDescribingTriviallyCopyable.java
+++ b/src/main/java/net/openhft/chronicle/wire/SelfDescribingTriviallyCopyable.java
@@ -27,38 +27,38 @@ import java.nio.BufferUnderflowException;
 import static net.openhft.chronicle.core.UnsafeMemory.MEMORY;
 
 /**
- * Represents a self-describing object that is trivially copyable, extending the functionality of {@link SelfDescribingMarshallable}.
- * The class provides mechanisms to efficiently manage the internal data layout of an instance based on various data types
- * such as longs, ints, shorts, and bytes. The layout is determined using a description integer.
+ * A self-describing object with a fixed binary layout that can be copied using
+ * trivial memory operations. Useful for high-performance scenarios where the
+ * layout is known and stable yet the object remains self-describing when
+ * marshalled.
  */
 @SuppressWarnings("this-escape")
 public abstract class SelfDescribingTriviallyCopyable extends SelfDescribingMarshallable {
 
-    // Contains the description of the data layout.
+    /** A transient integer encoding the number of longs, ints, shorts and bytes in this object's layout. */
     @FieldGroup("header")
     transient int description = $description();
 
     /**
-     * Fetches the description of the current data layout.
-     *
-     * @return An integer description of the layout.
+     * @return integer encoding of the primitive field layout
      */
     protected abstract int $description();
 
     /**
-     * Determines the starting offset for the data.
-     *
-     * @return The start offset.
+     * @return starting offset of the trivially copyable region
      */
     protected abstract int $start();
 
     /**
-     * Fetches the total length of the data based on its layout.
-     *
-     * @return The total data length.
+     * @return total length in bytes of the trivially copyable region
      */
     protected abstract int $length();
 
+    /**
+     * Reads the object's state from the bytes. If the layout description in the
+     * input matches {@link #$description()}, a fast unsafe copy is performed;
+     * otherwise {@link #carefulCopy(BytesIn, int)} handles schema differences.
+     */
     @Override
     public void readMarshallable(BytesIn<?> bytes) throws IORuntimeException, BufferUnderflowException, IllegalStateException {
         int description0 = bytes.readInt();
@@ -69,13 +69,10 @@ public abstract class SelfDescribingTriviallyCopyable extends SelfDescribingMars
     }
 
     /**
-     * Performs a controlled copy of data from an input source based on the given description.
-     * The method will read data of various sizes (long, int, short, byte) based on the description
-     * and will copy this data to the current instance's memory.
-     *
-     * @param in          The input source from which data will be read.
-     * @param description0 The description integer specifying the layout of the data in the input source.
-     * @throws IllegalStateException if the description is invalid or does not match the input's content.
+     * Performs a field-by-field copy from {@code in} according to the supplied
+     * description, coping with layout differences between source and target.
+     * Extra fields present in {@code in} are skipped; missing fields leave the
+     * current value untouched.
      */
     private void carefulCopy(BytesIn<?> in, int description0) {
         // Start offset for copying data
@@ -143,6 +140,10 @@ public abstract class SelfDescribingTriviallyCopyable extends SelfDescribingMars
         }
     }
 
+    /**
+     * Writes the description followed by the trivially copyable fields using an
+     * unsafe memory copy.
+     */
     @Override
     public void writeMarshallable(BytesOut<?> bytes) throws IllegalStateException, BufferOverflowException, BufferUnderflowException, ArithmeticException {
         bytes.writeInt($description());


### PR DESCRIPTION
## Summary
- clarify behaviour of `AbstractMarshallableCfg` around merging defaults
- document fast vs careful copying in `SelfDescribingTriviallyCopyable`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*