### PR TITLE
Improve WireMarshaller javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -76,11 +76,13 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Constructs a new instance of the WireMarshaller with the specified parameters.
+     * Protected constructor used by factory methods.
+     * Prefer {@link #of(Class)} or {@link #WIRE_MARSHALLER_CL} to obtain
+     * instances.
      *
-     * @param tClass  The class of the object to be marshalled.
-     * @param fields  An array of field accessors that provide access to the fields of the object.
-     * @param isLeaf  Indicates if the marshaller is for a leaf class.
+     * @param tClass the type being marshalled
+     * @param fields fields to marshall
+     * @param isLeaf whether the type is considered a leaf
      */
     protected WireMarshaller(@NotNull Class<T> tClass, @NotNull FieldAccess[] fields, boolean isLeaf) {
         this(fields, isLeaf, defaultValueForType(tClass));
@@ -95,6 +97,9 @@ public class WireMarshaller<T> {
                             : WireMarshaller.of(tClass)
             );
 
+    /**
+     * Internal constructor used by the factory methods.
+     */
     WireMarshaller(@NotNull FieldAccess[] fields, boolean isLeaf, @Nullable T defaultValue) {
         this.fields = fields;
         this.isLeaf = isLeaf;
@@ -105,12 +110,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Factory method to create an instance of the WireMarshaller for a specific class type.
-     * Determines the appropriate marshaller type (basic or one that handles unexpected fields)
-     * based on the characteristics of the provided class.
+     * Creates a marshaller for the given type.
+     * Synthetic fields introduced by later Java versions are filtered out.
      *
-     * @param tClass The class type for which the marshaller is to be created.
-     * @return A new instance of WireMarshaller for the provided class type.
+     * @param tClass the type to marshall
+     * @return marshaller instance for {@code tClass}
      */
     @NotNull
     public static <T> WireMarshaller<T> of(@NotNull Class<T> tClass) {
@@ -140,11 +144,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Checks if the provided field accessor corresponds to a "leaf" entity.
-     * An entity is considered a leaf if it doesn't need to be further broken down in the serialization process.
+     * Determines if the field type can be treated as a leaf during serialisation.
+     * Collections and non-dynamic-enum {@link WriteMarshallable} types are not leaves.
      *
-     * @param c The field accessor to be checked.
-     * @return {@code true} if the field accessor is leafable, {@code false} otherwise.
+     * @param c accessor for the field
+     * @return true if the field can be treated as a leaf
      */
     protected static boolean leafable(FieldAccess c) {
         Class<?> type = c.field.getType();
@@ -156,10 +160,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Determines if the provided class overrides the "unexpectedField" method from the ReadMarshallable interface.
+     * Checks whether {@code tClass} supplies its own
+     * {@link ReadMarshallable#unexpectedField(Object, ValueIn)} implementation.
      *
-     * @param tClass The class type to be checked.
-     * @return {@code true} if the class overrides the "unexpectedField" method, {@code false} otherwise.
+     * @param tClass the type to check
+     * @return true if {@code tClass} overrides the method
      */
     private static <T> boolean overridesUnexpectedFields(Class<T> tClass) {
         try {
@@ -171,11 +176,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Factory method to create an instance of the WireMarshaller for a Throwable class type.
-     * The method identifies fields that should be marshalled and prepares the marshaller accordingly.
+     * Factory for {@link Throwable} subclasses.
+     * Includes fields needed to serialise exception state.
      *
-     * @param tClass The Throwable class type for which the marshaller is to be created.
-     * @return A new instance of WireMarshaller for the provided Throwable class type.
+     * @param tClass exception type
+     * @return marshaller for the throwable
      */
     @NotNull
     private static <T> WireMarshaller<T> ofThrowable(@NotNull Class<T> tClass) {
@@ -190,10 +195,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Determines if the provided class is a collection type, including arrays, standard Collections, or Maps.
+     * Utility to check whether the class represents an array, a
+     * {@link Collection} or a {@link Map}.
      *
-     * @param c The class to be checked.
-     * @return {@code true} if the class is a collection type, {@code false} otherwise.
+     * @param c class to test
+     * @return true if it is a collection type
      */
     private static boolean isCollection(@NotNull Class<?> c) {
         return c.isArray() ||
@@ -202,12 +208,14 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Recursively fetches all non-static, non-transient fields from the provided class and its superclasses,
-     * up to but not including Object or AbstractCommonMarshallable, and adds them to the provided map.
-     * Fields that are flagged for exclusion (e.g., the "ordinal" field for Enum types) are skipped.
+     * Recursively collects all non-static and non-transient fields from
+     * {@code clazz} and its parents until {@link Object} or
+     * {@link AbstractCommonMarshallable}. The map is keyed by field name.
+     * Skips values such as {@code ordinal} on enums and inner-class synthetic
+     * links.
      *
-     * @param clazz The class type from which fields are to be extracted.
-     * @param map   The map to populate with field names and their corresponding Field objects.
+     * @param clazz class to inspect
+     * @param map   destination for discovered fields
      */
     public static void getAllField(@NotNull Class<?> clazz, @NotNull Map<String, Field> map) {
         if (clazz != Object.class && clazz != AbstractCommonMarshallable.class)
@@ -229,6 +237,12 @@ public class WireMarshaller<T> {
         }
     }
 
+    /**
+     * Creates a default instance for {@code tClass} when possible.
+     * Concrete, non-Java-core classes get an empty instance. For
+     * {@link DynamicEnum} types a special '[unset]' constant is produced.
+     * Returns {@code null} for primitives, arrays and interfaces.
+     */
     static <T> T defaultValueForType(@NotNull Class<T> tClass) {
 //        tClass = ObjectUtils.implementationToUse(tClass);
         if (ObjectUtils.isConcreteClass(tClass)
@@ -254,15 +268,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Compares two CharSequences lexicographically. This is a character-by-character comparison
-     * that returns the difference of the first unmatched characters or the difference in their lengths
-     * if one sequence is a prefix of the other.
-     *
-     * @param cs0 The first CharSequence to be compared.
-     * @param cs1 The second CharSequence to be compared.
-     * @return A positive integer if {@code cs0} comes after {@code cs1},
-     *         a negative integer if {@code cs0} comes before {@code cs1},
-     *         or zero if the sequences are equal.
+     * Lexicographical comparison used by {@link #fieldMap}.
      */
     private static int compare(CharSequence cs0, CharSequence cs1) {
         for (int i = 0, len = Math.min(cs0.length(), cs1.length()); i < len; i++) {
@@ -274,12 +280,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Computes the actual type arguments for a given field of an interface. This method determines
-     * the generic type arguments that the field uses based on the interface's type parameters.
-     *
-     * @param iface The interface containing the field.
-     * @param field The field whose type arguments need to be determined.
-     * @return An array of actual type arguments or the interface's type parameters if no actual arguments can be deduced.
+     * Helper used by reflection code to resolve the actual generic arguments for
+     * {@code field} relative to {@code iface}.
      */
     private static Type[] computeActualTypeArguments(Class<?> iface, Field field) {
         Type[] actual = consumeActualTypeArguments(new HashMap<>(), iface, field.getGenericType());
@@ -291,19 +293,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Determines the actual type arguments used by a class or interface for a given interface type.
-     * This method recursively inspects the type hierarchy to match type arguments against the
-     * interface's type parameters. It uses a previously built map of type parameter names to their
-     * actual types to deduce the correct arguments for the given interface.
-     *
-     * @param prevTypeParameters A map containing previously discovered type parameter names
-     *                           mapped to their actual types.
-     * @param iface              The interface for which we want to determine the type arguments.
-     * @param type               The type to inspect. This could be an actual class, interface, or
-     *                           a parameterized type that uses generic arguments.
-     *
-     * @return An array of actual type arguments used by the provided type for the specified interface,
-     *         or null if the type doesn't directly or indirectly implement or extend the given interface.
+     * Recursive helper for {@link #computeActualTypeArguments(Class, Field)}.
+     * Walks the type hierarchy to map parameter names to concrete classes.
      */
     private static Type[] consumeActualTypeArguments(Map<String, Type> prevTypeParameters, Class<?> iface, Type type) {
         Class<?> cls = null;
@@ -375,11 +366,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Excludes specified fields from the current marshaller and returns a new instance of the marshaller
-     * with the remaining fields.
-     *
-     * @param fieldNames Names of the fields to be excluded.
-     * @return A new instance of the {@link WireMarshaller} with the specified fields excluded.
+     * Returns a marshaller that omits the named fields.
+     * Useful when only a subset of a DTO should be serialised.
      */
     public WireMarshaller<T> excludeFields(String... fieldNames) {
         Set<String> fieldSet = new HashSet<>(Arrays.asList(fieldNames));
@@ -390,13 +378,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Writes the marshallable representation of the given object to the provided {@link WireOut} destination.
-     * This will traverse the fields and use their respective {@link FieldAccess} to write each field.
-     * The method also adjusts the hex dump indentation for better readability in the output.
-     *
-     * @param t   The object to write.
-     * @param out The destination {@link WireOut} where the object representation will be written.
-     * @throws InvalidMarshallableException If the object fails validation checks before serialization.
+     * Serialises {@code t} to {@code out} in field order. Hex dump indentation
+     * is adjusted for readability.
      */
     public void writeMarshallable(T t, @NotNull WireOut out) throws InvalidMarshallableException {
         ValidatableUtil.validate(t);
@@ -412,12 +395,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Writes the marshallable representation of the given object to the provided {@link Bytes} destination.
-     * Unlike the previous method, this doesn't adjust the hex dump indentation. It's a more direct
-     * serialization of the fields to bytes.
-     *
-     * @param t     The object to write.
-     * @param bytes The destination {@link Bytes} where the object representation will be written.
+     * Serialises {@code t} directly to the given byte store using raw field
+     * access.
      */
     public void writeMarshallable(T t, Bytes<?> bytes) {
         for (@NotNull FieldAccess field : fields) {
@@ -430,14 +409,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Writes the values of the fields from the provided object (DTO) to the output. Before writing,
-     * the object is validated. The method also supports optional copying of the values
-     * from the source object to a previous instance.
-     *
-     * @param t    Object whose field values are to be written.
-     * @param out  Output destination where the field values are written to.
-     * @param copy Flag indicating whether to copy values from the source object to the previous object.
-     * @throws InvalidMarshallableException If there's an error during marshalling.
+     * Serialises {@code t} to {@code out}, optionally copying written values
+     * into the stored default instance.
      */
     public void writeMarshallable(T t, @NotNull WireOut out, boolean copy) throws InvalidMarshallableException {
         // Validate the object before writing
@@ -453,13 +426,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Reads and populates the DTO based on the provided input. The input order can be hinted.
-     * After reading, the object is validated.
-     *
-     * @param t         Object to populate with read values.
-     * @param in        Input source from which values are read.
-     * @param overwrite Flag indicating whether to overwrite the existing value in the target object.
-     * @throws InvalidMarshallableException If there is an error during marshalling.
+     * Deserialises from {@code in} into {@code t}. When {@code overwrite} is
+     * true missing fields are reset from {@link #defaultValue}.
      */
     public void readMarshallable(T t, @NotNull WireIn in, boolean overwrite) throws InvalidMarshallableException {
         // Choose the reading method based on the hint
@@ -473,12 +441,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Reads and populates the DTO based on the provided order.
-     *
-     * @param t         Target object to populate with read values.
-     * @param in        Input source from which values are read.
-     * @param overwrite Flag indicating whether to overwrite the existing value in the target object.
-     * @throws InvalidMarshallableException If there is an error during marshalling.
+     * Deserialises fields in declared order from {@code in}.
+     * Fields not present are optionally taken from {@link #defaultValue}.
      */
     public void readMarshallableDTOOrder(T t, @NotNull WireIn in, boolean overwrite) throws InvalidMarshallableException {
         try {
@@ -493,12 +457,9 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Reads and populates the DTO based on the input's order.
-     *
-     * @param t         Target object to populate with read values.
-     * @param in        Input source from which values are read.
-     * @param overwrite Flag indicating whether to overwrite the existing value in the target object.
-     * @throws InvalidMarshallableException If there is an error during marshalling.
+     * Reads fields in the order they appear on the wire. Any DTO fields not
+     * encountered are optionally restored from {@link #defaultValue} once all
+     * input has been processed.
      */
     public void readMarshallableInputOrder(T t, @NotNull WireIn in, boolean overwrite) throws InvalidMarshallableException {
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
@@ -543,23 +504,14 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Checks if the given field name (represented by a StringBuilder) matches the field name of the provided {@link FieldAccess}.
-     * If the StringBuilder has a length of 0, it's assumed to match any field name.
-     *
-     * @param sb    The StringBuilder containing the field name to be checked.
-     * @param field The {@link FieldAccess} whose field name needs to be matched against.
-     * @return True if the field name matches or if the StringBuilder is empty; False otherwise.
+     * Case-insensitive field name check. An empty builder matches any field.
      */
     public boolean matchesFieldName(StringBuilder sb, FieldAccess field) {
         return sb.length() == 0 || StringUtils.equalsCaseIgnore(field.field.getName(), sb);
     }
 
     /**
-     * Writes the key representation of the given object to the provided {@link Bytes} destination.
-     * As per the assumption, only the first field (key) of the object is written.
-     *
-     * @param t     The object whose key needs to be written.
-     * @param bytes The destination {@link Bytes} where the object's key representation will be written.
+     * Writes the first field of {@code t} as a key to {@code bytes}.
      */
     public void writeKey(T t, Bytes<?> bytes) {
         // assume one key for now.
@@ -571,12 +523,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Compares two objects field by field to determine their equality.
-     * Uses each field's {@link FieldAccess} to perform the equality check.
-     *
-     * @param o1 The first object to compare.
-     * @param o2 The second object to compare.
-     * @return True if all fields of both objects are equal; False if at least one field differs.
+     * Compares two objects field by field.
      */
     public boolean isEqual(Object o1, Object o2) {
         for (@NotNull FieldAccess field : fields) {
@@ -587,12 +534,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Fetches the value of the specified field from the provided object.
-     *
-     * @param o    The object from which the field value needs to be fetched.
-     * @param name The name of the field whose value is to be fetched.
-     * @return The value of the specified field from the object.
-     * @throws NoSuchFieldException If no field with the specified name is found in the object.
+     * Returns the named field value using {@link FieldAccess}.
      */
     public Object getField(Object o, String name) throws NoSuchFieldException {
         try {
@@ -608,13 +550,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Retrieves the value of a specified field from the provided object and converts it to a long.
-     * If the field's type is not inherently long or int, it attempts a conversion using the ObjectUtils class.
-     *
-     * @param o    The object from which the field value is to be retrieved.
-     * @param name The name of the field whose value needs to be fetched.
-     * @return The long value of the specified field.
-     * @throws NoSuchFieldException If no field with the specified name is found in the object.
+     * Returns the named field value as a long, applying conversions when needed.
      */
     public long getLongField(@NotNull Object o, String name) throws NoSuchFieldException {
         try {
@@ -635,13 +571,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Sets the value of a specified field in the provided object.
-     * If the type of the value does not directly match the field's type, it attempts a conversion using the ObjectUtils class.
-     *
-     * @param o     The object in which the field's value needs to be set.
-     * @param name  The name of the field whose value needs to be set.
-     * @param value The value to set to the field.
-     * @throws NoSuchFieldException If no field with the specified name is found in the object.
+     * Writes {@code value} into the named field, performing type conversion when required.
      */
     public void setField(Object o, String name, Object value) throws NoSuchFieldException {
         try {
@@ -657,13 +587,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Sets a long value to a specified field in the provided object.
-     * If the field's type is not inherently long or int, it attempts a conversion using the ObjectUtils class.
-     *
-     * @param o     The object in which the field's value needs to be set.
-     * @param name  The name of the field whose value needs to be set.
-     * @param value The long value to set to the field.
-     * @throws NoSuchFieldException If no field with the specified name is found in the object.
+     * Convenience for writing a long value via {@link FieldAccess}.
      */
     public void setLongField(Object o, String name, long value) throws NoSuchFieldException {
         try {
@@ -693,9 +617,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Resets the fields of the given object 'o' to the default value.
-     *
-     * @param o The object whose fields are to be reset to the default value.
+     * Copies values from {@link #defaultValue} into {@code o}.
      */
     public void reset(T o) {
         try {
@@ -708,9 +630,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Checks if the current WireMarshaller is a leaf.
-     *
-     * @return true if the WireMarshaller is a leaf, false otherwise.
+     * @return true if this marshaller is for a leaf type
      */
     public boolean isLeaf() {
         return isLeaf;


### PR DESCRIPTION
## Summary
- clarify constructor and factory method Javadoc
- document helper methods used by reflection
- tighten method comments for write/read behaviour and field access helpers

## Testing
- `mvn -q verify` *(fails: command not found)*