### PR TITLE
Clarify deprecation of DynamicEnum

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/DynamicEnum.java
+++ b/src/main/java/net/openhft/chronicle/wire/DynamicEnum.java
@@ -22,23 +22,22 @@ import net.openhft.chronicle.core.util.CoreDynamicEnum;
 import java.util.List;
 
 /**
- * Represents a dynamic enumeration which can either be a traditional {@code Enum} or a class
- * possessing a {@code String name} field. The interface extends both {@link CoreDynamicEnum} and
- * {@link Marshallable}, facilitating serialization and specific dynamic enumeration operations.
+ * <b>Deprecated:</b> scheduled for removal in version x.28.
+ * Represents an enumeration whose values may not be fixed at compile time.
+ * Implementations can be either a traditional {@code Enum} or a class
+ * with a {@code String name} field. The interface extends
+ * {@link CoreDynamicEnum} and {@link Marshallable}.
  */
 @SuppressWarnings({"deprecation", "rawtypes", "unchecked"})
 @Deprecated(/* to be removed in x.28 */)
 public interface DynamicEnum extends CoreDynamicEnum, Marshallable {
 
     /**
-     * Refreshes the cached instance of a {@code DynamicEnum} based on the given template.
-     * This ensures that every deserialization of the enum value from its {@code name()} method
-     * is up-to-date with the most recent information.
-     * <p>
-     * Leveraging this method to update the cached enum details is essential for maintaining
-     * data consistency, especially during frequent deserialization operations.
+     * <b>Deprecated.</b> Refreshes a cached dynamic enum using the supplied template.
+     * It updates the cached instance with the same name so that subsequent lookups
+     * via {@link EnumCache#valueOf(String)} return the latest data.
      *
-     * @param e The {@code DynamicEnum} template used to refresh the cached version.
+     * @param e the template used to update the cached version
      */
     static <E extends DynamicEnum> void updateEnum(E e) {
         // Retrieve the enum cache corresponding to the class of the provided template
@@ -57,7 +56,8 @@ public interface DynamicEnum extends CoreDynamicEnum, Marshallable {
     }
 
     /**
-     * Not resettable, treat as immutable.
+     * <b>Deprecated.</b> Dynamic enums are treated as immutable and this
+     * default implementation always throws {@link UnsupportedOperationException}.
      */
     default void reset() {
         throw new UnsupportedOperationException();


### PR DESCRIPTION
## Summary
- emphasise that `DynamicEnum` is deprecated and scheduled for removal
- highlight deprecation in `updateEnum` and `reset`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*