### PR TITLE
Improve javadoc for SerializationStrategies

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
+++ b/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
@@ -46,16 +46,14 @@ import static net.openhft.chronicle.wire.BracketType.UNKNOWN;
 public enum SerializationStrategies implements SerializationStrategy {
 
     /**
-     * A serialization strategy for objects implementing the {@link Marshallable} interface.
-     * This strategy supports both self-describing messages and raw byte data serialization.
+     * Strategy for objects implementing {@link Marshallable}.
+     * Supports both self-describing and raw byte forms.
      */
     MARSHALLABLE {
         /**
-         * Reads an object from the provided input source using a wire format.
-         * The object can be deserialized either as a self-describing message or as raw byte data,
-         * based on its type.
-         *
-         * @return The populated object.
+         * Reads the object either via {@link ReadMarshallable#readMarshallable(WireIn)}
+         * or {@link ReadBytesMarshallable#readMarshallable(Bytes)}. The choice is
+         * governed by {@link WireIn#useSelfDescribingMessage(CommonMarshallable)}.
          */
         @NotNull
         @Override
@@ -81,10 +79,7 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * Creates a new instance of the specified type.
-         * If the type represents an interface or an abstract class, {@code null} is returned.
-         *
-         * @return A new instance of the provided type or {@code null} if the type is an interface or abstract.
+         * Returns {@code null} for interfaces or abstract types.
          */
         @Nullable
         @Override
@@ -94,15 +89,13 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy that supports any object type.
-     * This strategy infers the object type during deserialization.
+     * Handles objects of any type. The actual strategy is chosen at read time
+     * once the type has been inferred from the wire.
      */
     ANY_OBJECT {
         /**
-         * Reads an object from the provided input source, inferring its type.
-         * The type is not explicitly described in the serialized data.
-         *
-         * @return The populated object with its type inferred from the input.
+         * Infers the type from the wire and then delegates to {@link #ANY_NESTED}
+         * or another appropriate strategy.
          */
         @Nullable
         @Override
@@ -134,14 +127,12 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy that supports any scalar value.
-     * Scalar values are typically primitive types or their boxed equivalents.
+     * Handles scalar values such as primitives and boxed types. Scalars are
+     * written without explicit map or list brackets.
      */
     ANY_SCALAR {
         /**
-         * Reads a scalar object from the provided input source, inferring its type.
-         *
-         * @return The populated scalar object with its type inferred from the input.
+         * Reads a scalar value and infers the target type from the wire.
          */
         @Nullable
         @Override
@@ -173,13 +164,11 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy specifically designed for handling enumerations (enums).
+     * Strategy for standard {@link Enum} types. Values are written as their {@code name()}.
      */
     ENUM {
         /**
-         * Reads an enum value from the provided input source, represented as text.
-         *
-         * @return The textual representation of the enum value.
+         * Reads an enum by consuming its textual name.
          */
         @Nullable
         @Override
@@ -211,10 +200,8 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy designed for handling dynamic enumerations (enums).
-     * Dynamic enums are enums whose values can be altered or enhanced at runtime.
-     * This strategy incorporates custom handling to ensure proper deserialization
-     * of dynamic enums from the input source.
+     * Supports dynamic enums whose values may change at run time. Special logic
+     * deals with both simple text forms and map based representations.
      */
     DYNAMIC_ENUM {
 
@@ -222,12 +209,9 @@ public enum SerializationStrategies implements SerializationStrategy {
         private final Field ordinal = Jvm.getField(Enum.class, "ordinal");
 
         /**
-         * Reads a dynamic enum value from the provided input source.
-         * This method accounts for multiple input representations,
-         * such as direct textual names or custom serialized formats
-         * for more complex dynamic enums.
-         *
-         * @return The deserialized dynamic enum object or its textual representation.
+         * Reads a dynamic enum. A plain text name is resolved via {@link EnumCache}.
+         * If {@code o} implements {@link ReadMarshallable} and a map is present,
+         * that map is read into the instance.
          */
         @Nullable
         @Override
@@ -291,19 +275,13 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy designed for handling nested objects.
-     * This strategy reads nested objects without explicitly knowing
-     * their exact type, treating them as generic objects and performing
-     * a generic deserialization.
+     * Deserialises nested objects without knowing the target type. Data is
+     * typically encoded in a map style structure.
      */
     ANY_NESTED {
 
         /**
-         * Reads the nested object from the provided input source.
-         * If the input is null, it returns null. Otherwise, it
-         * deserializes the object and returns the constructed instance.
-         *
-         * @return The deserialized nested object.
+         * Reads a nested object or returns {@code null} if the input is null.
          */
         @Override
         public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -339,18 +317,15 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy specifically designed for handling
-     * {@link Demarshallable} objects. {@link Demarshallable} represents
-     * an object that can be deserialized from a wire format.
+     * Handles {@link Demarshallable} objects. A wrapper may be used during
+     * reading to defer construction until {@link #readUsing} is invoked.
      */
     DEMARSHALLABLE {
 
         /**
-         * Reads the {@link Demarshallable} object from the provided input source.
-         * This method has logic to handle multiple formats of input including
-         * wrapped objects and direct serialized formats.
-         *
-         * @return The deserialized {@link Demarshallable} object or wrapper.
+         * Reads a {@link Demarshallable}. If {@code using} is a
+         * {@link DemarshallableWrapper}, a new instance is created and stored in
+         * the wrapper. Otherwise the existing object is populated.
          */
         @NotNull
         @Override
@@ -378,9 +353,8 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * Constructs a new instance of a {@link Demarshallable} wrapped in a {@link DemarshallableWrapper}.
-         *
-         * @return The constructed {@link DemarshallableWrapper}.
+         * Returns a {@link DemarshallableWrapper} used as a temporary holder
+         * until the real object is read.
          */
         @NotNull
         @Override
@@ -390,20 +364,15 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling objects that implement the
-     * {@link java.io.Serializable} interface. This strategy checks if the object
-     * is also an instance of {@link Externalizable}, and if so, uses the
-     * {@link #EXTERNALIZABLE} strategy. Otherwise, it defaults to the
-     * {@link #ANY_OBJECT} strategy.
+     * Handles {@link Serializable} objects. If an instance is also
+     * {@link Externalizable} its own read logic is used, otherwise the data is
+     * read via {@link #ANY_OBJECT}.
      */
     SERIALIZABLE {
 
         /**
-         * Reads the {@link Serializable} object from the provided input source.
-         * Delegates the deserialization to the appropriate strategy based on
-         * whether the object is an instance of {@link Externalizable}.
-         *
-         * @return The deserialized {@link Serializable} object.
+         * Delegates to {@link #EXTERNALIZABLE} when required, otherwise to
+         * {@link #ANY_OBJECT}.
          */
         @Override
         public Object readUsing(Class clazz, Object o, ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -426,17 +395,14 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy specifically designed for handling
-     * {@link Externalizable} objects. Externalizable objects provide their
-     * own custom serialization mechanism that this strategy leverages.
+     * Handles {@link Externalizable} objects and calls their
+     * {@link java.io.Externalizable#readExternal(java.io.ObjectInput)} method.
      */
     EXTERNALIZABLE {
 
         /**
-         * Reads the {@link Externalizable} object from the provided input source
-         * using the object's custom serialization logic.
-         *
-         * @return The deserialized {@link Externalizable} object.
+         * Delegates to {@link java.io.Externalizable#readExternal(java.io.ObjectInput)}
+         * using an {@link java.io.ObjectInput} facade over the wire.
          */
         @NotNull
         @Override
@@ -474,17 +440,13 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling objects that implement the
-     * {@link java.util.Map} interface. This strategy deserializes a sequence
-     * of key-value pairs into a Map instance.
+     * Reads key value pairs into a {@link Map}.
      */
     MAP {
 
         /**
-         * Reads the {@link Map} object from the provided input source, mapping
-         * each key-value pair in the sequence.
-         *
-         * @return The deserialized {@link Map} object.
+         * Consumes key value pairs until no more entries remain in the current
+         * map context.
          */
         @Override
         public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -534,17 +496,13 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling objects that implement the
-     * {@link java.util.Set} interface. This strategy deserializes a sequence
-     * of items into a Set instance.
+     * Reads a sequence of items into a {@link Set} implementation.
      */
     SET {
 
         /**
-         * Reads the {@link Set} object from the provided input source, adding
-         * each item in the sequence to the set.
-         *
-         * @return The deserialized {@link Set} object.
+         * Consumes items from the wire and adds them to the given set, creating
+         * one if necessary.
          */
         @Override
         public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -601,17 +559,13 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling objects that implement the
-     * {@link java.util.List} interface. This strategy deserializes a sequence
-     * of items into a List instance.
+     * Reads a sequence of items into a {@link List} implementation.
      */
     LIST {
 
         /**
-         * Reads the {@link List} object from the provided input source, adding
-         * each item in the sequence to the list.
-         *
-         * @return The deserialized {@link List} object.
+         * Populates the supplied list. Existing entries are reused where
+         * possible; surplus entries are removed.
          */
         @Override
         public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -673,21 +627,14 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling arrays. This strategy deserializes
-     * a sequence of items into an array instance.
+     * Reads a sequence of items into an array. Uses {@link ArrayWrapper} when
+     * the target type is known at construction time.
      */
     ARRAY {
 
         /**
-         * Reads an array object from the provided input source, adding each
-         * item in the sequence to a list, which is then converted into an array.
-         * <p>
-         * If the 'using' parameter is an instance of ArrayWrapper, the method
-         * first deserializes items into a list and then wraps them into an array
-         * with the correct component type. Otherwise, it deserializes items into
-         * a list and then converts that list into an array.
-         *
-         * @return The deserialized array or an ArrayWrapper containing the array.
+         * Collects items into a list and then converts that list to an array or
+         * populates the supplied {@link ArrayWrapper}.
          */
         @NotNull
         @Override
@@ -745,21 +692,14 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling primitive arrays. This strategy
-     * deserializes a sequence of items into an array instance, dynamically
-     * resizing the array as required during deserialization.
+     * Reads primitive arrays using a {@link PrimArrayWrapper}. The array grows
+     * as items are read and is trimmed to size when complete.
      */
     PRIM_ARRAY {
 
         /**
-         * Reads a primitive array object from the provided input source,
-         * dynamically resizing the array during the deserialization process.
-         * <p>
-         * The method starts with an empty array and doubles its size as needed
-         * to accommodate the incoming data. After all items have been read,
-         * the array is resized to fit the number of items that were read.
-         *
-         * @return The PrimArrayWrapper containing the deserialized primitive array.
+         * Reads items into the primitive array held by the wrapper, expanding the
+         * array when it becomes full and finally shrinking it to the exact length.
          */
         @NotNull
         @Override
@@ -852,8 +792,8 @@ public enum SerializationStrategies implements SerializationStrategy {
     }
 
     /**
-     * A wrapper class for arrays which provides a mechanism for deserialization
-     * by resolving the actual array when being read from a serialized source.
+     * Temporary holder for arrays during deserialization. {@link #readResolve()}
+     * returns the actual array so callers see only the final result.
      */
     static class ArrayWrapper implements ReadResolvable<Object[]> {
 
@@ -878,10 +818,7 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * Provides a deserialization mechanism which returns the actual array
-         * when this wrapper is being read from a serialized source.
-         *
-         * @return The actual array wrapped by this wrapper.
+         * {@inheritDoc}
          */
         @NotNull
         @Override
@@ -891,12 +828,7 @@ public enum SerializationStrategies implements SerializationStrategy {
     }
 
     /**
-     * The following classes are wrappers that facilitate deserialization processes for
-     * specific types of objects. They implement the ReadResolvable interface to define
-     * the deserialization mechanism.
-     * <p>
-     * A wrapper class for primitive arrays which provides a mechanism for deserialization
-     * by resolving the actual array when being read from a serialized source.
+     * Temporary holder for primitive arrays during deserialization.
      */
     static class PrimArrayWrapper implements ReadResolvable<Object> {
 
@@ -921,10 +853,7 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * Provides a deserialization mechanism which returns the actual primitive array
-         * when this wrapper is being read from a serialized source.
-         *
-         * @return The actual primitive array wrapped by this wrapper.
+         * {@inheritDoc}
          */
         @NotNull
         @Override
@@ -934,8 +863,7 @@ public enum SerializationStrategies implements SerializationStrategy {
     }
 
     /**
-     * A wrapper class for Demarshallable objects which provides a mechanism for deserialization
-     * by resolving the actual Demarshallable object when being read from a serialized source.
+     * Wrapper used when reading {@link Demarshallable} objects lazily.
      */
     static class DemarshallableWrapper implements ReadResolvable<Demarshallable> {
 
@@ -960,10 +888,7 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * Provides a deserialization mechanism which returns the actual Demarshallable object
-         * when this wrapper is being read from a serialized source.
-         *
-         * @return The actual Demarshallable object wrapped by this wrapper.
+         * {@inheritDoc}
          */
         @NotNull
         @Override


### PR DESCRIPTION
## Summary
- rewrite javadoc comments for `SerializationStrategies` and its enum
  constants to clarify behaviour and type handling
- describe temporary wrapper classes used during deserialisation

## Testing
- `mvn -q verify` *(fails: mvn not found)*