### PR TITLE
Javadoc Serialization Strategy & WireMarshaller

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/ScalarStrategy.java
+++ b/src/main/java/net/openhft/chronicle/wire/ScalarStrategy.java
@@ -28,13 +28,20 @@ import java.util.function.Function;
 /**
  * Implements the {@link SerializationStrategy} for scalar data types.
  * This strategy is designed for simple types and provides mechanisms for reading
- * them using provided functions.
+ * them using provided functions. It typically uses {@link BracketType#NONE} as
+ * scalar values are usually not enclosed in map or sequence brackets.
  *
  * @param <E> The type of the scalar value that this strategy handles.
  */
 class ScalarStrategy<E> implements SerializationStrategy {
+    /**
+     * The {@link BiFunction} used to deserialize the scalar value. It takes an
+     * optional existing object (or {@code null}) and the {@link ValueIn} source,
+     * and returns the deserialized value.
+     */
     final BiFunction<? super E, ValueIn, E> read;
-    // The class type of the scalar value
+
+    /** The class type of the scalar value. */
     private final Class<E> type;
 
     /**
@@ -80,12 +87,20 @@ class ScalarStrategy<E> implements SerializationStrategy {
         });
     }
 
+    /**
+     * Returns {@link BracketType#NONE}, as scalar values are typically not enclosed
+     * in structural brackets.
+     */
     @NotNull
     @Override
     public BracketType bracketType() {
         return BracketType.NONE;
     }
 
+    /**
+     * Creates a new instance of the scalar type using {@link ObjectUtils#newInstance(Class)}.
+     * This is used when no existing object is provided for deserialization.
+     */
     @SuppressWarnings("rawtypes")
     @NotNull
     @Override
@@ -93,11 +108,18 @@ class ScalarStrategy<E> implements SerializationStrategy {
         return Jvm.uncheckedCast(ObjectUtils.newInstance(this.type));
     }
 
+    /**
+     * Returns the {@link Class} of the scalar type this strategy handles.
+     */
     @Override
     public Class<E> type() {
         return type;
     }
 
+    /**
+     * Reads the scalar value using the configured {@link #read} function. Returns
+     * {@code null} if the input {@link ValueIn#isNull()}.
+     */
     @SuppressWarnings("unchecked")
     @Nullable
     @Override
@@ -108,6 +130,9 @@ class ScalarStrategy<E> implements SerializationStrategy {
         return (T) read.apply((E) using, in);
     }
 
+    /**
+     * @return A string representation of this strategy, including the scalar type name.
+     */
     @NotNull
     @Override
     public String toString() {

--- a/src/main/java/net/openhft/chronicle/wire/ScalarStrategy.java
+++ b/src/main/java/net/openhft/chronicle/wire/ScalarStrategy.java
@@ -28,8 +28,7 @@ import java.util.function.Function;
 /**
  * Implements the {@link SerializationStrategy} for scalar data types.
  * This strategy is designed for simple types and provides mechanisms for reading
- * them using provided functions. It typically uses {@link BracketType#NONE} as
- * scalar values are usually not enclosed in map or sequence brackets.
+ * them using provided functions.
  *
  * @param <E> The type of the scalar value that this strategy handles.
  */

--- a/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
+++ b/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
@@ -48,14 +48,16 @@ import static net.openhft.chronicle.wire.BracketType.UNKNOWN;
 public enum SerializationStrategies implements SerializationStrategy {
 
     /**
-     * Strategy for objects implementing {@link Marshallable}.
-     * Supports both self-describing and raw byte forms.
+     * A serialization strategy for objects implementing the {@link Marshallable} interface.
+     * This strategy supports both self-describing messages and raw byte data serialization.
      */
     MARSHALLABLE {
         /**
-         * Reads the object either via {@link ReadMarshallable#readMarshallable(WireIn)}
-         * or {@link ReadBytesMarshallable#readMarshallable(Bytes)}. The choice is
-         * governed by {@link WireIn#useSelfDescribingMessage(CommonMarshallable)}.
+         * Reads an object from the provided input source using a wire format.
+         * The object can be deserialized either as a self-describing message or as raw byte data,
+         * based on its type.
+         *
+         * @return The populated object.
          */
         @NotNull
         @Override
@@ -81,7 +83,10 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * Returns {@code null} for interfaces or abstract types.
+         * Creates a new instance of the specified type.
+         * If the type represents an interface or an abstract class, {@code null} is returned.
+         *
+         * @return A new instance of the provided type or {@code null} if the type is an interface or abstract.
          */
         @Nullable
         @Override
@@ -91,13 +96,15 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Handles objects of any type. The actual strategy is chosen at read time
-     * once the type has been inferred from the wire.
+     * A serialization strategy that supports any object type.
+     * This strategy infers the object type during deserialization.
      */
     ANY_OBJECT {
         /**
-         * Infers the type from the wire and then delegates to {@link #ANY_NESTED}
-         * or another appropriate strategy.
+         * Reads an object from the provided input source, inferring its type.
+         * The type is not explicitly described in the serialized data.
+         *
+         * @return The populated object with its type inferred from the input.
          */
         @Nullable
         @Override
@@ -129,12 +136,14 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Handles scalar values such as primitives and boxed types. Scalars are
-     * written without explicit map or list brackets.
+     * A serialization strategy that supports any scalar value.
+     * Scalar values are typically primitive types or their boxed equivalents.
      */
     ANY_SCALAR {
         /**
-         * Reads a scalar value and infers the target type from the wire.
+         * Reads a scalar object from the provided input source, inferring its type.
+         *
+         * @return The populated scalar object with its type inferred from the input.
          */
         @Nullable
         @Override
@@ -166,11 +175,13 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Strategy for standard {@link Enum} types. Values are written as their {@code name()}.
+     * A serialization strategy specifically designed for handling enumerations (enums).
      */
     ENUM {
         /**
-         * Reads an enum by consuming its textual name.
+         * Reads an enum value from the provided input source, represented as text.
+         *
+         * @return The textual representation of the enum value.
          */
         @Nullable
         @Override
@@ -202,18 +213,23 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Supports dynamic enums whose values may change at run time. Special logic
-     * deals with both simple text forms and map based representations.
+     * A serialization strategy designed for handling dynamic enumerations (enums).
+     * Dynamic enums are enums whose values can be altered or enhanced at runtime.
+     * This strategy incorporates custom handling to ensure proper deserialization
+     * of dynamic enums from the input source.
      */
     DYNAMIC_ENUM {
 
         // Reflective field access to the ordinal of the Enum class
-        private final Field ordinal = Jvm.getField(Enum.class, "ordinal");
+        private Field ordinal = Jvm.getField(Enum.class, "ordinal");
 
         /**
-         * Reads a dynamic enum. A plain text name is resolved via {@link EnumCache}.
-         * If {@code o} implements {@link ReadMarshallable} and a map is present,
-         * that map is read into the instance.
+         * Reads a dynamic enum value from the provided input source.
+         * This method accounts for multiple input representations,
+         * such as direct textual names or custom serialized formats
+         * for more complex dynamic enums.
+         *
+         * @return The deserialized dynamic enum object or its textual representation.
          */
         @Nullable
         @Override
@@ -277,13 +293,19 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Deserialises nested objects without knowing the target type. Data is
-     * typically encoded in a map style structure.
+     * A serialization strategy designed for handling nested objects.
+     * This strategy reads nested objects without explicitly knowing
+     * their exact type, treating them as generic objects and performing
+     * a generic deserialization.
      */
     ANY_NESTED {
 
         /**
-         * Reads a nested object or returns {@code null} if the input is null.
+         * Reads the nested object from the provided input source.
+         * If the input is null, it returns null. Otherwise, it
+         * deserializes the object and returns the constructed instance.
+         *
+         * @return The deserialized nested object.
          */
         @Override
         public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -319,15 +341,18 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Handles {@link Demarshallable} objects. A wrapper may be used during
-     * reading to defer construction until {@link #readUsing} is invoked.
+     * A serialization strategy specifically designed for handling
+     * {@link Demarshallable} objects. {@link Demarshallable} represents
+     * an object that can be deserialized from a wire format.
      */
     DEMARSHALLABLE {
 
         /**
-         * Reads a {@link Demarshallable}. If {@code using} is a
-         * {@link DemarshallableWrapper}, a new instance is created and stored in
-         * the wrapper. Otherwise the existing object is populated.
+         * Reads the {@link Demarshallable} object from the provided input source.
+         * This method has logic to handle multiple formats of input including
+         * wrapped objects and direct serialized formats.
+         *
+         * @return The deserialized {@link Demarshallable} object or wrapper.
          */
         @NotNull
         @Override
@@ -355,8 +380,9 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * Returns a {@link DemarshallableWrapper} used as a temporary holder
-         * until the real object is read.
+         * Constructs a new instance of a {@link Demarshallable} wrapped in a {@link DemarshallableWrapper}.
+         *
+         * @return The constructed {@link DemarshallableWrapper}.
          */
         @NotNull
         @Override
@@ -366,15 +392,20 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Handles {@link Serializable} objects. If an instance is also
-     * {@link Externalizable} its own read logic is used, otherwise the data is
-     * read via {@link #ANY_OBJECT}.
+     * A serialization strategy for handling objects that implement the
+     * {@link java.io.Serializable} interface. This strategy checks if the object
+     * is also an instance of {@link Externalizable}, and if so, uses the
+     * {@link #EXTERNALIZABLE} strategy. Otherwise, it defaults to the
+     * {@link #ANY_OBJECT} strategy.
      */
     SERIALIZABLE {
 
         /**
-         * Delegates to {@link #EXTERNALIZABLE} when required, otherwise to
-         * {@link #ANY_OBJECT}.
+         * Reads the {@link Serializable} object from the provided input source.
+         * Delegates the deserialization to the appropriate strategy based on
+         * whether the object is an instance of {@link Externalizable}.
+         *
+         * @return The deserialized {@link Serializable} object.
          */
         @Override
         public Object readUsing(Class clazz, Object o, ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -397,14 +428,17 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Handles {@link Externalizable} objects and calls their
-     * {@link java.io.Externalizable#readExternal(java.io.ObjectInput)} method.
+     * A serialization strategy specifically designed for handling
+     * {@link Externalizable} objects. Externalizable objects provide their
+     * own custom serialization mechanism that this strategy leverages.
      */
     EXTERNALIZABLE {
 
         /**
-         * Delegates to {@link java.io.Externalizable#readExternal(java.io.ObjectInput)}
-         * using an {@link java.io.ObjectInput} facade over the wire.
+         * Reads the {@link Externalizable} object from the provided input source
+         * using the object's custom serialization logic.
+         *
+         * @return The deserialized {@link Externalizable} object.
          */
         @NotNull
         @Override
@@ -442,13 +476,17 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Reads key value pairs into a {@link Map}.
+     * A serialization strategy for handling objects that implement the
+     * {@link java.util.Map} interface. This strategy deserializes a sequence
+     * of key-value pairs into a Map instance.
      */
     MAP {
 
         /**
-         * Consumes key value pairs until no more entries remain in the current
-         * map context.
+         * Reads the {@link Map} object from the provided input source, mapping
+         * each key-value pair in the sequence.
+         *
+         * @return The deserialized {@link Map} object.
          */
         @Override
         public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -498,13 +536,17 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Reads a sequence of items into a {@link Set} implementation.
+     * A serialization strategy for handling objects that implement the
+     * {@link java.util.Set} interface. This strategy deserializes a sequence
+     * of items into a Set instance.
      */
     SET {
 
         /**
-         * Consumes items from the wire and adds them to the given set, creating
-         * one if necessary.
+         * Reads the {@link Set} object from the provided input source, adding
+         * each item in the sequence to the set.
+         *
+         * @return The deserialized {@link Set} object.
          */
         @Override
         public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -561,13 +603,17 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Reads a sequence of items into a {@link List} implementation.
+     * A serialization strategy for handling objects that implement the
+     * {@link java.util.List} interface. This strategy deserializes a sequence
+     * of items into a List instance.
      */
     LIST {
 
         /**
-         * Populates the supplied list. Existing entries are reused where
-         * possible; surplus entries are removed.
+         * Reads the {@link List} object from the provided input source, adding
+         * each item in the sequence to the list.
+         *
+         * @return The deserialized {@link List} object.
          */
         @Override
         public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -629,14 +675,21 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Reads a sequence of items into an array. Uses {@link ArrayWrapper} when
-     * the target type is known at construction time.
+     * A serialization strategy for handling arrays. This strategy deserializes
+     * a sequence of items into an array instance.
      */
     ARRAY {
 
         /**
-         * Collects items into a list and then converts that list to an array or
-         * populates the supplied {@link ArrayWrapper}.
+         * Reads an array object from the provided input source, adding each
+         * item in the sequence to a list, which is then converted into an array.
+         * <p>
+         * If the 'using' parameter is an instance of ArrayWrapper, the method
+         * first deserializes items into a list and then wraps them into an array
+         * with the correct component type. Otherwise, it deserializes items into
+         * a list and then converts that list into an array.
+         *
+         * @return The deserialized array or an ArrayWrapper containing the array.
          */
         @NotNull
         @Override
@@ -694,14 +747,21 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Reads primitive arrays using a {@link PrimArrayWrapper}. The array grows
-     * as items are read and is trimmed to size when complete.
+     * A serialization strategy for handling primitive arrays. This strategy
+     * deserializes a sequence of items into an array instance, dynamically
+     * resizing the array as required during deserialization.
      */
     PRIM_ARRAY {
 
         /**
-         * Reads items into the primitive array held by the wrapper, expanding the
-         * array when it becomes full and finally shrinking it to the exact length.
+         * Reads a primitive array object from the provided input source,
+         * dynamically resizing the array during the deserialization process.
+         * <p>
+         * The method starts with an empty array and doubles its size as needed
+         * to accommodate the incoming data. After all items have been read,
+         * the array is resized to fit the number of items that were read.
+         *
+         * @return The PrimArrayWrapper containing the deserialized primitive array.
          */
         @NotNull
         @Override
@@ -794,8 +854,8 @@ public enum SerializationStrategies implements SerializationStrategy {
     }
 
     /**
-     * Temporary holder for arrays during deserialization. {@link #readResolve()}
-     * returns the actual array so callers see only the final result.
+     * A wrapper class for arrays which provides a mechanism for deserialization
+     * by resolving the actual array when being read from a serialized source.
      */
     static class ArrayWrapper implements ReadResolvable<Object[]> {
 
@@ -820,7 +880,10 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * {@inheritDoc}
+         * Provides a deserialization mechanism which returns the actual array
+         * when this wrapper is being read from a serialized source.
+         *
+         * @return The actual array wrapped by this wrapper.
          */
         @NotNull
         @Override
@@ -830,7 +893,12 @@ public enum SerializationStrategies implements SerializationStrategy {
     }
 
     /**
-     * Temporary holder for primitive arrays during deserialization.
+     * The following classes are wrappers that facilitate deserialization processes for
+     * specific types of objects. They implement the ReadResolvable interface to define
+     * the deserialization mechanism.
+     * <p>
+     * A wrapper class for primitive arrays which provides a mechanism for deserialization
+     * by resolving the actual array when being read from a serialized source.
      */
     static class PrimArrayWrapper implements ReadResolvable<Object> {
 
@@ -855,7 +923,10 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * {@inheritDoc}
+         * Provides a deserialization mechanism which returns the actual primitive array
+         * when this wrapper is being read from a serialized source.
+         *
+         * @return The actual primitive array wrapped by this wrapper.
          */
         @NotNull
         @Override
@@ -865,7 +936,8 @@ public enum SerializationStrategies implements SerializationStrategy {
     }
 
     /**
-     * Wrapper used when reading {@link Demarshallable} objects lazily.
+     * A wrapper class for Demarshallable objects which provides a mechanism for deserialization
+     * by resolving the actual Demarshallable object when being read from a serialized source.
      */
     static class DemarshallableWrapper implements ReadResolvable<Demarshallable> {
 
@@ -890,7 +962,10 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * {@inheritDoc}
+         * Provides a deserialization mechanism which returns the actual Demarshallable object
+         * when this wrapper is being read from a serialized source.
+         *
+         * @return The actual Demarshallable object wrapped by this wrapper.
          */
         @NotNull
         @Override

--- a/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
+++ b/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
@@ -48,16 +48,14 @@ import static net.openhft.chronicle.wire.BracketType.UNKNOWN;
 public enum SerializationStrategies implements SerializationStrategy {
 
     /**
-     * A serialization strategy for objects implementing the {@link Marshallable} interface.
-     * This strategy supports both self-describing messages and raw byte data serialization.
+     * Strategy for objects implementing {@link Marshallable}.
+     * Supports both self-describing and raw byte forms.
      */
     MARSHALLABLE {
         /**
-         * Reads an object from the provided input source using a wire format.
-         * The object can be deserialized either as a self-describing message or as raw byte data,
-         * based on its type.
-         *
-         * @return The populated object.
+         * Reads the object either via {@link ReadMarshallable#readMarshallable(WireIn)}
+         * or {@link ReadBytesMarshallable#readMarshallable(Bytes)}. The choice is
+         * governed by {@link WireIn#useSelfDescribingMessage(CommonMarshallable)}.
          */
         @NotNull
         @Override
@@ -83,10 +81,7 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * Creates a new instance of the specified type.
-         * If the type represents an interface or an abstract class, {@code null} is returned.
-         *
-         * @return A new instance of the provided type or {@code null} if the type is an interface or abstract.
+         * Returns {@code null} for interfaces or abstract types.
          */
         @Nullable
         @Override
@@ -96,15 +91,13 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy that supports any object type.
-     * This strategy infers the object type during deserialization.
+     * Handles objects of any type. The actual strategy is chosen at read time
+     * once the type has been inferred from the wire.
      */
     ANY_OBJECT {
         /**
-         * Reads an object from the provided input source, inferring its type.
-         * The type is not explicitly described in the serialized data.
-         *
-         * @return The populated object with its type inferred from the input.
+         * Infers the type from the wire and then delegates to {@link #ANY_NESTED}
+         * or another appropriate strategy.
          */
         @Nullable
         @Override
@@ -136,14 +129,12 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy that supports any scalar value.
-     * Scalar values are typically primitive types or their boxed equivalents.
+     * Handles scalar values such as primitives and boxed types. Scalars are
+     * written without explicit map or list brackets.
      */
     ANY_SCALAR {
         /**
-         * Reads a scalar object from the provided input source, inferring its type.
-         *
-         * @return The populated scalar object with its type inferred from the input.
+         * Reads a scalar value and infers the target type from the wire.
          */
         @Nullable
         @Override
@@ -175,13 +166,11 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy specifically designed for handling enumerations (enums).
+     * Strategy for standard {@link Enum} types. Values are written as their {@code name()}.
      */
     ENUM {
         /**
-         * Reads an enum value from the provided input source, represented as text.
-         *
-         * @return The textual representation of the enum value.
+         * Reads an enum by consuming its textual name.
          */
         @Nullable
         @Override
@@ -213,10 +202,8 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy designed for handling dynamic enumerations (enums).
-     * Dynamic enums are enums whose values can be altered or enhanced at runtime.
-     * This strategy incorporates custom handling to ensure proper deserialization
-     * of dynamic enums from the input source.
+     * Supports dynamic enums whose values may change at run time. Special logic
+     * deals with both simple text forms and map based representations.
      */
     DYNAMIC_ENUM {
 
@@ -224,12 +211,9 @@ public enum SerializationStrategies implements SerializationStrategy {
         private final Field ordinal = Jvm.getField(Enum.class, "ordinal");
 
         /**
-         * Reads a dynamic enum value from the provided input source.
-         * This method accounts for multiple input representations,
-         * such as direct textual names or custom serialized formats
-         * for more complex dynamic enums.
-         *
-         * @return The deserialized dynamic enum object or its textual representation.
+         * Reads a dynamic enum. A plain text name is resolved via {@link EnumCache}.
+         * If {@code o} implements {@link ReadMarshallable} and a map is present,
+         * that map is read into the instance.
          */
         @Nullable
         @Override
@@ -293,19 +277,13 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy designed for handling nested objects.
-     * This strategy reads nested objects without explicitly knowing
-     * their exact type, treating them as generic objects and performing
-     * a generic deserialization.
+     * Deserialises nested objects without knowing the target type. Data is
+     * typically encoded in a map style structure.
      */
     ANY_NESTED {
 
         /**
-         * Reads the nested object from the provided input source.
-         * If the input is null, it returns null. Otherwise, it
-         * deserializes the object and returns the constructed instance.
-         *
-         * @return The deserialized nested object.
+         * Reads a nested object or returns {@code null} if the input is null.
          */
         @Override
         public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -341,18 +319,15 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy specifically designed for handling
-     * {@link Demarshallable} objects. {@link Demarshallable} represents
-     * an object that can be deserialized from a wire format.
+     * Handles {@link Demarshallable} objects. A wrapper may be used during
+     * reading to defer construction until {@link #readUsing} is invoked.
      */
     DEMARSHALLABLE {
 
         /**
-         * Reads the {@link Demarshallable} object from the provided input source.
-         * This method has logic to handle multiple formats of input including
-         * wrapped objects and direct serialized formats.
-         *
-         * @return The deserialized {@link Demarshallable} object or wrapper.
+         * Reads a {@link Demarshallable}. If {@code using} is a
+         * {@link DemarshallableWrapper}, a new instance is created and stored in
+         * the wrapper. Otherwise the existing object is populated.
          */
         @NotNull
         @Override
@@ -380,9 +355,8 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * Constructs a new instance of a {@link Demarshallable} wrapped in a {@link DemarshallableWrapper}.
-         *
-         * @return The constructed {@link DemarshallableWrapper}.
+         * Returns a {@link DemarshallableWrapper} used as a temporary holder
+         * until the real object is read.
          */
         @NotNull
         @Override
@@ -392,20 +366,15 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling objects that implement the
-     * {@link java.io.Serializable} interface. This strategy checks if the object
-     * is also an instance of {@link Externalizable}, and if so, uses the
-     * {@link #EXTERNALIZABLE} strategy. Otherwise, it defaults to the
-     * {@link #ANY_OBJECT} strategy.
+     * Handles {@link Serializable} objects. If an instance is also
+     * {@link Externalizable} its own read logic is used, otherwise the data is
+     * read via {@link #ANY_OBJECT}.
      */
     SERIALIZABLE {
 
         /**
-         * Reads the {@link Serializable} object from the provided input source.
-         * Delegates the deserialization to the appropriate strategy based on
-         * whether the object is an instance of {@link Externalizable}.
-         *
-         * @return The deserialized {@link Serializable} object.
+         * Delegates to {@link #EXTERNALIZABLE} when required, otherwise to
+         * {@link #ANY_OBJECT}.
          */
         @Override
         public Object readUsing(Class clazz, Object o, ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -428,17 +397,14 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy specifically designed for handling
-     * {@link Externalizable} objects. Externalizable objects provide their
-     * own custom serialization mechanism that this strategy leverages.
+     * Handles {@link Externalizable} objects and calls their
+     * {@link java.io.Externalizable#readExternal(java.io.ObjectInput)} method.
      */
     EXTERNALIZABLE {
 
         /**
-         * Reads the {@link Externalizable} object from the provided input source
-         * using the object's custom serialization logic.
-         *
-         * @return The deserialized {@link Externalizable} object.
+         * Delegates to {@link java.io.Externalizable#readExternal(java.io.ObjectInput)}
+         * using an {@link java.io.ObjectInput} facade over the wire.
          */
         @NotNull
         @Override
@@ -476,17 +442,13 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling objects that implement the
-     * {@link java.util.Map} interface. This strategy deserializes a sequence
-     * of key-value pairs into a Map instance.
+     * Reads key value pairs into a {@link Map}.
      */
     MAP {
 
         /**
-         * Reads the {@link Map} object from the provided input source, mapping
-         * each key-value pair in the sequence.
-         *
-         * @return The deserialized {@link Map} object.
+         * Consumes key value pairs until no more entries remain in the current
+         * map context.
          */
         @Override
         public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -536,17 +498,13 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling objects that implement the
-     * {@link java.util.Set} interface. This strategy deserializes a sequence
-     * of items into a Set instance.
+     * Reads a sequence of items into a {@link Set} implementation.
      */
     SET {
 
         /**
-         * Reads the {@link Set} object from the provided input source, adding
-         * each item in the sequence to the set.
-         *
-         * @return The deserialized {@link Set} object.
+         * Consumes items from the wire and adds them to the given set, creating
+         * one if necessary.
          */
         @Override
         public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -603,17 +561,13 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling objects that implement the
-     * {@link java.util.List} interface. This strategy deserializes a sequence
-     * of items into a List instance.
+     * Reads a sequence of items into a {@link List} implementation.
      */
     LIST {
 
         /**
-         * Reads the {@link List} object from the provided input source, adding
-         * each item in the sequence to the list.
-         *
-         * @return The deserialized {@link List} object.
+         * Populates the supplied list. Existing entries are reused where
+         * possible; surplus entries are removed.
          */
         @Override
         public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -675,21 +629,14 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling arrays. This strategy deserializes
-     * a sequence of items into an array instance.
+     * Reads a sequence of items into an array. Uses {@link ArrayWrapper} when
+     * the target type is known at construction time.
      */
     ARRAY {
 
         /**
-         * Reads an array object from the provided input source, adding each
-         * item in the sequence to a list, which is then converted into an array.
-         * <p>
-         * If the 'using' parameter is an instance of ArrayWrapper, the method
-         * first deserializes items into a list and then wraps them into an array
-         * with the correct component type. Otherwise, it deserializes items into
-         * a list and then converts that list into an array.
-         *
-         * @return The deserialized array or an ArrayWrapper containing the array.
+         * Collects items into a list and then converts that list to an array or
+         * populates the supplied {@link ArrayWrapper}.
          */
         @NotNull
         @Override
@@ -747,21 +694,14 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling primitive arrays. This strategy
-     * deserializes a sequence of items into an array instance, dynamically
-     * resizing the array as required during deserialization.
+     * Reads primitive arrays using a {@link PrimArrayWrapper}. The array grows
+     * as items are read and is trimmed to size when complete.
      */
     PRIM_ARRAY {
 
         /**
-         * Reads a primitive array object from the provided input source,
-         * dynamically resizing the array during the deserialization process.
-         * <p>
-         * The method starts with an empty array and doubles its size as needed
-         * to accommodate the incoming data. After all items have been read,
-         * the array is resized to fit the number of items that were read.
-         *
-         * @return The PrimArrayWrapper containing the deserialized primitive array.
+         * Reads items into the primitive array held by the wrapper, expanding the
+         * array when it becomes full and finally shrinking it to the exact length.
          */
         @NotNull
         @Override
@@ -854,8 +794,8 @@ public enum SerializationStrategies implements SerializationStrategy {
     }
 
     /**
-     * A wrapper class for arrays which provides a mechanism for deserialization
-     * by resolving the actual array when being read from a serialized source.
+     * Temporary holder for arrays during deserialization. {@link #readResolve()}
+     * returns the actual array so callers see only the final result.
      */
     static class ArrayWrapper implements ReadResolvable<Object[]> {
 
@@ -880,10 +820,7 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * Provides a deserialization mechanism which returns the actual array
-         * when this wrapper is being read from a serialized source.
-         *
-         * @return The actual array wrapped by this wrapper.
+         * {@inheritDoc}
          */
         @NotNull
         @Override
@@ -893,12 +830,7 @@ public enum SerializationStrategies implements SerializationStrategy {
     }
 
     /**
-     * The following classes are wrappers that facilitate deserialization processes for
-     * specific types of objects. They implement the ReadResolvable interface to define
-     * the deserialization mechanism.
-     * <p>
-     * A wrapper class for primitive arrays which provides a mechanism for deserialization
-     * by resolving the actual array when being read from a serialized source.
+     * Temporary holder for primitive arrays during deserialization.
      */
     static class PrimArrayWrapper implements ReadResolvable<Object> {
 
@@ -923,10 +855,7 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * Provides a deserialization mechanism which returns the actual primitive array
-         * when this wrapper is being read from a serialized source.
-         *
-         * @return The actual primitive array wrapped by this wrapper.
+         * {@inheritDoc}
          */
         @NotNull
         @Override
@@ -936,8 +865,7 @@ public enum SerializationStrategies implements SerializationStrategy {
     }
 
     /**
-     * A wrapper class for Demarshallable objects which provides a mechanism for deserialization
-     * by resolving the actual Demarshallable object when being read from a serialized source.
+     * Wrapper used when reading {@link Demarshallable} objects lazily.
      */
     static class DemarshallableWrapper implements ReadResolvable<Demarshallable> {
 
@@ -962,10 +890,7 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * Provides a deserialization mechanism which returns the actual Demarshallable object
-         * when this wrapper is being read from a serialized source.
-         *
-         * @return The actual Demarshallable object wrapped by this wrapper.
+         * {@inheritDoc}
          */
         @NotNull
         @Override

--- a/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
+++ b/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
@@ -221,7 +221,7 @@ public enum SerializationStrategies implements SerializationStrategy {
     DYNAMIC_ENUM {
 
         // Reflective field access to the ordinal of the Enum class
-        private Field ordinal = Jvm.getField(Enum.class, "ordinal");
+        private final Field ordinal = Jvm.getField(Enum.class, "ordinal");
 
         /**
          * Reads a dynamic enum value from the provided input source.

--- a/src/main/java/net/openhft/chronicle/wire/SerializationStrategy.java
+++ b/src/main/java/net/openhft/chronicle/wire/SerializationStrategy.java
@@ -33,15 +33,14 @@ import org.jetbrains.annotations.Nullable;
 public interface SerializationStrategy {
 
     /**
-     * Reads an object of type {@code T} from the supplied input.
+     * Reads an object of type {@code T} from the provided input source and populates
+     * the given 'using' object, if not null. The method uses the given {@link BracketType}
+     * to aid in the deserialization.
      *
      * @param clazz       expected class of the object, or {@code null} to infer
      *                    from the wire or {@code using} instance
-     * @param using       optional instance to populate; if {@code null} this
-     *                    method may call {@link #newInstanceOrNull(Class)}. If
-     *                    that also returns {@code null} the strategy decides
-     *                    whether to return {@code null} or throw
-     *                    {@link InvalidMarshallableException}
+     * @param using       An optional object of type {@code T} that can be populated with the read data.
+     *      *              If null, a new object will be created or an exception might be thrown depending on implementation.
      * @param in          source of the wire data
      * @param bracketType hint about the expected structure such as map, sequence
      *                    or none
@@ -53,11 +52,12 @@ public interface SerializationStrategy {
     <T> T readUsing(Class<?> clazz, T using, ValueIn in, BracketType bracketType) throws InvalidMarshallableException;
 
     /**
-     * Attempts to create a new instance of the given type.
-     * Called when {@link #readUsing} needs an object but none was supplied.
+     * Constructs and returns a new instance of the provided {@code type}
+     * as a reference. If the instance cannot be constructed for any reason,
+     * {@code null} is returned.
      *
-     * @param type class of object to be created
-     * @return newly created instance or {@code null} if construction failed
+     * @param type The class type for which a new instance is required.
+     * @return A new instance of the provided {@code type} or {@code null} if instantiation is not possible.
      */
     @Nullable
     <T> T newInstanceOrNull(Class<T> type);
@@ -70,12 +70,10 @@ public interface SerializationStrategy {
     Class<?> type();
 
     /**
-     * The bracket type expected in the wire representation.
-     * For example {@link BracketType#MAP} for key-value pairs,
-     * {@link BracketType#SEQ} for sequences or {@link BracketType#NONE} for
-     * scalar values.
+     * Provides the bracket type used in the serialized format, which might
+     * give hints or constraints on how the data is structured.
      *
-     * @return the {@link BracketType} used by this strategy
+     * @return the {@link BracketType} used by this serialization strategy.
      */
     @NotNull
     BracketType bracketType();

--- a/src/main/java/net/openhft/chronicle/wire/SerializationStrategy.java
+++ b/src/main/java/net/openhft/chronicle/wire/SerializationStrategy.java
@@ -22,51 +22,60 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Represents a strategy for serializing and deserializing objects of type {@code T}.
- * Implementations of this interface define methods for reading, instantiating,
- * and providing metadata about the serialized format.
+ * Strategy for serialising and deserialising objects of type {@code T}.
+ * Implementations read data from a {@link ValueIn}, create instances as
+ * required and describe the wire format used. A strategy usually targets a
+ * particular Java type or category such as enums, {@link Marshallable}
+ * objects or collections. It dictates how objects are converted to and from a
+ * wire representation. See {@link SerializationStrategies} for the common
+ * built-in strategies.
  */
 public interface SerializationStrategy {
 
     /**
-     * Reads an object of type {@code T} from the provided input source and populates
-     * the given 'using' object, if not null. The method uses the given {@link BracketType}
-     * to aid in the deserialization.
+     * Reads an object of type {@code T} from the supplied input.
      *
-     * @param clazz The class type to be deserialized.
-     * @param using An optional object of type {@code T} that can be populated with the read data.
-     *              If null, a new object will be created or an exception might be thrown depending on implementation.
-     * @param in The input source containing serialized data.
-     * @param bracketType The type of bracket used in the serialized format.
-     * @return The populated or newly created object of type {@code T}.
-     * @throws InvalidMarshallableException If an error occurs during the deserialization process.
+     * @param clazz       expected class of the object, or {@code null} to infer
+     *                    from the wire or {@code using} instance
+     * @param using       optional instance to populate; if {@code null} this
+     *                    method may call {@link #newInstanceOrNull(Class)}. If
+     *                    that also returns {@code null} the strategy decides
+     *                    whether to return {@code null} or throw
+     *                    {@link InvalidMarshallableException}
+     * @param in          source of the wire data
+     * @param bracketType hint about the expected structure such as map, sequence
+     *                    or none
+     * @return the populated or newly created object, or {@code null} if no
+     * instance could be obtained
+     * @throws InvalidMarshallableException if the deserialisation fails
      */
     @Nullable
     <T> T readUsing(Class<?> clazz, T using, ValueIn in, BracketType bracketType) throws InvalidMarshallableException;
 
     /**
-     * Constructs and returns a new instance of the provided {@code type}
-     * as a reference. If the instance cannot be constructed for any reason,
-     * {@code null} is returned.
+     * Attempts to create a new instance of the given type.
+     * Called when {@link #readUsing} needs an object but none was supplied.
      *
-     * @param type The class type for which a new instance is required.
-     * @return A new instance of the provided {@code type} or {@code null} if instantiation is not possible.
+     * @param type class of object to be created
+     * @return newly created instance or {@code null} if construction failed
      */
     @Nullable
     <T> T newInstanceOrNull(Class<T> type);
 
     /**
-     * Returns the class type of objects this serialization strategy is designed to handle.
-     *
-     * @return The class type of objects this strategy can serialize and deserialize.
+     * Returns the primary Java {@link Class} that this strategy deals with.
+     * It may be a concrete type, an interface or a broad category such as
+     * {@code java.lang.Enum}.
      */
     Class<?> type();
 
     /**
-     * Provides the bracket type used in the serialized format, which might
-     * give hints or constraints on how the data is structured.
+     * The bracket type expected in the wire representation.
+     * For example {@link BracketType#MAP} for key-value pairs,
+     * {@link BracketType#SEQ} for sequences or {@link BracketType#NONE} for
+     * scalar values.
      *
-     * @return the {@link BracketType} used by this serialization strategy.
+     * @return the {@link BracketType} used by this strategy
      */
     @NotNull
     BracketType bracketType();

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -137,11 +137,12 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Creates a marshaller for the given type.
-     * Synthetic fields introduced by later Java versions are filtered out.
+     * Factory method to create an instance of the WireMarshaller for a specific class type.
+     * Determines the appropriate marshaller type (basic or one that handles unexpected fields)
+     * based on the characteristics of the provided class.
      *
-     * @param tClass the type to marshall
-     * @return marshaller instance for {@code tClass}
+     * @param tClass The class type for which the marshaller is to be created.
+     * @return A new instance of WireMarshaller for the provided class type.
      */
     @NotNull
     public static <T> WireMarshaller<T> of(@NotNull Class<T> tClass) {
@@ -171,11 +172,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Determines if the field type can be treated as a leaf during serialisation.
-     * Collections and non-dynamic-enum {@link WriteMarshallable} types are not leaves.
+     * Checks if the provided field accessor corresponds to a "leaf" entity.
+     * An entity is considered a leaf if it doesn't need to be further broken down in the serialization process.
      *
-     * @param c accessor for the field
-     * @return true if the field can be treated as a leaf
+     * @param c The field accessor to be checked.
+     * @return {@code true} if the field accessor is leafable, {@code false} otherwise.
      */
     protected static boolean leafable(FieldAccess c) {
         Class<?> type = c.field.getType();
@@ -203,11 +204,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Factory for {@link Throwable} subclasses.
-     * Includes fields needed to serialise exception state.
+     * Factory method to create an instance of the WireMarshaller for a Throwable class type.
+     * The method identifies fields that should be marshalled and prepares the marshaller accordingly.
      *
-     * @param tClass exception type
-     * @return marshaller for the throwable
+     * @param tClass The Throwable class type for which the marshaller is to be created.
+     * @return A new instance of WireMarshaller for the provided Throwable class type.
      */
     @NotNull
     private static <T> WireMarshaller<T> ofThrowable(@NotNull Class<T> tClass) {
@@ -222,11 +223,10 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Utility to check whether the class represents an array, a
-     * {@link Collection} or a {@link Map}.
+     * Determines if the provided class is a collection type, including arrays, standard Collections, or Maps.
      *
-     * @param c class to test
-     * @return true if it is a collection type
+     * @param c The class to be checked.
+     * @return {@code true} if the class is a collection type, {@code false} otherwise.
      */
     private static boolean isCollection(@NotNull Class<?> c) {
         return c.isArray() ||
@@ -235,14 +235,12 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Recursively collects all non-static and non-transient fields from
-     * {@code clazz} and its parents until {@link Object} or
-     * {@link AbstractCommonMarshallable}. The map is keyed by field name.
-     * Skips values such as {@code ordinal} on enums and inner-class synthetic
-     * links.
+     * Recursively fetches all non-static, non-transient fields from the provided class and its superclasses,
+     * up to but not including Object or AbstractCommonMarshallable, and adds them to the provided map.
+     * Fields that are flagged for exclusion (e.g., the "ordinal" field for Enum types) are skipped.
      *
-     * @param clazz class to inspect
-     * @param map   destination for discovered fields
+     * @param clazz The class type from which fields are to be extracted.
+     * @param map   The map to populate with field names and their corresponding Field objects.
      */
     public static void getAllField(@NotNull Class<?> clazz, @NotNull Map<String, Field> map) {
         if (clazz != Object.class && clazz != AbstractCommonMarshallable.class)
@@ -295,7 +293,15 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Lexicographical comparison used by {@link #fieldMap}.
+     * Compares two CharSequences lexicographically. This is a character-by-character comparison
+     * that returns the difference of the first unmatched characters or the difference in their lengths
+     * if one sequence is a prefix of the other.
+     *
+     * @param cs0 The first CharSequence to be compared.
+     * @param cs1 The second CharSequence to be compared.
+     * @return A positive integer if {@code cs0} comes after {@code cs1},
+     *         a negative integer if {@code cs0} comes before {@code cs1},
+     *         or zero if the sequences are equal.
      */
     private static int compare(CharSequence cs0, CharSequence cs1) {
         for (int i = 0, len = Math.min(cs0.length(), cs1.length()); i < len; i++) {
@@ -307,8 +313,12 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Helper used by reflection code to resolve the actual generic arguments for
-     * {@code field} relative to {@code iface}.
+     * Computes the actual type arguments for a given field of an interface. This method determines
+     * the generic type arguments that the field uses based on the interface's type parameters.
+     *
+     * @param iface The interface containing the field.
+     * @param field The field whose type arguments need to be determined.
+     * @return An array of actual type arguments or the interface's type parameters if no actual arguments can be deduced.
      */
     private static Type[] computeActualTypeArguments(Class<?> iface, Field field) {
         Type[] actual = consumeActualTypeArguments(new HashMap<>(), iface, field.getGenericType());
@@ -320,8 +330,19 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Recursive helper for {@link #computeActualTypeArguments(Class, Field)}.
-     * Walks the type hierarchy to map parameter names to concrete classes.
+     * Determines the actual type arguments used by a class or interface for a given interface type.
+     * This method recursively inspects the type hierarchy to match type arguments against the
+     * interface's type parameters. It uses a previously built map of type parameter names to their
+     * actual types to deduce the correct arguments for the given interface.
+     *
+     * @param prevTypeParameters A map containing previously discovered type parameter names
+     *                           mapped to their actual types.
+     * @param iface              The interface for which we want to determine the type arguments.
+     * @param type               The type to inspect. This could be an actual class, interface, or
+     *                           a parameterized type that uses generic arguments.
+     *
+     * @return An array of actual type arguments used by the provided type for the specified interface,
+     *         or null if the type doesn't directly or indirectly implement or extend the given interface.
      */
     private static Type[] consumeActualTypeArguments(Map<String, Type> prevTypeParameters, Class<?> iface, Type type) {
         Class<?> cls = null;
@@ -393,8 +414,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Returns a marshaller that omits the named fields.
-     * Useful when only a subset of a DTO should be serialised.
+     * Excludes specified fields from the current marshaller and returns a new instance of the marshaller
+     * with the remaining fields.
+     *
+     * @param fieldNames Names of the fields to be excluded.
+     * @return A new instance of the {@link WireMarshaller} with the specified fields excluded.
      */
     public WireMarshaller<T> excludeFields(String... fieldNames) {
         Set<String> fieldSet = new HashSet<>(Arrays.asList(fieldNames));
@@ -405,8 +429,13 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Serialises {@code t} to {@code out} in field order. Hex dump indentation
-     * is adjusted for readability.
+     * Writes the marshallable representation of the given object to the provided {@link WireOut} destination.
+     * This will traverse the fields and use their respective {@link FieldAccess} to write each field.
+     * The method also adjusts the hex dump indentation for better readability in the output.
+     *
+     * @param t   The object to write.
+     * @param out The destination {@link WireOut} where the object representation will be written.
+     * @throws InvalidMarshallableException If the object fails validation checks before serialization.
      */
     public void writeMarshallable(T t, @NotNull WireOut out) throws InvalidMarshallableException {
         ValidatableUtil.validate(t);
@@ -422,8 +451,12 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Serialises {@code t} directly to the given byte store using raw field
-     * access.
+     * Writes the marshallable representation of the given object to the provided {@link Bytes} destination.
+     * Unlike the previous method, this doesn't adjust the hex dump indentation. It's a more direct
+     * serialization of the fields to bytes.
+     *
+     * @param t     The object to write.
+     * @param bytes The destination {@link Bytes} where the object representation will be written.
      */
     public void writeMarshallable(T t, Bytes<?> bytes) {
         for (@NotNull FieldAccess field : fields) {
@@ -436,8 +469,14 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Serialises {@code t} to {@code out}, optionally copying written values
-     * into the stored default instance.
+     * Writes the values of the fields from the provided object (DTO) to the output. Before writing,
+     * the object is validated. The method also supports optional copying of the values
+     * from the source object to a previous instance.
+     *
+     * @param t    Object whose field values are to be written.
+     * @param out  Output destination where the field values are written to.
+     * @param copy Flag indicating whether to copy values from the source object to the previous object.
+     * @throws InvalidMarshallableException If there's an error during marshalling.
      */
     public void writeMarshallable(T t, @NotNull WireOut out, boolean copy) throws InvalidMarshallableException {
         // Validate the object before writing
@@ -453,8 +492,13 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Deserialises from {@code in} into {@code t}. When {@code overwrite} is
-     * true missing fields are reset from {@link #defaultValue}.
+     * Reads and populates the DTO based on the provided input. The input order can be hinted.
+     * After reading, the object is validated.
+     *
+     * @param t         Object to populate with read values.
+     * @param in        Input source from which values are read.
+     * @param overwrite Flag indicating whether to overwrite the existing value in the target object.
+     * @throws InvalidMarshallableException If there is an error during marshalling.
      */
     public void readMarshallable(T t, @NotNull WireIn in, boolean overwrite) throws InvalidMarshallableException {
         // Choose the reading method based on the hint
@@ -468,8 +512,12 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Deserialises fields in declared order from {@code in}.
-     * Fields not present are optionally taken from {@link #defaultValue}.
+     * Reads and populates the DTO based on the provided order.
+     *
+     * @param t         Target object to populate with read values.
+     * @param in        Input source from which values are read.
+     * @param overwrite Flag indicating whether to overwrite the existing value in the target object.
+     * @throws InvalidMarshallableException If there is an error during marshalling.
      */
     public void readMarshallableDTOOrder(T t, @NotNull WireIn in, boolean overwrite) throws InvalidMarshallableException {
         try {
@@ -484,9 +532,12 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Reads fields in the order they appear on the wire. Any DTO fields not
-     * encountered are optionally restored from {@link #defaultValue} once all
-     * input has been processed.
+     * Reads and populates the DTO based on the input's order.
+     *
+     * @param t         Target object to populate with read values.
+     * @param in        Input source from which values are read.
+     * @param overwrite Flag indicating whether to overwrite the existing value in the target object.
+     * @throws InvalidMarshallableException If there is an error during marshalling.
      */
     public void readMarshallableInputOrder(T t, @NotNull WireIn in, boolean overwrite) throws InvalidMarshallableException {
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
@@ -531,14 +582,23 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Case-insensitive field name check. An empty builder matches any field.
+     * Checks if the given field name (represented by a StringBuilder) matches the field name of the provided {@link FieldAccess}.
+     * If the StringBuilder has a length of 0, it's assumed to match any field name.
+     *
+     * @param sb    The StringBuilder containing the field name to be checked.
+     * @param field The {@link FieldAccess} whose field name needs to be matched against.
+     * @return True if the field name matches or if the StringBuilder is empty; False otherwise.
      */
     public boolean matchesFieldName(StringBuilder sb, FieldAccess field) {
         return sb.length() == 0 || StringUtils.equalsCaseIgnore(field.field.getName(), sb);
     }
 
     /**
-     * Writes the first field of {@code t} as a key to {@code bytes}.
+     * Writes the key representation of the given object to the provided {@link Bytes} destination.
+     * As per the assumption, only the first field (key) of the object is written.
+     *
+     * @param t     The object whose key needs to be written.
+     * @param bytes The destination {@link Bytes} where the object's key representation will be written.
      */
     public void writeKey(T t, Bytes<?> bytes) {
         // assume one key for now.
@@ -577,7 +637,13 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Returns the named field value as a long, applying conversions when needed.
+     * Retrieves the value of a specified field from the provided object and converts it to a long.
+     * If the field's type is not inherently long or int, it attempts a conversion using the ObjectUtils class.
+     *
+     * @param o    The object from which the field value is to be retrieved.
+     * @param name The name of the field whose value needs to be fetched.
+     * @return The long value of the specified field.
+     * @throws NoSuchFieldException If no field with the specified name is found in the object.
      */
     public long getLongField(@NotNull Object o, String name) throws NoSuchFieldException {
         try {
@@ -598,7 +664,13 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Writes {@code value} into the named field, performing type conversion when required.
+     * Sets the value of a specified field in the provided object.
+     * If the type of the value does not directly match the field's type, it attempts a conversion using the ObjectUtils class.
+     *
+     * @param o     The object in which the field's value needs to be set.
+     * @param name  The name of the field whose value needs to be set.
+     * @param value The value to set to the field.
+     * @throws NoSuchFieldException If no field with the specified name is found in the object.
      */
     public void setField(Object o, String name, Object value) throws NoSuchFieldException {
         try {
@@ -614,7 +686,13 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Convenience for writing a long value via {@link FieldAccess}.
+     * Sets a long value to a specified field in the provided object.
+     * If the field's type is not inherently long or int, it attempts a conversion using the ObjectUtils class.
+     *
+     * @param o     The object in which the field's value needs to be set.
+     * @param name  The name of the field whose value needs to be set.
+     * @param value The long value to set to the field.
+     * @throws NoSuchFieldException If no field with the specified name is found in the object.
      */
     public void setLongField(Object o, String name, long value) throws NoSuchFieldException {
         try {
@@ -644,7 +722,9 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Copies values from {@link #defaultValue} into {@code o}.
+     * Resets the fields of the given object 'o' to the default value.
+     *
+     * @param o The object whose fields are to be reset to the default value.
      */
     public void reset(T o) {
         try {
@@ -664,8 +744,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for values annotated with {@link LongConversion}.
-     * Converts between the numeric value stored in the object and its text representation.
+     * Provides a field accessor that's specialized for handling fields which require
+     * conversion between integer values and string representations using a LongConverter.
      */
     static class LongConverterFieldAccess extends FieldAccess {
 
@@ -703,11 +783,11 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Writes the long value using {@link LongConverter} when text is required.
+         * Reads the long value from an object and writes it using the provided ValueOut writer.
          *
-         * @param o        source object
-         * @param write    destination
-         * @param previous ignored previous value
+         * @param o        The source object.
+         * @param write    The writer for output.
+         * @param previous The previous value (currently not used).
          */
         @Override
         protected void getValue(Object o, @NotNull ValueOut write, @Nullable Object previous) {
@@ -834,8 +914,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Base class that performs low level field access for marshalling.
-     * Implementations specialise the handling for the field's type.
+     * Abstract class to manage access to fields of objects.
+     * This class provides utility methods to read and write fields from/to objects.
      */
     abstract static class FieldAccess {
         @NotNull
@@ -848,19 +928,19 @@ public class WireMarshaller<T> {
         Boolean isLeaf;
 
         /**
-         * Creates an accessor for {@code field}.
+         * Constructor initializing field with given value.
          *
-         * @param field the field being accessed
+         * @param field Field to be accessed.
          */
         FieldAccess(@NotNull Field field) {
             this(field, null);
         }
 
         /**
-         * Creates an accessor for {@code field}.
+         * Constructor initializing field and isLeaf with given values.
          *
-         * @param field  the field being accessed
-         * @param isLeaf whether this field should be treated as a leaf. {@code null} for auto-detect
+         * @param field  Field to be accessed.
+         * @param isLeaf Flag to indicate whether the field is a leaf node.
          */
         FieldAccess(@NotNull Field field, Boolean isLeaf) {
             this.field = field;
@@ -878,13 +958,10 @@ public class WireMarshaller<T> {
         // ... (code continues)
 
         /**
-         * Builds a {@link FieldAccess} suited to {@code field}'s type.
-         * Handles primitives, strings, collections, maps, enum sets and fields
-         * annotated with {@link LongConversion}.
+         * Create a specific FieldAccess object based on the field type.
          *
-         * @param field         field to create an accessor for
-         * @param defaultObject optional default instance used for Resettable fields
-         * @return an accessor for the given field
+         * @param field Field for which FieldAccess object is created.
+         * @return FieldAccess object specific to the field type.
          */
         @Nullable
         public static Object create(@NotNull Field field, @Nullable Object defaultObject) {
@@ -983,11 +1060,13 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Helper to obtain a {@link LongConverter} for {@code field} when annotated
-         * with {@link LongConversion}.
-         *
-         * @param field field being inspected
-         * @return converter instance or {@code null} if not annotated
+         * Acquires a LongConverter instance associated with a given field, if available.
+         * <p>
+         * This method checks if the provided field has a LongConversion annotation. If present,
+         * it retrieves the corresponding LongConverter using the LongConverterFieldAccess helper class.
+                 *
+         * @param field The field for which the LongConverter needs to be obtained
+         * @return The associated LongConverter instance, or null if not present
          */
         @Nullable
         private static LongConverter acquireLongConverter(@NotNull Field field) {
@@ -999,11 +1078,13 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Returns the raw {@link Class} for the supplied {@link Type}.
-         * Handles {@link ParameterizedType} by returning its raw type.
-         *
-         * @param type0 input type
-         * @return resolved class or {@link Object} if unknown
+         * Extracts the raw Class type from a given Type object.
+         * <p>
+         * This method aims to handle various Type representations, like Class or ParameterizedType,
+         * and return the underlying Class representation.
+                 *
+         * @param type0 The type from which the class should be extracted
+         * @return The extracted Class representation
          */
         @NotNull
         static Class<?> extractClass(Type type0) {
@@ -1025,13 +1106,16 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Writes this field from {@code o} to {@code out}.
-         * If a {@link Comment} annotation is present the comment is emitted after the value.
-         *
-         * @param o   source object
-         * @param out target wire
-         * @throws IllegalAccessException        if field access fails
-         * @throws InvalidMarshallableException  if a value cannot be marshalled
+         * Writes the value of a given object's field to a provided WireOut instance.
+         * <p>
+         * This method serializes the value of the specified object's field and writes it to
+         * the WireOut. If the field has a Comment annotation, a special processing is done
+         * using the CommentAnnotationNotifier.
+                 *
+         * @param o    The object containing the field to be written
+         * @param out  The WireOut instance to write the field value to
+         * @throws IllegalAccessException If the field cannot be accessed
+         * @throws InvalidMarshallableException If the object cannot be marshalled
          */
         void write(Object o, @NotNull WireOut out) throws IllegalAccessException, InvalidMarshallableException {
 
@@ -1047,13 +1131,17 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Writes the field value followed by its {@link Comment} text.
-         *
-         * @param o        source object
-         * @param out      target wire
-         * @param valueOut {@code out} wrapper for the value
-         * @throws IllegalAccessException       if reflection fails
-         * @throws InvalidMarshallableException if marshalling fails
+         * Retrieves the value of the provided object's field and writes it to the provided WireOut instance,
+         * appending a comment based on the associated Comment annotation.
+         * <p>
+         * If the field has a Comment annotation, its value is formatted using the field's value and appended as a comment.
+         * The CommentAnnotationNotifier is used to indicate that the written value is preceded by a comment.
+                 *
+         * @param o         The object containing the field whose value needs to be retrieved
+         * @param out       The WireOut instance to which the value and the comment are written
+         * @param valueOut  The ValueOut instance representing the field's value
+         * @throws IllegalAccessException If the field cannot be accessed
+         * @throws InvalidMarshallableException If the object cannot be marshalled
          */
         private void getValueCommentAnnotated(Object o, @NotNull WireOut out, ValueOut valueOut) throws IllegalAccessException, InvalidMarshallableException {
             CommentAnnotationNotifier notifier = (CommentAnnotationNotifier) valueOut;
@@ -1092,12 +1180,12 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Tests whether this field holds equal values in {@code o} and {@code o2}.
+         * Check if the values of a field in two objects are the same.
          *
-         * @param o  first object
-         * @param o2 second object
-         * @return {@code true} if the values are equal
-         * @throws IllegalAccessException if reflection fails
+         * @param o  First object.
+         * @param o2 Second object.
+         * @return true if values are the same, false otherwise.
+         * @throws IllegalAccessException If unable to access the field.
          */
         protected boolean sameValue(Object o, Object o2) throws IllegalAccessException {
             final Object v1 = field.get(o);
@@ -1108,11 +1196,11 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Copies this field from {@code from} to {@code to}.
+         * Copies the value of a field from one object to another.
          *
-         * @param from source object
-         * @param to   destination object
-         * @throws IllegalAccessException if reflection fails
+         * @param from Source object.
+         * @param to   Destination object.
+         * @throws IllegalAccessException If unable to access the field.
          */
         protected void copy(Object from, Object to) throws IllegalAccessException {
             ObjectUtils.requireNonNull(from);
@@ -1122,14 +1210,13 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Writes this field from {@code o} to {@code write}.
-         * Implementations may use {@code previous} for delta encoding.
+         * Abstract method to get the value of a field from an object.
          *
-         * @param o        source object
-         * @param write    destination
-         * @param previous previous state or {@code null}
-         * @throws IllegalAccessException       if reflection fails
-         * @throws InvalidMarshallableException on marshalling error
+         * @param o        Object from which to get the value.
+         * @param write    Output destination.
+         * @param previous Previous object for comparison.
+         * @throws IllegalAccessException       If unable to access the field.
+         * @throws InvalidMarshallableException If marshalling fails.
          */
         protected abstract void getValue(Object o, ValueOut write, Object previous) throws IllegalAccessException, InvalidMarshallableException;
 
@@ -1167,32 +1254,33 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Reads this field from {@code read} and updates {@code o}.
+         * Abstract method to set the value of a field in an object.
          *
-         * @param o         target object
-         * @param read      wire input
-         * @param overwrite if false a missing value leaves the field unchanged
-         * @throws IllegalAccessException if reflection fails
+         * @param o         Object to set the value in.
+         * @param read      Input source.
+         * @param overwrite Whether to overwrite existing value.
+         * @throws IllegalAccessException If unable to access the field.
          */
         protected abstract void setValue(Object o, ValueIn read, boolean overwrite) throws IllegalAccessException;
 
         /**
-         * Resets this field on {@code o} using the value from {@code defaultObject}.
-         * Existing objects are reused where possible to avoid allocation.
+         * Abstract method to reset the value of a field in an object to default value.
+         * The default value is the one present in objects of that class after no-argument constructor.
+         * Where possible, existing data structures should be preserved without reallocation to avoid garbage.
          *
-         * @param defaultObject reference instance containing default values
-         * @param o             target object
+         * @param defaultObject A reference unmodified instance of this class.
+         * @param o             Object to reset the value in.
          */
         protected void setDefaultValue(Object defaultObject, Object o) throws IllegalAccessException {
             copy(defaultObject, o);
         }
 
         /**
-         * Writes the value of this field to {@code bytes} in binary form.
+         * Abstract method to convert the value of a field in an object to bytes.
          *
-         * @param o     source object
-         * @param bytes destination buffer
-         * @throws IllegalAccessException if reflection fails
+         * @param o     Object containing the field.
+         * @param bytes Destination to write the bytes to.
+         * @throws IllegalAccessException If unable to access the field.
          */
         public abstract void getAsBytes(Object o, Bytes<?> bytes) throws IllegalAccessException;
 
@@ -1213,7 +1301,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@link IntValue} references.
+     * This is a specialized FieldAccess implementation for fields of type IntValue.
+     * It provides implementations for reading and writing the IntValue from and to various sources.
      */
     static class IntValueAccess extends FieldAccess {
 
@@ -1250,7 +1339,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@link LongValue} references.
+     * This is a specialized FieldAccess implementation for fields of type LongValue.
+     * It provides implementations for reading and writing the LongValue from and to various sources.
      */
     static class LongValueAccess extends FieldAccess {
 
@@ -1287,7 +1377,9 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for arbitrary object references. Supports {@link AsMarshallable}.
+     * This is a specialized FieldAccess implementation for generic object fields.
+     * It provides methods for reading and writing object fields from and to various sources,
+     * taking into account special cases where the field may be marshaled differently based on annotations.
      */
     static class ObjectFieldAccess extends FieldAccess {
         private final Class<?> type; // Type of the object field
@@ -1573,7 +1665,12 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for array fields.
+     * The ArrayFieldAccess class extends FieldAccess to provide specialized access
+     * and manipulation methods for fields that are arrays.
+     * <p>
+     * It calculates the component type of the array and retrieves its equivalent object type
+     * for ease of use. The class is designed to handle arrays in a generic manner and
+     * use the provided methods of the superclass for actual field manipulation.
      */
     static class ArrayFieldAccess extends FieldAccess {
         private final Class<?> componentType;
@@ -1651,7 +1748,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@code byte[]} fields.
+     * The ByteArrayFieldAccess class extends FieldAccess to provide specialized access
+     * and manipulation methods for fields that are byte arrays.
+     * <p>
+     * The class is optimized for reading and writing byte arrays to and from a wire format
+     * while preserving encapsulation and supporting null values.
      */
     static class ByteArrayFieldAccess extends FieldAccess {
 
@@ -1708,7 +1809,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@link EnumSet} fields.
+     * The EnumSetFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
+     * for fields that are of type {@link EnumSet}.
+     * <p>
+     * This class allows efficient reading and writing of EnumSet fields to and from a wire format while
+     * preserving encapsulation and supporting null values.
      */
     static class EnumSetFieldAccess extends FieldAccess {
 
@@ -1855,7 +1960,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@link Collection} types.
+     * The CollectionFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
+     * for fields that are of type {@link Collection}.
+     * <p>
+     * It is optimized to handle both random-access and non-random-access collections efficiently. Additionally,
+     * the class provides flexibility by allowing users to supply custom collection creation logic if needed.
      */
     static class CollectionFieldAccess extends FieldAccess {
 
@@ -2028,7 +2137,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for collections of {@link String} values.
+     * The StringCollectionFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
+     * for fields that are of type {@link Collection} where the elements of the collection are {@link String} instances.
+     * <p>
+     * This extension particularly manages the parsing of strings from the given input and offers utility functions
+     * for instantiation of the correct {@link Collection} type.
      */
     static class StringCollectionFieldAccess extends FieldAccess {
 
@@ -2145,7 +2258,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@link Map} types.
+     * The MapFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
+     * for fields that are of type {@link Map}.
+     * <p>
+     * This extension is designed to manage the parsing and instantiation of the correct {@link Map} type
+     * and provides functionality to work with the key-value pairs within the map.
      */
     static class MapFieldAccess extends FieldAccess {
 
@@ -2250,7 +2367,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@code boolean} fields.
+     * The BooleanFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
+     * for fields that are of type boolean or {@link Boolean}.
+     * <p>
+     * This extension uses unsafe operations to get and set the boolean value efficiently without invoking reflection
+     * on each operation.
      */
     static class BooleanFieldAccess extends FieldAccess {
         BooleanFieldAccess(@NotNull Field field) {
@@ -2284,7 +2405,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@code byte} fields.
+     * The ByteFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
+     * for fields that are of type byte or {@link Byte}.
+     * <p>
+     * This extension leverages unsafe operations to get and set the byte value directly without the need for
+     * reflective access each time, ensuring better performance.
      */
     static class ByteFieldAccess extends FieldAccess {
         ByteFieldAccess(@NotNull Field field) {
@@ -2318,7 +2443,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@code short} fields.
+     * The ShortFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
+     * for fields that are of type short or {@link Short}.
+     * <p>
+     * This extension leverages unsafe operations to get and set the short value directly without the need for
+     * reflective access each time, ensuring optimal performance.
      */
     static class ShortFieldAccess extends FieldAccess {
         ShortFieldAccess(@NotNull Field field) {
@@ -2352,7 +2481,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@code char} fields.
+     * The CharFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
+     * for fields that are of type char or {@link Character}.
+     * <p>
+     * This extension leverages unsafe operations to get and set the character value directly without the need for
+     * reflective access each time, ensuring optimal performance.
      */
     static class CharFieldAccess extends FieldAccess {
 
@@ -2408,7 +2541,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@code int} fields.
+     * The IntegerFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
+     * for fields that are of type int or {@link Integer}.
+     * <p>
+     * This extension leverages unsafe operations to get and set the integer value directly without the need for
+     * reflective access each time, ensuring optimal performance.
      */
     static class IntegerFieldAccess extends FieldAccess {
         IntegerFieldAccess(@NotNull Field field) {
@@ -2777,7 +2914,9 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@code float} fields.
+     * The FloatFieldAccess class extends the FieldAccess class, providing specialized access
+     * to float fields of an object. This class supports reading and writing float values,
+     * considering a potential "previous" value for optimized serialization or other comparative tasks.
      */
     static class FloatFieldAccess extends FieldAccess {
         FloatFieldAccess(@NotNull Field field) {
@@ -2815,7 +2954,10 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@code long} fields.
+     * The LongFieldAccess class extends FieldAccess to provide specialized access
+     * to long fields of an object. It supports reading and writing long values,
+     * considering a potential "previous" value for optimized serialization or other
+     * comparative tasks.
      */
     static class LongFieldAccess extends FieldAccess {
         LongFieldAccess(@NotNull Field field) {
@@ -2853,7 +2995,10 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@code double} fields.
+     * The DoubleFieldAccess class extends FieldAccess to provide specialized access
+     * to double fields of an object. It supports reading and writing double values,
+     * considering a potential "previous" value for optimized serialization or other
+     * comparative tasks.
      */
     static class DoubleFieldAccess extends FieldAccess {
         DoubleFieldAccess(@NotNull Field field) {

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -44,27 +44,49 @@ import java.util.stream.Stream;
 import static net.openhft.chronicle.core.UnsafeMemory.*;
 
 /**
- * The WireMarshaller class is responsible for marshalling and unmarshalling of objects of type T.
- * This class provides an efficient mechanism for serialization/deserialization using wire protocols.
- * It utilizes field accessors to read and write values directly to and from the fields of the object.
+ * Engine for marshalling and unmarshalling objects based on their field
+ * definitions. Each {@code WireMarshaller} is typically cached per class via
+ * {@link #WIRE_MARSHALLER_CL}. Reflection is used once to discover the fields
+ * and then optimised {@link FieldAccess} instances perform subsequent read and
+ * write operations.
  *
- * @param <T> The type of the object to be marshalled/unmarshalled.
+ * @param <T> the type handled by this marshaller
  */
 @SuppressWarnings({"rawtypes", "unchecked", "deprecation"})
 public class WireMarshaller<T> {
     private static final Class[] UNEXPECTED_FIELDS_PARAMETER_TYPES = {Object.class, ValueIn.class};
+    /**
+     * An empty array of {@link FieldAccess}, used for classes that have no
+     * marshallable fields such as interfaces or some enum types.
+     */
     private static final FieldAccess[] NO_FIELDS = {};
+    /**
+     * Reflection accessor for {@link Class#isRecord()} available on Java 14+.
+     */
     private static Method isRecord;
+    /**
+     * One entry per marshallable field of {@code T}. The ordering is preserved
+     * so that field writers can honour input order hints if provided.
+     */
     @NotNull
     final FieldAccess[] fields;
 
-    // Map for quick field look-up based on their names.
+    /**
+     * Map for quick field look-up based on the name. Implemented as a
+     * {@link TreeMap} to allow ordered iteration and case-insensitive searches.
+     */
     final TreeMap<CharSequence, FieldAccess> fieldMap = new TreeMap<>(WireMarshaller::compare);
 
-    // Flag to determine if this marshaller is for a leaf class.
+    /**
+     * Indicates if {@code T} is considered a leaf in the object graph. Leaf
+     * types may be treated more compactly by some wire formats.
+     */
     private final boolean isLeaf;
 
-    // Default value for the type T.
+    /**
+     * Pre-instantiated default instance used to identify unchanged fields and
+     * to populate missing values during read operations.
+     */
     @Nullable
     private final T defaultValue;
 
@@ -90,8 +112,11 @@ public class WireMarshaller<T> {
         this(fields, isLeaf, defaultValueForType(tClass));
     }
 
-    // A class-local storage for caching WireMarshallers for different types.
-    // Depending on the type of class, it either creates a marshaller for exceptions or a generic one.
+    /**
+     * A class-local cache of {@code WireMarshaller} instances. {@link Throwable}
+     * types receive a specialised marshaller that handles their field discovery
+     * slightly differently, while all other classes use the generic variant.
+     */
     public static final ClassLocal<WireMarshaller> WIRE_MARSHALLER_CL = ClassLocal.withInitial
             (tClass ->
                     Throwable.class.isAssignableFrom(tClass)

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -78,11 +78,13 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Constructs a new instance of the WireMarshaller with the specified parameters.
+     * Protected constructor used by factory methods.
+     * Prefer {@link #of(Class)} or {@link #WIRE_MARSHALLER_CL} to obtain
+     * instances.
      *
-     * @param tClass  The class of the object to be marshalled.
-     * @param fields  An array of field accessors that provide access to the fields of the object.
-     * @param isLeaf  Indicates if the marshaller is for a leaf class.
+     * @param tClass the type being marshalled
+     * @param fields fields to marshall
+     * @param isLeaf whether the type is considered a leaf
      */
     protected WireMarshaller(@NotNull Class<T> tClass, @NotNull FieldAccess[] fields, boolean isLeaf) {
         this(fields, isLeaf, defaultValueForType(tClass));
@@ -97,6 +99,9 @@ public class WireMarshaller<T> {
                             : WireMarshaller.of(tClass)
             );
 
+    /**
+     * Internal constructor used by the factory methods.
+     */
     WireMarshaller(@NotNull FieldAccess[] fields, boolean isLeaf, @Nullable T defaultValue) {
         this.fields = fields;
         this.isLeaf = isLeaf;
@@ -107,12 +112,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Factory method to create an instance of the WireMarshaller for a specific class type.
-     * Determines the appropriate marshaller type (basic or one that handles unexpected fields)
-     * based on the characteristics of the provided class.
+     * Creates a marshaller for the given type.
+     * Synthetic fields introduced by later Java versions are filtered out.
      *
-     * @param tClass The class type for which the marshaller is to be created.
-     * @return A new instance of WireMarshaller for the provided class type.
+     * @param tClass the type to marshall
+     * @return marshaller instance for {@code tClass}
      */
     @NotNull
     public static <T> WireMarshaller<T> of(@NotNull Class<T> tClass) {
@@ -142,11 +146,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Checks if the provided field accessor corresponds to a "leaf" entity.
-     * An entity is considered a leaf if it doesn't need to be further broken down in the serialization process.
+     * Determines if the field type can be treated as a leaf during serialisation.
+     * Collections and non-dynamic-enum {@link WriteMarshallable} types are not leaves.
      *
-     * @param c The field accessor to be checked.
-     * @return {@code true} if the field accessor is leafable, {@code false} otherwise.
+     * @param c accessor for the field
+     * @return true if the field can be treated as a leaf
      */
     protected static boolean leafable(FieldAccess c) {
         Class<?> type = c.field.getType();
@@ -158,10 +162,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Determines if the provided class overrides the "unexpectedField" method from the ReadMarshallable interface.
+     * Checks whether {@code tClass} supplies its own
+     * {@link ReadMarshallable#unexpectedField(Object, ValueIn)} implementation.
      *
-     * @param tClass The class type to be checked.
-     * @return {@code true} if the class overrides the "unexpectedField" method, {@code false} otherwise.
+     * @param tClass the type to check
+     * @return true if {@code tClass} overrides the method
      */
     private static <T> boolean overridesUnexpectedFields(Class<T> tClass) {
         try {
@@ -173,11 +178,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Factory method to create an instance of the WireMarshaller for a Throwable class type.
-     * The method identifies fields that should be marshalled and prepares the marshaller accordingly.
+     * Factory for {@link Throwable} subclasses.
+     * Includes fields needed to serialise exception state.
      *
-     * @param tClass The Throwable class type for which the marshaller is to be created.
-     * @return A new instance of WireMarshaller for the provided Throwable class type.
+     * @param tClass exception type
+     * @return marshaller for the throwable
      */
     @NotNull
     private static <T> WireMarshaller<T> ofThrowable(@NotNull Class<T> tClass) {
@@ -192,10 +197,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Determines if the provided class is a collection type, including arrays, standard Collections, or Maps.
+     * Utility to check whether the class represents an array, a
+     * {@link Collection} or a {@link Map}.
      *
-     * @param c The class to be checked.
-     * @return {@code true} if the class is a collection type, {@code false} otherwise.
+     * @param c class to test
+     * @return true if it is a collection type
      */
     private static boolean isCollection(@NotNull Class<?> c) {
         return c.isArray() ||
@@ -204,12 +210,14 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Recursively fetches all non-static, non-transient fields from the provided class and its superclasses,
-     * up to but not including Object or AbstractCommonMarshallable, and adds them to the provided map.
-     * Fields that are flagged for exclusion (e.g., the "ordinal" field for Enum types) are skipped.
+     * Recursively collects all non-static and non-transient fields from
+     * {@code clazz} and its parents until {@link Object} or
+     * {@link AbstractCommonMarshallable}. The map is keyed by field name.
+     * Skips values such as {@code ordinal} on enums and inner-class synthetic
+     * links.
      *
-     * @param clazz The class type from which fields are to be extracted.
-     * @param map   The map to populate with field names and their corresponding Field objects.
+     * @param clazz class to inspect
+     * @param map   destination for discovered fields
      */
     public static void getAllField(@NotNull Class<?> clazz, @NotNull Map<String, Field> map) {
         if (clazz != Object.class && clazz != AbstractCommonMarshallable.class)
@@ -231,6 +239,12 @@ public class WireMarshaller<T> {
         }
     }
 
+    /**
+     * Creates a default instance for {@code tClass} when possible.
+     * Concrete, non-Java-core classes get an empty instance. For
+     * {@link DynamicEnum} types a special '[unset]' constant is produced.
+     * Returns {@code null} for primitives, arrays and interfaces.
+     */
     static <T> T defaultValueForType(@NotNull Class<T> tClass) {
 //        tClass = ObjectUtils.implementationToUse(tClass);
         if (ObjectUtils.isConcreteClass(tClass)
@@ -256,15 +270,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Compares two CharSequences lexicographically. This is a character-by-character comparison
-     * that returns the difference of the first unmatched characters or the difference in their lengths
-     * if one sequence is a prefix of the other.
-     *
-     * @param cs0 The first CharSequence to be compared.
-     * @param cs1 The second CharSequence to be compared.
-     * @return A positive integer if {@code cs0} comes after {@code cs1},
-     *         a negative integer if {@code cs0} comes before {@code cs1},
-     *         or zero if the sequences are equal.
+     * Lexicographical comparison used by {@link #fieldMap}.
      */
     private static int compare(CharSequence cs0, CharSequence cs1) {
         for (int i = 0, len = Math.min(cs0.length(), cs1.length()); i < len; i++) {
@@ -276,12 +282,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Computes the actual type arguments for a given field of an interface. This method determines
-     * the generic type arguments that the field uses based on the interface's type parameters.
-     *
-     * @param iface The interface containing the field.
-     * @param field The field whose type arguments need to be determined.
-     * @return An array of actual type arguments or the interface's type parameters if no actual arguments can be deduced.
+     * Helper used by reflection code to resolve the actual generic arguments for
+     * {@code field} relative to {@code iface}.
      */
     private static Type[] computeActualTypeArguments(Class<?> iface, Field field) {
         Type[] actual = consumeActualTypeArguments(new HashMap<>(), iface, field.getGenericType());
@@ -293,19 +295,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Determines the actual type arguments used by a class or interface for a given interface type.
-     * This method recursively inspects the type hierarchy to match type arguments against the
-     * interface's type parameters. It uses a previously built map of type parameter names to their
-     * actual types to deduce the correct arguments for the given interface.
-     *
-     * @param prevTypeParameters A map containing previously discovered type parameter names
-     *                           mapped to their actual types.
-     * @param iface              The interface for which we want to determine the type arguments.
-     * @param type               The type to inspect. This could be an actual class, interface, or
-     *                           a parameterized type that uses generic arguments.
-     *
-     * @return An array of actual type arguments used by the provided type for the specified interface,
-     *         or null if the type doesn't directly or indirectly implement or extend the given interface.
+     * Recursive helper for {@link #computeActualTypeArguments(Class, Field)}.
+     * Walks the type hierarchy to map parameter names to concrete classes.
      */
     private static Type[] consumeActualTypeArguments(Map<String, Type> prevTypeParameters, Class<?> iface, Type type) {
         Class<?> cls = null;
@@ -377,11 +368,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Excludes specified fields from the current marshaller and returns a new instance of the marshaller
-     * with the remaining fields.
-     *
-     * @param fieldNames Names of the fields to be excluded.
-     * @return A new instance of the {@link WireMarshaller} with the specified fields excluded.
+     * Returns a marshaller that omits the named fields.
+     * Useful when only a subset of a DTO should be serialised.
      */
     public WireMarshaller<T> excludeFields(String... fieldNames) {
         Set<String> fieldSet = new HashSet<>(Arrays.asList(fieldNames));
@@ -392,13 +380,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Writes the marshallable representation of the given object to the provided {@link WireOut} destination.
-     * This will traverse the fields and use their respective {@link FieldAccess} to write each field.
-     * The method also adjusts the hex dump indentation for better readability in the output.
-     *
-     * @param t   The object to write.
-     * @param out The destination {@link WireOut} where the object representation will be written.
-     * @throws InvalidMarshallableException If the object fails validation checks before serialization.
+     * Serialises {@code t} to {@code out} in field order. Hex dump indentation
+     * is adjusted for readability.
      */
     public void writeMarshallable(T t, @NotNull WireOut out) throws InvalidMarshallableException {
         ValidatableUtil.validate(t);
@@ -414,12 +397,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Writes the marshallable representation of the given object to the provided {@link Bytes} destination.
-     * Unlike the previous method, this doesn't adjust the hex dump indentation. It's a more direct
-     * serialization of the fields to bytes.
-     *
-     * @param t     The object to write.
-     * @param bytes The destination {@link Bytes} where the object representation will be written.
+     * Serialises {@code t} directly to the given byte store using raw field
+     * access.
      */
     public void writeMarshallable(T t, Bytes<?> bytes) {
         for (@NotNull FieldAccess field : fields) {
@@ -432,14 +411,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Writes the values of the fields from the provided object (DTO) to the output. Before writing,
-     * the object is validated. The method also supports optional copying of the values
-     * from the source object to a previous instance.
-     *
-     * @param t    Object whose field values are to be written.
-     * @param out  Output destination where the field values are written to.
-     * @param copy Flag indicating whether to copy values from the source object to the previous object.
-     * @throws InvalidMarshallableException If there's an error during marshalling.
+     * Serialises {@code t} to {@code out}, optionally copying written values
+     * into the stored default instance.
      */
     public void writeMarshallable(T t, @NotNull WireOut out, boolean copy) throws InvalidMarshallableException {
         // Validate the object before writing
@@ -455,13 +428,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Reads and populates the DTO based on the provided input. The input order can be hinted.
-     * After reading, the object is validated.
-     *
-     * @param t         Object to populate with read values.
-     * @param in        Input source from which values are read.
-     * @param overwrite Flag indicating whether to overwrite the existing value in the target object.
-     * @throws InvalidMarshallableException If there is an error during marshalling.
+     * Deserialises from {@code in} into {@code t}. When {@code overwrite} is
+     * true missing fields are reset from {@link #defaultValue}.
      */
     public void readMarshallable(T t, @NotNull WireIn in, boolean overwrite) throws InvalidMarshallableException {
         // Choose the reading method based on the hint
@@ -475,12 +443,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Reads and populates the DTO based on the provided order.
-     *
-     * @param t         Target object to populate with read values.
-     * @param in        Input source from which values are read.
-     * @param overwrite Flag indicating whether to overwrite the existing value in the target object.
-     * @throws InvalidMarshallableException If there is an error during marshalling.
+     * Deserialises fields in declared order from {@code in}.
+     * Fields not present are optionally taken from {@link #defaultValue}.
      */
     public void readMarshallableDTOOrder(T t, @NotNull WireIn in, boolean overwrite) throws InvalidMarshallableException {
         try {
@@ -495,12 +459,9 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Reads and populates the DTO based on the input's order.
-     *
-     * @param t         Target object to populate with read values.
-     * @param in        Input source from which values are read.
-     * @param overwrite Flag indicating whether to overwrite the existing value in the target object.
-     * @throws InvalidMarshallableException If there is an error during marshalling.
+     * Reads fields in the order they appear on the wire. Any DTO fields not
+     * encountered are optionally restored from {@link #defaultValue} once all
+     * input has been processed.
      */
     public void readMarshallableInputOrder(T t, @NotNull WireIn in, boolean overwrite) throws InvalidMarshallableException {
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
@@ -545,23 +506,14 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Checks if the given field name (represented by a StringBuilder) matches the field name of the provided {@link FieldAccess}.
-     * If the StringBuilder has a length of 0, it's assumed to match any field name.
-     *
-     * @param sb    The StringBuilder containing the field name to be checked.
-     * @param field The {@link FieldAccess} whose field name needs to be matched against.
-     * @return True if the field name matches or if the StringBuilder is empty; False otherwise.
+     * Case-insensitive field name check. An empty builder matches any field.
      */
     public boolean matchesFieldName(StringBuilder sb, FieldAccess field) {
         return sb.length() == 0 || StringUtils.equalsCaseIgnore(field.field.getName(), sb);
     }
 
     /**
-     * Writes the key representation of the given object to the provided {@link Bytes} destination.
-     * As per the assumption, only the first field (key) of the object is written.
-     *
-     * @param t     The object whose key needs to be written.
-     * @param bytes The destination {@link Bytes} where the object's key representation will be written.
+     * Writes the first field of {@code t} as a key to {@code bytes}.
      */
     public void writeKey(T t, Bytes<?> bytes) {
         // assume one key for now.
@@ -573,12 +525,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Compares two objects field by field to determine their equality.
-     * Uses each field's {@link FieldAccess} to perform the equality check.
-     *
-     * @param o1 The first object to compare.
-     * @param o2 The second object to compare.
-     * @return True if all fields of both objects are equal; False if at least one field differs.
+     * Compares two objects field by field.
      */
     public boolean isEqual(Object o1, Object o2) {
         for (@NotNull FieldAccess field : fields) {
@@ -589,12 +536,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Fetches the value of the specified field from the provided object.
-     *
-     * @param o    The object from which the field value needs to be fetched.
-     * @param name The name of the field whose value is to be fetched.
-     * @return The value of the specified field from the object.
-     * @throws NoSuchFieldException If no field with the specified name is found in the object.
+     * Returns the named field value using {@link FieldAccess}.
      */
     public Object getField(Object o, String name) throws NoSuchFieldException {
         try {
@@ -610,13 +552,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Retrieves the value of a specified field from the provided object and converts it to a long.
-     * If the field's type is not inherently long or int, it attempts a conversion using the ObjectUtils class.
-     *
-     * @param o    The object from which the field value is to be retrieved.
-     * @param name The name of the field whose value needs to be fetched.
-     * @return The long value of the specified field.
-     * @throws NoSuchFieldException If no field with the specified name is found in the object.
+     * Returns the named field value as a long, applying conversions when needed.
      */
     public long getLongField(@NotNull Object o, String name) throws NoSuchFieldException {
         try {
@@ -637,13 +573,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Sets the value of a specified field in the provided object.
-     * If the type of the value does not directly match the field's type, it attempts a conversion using the ObjectUtils class.
-     *
-     * @param o     The object in which the field's value needs to be set.
-     * @param name  The name of the field whose value needs to be set.
-     * @param value The value to set to the field.
-     * @throws NoSuchFieldException If no field with the specified name is found in the object.
+     * Writes {@code value} into the named field, performing type conversion when required.
      */
     public void setField(Object o, String name, Object value) throws NoSuchFieldException {
         try {
@@ -659,13 +589,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Sets a long value to a specified field in the provided object.
-     * If the field's type is not inherently long or int, it attempts a conversion using the ObjectUtils class.
-     *
-     * @param o     The object in which the field's value needs to be set.
-     * @param name  The name of the field whose value needs to be set.
-     * @param value The long value to set to the field.
-     * @throws NoSuchFieldException If no field with the specified name is found in the object.
+     * Convenience for writing a long value via {@link FieldAccess}.
      */
     public void setLongField(Object o, String name, long value) throws NoSuchFieldException {
         try {
@@ -695,9 +619,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Resets the fields of the given object 'o' to the default value.
-     *
-     * @param o The object whose fields are to be reset to the default value.
+     * Copies values from {@link #defaultValue} into {@code o}.
      */
     public void reset(T o) {
         try {
@@ -710,9 +632,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Checks if the current WireMarshaller is a leaf.
-     *
-     * @return true if the WireMarshaller is a leaf, false otherwise.
+     * @return true if this marshaller is for a leaf type
      */
     public boolean isLeaf() {
         return isLeaf;

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -639,8 +639,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Provides a field accessor that's specialized for handling fields which require
-     * conversion between integer values and string representations using a LongConverter.
+     * Field access for values annotated with {@link LongConversion}.
+     * Converts between the numeric value stored in the object and its text representation.
      */
     static class LongConverterFieldAccess extends FieldAccess {
 
@@ -678,11 +678,11 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Reads the long value from an object and writes it using the provided ValueOut writer.
+         * Writes the long value using {@link LongConverter} when text is required.
          *
-         * @param o        The source object.
-         * @param write    The writer for output.
-         * @param previous The previous value (currently not used).
+         * @param o        source object
+         * @param write    destination
+         * @param previous ignored previous value
          */
         @Override
         protected void getValue(Object o, @NotNull ValueOut write, @Nullable Object previous) {
@@ -809,8 +809,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Abstract class to manage access to fields of objects.
-     * This class provides utility methods to read and write fields from/to objects.
+     * Base class that performs low level field access for marshalling.
+     * Implementations specialise the handling for the field's type.
      */
     abstract static class FieldAccess {
         @NotNull
@@ -823,19 +823,19 @@ public class WireMarshaller<T> {
         Boolean isLeaf;
 
         /**
-         * Constructor initializing field with given value.
+         * Creates an accessor for {@code field}.
          *
-         * @param field Field to be accessed.
+         * @param field the field being accessed
          */
         FieldAccess(@NotNull Field field) {
             this(field, null);
         }
 
         /**
-         * Constructor initializing field and isLeaf with given values.
+         * Creates an accessor for {@code field}.
          *
-         * @param field  Field to be accessed.
-         * @param isLeaf Flag to indicate whether the field is a leaf node.
+         * @param field  the field being accessed
+         * @param isLeaf whether this field should be treated as a leaf. {@code null} for auto-detect
          */
         FieldAccess(@NotNull Field field, Boolean isLeaf) {
             this.field = field;
@@ -853,10 +853,13 @@ public class WireMarshaller<T> {
         // ... (code continues)
 
         /**
-         * Create a specific FieldAccess object based on the field type.
+         * Builds a {@link FieldAccess} suited to {@code field}'s type.
+         * Handles primitives, strings, collections, maps, enum sets and fields
+         * annotated with {@link LongConversion}.
          *
-         * @param field Field for which FieldAccess object is created.
-         * @return FieldAccess object specific to the field type.
+         * @param field         field to create an accessor for
+         * @param defaultObject optional default instance used for Resettable fields
+         * @return an accessor for the given field
          */
         @Nullable
         public static Object create(@NotNull Field field, @Nullable Object defaultObject) {
@@ -955,13 +958,11 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Acquires a LongConverter instance associated with a given field, if available.
-         * <p>
-         * This method checks if the provided field has a LongConversion annotation. If present,
-         * it retrieves the corresponding LongConverter using the LongConverterFieldAccess helper class.
-                 *
-         * @param field The field for which the LongConverter needs to be obtained
-         * @return The associated LongConverter instance, or null if not present
+         * Helper to obtain a {@link LongConverter} for {@code field} when annotated
+         * with {@link LongConversion}.
+         *
+         * @param field field being inspected
+         * @return converter instance or {@code null} if not annotated
          */
         @Nullable
         private static LongConverter acquireLongConverter(@NotNull Field field) {
@@ -973,13 +974,11 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Extracts the raw Class type from a given Type object.
-         * <p>
-         * This method aims to handle various Type representations, like Class or ParameterizedType,
-         * and return the underlying Class representation.
-                 *
-         * @param type0 The type from which the class should be extracted
-         * @return The extracted Class representation
+         * Returns the raw {@link Class} for the supplied {@link Type}.
+         * Handles {@link ParameterizedType} by returning its raw type.
+         *
+         * @param type0 input type
+         * @return resolved class or {@link Object} if unknown
          */
         @NotNull
         static Class<?> extractClass(Type type0) {
@@ -1001,16 +1000,13 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Writes the value of a given object's field to a provided WireOut instance.
-         * <p>
-         * This method serializes the value of the specified object's field and writes it to
-         * the WireOut. If the field has a Comment annotation, a special processing is done
-         * using the CommentAnnotationNotifier.
-                 *
-         * @param o    The object containing the field to be written
-         * @param out  The WireOut instance to write the field value to
-         * @throws IllegalAccessException If the field cannot be accessed
-         * @throws InvalidMarshallableException If the object cannot be marshalled
+         * Writes this field from {@code o} to {@code out}.
+         * If a {@link Comment} annotation is present the comment is emitted after the value.
+         *
+         * @param o   source object
+         * @param out target wire
+         * @throws IllegalAccessException        if field access fails
+         * @throws InvalidMarshallableException  if a value cannot be marshalled
          */
         void write(Object o, @NotNull WireOut out) throws IllegalAccessException, InvalidMarshallableException {
 
@@ -1026,17 +1022,13 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Retrieves the value of the provided object's field and writes it to the provided WireOut instance,
-         * appending a comment based on the associated Comment annotation.
-         * <p>
-         * If the field has a Comment annotation, its value is formatted using the field's value and appended as a comment.
-         * The CommentAnnotationNotifier is used to indicate that the written value is preceded by a comment.
-                 *
-         * @param o         The object containing the field whose value needs to be retrieved
-         * @param out       The WireOut instance to which the value and the comment are written
-         * @param valueOut  The ValueOut instance representing the field's value
-         * @throws IllegalAccessException If the field cannot be accessed
-         * @throws InvalidMarshallableException If the object cannot be marshalled
+         * Writes the field value followed by its {@link Comment} text.
+         *
+         * @param o        source object
+         * @param out      target wire
+         * @param valueOut {@code out} wrapper for the value
+         * @throws IllegalAccessException       if reflection fails
+         * @throws InvalidMarshallableException if marshalling fails
          */
         private void getValueCommentAnnotated(Object o, @NotNull WireOut out, ValueOut valueOut) throws IllegalAccessException, InvalidMarshallableException {
             CommentAnnotationNotifier notifier = (CommentAnnotationNotifier) valueOut;
@@ -1050,16 +1042,15 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Writes the value of the field from the provided object to the output. If the value is the same
-         * as the previous value, it skips the writing. If the copy flag is set, it also copies the value
-         * from the source object to the previous object.
+         * Writes this field to {@code out} if it differs from {@code previous}.
+         * When {@code copy} is true the written value is also copied into {@code previous}.
          *
-         * @param o        Object from which the field value is fetched.
-         * @param out      Output destination where the value is written to.
-         * @param previous Previous object to compare for sameness and optionally copy to.
-         * @param copy     Flag indicating whether to copy the value from source to the previous object.
-         * @throws IllegalAccessException       If there's an access violation when fetching the field value.
-         * @throws InvalidMarshallableException If there's an error during marshalling.
+         * @param o        source object
+         * @param out      target wire
+         * @param previous object containing the last written value
+         * @param copy     copy the new value into {@code previous} after writing
+         * @throws IllegalAccessException       if reflection fails
+         * @throws InvalidMarshallableException on marshalling error
          */
         void write(Object o, @NotNull WireOut out, Object previous, boolean copy) throws IllegalAccessException, InvalidMarshallableException {
             // Check if the current and previous values are the same
@@ -1076,12 +1067,12 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Check if the values of a field in two objects are the same.
+         * Tests whether this field holds equal values in {@code o} and {@code o2}.
          *
-         * @param o  First object.
-         * @param o2 Second object.
-         * @return true if values are the same, false otherwise.
-         * @throws IllegalAccessException If unable to access the field.
+         * @param o  first object
+         * @param o2 second object
+         * @return {@code true} if the values are equal
+         * @throws IllegalAccessException if reflection fails
          */
         protected boolean sameValue(Object o, Object o2) throws IllegalAccessException {
             final Object v1 = field.get(o);
@@ -1092,11 +1083,11 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Copies the value of a field from one object to another.
+         * Copies this field from {@code from} to {@code to}.
          *
-         * @param from Source object.
-         * @param to   Destination object.
-         * @throws IllegalAccessException If unable to access the field.
+         * @param from source object
+         * @param to   destination object
+         * @throws IllegalAccessException if reflection fails
          */
         protected void copy(Object from, Object to) throws IllegalAccessException {
             ObjectUtils.requireNonNull(from);
@@ -1106,25 +1097,27 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Abstract method to get the value of a field from an object.
+         * Writes this field from {@code o} to {@code write}.
+         * Implementations may use {@code previous} for delta encoding.
          *
-         * @param o        Object from which to get the value.
-         * @param write    Output destination.
-         * @param previous Previous object for comparison.
-         * @throws IllegalAccessException       If unable to access the field.
-         * @throws InvalidMarshallableException If marshalling fails.
+         * @param o        source object
+         * @param write    destination
+         * @param previous previous state or {@code null}
+         * @throws IllegalAccessException       if reflection fails
+         * @throws InvalidMarshallableException on marshalling error
          */
         protected abstract void getValue(Object o, ValueOut write, Object previous) throws IllegalAccessException, InvalidMarshallableException;
 
         /**
-         * Reads the value of a field from an input and sets it in an object.
+         * Reads the field value from {@code read} and applies it to {@code o}.
+         * If the value is absent and {@code overwrite} is true the value from {@code defaults} is used.
          *
-         * @param o         Object to set the value in.
-         * @param defaults  Default values.
-         * @param read      Input source.
-         * @param overwrite Whether to overwrite existing value.
-         * @throws IllegalAccessException       If unable to access the field.
-         * @throws InvalidMarshallableException If marshalling fails.
+         * @param o         target object
+         * @param defaults  object providing default values
+         * @param read      source of data
+         * @param overwrite whether an absent value should reset to default
+         * @throws IllegalAccessException       if reflection fails
+         * @throws InvalidMarshallableException on parsing error
          */
         protected void readValue(Object o, Object defaults, ValueIn read, boolean overwrite) throws IllegalAccessException, InvalidMarshallableException {
             if (!read.isPresent()) {
@@ -1149,42 +1142,41 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Abstract method to set the value of a field in an object.
+         * Reads this field from {@code read} and updates {@code o}.
          *
-         * @param o         Object to set the value in.
-         * @param read      Input source.
-         * @param overwrite Whether to overwrite existing value.
-         * @throws IllegalAccessException If unable to access the field.
+         * @param o         target object
+         * @param read      wire input
+         * @param overwrite if false a missing value leaves the field unchanged
+         * @throws IllegalAccessException if reflection fails
          */
         protected abstract void setValue(Object o, ValueIn read, boolean overwrite) throws IllegalAccessException;
 
         /**
-         * Abstract method to reset the value of a field in an object to default value.
-         * The default value is the one present in objects of that class after no-argument constructor.
-         * Where possible, existing data structures should be preserved without reallocation to avoid garbage.
+         * Resets this field on {@code o} using the value from {@code defaultObject}.
+         * Existing objects are reused where possible to avoid allocation.
          *
-         * @param defaultObject A reference unmodified instance of this class.
-         * @param o             Object to reset the value in.
+         * @param defaultObject reference instance containing default values
+         * @param o             target object
          */
         protected void setDefaultValue(Object defaultObject, Object o) throws IllegalAccessException {
             copy(defaultObject, o);
         }
 
         /**
-         * Abstract method to convert the value of a field in an object to bytes.
+         * Writes the value of this field to {@code bytes} in binary form.
          *
-         * @param o     Object containing the field.
-         * @param bytes Destination to write the bytes to.
-         * @throws IllegalAccessException If unable to access the field.
+         * @param o     source object
+         * @param bytes destination buffer
+         * @throws IllegalAccessException if reflection fails
          */
         public abstract void getAsBytes(Object o, Bytes<?> bytes) throws IllegalAccessException;
 
         /**
-         * Checks whether the values of a field in two objects are equal.
+         * Compares this field in {@code o1} and {@code o2} for equality.
          *
-         * @param o1 First object.
-         * @param o2 Second object.
-         * @return true if the values are equal, false otherwise.
+         * @param o1 first object
+         * @param o2 second object
+         * @return {@code true} if the values match
          */
         public boolean isEqual(Object o1, Object o2) {
             try {
@@ -1196,8 +1188,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * This is a specialized FieldAccess implementation for fields of type IntValue.
-     * It provides implementations for reading and writing the IntValue from and to various sources.
+     * Field access for {@link IntValue} references.
      */
     static class IntValueAccess extends FieldAccess {
 
@@ -1234,8 +1225,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * This is a specialized FieldAccess implementation for fields of type LongValue.
-     * It provides implementations for reading and writing the LongValue from and to various sources.
+     * Field access for {@link LongValue} references.
      */
     static class LongValueAccess extends FieldAccess {
 
@@ -1272,9 +1262,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * This is a specialized FieldAccess implementation for generic object fields.
-     * It provides methods for reading and writing object fields from and to various sources,
-     * taking into account special cases where the field may be marshaled differently based on annotations.
+     * Field access for arbitrary object references. Supports {@link AsMarshallable}.
      */
     static class ObjectFieldAccess extends FieldAccess {
         private final Class<?> type; // Type of the object field
@@ -1560,12 +1548,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The ArrayFieldAccess class extends FieldAccess to provide specialized access
-     * and manipulation methods for fields that are arrays.
-     * <p>
-     * It calculates the component type of the array and retrieves its equivalent object type
-     * for ease of use. The class is designed to handle arrays in a generic manner and
-     * use the provided methods of the superclass for actual field manipulation.
+     * Field access for array fields.
      */
     static class ArrayFieldAccess extends FieldAccess {
         private final Class<?> componentType;
@@ -1643,11 +1626,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The ByteArrayFieldAccess class extends FieldAccess to provide specialized access
-     * and manipulation methods for fields that are byte arrays.
-     * <p>
-     * The class is optimized for reading and writing byte arrays to and from a wire format
-     * while preserving encapsulation and supporting null values.
+     * Field access for {@code byte[]} fields.
      */
     static class ByteArrayFieldAccess extends FieldAccess {
 
@@ -1704,11 +1683,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The EnumSetFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
-     * for fields that are of type {@link EnumSet}.
-     * <p>
-     * This class allows efficient reading and writing of EnumSet fields to and from a wire format while
-     * preserving encapsulation and supporting null values.
+     * Field access for {@link EnumSet} fields.
      */
     static class EnumSetFieldAccess extends FieldAccess {
 
@@ -1855,11 +1830,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The CollectionFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
-     * for fields that are of type {@link Collection}.
-     * <p>
-     * It is optimized to handle both random-access and non-random-access collections efficiently. Additionally,
-     * the class provides flexibility by allowing users to supply custom collection creation logic if needed.
+     * Field access for {@link Collection} types.
      */
     static class CollectionFieldAccess extends FieldAccess {
 
@@ -2032,11 +2003,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The StringCollectionFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
-     * for fields that are of type {@link Collection} where the elements of the collection are {@link String} instances.
-     * <p>
-     * This extension particularly manages the parsing of strings from the given input and offers utility functions
-     * for instantiation of the correct {@link Collection} type.
+     * Field access for collections of {@link String} values.
      */
     static class StringCollectionFieldAccess extends FieldAccess {
 
@@ -2153,11 +2120,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The MapFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
-     * for fields that are of type {@link Map}.
-     * <p>
-     * This extension is designed to manage the parsing and instantiation of the correct {@link Map} type
-     * and provides functionality to work with the key-value pairs within the map.
+     * Field access for {@link Map} types.
      */
     static class MapFieldAccess extends FieldAccess {
 
@@ -2262,11 +2225,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The BooleanFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
-     * for fields that are of type boolean or {@link Boolean}.
-     * <p>
-     * This extension uses unsafe operations to get and set the boolean value efficiently without invoking reflection
-     * on each operation.
+     * Field access for {@code boolean} fields.
      */
     static class BooleanFieldAccess extends FieldAccess {
         BooleanFieldAccess(@NotNull Field field) {
@@ -2300,11 +2259,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The ByteFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
-     * for fields that are of type byte or {@link Byte}.
-     * <p>
-     * This extension leverages unsafe operations to get and set the byte value directly without the need for
-     * reflective access each time, ensuring better performance.
+     * Field access for {@code byte} fields.
      */
     static class ByteFieldAccess extends FieldAccess {
         ByteFieldAccess(@NotNull Field field) {
@@ -2338,11 +2293,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The ShortFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
-     * for fields that are of type short or {@link Short}.
-     * <p>
-     * This extension leverages unsafe operations to get and set the short value directly without the need for
-     * reflective access each time, ensuring optimal performance.
+     * Field access for {@code short} fields.
      */
     static class ShortFieldAccess extends FieldAccess {
         ShortFieldAccess(@NotNull Field field) {
@@ -2376,11 +2327,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The CharFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
-     * for fields that are of type char or {@link Character}.
-     * <p>
-     * This extension leverages unsafe operations to get and set the character value directly without the need for
-     * reflective access each time, ensuring optimal performance.
+     * Field access for {@code char} fields.
      */
     static class CharFieldAccess extends FieldAccess {
 
@@ -2436,11 +2383,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The IntegerFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
-     * for fields that are of type int or {@link Integer}.
-     * <p>
-     * This extension leverages unsafe operations to get and set the integer value directly without the need for
-     * reflective access each time, ensuring optimal performance.
+     * Field access for {@code int} fields.
      */
     static class IntegerFieldAccess extends FieldAccess {
         IntegerFieldAccess(@NotNull Field field) {
@@ -2809,9 +2752,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The FloatFieldAccess class extends the FieldAccess class, providing specialized access
-     * to float fields of an object. This class supports reading and writing float values,
-     * considering a potential "previous" value for optimized serialization or other comparative tasks.
+     * Field access for {@code float} fields.
      */
     static class FloatFieldAccess extends FieldAccess {
         FloatFieldAccess(@NotNull Field field) {
@@ -2849,10 +2790,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The LongFieldAccess class extends FieldAccess to provide specialized access
-     * to long fields of an object. It supports reading and writing long values,
-     * considering a potential "previous" value for optimized serialization or other
-     * comparative tasks.
+     * Field access for {@code long} fields.
      */
     static class LongFieldAccess extends FieldAccess {
         LongFieldAccess(@NotNull Field field) {
@@ -2890,10 +2828,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The DoubleFieldAccess class extends FieldAccess to provide specialized access
-     * to double fields of an object. It supports reading and writing double values,
-     * considering a potential "previous" value for optimized serialization or other
-     * comparative tasks.
+     * Field access for {@code double} fields.
      */
     static class DoubleFieldAccess extends FieldAccess {
         DoubleFieldAccess(@NotNull Field field) {

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshallerForUnexpectedFields.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshallerForUnexpectedFields.java
@@ -23,15 +23,24 @@ import net.openhft.chronicle.core.scoped.ScopedResource;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * This class extends the WireMarshaller and provides the ability to handle unexpected fields.
- * It maps fields by their name (both in their original form and lower-cased) for easy access.
- * It overrides the method to read marshallable objects and provides specialized logic to
- * handle unexpected fields that might be present in the data source.
+ * Extends {@link WireMarshaller} to provide custom handling for unexpected fields during
+ * deserialisation. Used when the target class overrides
+ * {@link ReadMarshallable#unexpectedField(CharSequence, ValueIn)} to gain control of unknown
+ * data.
  */
 public class WireMarshallerForUnexpectedFields<T> extends WireMarshaller<T> {
-    // Map for storing fields based on their names.
+    /**
+     * A {@link CharSequenceObjectMap} for efficient lookup of {@link FieldAccess} objects by
+     * field name, supporting both original and lower-cased names for flexibility in matching
+     * fields from the input wire.
+     */
     final CharSequenceObjectMap<FieldAccess> fieldMap;
 
+    /**
+     * Constructs a marshaller that can delegate to
+     * {@link ReadMarshallable#unexpectedField(CharSequence, ValueIn)} if unknown fields are
+     * encountered. Initialises the internal field map for quick lookups.
+     */
     public WireMarshallerForUnexpectedFields(@NotNull FieldAccess[] fields, boolean isLeaf, T defaultValue) {
         super(fields, isLeaf, defaultValue);
         fieldMap = new CharSequenceObjectMap<>(fields.length * 3);
@@ -41,6 +50,15 @@ public class WireMarshallerForUnexpectedFields<T> extends WireMarshaller<T> {
         }
     }
 
+    /**
+     * Overrides the default deserialisation logic to handle unexpected fields. When a field name
+     * read from {@code WireIn} is not found in the known {@link #fields} (even after
+     * case-insensitive matching), it calls
+     * {@link ReadMarshallable#unexpectedField(CharSequence, ValueIn)} on object {@code t} if
+     * possible. Known fields are processed as usual. The check
+     * {@code sb.length() == 0 && vin.isPresent()} optimises for DTO-order field reading by using
+     * the next field directly. Ensures progress is made during parsing to avoid infinite loops.
+     */
     @Override
     public void readMarshallable(T t, @NotNull WireIn in, boolean overwrite) throws InvalidMarshallableException {
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshallerForUnexpectedFields.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshallerForUnexpectedFields.java
@@ -23,10 +23,10 @@ import net.openhft.chronicle.core.scoped.ScopedResource;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Extends {@link WireMarshaller} to provide custom handling for unexpected fields during
- * deserialisation. Used when the target class overrides
- * {@link ReadMarshallable#unexpectedField(CharSequence, ValueIn)} to gain control of unknown
- * data.
+ * This class extends the WireMarshaller and provides the ability to handle unexpected fields.
+ * It maps fields by their name (both in their original form and lower-cased) for easy access.
+ * It overrides the method to read marshallable objects and provides specialized logic to
+ * handle unexpected fields that might be present in the data source.
  */
 public class WireMarshallerForUnexpectedFields<T> extends WireMarshaller<T> {
     /**
@@ -36,11 +36,6 @@ public class WireMarshallerForUnexpectedFields<T> extends WireMarshaller<T> {
      */
     final CharSequenceObjectMap<FieldAccess> fieldMap;
 
-    /**
-     * Constructs a marshaller that can delegate to
-     * {@link ReadMarshallable#unexpectedField(CharSequence, ValueIn)} if unknown fields are
-     * encountered. Initialises the internal field map for quick lookups.
-     */
     public WireMarshallerForUnexpectedFields(@NotNull FieldAccess[] fields, boolean isLeaf, T defaultValue) {
         super(fields, isLeaf, defaultValue);
         fieldMap = new CharSequenceObjectMap<>(fields.length * 3);
@@ -54,7 +49,7 @@ public class WireMarshallerForUnexpectedFields<T> extends WireMarshaller<T> {
      * Overrides the default deserialisation logic to handle unexpected fields. When a field name
      * read from {@code WireIn} is not found in the known {@link #fields} (even after
      * case-insensitive matching), it calls
-     * {@link ReadMarshallable#unexpectedField(CharSequence, ValueIn)} on object {@code t} if
+     * {@link ReadMarshallable#unexpectedField(Object, ValueIn)} on object {@code t} if
      * possible. Known fields are processed as usual. The check
      * {@code sb.length() == 0 && vin.isPresent()} optimises for DTO-order field reading by using
      * the next field directly. Ensures progress is made during parsing to avoid infinite loops.

--- a/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
@@ -32,22 +32,18 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Tokeniser for YAML documents.
- * Converts a raw YAML stream into a sequence of {@link YamlToken tokens},
- * each representing a distinct construct or symbol.
- * It is used internally by {@link YamlWire} to drive the parsing process.
+ * A tokenizer for YAML documents. The YamlTokeniser class is responsible for
+ * converting a raw YAML input into individual tokens, each representing
+ * a distinct construct or symbol in YAML. This class is integral to
+ * processes such as parsing or tokenization of YAML documents.
  */
 @SuppressWarnings({"this-escape","deprecation"})
 public class YamlTokeniser {
 
-    /**
-     * Represents an undefined or invalid indentation.
-     */
+    /** Represents an undefined or invalid indentation. */
     static final int NO_INDENT = -1;
 
-    /**
-     * Set of YAML tokens that contain no textual content.
-     */
+    /** Set of YAML tokens that don't contain any associated text content. */
     static final Set<YamlToken> NO_TEXT = EnumSet.of(
             YamlToken.SEQUENCE_START,
             YamlToken.SEQUENCE_ENTRY,
@@ -57,79 +53,46 @@ public class YamlTokeniser {
             YamlToken.MAPPING_END,
             YamlToken.DIRECTIVES_END);
 
-    /**
-     * A thread-local pool of {@link StringBuilder} instances for efficient
-     * string manipulation during tokenisation.
-     */
+    /** A pool of StringBuilders to improve efficiency and reduce memory overhead. */
     static final ScopedResourcePool<StringBuilder> SBP = StringBuilderPool.createThreadLocal(1);
 
-    /**
-     * A stack of {@link YTContext} objects describing the current nesting of
-     * YAML structures.
-     */
+    /** Stack to manage contextual information during tokenization. */
     protected final List<YTContext> contexts = new ArrayList<>();
 
-    /**
-     * The {@link BytesIn} providing the raw YAML input stream.
-     */
+    /** The input source containing the raw YAML content. */
     private final BytesIn<?> in;
 
-    /**
-     * Pool of reusable {@link YTContext} instances to reduce allocations.
-     */
+    /** Pool of reusable {@link YTContext} instances to reduce allocations. */
     private final List<YTContext> freeContexts = new ArrayList<>();
 
-    /**
-     * Tokens that have been pushed back and will be returned before further
-     * parsing the input.
-     */
+    /** List of tokens that have been identified but not yet processed. */
     private final List<YamlToken> pushed = new ArrayList<>();
 
-    /**
-     * Temporary buffer, often used for accumulating literal block content.
-     */
+    /** Temporary bytes buffer. */
     Bytes<?> temp = null;
 
-    /**
-     * Byte offset marking the start of the current line in {@link #in}.
-     */
+    /** Position marker for the start of a line. */
     long lineStart;
 
-    /**
-     * Byte offset for the start of the textual content of the current scalar.
-     */
+    /** Position marker for the start of a block. */
     long blockStart;
 
-    /**
-     * Byte offset for the end of the textual content of the current scalar.
-     */
+    /** Position marker for the end of a block. */
     long blockEnd;
 
-    /**
-     * Tracks the nesting depth of flow style collections ({@code {...}} or
-     * {@code [...]}).
-     */
+    /** Current depth of flow structures, like lists or maps. */
     int flowDepth = Integer.MAX_VALUE;
 
-    /**
-     * Quote character if the current scalar was quoted; {@code 0} otherwise.
-     */
+    /** Character used to denote quoting in a block. */
     char blockQuote = 0;
 
-    /**
-     * Flag used to manage implicit {@link YamlToken#SEQUENCE_ENTRY} tokens
-     * within flow sequences.
-     */
+    /** Flag to indicate if a sequence entry has been encountered. */
     boolean hasSequenceEntry;
 
-    /**
-     * Byte offset of the start of the most recently parsed mapping key.
-     */
+    /** Position marker for the last key in a key-value pair. */
     long lastKeyPosition = -1;
 
-    /**
-     * The most recently returned token.
-     */
+    /** The last token that was processed. */
     private YamlToken last = YamlToken.STREAM_START;
 
     /**
@@ -152,8 +115,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Resets the tokeniser to its initial state, clearing all contexts,
-     * buffers and flags. Prepares it to tokenise a new stream or restart
+     * Resets the tokenizer to its initial state, clearing all contexts,
+     * buffers and flags. Prepares it to tokenize a new stream or restart
      * from the beginning of the current input.
      */
     void reset() {
@@ -173,8 +136,10 @@ public class YamlTokeniser {
     }
 
     /**
-     * Returns the token at the top of the context stack or
-     * {@link YamlToken#STREAM_START} if none.
+     * Returns the context of the YAML tokenization process.
+     * This method provides the top-level token context based on the tokenization history.
+     *
+     * @return The top context token if contexts are present, otherwise returns STREAM_START.
      */
     public YamlToken context() {
         return contexts.isEmpty() ? YamlToken.STREAM_START : topContext().token;
@@ -195,9 +160,10 @@ public class YamlTokeniser {
     }
 
     /**
-     * Returns the last token produced by {@link #next(int)}. If the parser
-     * is at the start of the stream, calling this method will parse and return
-     * the first real token.
+     * Gets the current token in the tokenization process.
+     * If the last token was the start of the stream, this method fetches the next token.
+     *
+     * @return The current YamlToken object representing the tokenization status.
      */
     public YamlToken current() {
         if (last == YamlToken.STREAM_START)
@@ -206,19 +172,21 @@ public class YamlTokeniser {
     }
 
     /**
-     * Convenience wrapper for {@link #next(int)} using the current context
-     * indentation.
+     * Fetches the next token based on the current context's indentation.
+     *
+     * @return The next YamlToken object in line based on the current indentation context.
      */
     public YamlToken next() {
         return next(contextIndent());
     }
 
     /**
-     * Core tokenisation method. It first checks the {@link #pushed} stack and,
-     * if empty, parses the next token from the input stream via
-     * {@link #next0(int)}. The {@code minIndent} parameter is used to detect
-     * de-indentation and close block contexts. Updates {@link #last} with the
-     * produced token.
+     * Retrieves the next YAML token considering the minimum indentation provided.
+     * This method drives the core tokenization process, fetching tokens based on
+     * the minimum indentation and updating the last token processed.
+     *
+     * @param minIndent The minimum indentation to consider while tokenizing.
+     * @return The next YamlToken object based on the specified indentation.
      */
     @NotNull
     public YamlToken next(int minIndent) {
@@ -231,12 +199,13 @@ public class YamlTokeniser {
     }
 
     /**
-     * Internal tokenisation logic. Consumes leading whitespace and then
-     * examines the next character to determine the {@link YamlToken}. Handles
-     * comments, quoted strings, directives, tags, anchors, aliases, literal
-     * blocks, flow collections and plain scalars. The {@code minIndent}
-     * parameter controls when block contexts are closed due to
-     * de-indentation.
+     * Core method to tokenize the YAML content based on the given minimum indentation.
+     * The method processes the current position in the input stream and returns the
+     * next tokenized YAML construct. It utilizes the current context and the indentation
+     * level to identify and process different YAML constructs.
+     *
+     * @param minIndent The minimum indentation level to consider while tokenizing.
+     * @return The next {@link YamlToken} in the tokenization sequence.
      */
     YamlToken next0(int minIndent) {
         // Consuming any whitespace present at the start of a line
@@ -430,8 +399,11 @@ public class YamlTokeniser {
     }
 
     /**
-     * Checks whether parsing at the supplied {@code indent} would require the
-     * context stack to pop given the caller's {@code minIndent}.
+     * Determine if the current context would change given the indentation levels.
+     *
+     * @param minIndent The minimum indentation to consider.
+     * @param indent The current indentation level.
+     * @return True if context would change, false otherwise.
      */
     private boolean wouldChangeContext(int minIndent, int indent) {
         if (isInFlow())
@@ -449,8 +421,13 @@ public class YamlTokeniser {
     }
 
     /**
-     * Pops contexts until the given start token is reached when closing a flow
-     * collection.
+     * Pop from the context stack until a specified start token is encountered.
+     * This method is useful for flow constructs where we need to determine the
+     * boundaries (like a list or map).
+     *
+     * @param start The token to identify the start of the flow construct.
+     * @param end The character representing the end of the flow construct.
+     * @return The appropriate {@link YamlToken} after popping the context.
      */
     private YamlToken flowPop(YamlToken start, char end) {
         int pos = pushed.size();
@@ -465,7 +442,11 @@ public class YamlTokeniser {
     }
 
     /**
-     * Handles opening of flow collections and manages the context stack.
+     * Handles YAML flow constructs such as sequences and maps.
+     * This method manages the context and the stack of tokens accordingly.
+     *
+     * @param token The {@link YamlToken} to be processed.
+     * @return The next token in the sequence.
      */
     private YamlToken flow(YamlToken token) {
         pushed.add(token);
@@ -528,11 +509,13 @@ public class YamlTokeniser {
     }
 
     /**
-     * Parses a YAML literal block scalar. When {@code withNewLines} is
-     * {@code true} (for the {@code |} style) newlines are kept; when
-     * {@code false} (for {@code >}) they are folded into spaces except for
-     * blank lines. Accumulates the content into {@link #temp} until a line with
-     * less indentation is encountered.
+     * Reads and processes a literal scalar block from the YAML input.
+     * In YAML, literal scalars are indicated by the pipe character '|'.
+     * This method will capture content preserving formatting and any newlines
+     * present, depending on the withNewLines flag.
+     *
+     * @param withNewLines A flag indicating if newlines should be preserved (true)
+     * or converted to spaces (false) during the read process.
      */
     private void readLiteral(boolean withNewLines) {
         readNewline(); // read to the end of the line.
@@ -615,9 +598,13 @@ public class YamlTokeniser {
     }
 
     /**
-     * Manages indentation changes. De-indentation may pop existing contexts and
-     * emit their end tokens, whilst increasing indentation pushes a new context
-     * and its start token onto {@link #pushed}.
+     * Handles and determines the indentation level and relevant token type based on context.
+     *
+     * @param indented The token for the start of indentation context.
+     * @param key The key token type.
+     * @param push The token type to be pushed to the stack.
+     * @param indent The current indentation level.
+     * @return The next token after processing the current input.
      */
     private YamlToken indent(
             YamlToken indented,
@@ -848,9 +835,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Pushes a new parsing context. Inserts an implicit
-     * {@link YamlToken#DIRECTIVES_END} if starting from
-     * {@link YamlToken#STREAM_START}.
+     * Pushes a new parsing context.
+     * Inserts an implicit {@link YamlToken#DIRECTIVES_END}
+     * if starting from{@link YamlToken#STREAM_START}.
      */
     private void contextPush(YamlToken context, int indent) {
         // If we're at the start of a stream and the context isn't the end of directives,
@@ -865,9 +852,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Parses text between double quotes. Sets {@link #blockStart},
-     * {@link #blockEnd} and {@link #blockQuote} but leaves unescaping to
-     * {@link #text()}.
+     * Reads a value enclosed in double quotes from the input stream.
+     * Supports escape sequences.
      */
     private void readDoublyQuoted() {
         blockQuote = '"';
@@ -889,8 +875,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Parses text between single quotes. Consecutive quotes represent an
-     * escaped quote. Unescaping is performed in {@link #text()}.
+     * Reads a value enclosed in single quotes from the input stream.
+     * Supports consecutive single quotes as escape for a single quote.
      */
     private void readSinglyQuoted() {
         blockQuote = '\'';
@@ -916,8 +902,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Tests whether the characters after the current plain scalar form a
-     * key-value separator ({@code :}).
+     * Checks if the current position in the stream marks the end of a field (denoted by a colon).
+     *
+     * @return true if the current position is a field end, false otherwise.
      */
     private boolean isFieldEnd() {
         consumeSpaces(); // Consume any spaces or tabs.
@@ -1019,8 +1006,10 @@ public class YamlTokeniser {
     }
 
     /**
-     * Obtains a context from {@link #freeContexts} or creates one and pushes it
-     * onto the stack.
+     * Pushes a new context onto the stack, or reuses one from the freeContexts list.
+     *
+     * @param token  The YAML token for the context.
+     * @param indent The indentation level for the context.
      */
     private void pushContext0(YamlToken token, int indent) {
         YTContext context = freeContexts.isEmpty() ? new YTContext() : freeContexts.remove(freeContexts.size() - 1);
@@ -1047,11 +1036,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Returns the textual content of the last scalar token. If the token came
-     * from a literal block the data is taken from {@link #temp}; otherwise the
-     * region within {@link #in} between {@link #blockStart} and
-     * {@link #blockEnd} is used. Unescaping based on {@link #blockQuote} is
-     * applied.
+     * Used primarily for testing purposes to extract the current block's text.
+     *
+     * @return the text of the current block or an empty string if no text.
      */
     public String text() {
         try (ScopedResource<StringBuilder> sbTl = SBP.get()) {
@@ -1062,8 +1049,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Variant of {@link #text()} that appends the value to the supplied
-     * {@link StringBuilder}.
+     * Extracts the text of the current block into the provided StringBuilder.
+     *
+     * @param sb StringBuilder to which the block's text will be appended.
      */
     public void text(StringBuilder sb) {
         // If blockEnd is not set and a temporary value exists, use that.
@@ -1087,7 +1075,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Parses the text of the last scalar token as a double.
+     * Parses the current block's content as a double.
+     *
+     * @return the parsed double value.
      */
     public double parseDouble() {
         if (blockEnd < 0 && temp != null) {
@@ -1107,8 +1097,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Parses the text of the last scalar token as a long. YAML octal notation
-     * ({@code 0o...}) is supported.
+     * Parses the current block's content as a long. Handles octal numbers as well.
+     *
+     * @return the parsed long value.
      */
     public long parseLong() {
         if (blockEnd < 0 && temp != null) {
@@ -1187,8 +1178,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Represents a level in the parsing context stack, storing the structure
-     * type, its indentation and any skipped keys.
+     * Inner static class that represents the context during YAML parsing.
+     * This can include the current token, the indent level, and associated keys.
      */
     static class YTContext extends SelfDescribingMarshallable {
         YamlToken token;     // The current token in this context.

--- a/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
@@ -32,18 +32,22 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * A tokenizer for YAML documents. The YamlTokeniser class is responsible for
- * converting a raw YAML input into individual tokens, each representing
- * a distinct construct or symbol in YAML. This class is integral to
- * processes such as parsing or tokenization of YAML documents.
+ * Tokeniser for YAML documents.
+ * Converts a raw YAML stream into a sequence of {@link YamlToken tokens},
+ * each representing a distinct construct or symbol.
+ * It is used internally by {@link YamlWire} to drive the parsing process.
  */
 @SuppressWarnings({"this-escape","deprecation"})
 public class YamlTokeniser {
 
-    /** Represents an undefined or invalid indentation. */
+    /**
+     * Represents an undefined or invalid indentation.
+     */
     static final int NO_INDENT = -1;
 
-    /** Set of YAML tokens that don't contain any associated text content. */
+    /**
+     * Set of YAML tokens that contain no textual content.
+     */
     static final Set<YamlToken> NO_TEXT = EnumSet.of(
             YamlToken.SEQUENCE_START,
             YamlToken.SEQUENCE_ENTRY,
@@ -53,46 +57,79 @@ public class YamlTokeniser {
             YamlToken.MAPPING_END,
             YamlToken.DIRECTIVES_END);
 
-    /** A pool of StringBuilders to improve efficiency and reduce memory overhead. */
+    /**
+     * A thread-local pool of {@link StringBuilder} instances for efficient
+     * string manipulation during tokenisation.
+     */
     static final ScopedResourcePool<StringBuilder> SBP = StringBuilderPool.createThreadLocal(1);
 
-    /** Stack to manage contextual information during tokenization. */
+    /**
+     * A stack of {@link YTContext} objects describing the current nesting of
+     * YAML structures.
+     */
     protected final List<YTContext> contexts = new ArrayList<>();
 
-    /** The input source containing the raw YAML content. */
+    /**
+     * The {@link BytesIn} providing the raw YAML input stream.
+     */
     private final BytesIn<?> in;
 
-    /** A pool of reusable context objects to manage YAML structures. */
+    /**
+     * Pool of reusable {@link YTContext} instances to reduce allocations.
+     */
     private final List<YTContext> freeContexts = new ArrayList<>();
 
-    /** List of tokens that have been identified but not yet processed. */
+    /**
+     * Tokens that have been pushed back and will be returned before further
+     * parsing the input.
+     */
     private final List<YamlToken> pushed = new ArrayList<>();
 
-    /** Temporary bytes buffer. */
+    /**
+     * Temporary buffer, often used for accumulating literal block content.
+     */
     Bytes<?> temp = null;
 
-    /** Position marker for the start of a line. */
+    /**
+     * Byte offset marking the start of the current line in {@link #in}.
+     */
     long lineStart;
 
-    /** Position marker for the start of a block. */
+    /**
+     * Byte offset for the start of the textual content of the current scalar.
+     */
     long blockStart;
 
-    /** Position marker for the end of a block. */
+    /**
+     * Byte offset for the end of the textual content of the current scalar.
+     */
     long blockEnd;
 
-    /** Current depth of flow structures, like lists or maps. */
+    /**
+     * Tracks the nesting depth of flow style collections ({@code {...}} or
+     * {@code [...]}).
+     */
     int flowDepth = Integer.MAX_VALUE;
 
-    /** Character used to denote quoting in a block. */
+    /**
+     * Quote character if the current scalar was quoted; {@code 0} otherwise.
+     */
     char blockQuote = 0;
 
-    /** Flag to indicate if a sequence entry has been encountered. */
+    /**
+     * Flag used to manage implicit {@link YamlToken#SEQUENCE_ENTRY} tokens
+     * within flow sequences.
+     */
     boolean hasSequenceEntry;
 
-    /** Position marker for the last key in a key-value pair. */
+    /**
+     * Byte offset of the start of the most recently parsed mapping key.
+     */
     long lastKeyPosition = -1;
 
-    /** The last token that was processed. */
+    /**
+     * The most recently returned token.
+     */
     private YamlToken last = YamlToken.STREAM_START;
 
     /**
@@ -115,8 +152,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Resets the state of the tokenizer. This method prepares the tokenizer
-     * for processing a new input or to restart the tokenization of the current input.
+     * Resets the tokeniser to its initial state, clearing all contexts,
+     * buffers and flags. Prepares it to tokenise a new stream or restart
+     * from the beginning of the current input.
      */
     void reset() {
         contexts.clear();
@@ -135,40 +173,31 @@ public class YamlTokeniser {
     }
 
     /**
-     * Returns the context of the YAML tokenization process.
-     * This method provides the top-level token context based on the tokenization history.
-     *
-     * @return The top context token if contexts are present, otherwise returns STREAM_START.
+     * Returns the token at the top of the context stack or
+     * {@link YamlToken#STREAM_START} if none.
      */
     public YamlToken context() {
         return contexts.isEmpty() ? YamlToken.STREAM_START : topContext().token;
     }
 
     /**
-     * Retrieves the top context from the context stack.
-     * This method provides the most recent tokenization context.
-     *
-     * @return The top YTContext object from the context stack.
+     * Most recent entry on the context stack.
      */
     public YTContext topContext() {
         return contexts.get(contextSize() - 1);
     }
 
     /**
-     * Retrieves the second to top context from the context stack.
-     * This method provides the tokenization context that's just below the topmost one.
-     *
-     * @return The second top YTContext object from the context stack.
+     * Context entry one below the top of the stack.
      */
     public YTContext secondTopContext() {
         return contexts.get(contextSize() - 2);
     }
 
     /**
-     * Gets the current token in the tokenization process.
-     * If the last token was the start of the stream, this method fetches the next token.
-     *
-     * @return The current YamlToken object representing the tokenization status.
+     * Returns the last token produced by {@link #next(int)}. If the parser
+     * is at the start of the stream, calling this method will parse and return
+     * the first real token.
      */
     public YamlToken current() {
         if (last == YamlToken.STREAM_START)
@@ -177,21 +206,19 @@ public class YamlTokeniser {
     }
 
     /**
-     * Fetches the next token based on the current context's indentation.
-     *
-     * @return The next YamlToken object in line based on the current indentation context.
+     * Convenience wrapper for {@link #next(int)} using the current context
+     * indentation.
      */
     public YamlToken next() {
         return next(contextIndent());
     }
 
     /**
-     * Retrieves the next YAML token considering the minimum indentation provided.
-     * This method drives the core tokenization process, fetching tokens based on
-     * the minimum indentation and updating the last token processed.
-     *
-     * @param minIndent The minimum indentation to consider while tokenizing.
-     * @return The next YamlToken object based on the specified indentation.
+     * Core tokenisation method. It first checks the {@link #pushed} stack and,
+     * if empty, parses the next token from the input stream via
+     * {@link #next0(int)}. The {@code minIndent} parameter is used to detect
+     * de-indentation and close block contexts. Updates {@link #last} with the
+     * produced token.
      */
     @NotNull
     public YamlToken next(int minIndent) {
@@ -204,13 +231,12 @@ public class YamlTokeniser {
     }
 
     /**
-     * Core method to tokenize the YAML content based on the given minimum indentation.
-     * The method processes the current position in the input stream and returns the
-     * next tokenized YAML construct. It utilizes the current context and the indentation
-     * level to identify and process different YAML constructs.
-     *
-     * @param minIndent The minimum indentation level to consider while tokenizing.
-     * @return The next {@link YamlToken} in the tokenization sequence.
+     * Internal tokenisation logic. Consumes leading whitespace and then
+     * examines the next character to determine the {@link YamlToken}. Handles
+     * comments, quoted strings, directives, tags, anchors, aliases, literal
+     * blocks, flow collections and plain scalars. The {@code minIndent}
+     * parameter controls when block contexts are closed due to
+     * de-indentation.
      */
     YamlToken next0(int minIndent) {
         // Consuming any whitespace present at the start of a line
@@ -404,11 +430,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Determine if the current context would change given the indentation levels.
-     *
-     * @param minIndent The minimum indentation to consider.
-     * @param indent The current indentation level.
-     * @return True if context would change, false otherwise.
+     * Checks whether parsing at the supplied {@code indent} would require the
+     * context stack to pop given the caller's {@code minIndent}.
      */
     private boolean wouldChangeContext(int minIndent, int indent) {
         if (isInFlow())
@@ -417,10 +440,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Helper method to handle scenarios where the character shouldn't be tokenized.
-     * This method ensures the last read character is reverted back and a NONE token is returned.
-     *
-     * @return The {@link YamlToken#NONE} token.
+     * Helper used when a peeked character should not be consumed.
+     * Unreads the character and returns {@link YamlToken#NONE}.
      */
     private YamlToken dontRead() {
         unreadLast();
@@ -428,13 +449,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Pop from the context stack until a specified start token is encountered.
-     * This method is useful for flow constructs where we need to determine the
-     * boundaries (like a list or map).
-     *
-     * @param start The token to identify the start of the flow construct.
-     * @param end The character representing the end of the flow construct.
-     * @return The appropriate {@link YamlToken} after popping the context.
+     * Pops contexts until the given start token is reached when closing a flow
+     * collection.
      */
     private YamlToken flowPop(YamlToken start, char end) {
         int pos = pushed.size();
@@ -449,11 +465,7 @@ public class YamlTokeniser {
     }
 
     /**
-     * Handles YAML flow constructs such as sequences and maps.
-     * This method manages the context and the stack of tokens accordingly.
-     *
-     * @param token The {@link YamlToken} to be processed.
-     * @return The next token in the sequence.
+     * Handles opening of flow collections and manages the context stack.
      */
     private YamlToken flow(YamlToken token) {
         pushed.add(token);
@@ -516,13 +528,11 @@ public class YamlTokeniser {
     }
 
     /**
-     * Reads and processes a literal scalar block from the YAML input.
-     * In YAML, literal scalars are indicated by the pipe character '|'.
-     * This method will capture content preserving formatting and any newlines
-     * present, depending on the withNewLines flag.
-     *
-     * @param withNewLines A flag indicating if newlines should be preserved (true)
-     * or converted to spaces (false) during the read process.
+     * Parses a YAML literal block scalar. When {@code withNewLines} is
+     * {@code true} (for the {@code |} style) newlines are kept; when
+     * {@code false} (for {@code >}) they are folded into spaces except for
+     * blank lines. Accumulates the content into {@link #temp} until a line with
+     * less indentation is encountered.
      */
     private void readLiteral(boolean withNewLines) {
         readNewline(); // read to the end of the line.
@@ -605,13 +615,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Handles and determines the indentation level and relevant token type based on context.
-     *
-     * @param indented The token for the start of indentation context.
-     * @param key The key token type.
-     * @param push The token type to be pushed to the stack.
-     * @param indent The current indentation level.
-     * @return The next token after processing the current input.
+     * Manages indentation changes. De-indentation may pop existing contexts and
+     * emit their end tokens, whilst increasing indentation pushes a new context
+     * and its start token onto {@link #pushed}.
      */
     private YamlToken indent(
             YamlToken indented,
@@ -646,10 +652,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Reads plain scalar text from the YAML input, handling mappings and sequences.
-     *
-     * @param indent2 The current indentation level.
-     * @return The token after processing the text.
+     * Reads a plain scalar (unquoted text). Uses {@link #readWords()} to update
+     * {@link #blockStart} and {@link #blockEnd}. If the scalar is followed by a
+     * colon it is treated as a {@link YamlToken#MAPPING_KEY}.
      */
     private YamlToken readText(int indent2) {
         long pos = in.readPosition(); // Store the current position of input.
@@ -670,10 +675,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Handles the sequence logic within the YAML structure.
-     *
-     * @param token The current token being processed.
-     * @return A {@link YamlToken} after processing the sequence logic.
+     * Helper to manage {@link YamlToken#SEQUENCE_ENTRY} tokens inside flow
+     * sequences.
      */
     private YamlToken seq(YamlToken token) {
         // If a sequence entry has not been processed yet and the current context is a sequence start, and it's in flow
@@ -812,7 +815,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Removes the top context from the context stack, and frees up the context.
+     * Pops the top context and adds it to {@link #freeContexts}. Emits the
+     * context's end token if present.
      */
     private void contextPop() {
         YTContext context0 = contexts.remove(contextSize() - 1); // Remove the top context.
@@ -830,9 +834,7 @@ public class YamlTokeniser {
     }
 
     /**
-     * Reverts to a specified context level.
-     *
-     * @param contextSize The desired context level.
+     * Drops contexts until the stack reaches the supplied {@code contextSize}.
      */
     void revertToContext(int contextSize) {
         pushed.clear(); // Clear the pushed tokens.
@@ -846,10 +848,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Pushes a new context to the context stack.
-     *
-     * @param context The YAML token representing the context.
-     * @param indent  The indentation level for this context.
+     * Pushes a new parsing context. Inserts an implicit
+     * {@link YamlToken#DIRECTIVES_END} if starting from
+     * {@link YamlToken#STREAM_START}.
      */
     private void contextPush(YamlToken context, int indent) {
         // If we're at the start of a stream and the context isn't the end of directives,
@@ -864,8 +865,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Reads a value enclosed in double quotes from the input stream.
-     * Supports escape sequences.
+     * Parses text between double quotes. Sets {@link #blockStart},
+     * {@link #blockEnd} and {@link #blockQuote} but leaves unescaping to
+     * {@link #text()}.
      */
     private void readDoublyQuoted() {
         blockQuote = '"';
@@ -887,8 +889,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Reads a value enclosed in single quotes from the input stream.
-     * Supports consecutive single quotes as escape for a single quote.
+     * Parses text between single quotes. Consecutive quotes represent an
+     * escaped quote. Unescaping is performed in {@link #text()}.
      */
     private void readSinglyQuoted() {
         blockQuote = '\'';
@@ -914,9 +916,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Checks if the current position in the stream marks the end of a field (denoted by a colon).
-     *
-     * @return true if the current position is a field end, false otherwise.
+     * Tests whether the characters after the current plain scalar form a
+     * key-value separator ({@code :}).
      */
     private boolean isFieldEnd() {
         consumeSpaces(); // Consume any spaces or tabs.
@@ -1018,10 +1019,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Pushes a new context onto the stack, or reuses one from the freeContexts list.
-     *
-     * @param token  The YAML token for the context.
-     * @param indent The indentation level for the context.
+     * Obtains a context from {@link #freeContexts} or creates one and pushes it
+     * onto the stack.
      */
     private void pushContext0(YamlToken token, int indent) {
         YTContext context = freeContexts.isEmpty() ? new YTContext() : freeContexts.remove(freeContexts.size() - 1);
@@ -1048,9 +1047,11 @@ public class YamlTokeniser {
     }
 
     /**
-     * Used primarily for testing purposes to extract the current block's text.
-     *
-     * @return the text of the current block or an empty string if no text.
+     * Returns the textual content of the last scalar token. If the token came
+     * from a literal block the data is taken from {@link #temp}; otherwise the
+     * region within {@link #in} between {@link #blockStart} and
+     * {@link #blockEnd} is used. Unescaping based on {@link #blockQuote} is
+     * applied.
      */
     public String text() {
         try (ScopedResource<StringBuilder> sbTl = SBP.get()) {
@@ -1061,9 +1062,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Extracts the text of the current block into the provided StringBuilder.
-     *
-     * @param sb StringBuilder to which the block's text will be appended.
+     * Variant of {@link #text()} that appends the value to the supplied
+     * {@link StringBuilder}.
      */
     public void text(StringBuilder sb) {
         // If blockEnd is not set and a temporary value exists, use that.
@@ -1087,9 +1087,7 @@ public class YamlTokeniser {
     }
 
     /**
-     * Parses the current block's content as a double.
-     *
-     * @return the parsed double value.
+     * Parses the text of the last scalar token as a double.
      */
     public double parseDouble() {
         if (blockEnd < 0 && temp != null) {
@@ -1109,9 +1107,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Parses the current block's content as a long. Handles octal numbers as well.
-     *
-     * @return the parsed long value.
+     * Parses the text of the last scalar token as a long. YAML octal notation
+     * ({@code 0o...}) is supported.
      */
     public long parseLong() {
         if (blockEnd < 0 && temp != null) {
@@ -1190,8 +1187,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Inner static class that represents the context during YAML parsing.
-     * This can include the current token, the indent level, and associated keys.
+     * Represents a level in the parsing context stack, storing the structure
+     * type, its indentation and any skipped keys.
      */
     static class YTContext extends SelfDescribingMarshallable {
         YamlToken token;     // The current token in this context.

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -2532,3 +2532,4 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         writeContext.rollbackIfNotComplete();
     }
 }
+


### PR DESCRIPTION
A housekeeping sweep across **serialization-strategy infrastructure** and the core marshaller

| Area                             | Change                                                                                                                                                                                                                                                                              | Rationale                                                                                                                                          |
| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
| **API Docs**                     | Re-wrote/expanded Javadoc for:<br>• `SerializationStrategy` + the `SerializationStrategies` enum<br>• `ScalarStrategy`<br>• `WireMarshaller`, `FieldAccess`, and the “unexpected field” marshaller<br>• `SerializationStrategies` nested wrappers (Array/PrimArray/Demarshallable). | \* Clearer contracts and type expectations  \* Links to related types  \* Added bracket-type semantics  \* Marked deprecations & removal schedules |
| **Internal comments & tidy-ups** | • Added missing `@return` / `@param` docs<br>• Removed outdated references (DeltaWire, legacy flags)<br>• Consistent first-line summary sentences                                                                                                                                   | Easier onboarding; IDE hovers are now useful.                                                                                                      |

---

## Breakdown by commit

| Commit  | Message                                                   | Highlight                                                    |
| ------- | --------------------------------------------------------- | ------------------------------------------------------------ |
| **1/8** | Create branch                                             | make `ordinal` field `final`                                 |
| **2/8** | *Improve SerializationStrategy Javadoc* (#1039)           | new param/return docs, bracket-type clarifications           |
| **3/8** | *Improve javadoc for SerializationStrategies* (#1040)     | each enum constant now fully documented                      |
| **4/8** | *Improve Javadoc in ScalarStrategy* (#1041)               | explained builder helpers, NONE bracket type                 |
| **5/8** | *Improve javadoc for WireMarshaller* (#1042)              | overview, constructor notes, leaf/default logic              |
| **6/8** | *Further WireMarshaller docs* (#1043)                     | added per-method explanations                                |
| **7/8** | *Improve javadoc for FieldAccess* (#1045)                 | covered every nested accessor class                          |
| **8/8** | *Improve Javadoc for unexpected field marshaller* (#1044) | explained custom flow when `unexpectedField()` is overridden |
