### PR TITLE
Improve javadoc for reflection field info classes

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/internal/VanillaFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/VanillaFieldInfo.java
@@ -28,18 +28,45 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Objects;
 
+/**
+ * Standard reflection-backed implementation of {@link AbstractFieldInfo}.
+ * The associated {@link Field} is recreated on demand so that instances
+ * remain functional after deserialisation. Intended for internal marshalling
+ * tasks where unsafe access is not required.
+ */
 @SuppressWarnings("rawtypes")
 public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
 
+    /**
+     * Declaring class of the target field. Used to re-acquire the
+     * {@link #field} instance if needed.
+     */
     private final Class<?> parent;
+
+    /**
+     * Reflection handle to the actual field. Marked transient and looked up
+     * lazily via {@link #getField()}.
+     */
     private transient Field field;
 
+    /**
+     * Creates an instance for a specific field.
+     *
+     * @param name         textual name of the field
+     * @param type         runtime type of the field
+     * @param bracketType  bracket style used when writing
+     * @param field        reflection field for direct access
+     */
     public VanillaFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
         super(type, bracketType, name);
         parent = field.getDeclaringClass();
         this.field = field;
     }
 
+    /**
+     * Retrieves the value of this field from {@code object}. The method logs
+     * and returns {@code null} if reflection fails.
+     */
     @Nullable
     @Override
     public Object get(Object object) {
@@ -51,6 +78,11 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         }
     }
 
+    /**
+     * Reads the primitive {@code long} value.
+     *
+     * @return the field value or {@code Long.MIN_VALUE} on error
+     */
     @Override
     public long getLong(Object object) {
         try {
@@ -61,6 +93,11 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         }
     }
 
+    /**
+     * Reads the primitive {@code int} value.
+     *
+     * @return the field value or {@code Integer.MIN_VALUE} on error
+     */
     @Override
     public int getInt(Object object) {
         try {
@@ -71,6 +108,11 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         }
     }
 
+    /**
+     * Reads the primitive {@code char} value.
+     *
+     * @return the field value or {@code Character.MAX_VALUE} on error
+     */
     @Override
     public char getChar(Object object) {
         try {
@@ -81,6 +123,11 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         }
     }
 
+    /**
+     * Reads the primitive {@code double} value.
+     *
+     * @return the field value or {@code Double.NaN} on error
+     */
     @Override
     public double getDouble(Object object) {
         try {
@@ -92,6 +139,11 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
     }
 
     @SuppressWarnings("unchecked")
+    /**
+     * Converts {@code value} to the field type and writes it using reflection.
+     *
+     * @throws IllegalArgumentException if the field cannot be accessed
+     */
     @Override
     public void set(Object object, Object value) throws IllegalArgumentException {
         Object value2 = ObjectUtils.convertTo(type, value);
@@ -102,6 +154,11 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         }
     }
 
+    /**
+     * Writes an {@code int} value to the field.
+     *
+     * @throws IllegalArgumentException if reflection fails
+     */
     @Override
     public void set(Object object, int value) throws IllegalArgumentException {
         try {
@@ -111,6 +168,11 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         }
     }
 
+    /**
+     * Writes a {@code char} value to the field.
+     *
+     * @throws IllegalArgumentException if reflection fails
+     */
     @Override
     public void set(Object object, char value) throws IllegalArgumentException {
         try {
@@ -120,6 +182,11 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         }
     }
 
+    /**
+     * Writes a {@code long} value to the field.
+     *
+     * @throws IllegalArgumentException if reflection fails
+     */
     @Override
     public void set(Object object, long value) throws IllegalArgumentException {
         try {
@@ -129,6 +196,11 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         }
     }
 
+    /**
+     * Writes a {@code double} value to the field.
+     *
+     * @throws IllegalArgumentException if reflection fails
+     */
     @Override
     public void set(Object object, double value) throws IllegalArgumentException {
         try {
@@ -138,6 +210,12 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         }
     }
 
+    /**
+     * Lazily retrieves the underlying {@link Field}, re-acquiring it from
+     * {@link #parent} when required.
+     *
+     * @throws NoSuchFieldException if the field does not exist on the parent
+     */
     public Field getField() throws NoSuchFieldException {
         if (field == null) {
             field = parent.getDeclaredField(name);
@@ -146,6 +224,10 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         return field;
     }
 
+    /**
+     * Returns the {@link Class} of the generic argument at the given index if
+     * this field is parameterised.
+     */
     @Override
     public Class<?> genericType(int index) {
         ParameterizedType genericType = (ParameterizedType) field.getGenericType();
@@ -153,6 +235,11 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         return (Class) type;
     }
 
+    /**
+     * Compares the value of this field in two objects. Primitive types are
+     * compared directly, otherwise {@link Objects#deepEquals(Object, Object)}
+     * is used.
+     */
     @Override
     public boolean isEqual(Object a, Object b) {
         if (type.isPrimitive()) {

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/CharFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/CharFieldInfo.java
@@ -24,25 +24,26 @@ import org.jetbrains.annotations.NotNull;
 import java.lang.reflect.Field;
 
 /**
- * Represents field information for character fields, extending the generic field information capabilities
- * provided by {@link UnsafeFieldInfo}. It offers direct memory access functionality to get and set
- * character values in objects, leveraging unsafe operations for performance.
+ * Internal {@link net.openhft.chronicle.wire.FieldInfo} for {@code char} fields
+ * using {@link UnsafeMemory} to read and write values via memory offsets.
  */
 public final class CharFieldInfo extends UnsafeFieldInfo {
 
     /**
-     * Constructs an instance of CharFieldInfo with the provided details about a character field.
-     *
-     * @param name        The name of the field.
-     * @param type        The type of the field.
-     * @param bracketType The bracket type associated with the field.
-     * @param field       The field object representation.
+     * @param name        field name used in text form
+     * @param type        runtime type
+     * @param bracketType formatting hint when writing
+     * @param field       reflection field used for unsafe access
      */
     public CharFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
         super(name, type, bracketType, field);
     }
 
     @Override
+    /**
+     * @return the {@code char} value or {@link Character#MAX_VALUE} if the
+     * offset could not be determined
+     */
     public char getChar(Object object) {
         try {
             return UnsafeMemory.unsafeGetChar(object, getOffset());
@@ -53,6 +54,7 @@ public final class CharFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
+    /** Writes the value using {@link UnsafeMemory}. */
     public void set(Object object, char value) throws IllegalArgumentException {
         try {
             UnsafeMemory.unsafePutChar(object, getOffset(), value);
@@ -62,11 +64,13 @@ public final class CharFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
+    /** Compares the character values in {@code a} and {@code b}. */
     public boolean isEqual(Object a, Object b) {
         return getChar(a) == getChar(b);
     }
 
     @Override
+    /** Copies the character value from {@code source} to {@code destination}. */
     public void copy(Object source, Object destination) {
         set(destination, getChar(source));
     }

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/DoubleFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/DoubleFieldInfo.java
@@ -24,25 +24,25 @@ import org.jetbrains.annotations.NotNull;
 import java.lang.reflect.Field;
 
 /**
- * Represents field information for double fields, extending the generic field information capabilities
- * provided by {@link UnsafeFieldInfo}. It offers direct memory access functionality to get and set
- * double values in objects, leveraging unsafe operations for enhanced performance.
+ * Internal {@link net.openhft.chronicle.wire.FieldInfo} for {@code double}
+ * fields using {@link UnsafeMemory} for direct access.
  */
 public final class DoubleFieldInfo extends UnsafeFieldInfo {
 
     /**
-     * Constructs an instance of DoubleFieldInfo with the provided details about a double field.
-     *
-     * @param name        The name of the field.
-     * @param type        The type of the field.
-     * @param bracketType The bracket type associated with the field.
-     * @param field       The field object representation.
+     * @param name        field name used in text form
+     * @param type        runtime type
+     * @param bracketType formatting hint when writing
+     * @param field       reflection field used for unsafe access
      */
     public DoubleFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
         super(name, type, bracketType, field);
     }
 
     @Override
+    /**
+     * @return the field value or {@code Double.NaN} if the offset is unavailable
+     */
     public double getDouble(Object object) {
         try {
             return UnsafeMemory.unsafeGetDouble(object, getOffset());
@@ -53,6 +53,7 @@ public final class DoubleFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
+    /** Writes the value using {@link UnsafeMemory}. */
     public void set(Object object, double value) throws IllegalArgumentException {
         try {
             UnsafeMemory.unsafePutDouble(object, getOffset(), value);
@@ -62,11 +63,13 @@ public final class DoubleFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
+    /** Compares the double values in {@code a} and {@code b}. */
     public boolean isEqual(Object a, Object b) {
         return getDouble(a) == getDouble(b);
     }
 
     @Override
+    /** Copies the double value from {@code source} to {@code destination}. */
     public void copy(Object source, Object destination) {
         set(destination, getDouble(source));
     }

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/IntFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/IntFieldInfo.java
@@ -24,25 +24,25 @@ import org.jetbrains.annotations.NotNull;
 import java.lang.reflect.Field;
 
 /**
- * Represents field information for integer fields, extending the generic field information capabilities
- * provided by {@link UnsafeFieldInfo}. It offers direct memory access functionality to get and set
- * integer values in objects, leveraging unsafe operations for enhanced performance.
+ * Internal {@link net.openhft.chronicle.wire.FieldInfo} for {@code int} fields
+ * using {@link UnsafeMemory} for direct access.
  */
 public final class IntFieldInfo extends UnsafeFieldInfo {
 
     /**
-     * Constructs an instance of IntFieldInfo with the provided details about an integer field.
-     *
-     * @param name        The name of the field.
-     * @param type        The type of the field.
-     * @param bracketType The bracket type associated with the field.
-     * @param field       The field object representation.
+     * @param name        field name used in text form
+     * @param type        runtime type
+     * @param bracketType formatting hint when writing
+     * @param field       reflection field used for unsafe access
      */
     public IntFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
         super(name, type, bracketType, field);
     }
 
     @Override
+    /**
+     * @return the field value or {@code Integer.MIN_VALUE} if the offset is unavailable
+     */
     public int getInt(Object object) {
         try {
             return UnsafeMemory.unsafeGetInt(object, getOffset());
@@ -53,6 +53,7 @@ public final class IntFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
+    /** Writes the value using {@link UnsafeMemory}. */
     public void set(Object object, int value) throws IllegalArgumentException {
         try {
             UnsafeMemory.unsafePutInt(object, getOffset(), value);
@@ -62,11 +63,13 @@ public final class IntFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
+    /** Compares the int values in {@code a} and {@code b}. */
     public boolean isEqual(Object a, Object b) {
         return getInt(a) == getInt(b);
     }
 
     @Override
+    /** Copies the int value from {@code source} to {@code destination}. */
     public void copy(Object source, Object destination) {
         set(destination, getInt(source));
     }

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/LongFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/LongFieldInfo.java
@@ -24,25 +24,25 @@ import org.jetbrains.annotations.NotNull;
 import java.lang.reflect.Field;
 
 /**
- * Represents field information for long fields, extending the generic field information capabilities
- * provided by {@link UnsafeFieldInfo}. This class offers direct memory access functionality to get and set
- * long values in objects, leveraging unsafe operations for performance enhancement.
+ * Internal {@link net.openhft.chronicle.wire.FieldInfo} for {@code long} fields
+ * using {@link UnsafeMemory} for direct access.
  */
 public final class LongFieldInfo extends UnsafeFieldInfo {
 
     /**
-     * Constructs an instance of LongFieldInfo with the provided details about a long field.
-     *
-     * @param name        The name of the field.
-     * @param type        The type of the field.
-     * @param bracketType The bracket type associated with the field.
-     * @param field       The actual field representation.
+     * @param name        field name used in text form
+     * @param type        runtime type
+     * @param bracketType formatting hint when writing
+     * @param field       reflection field used for unsafe access
      */
     public LongFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
         super(name, type, bracketType, field);
     }
 
     @Override
+    /**
+     * @return the field value or {@code Long.MIN_VALUE} if the offset is unavailable
+     */
     public long getLong(Object object) {
         try {
             return UnsafeMemory.unsafeGetLong(object, getOffset());
@@ -53,6 +53,7 @@ public final class LongFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
+    /** Writes the value using {@link UnsafeMemory}. */
     public void set(Object object, long value) throws IllegalArgumentException {
         try {
             UnsafeMemory.unsafePutLong(object, getOffset(), value);
@@ -62,11 +63,13 @@ public final class LongFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
+    /** Compares the long values in {@code a} and {@code b}. */
     public boolean isEqual(Object a, Object b) {
         return getLong(a) == getLong(b);
     }
 
     @Override
+    /** Copies the long value from {@code source} to {@code destination}. */
     public void copy(Object source, Object destination) {
         set(destination, getLong(source));
     }

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/ObjectFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/ObjectFieldInfo.java
@@ -27,25 +27,25 @@ import java.lang.reflect.Field;
 import java.util.Objects;
 
 /**
- * Represents field information for object fields, extending the generic field information capabilities
- * provided by {@link UnsafeFieldInfo}. This class offers direct memory access functionality to get and set
- * object values in objects, leveraging unsafe operations for performance enhancement.
+ * Internal {@link net.openhft.chronicle.wire.FieldInfo} for reference fields
+ * using {@link UnsafeMemory} for direct access.
  */
 public final class ObjectFieldInfo extends UnsafeFieldInfo {
 
     /**
-     * Constructs an instance of ObjectFieldInfo with the provided details about an object field.
-     *
-     * @param name        The name of the field.
-     * @param type        The type of the field.
-     * @param bracketType The bracket type associated with the field.
-     * @param field       The actual field representation.
+     * @param name        field name used in text form
+     * @param type        runtime type
+     * @param bracketType formatting hint when writing
+     * @param field       reflection field used for unsafe access
      */
     public ObjectFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
         super(name, type, bracketType, field);
     }
 
     @Override
+    /**
+     * @return the field value or {@code null} if the offset could not be determined
+     */
     public @Nullable Object get(Object object) {
         try {
             return UnsafeMemory.unsafeGetObject(object, getOffset());
@@ -56,6 +56,7 @@ public final class ObjectFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
+    /** Writes the value using {@link UnsafeMemory}, converting as required. */
     public void set(Object object, Object value) throws IllegalArgumentException {
         Object value2 = ObjectUtils.convertTo(type, value);
         try {
@@ -66,11 +67,13 @@ public final class ObjectFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
+    /** Compares the object values in {@code a} and {@code b}. */
     public boolean isEqual(Object a, Object b) {
         return Objects.deepEquals(get(a), get(b));
     }
 
     @Override
+    /** Copies the object value from {@code source} to {@code destination}. */
     public void copy(Object source, Object destination) {
         set(destination, get(source));
     }

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/UnsafeFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/UnsafeFieldInfo.java
@@ -23,33 +23,39 @@ import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Field;
 
+/**
+ * Base class for field access using {@link UnsafeMemory}. It resolves the
+ * memory offset of the underlying field and stores it for direct operations.
+ */
 @SuppressWarnings("deprecation" /* The parent class will either be moved to internal or cease to exist in x.26 */)
 class UnsafeFieldInfo extends VanillaFieldInfo {
-    // Offset value to indicate that it hasn't been set yet.
+    /** Offset value to indicate that it has not been set yet. */
     private static final long UNSET_OFFSET = Long.MAX_VALUE;
 
-    // Offset in memory where the value for this field can be found.
+    /**
+     * Memory offset of this field within its declaring class. Calculated on
+     * first use and cached. Marked transient as it is JVM specific.
+     */
     private transient long offset = UNSET_OFFSET;
 
     /**
-     * Constructs an instance of UnsafeFieldInfo with the provided details about a field.
+     * Creates an instance linked to a particular field.
      *
-     * @param name        The name of the field.
-     * @param type        The type of the field.
-     * @param bracketType The bracket type associated with the field.
-     * @param field       The actual field representation.
+     * @param name        textual field name
+     * @param type        runtime type of the field
+     * @param bracketType formatting hint used when writing
+     * @param field       reflection field from which the offset will be derived
      */
     public UnsafeFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
         super(name, type, bracketType, field);
     }
 
     /**
-     * Retrieves the memory offset where the value for this field is stored.
-     * If the offset hasn't been retrieved before, it leverages unsafe operations
-     * to get it and then caches the result.
+     * Obtains the memory offset of this field using {@link UnsafeMemory} on the
+     * first call and caches it for subsequent access.
      *
-     * @return The memory offset for this field.
-     * @throws NoSuchFieldException if there's a field access issue.
+     * @return the memory offset for direct field operations
+     * @throws NoSuchFieldException if {@link #getField()} fails
      */
     protected long getOffset() throws NoSuchFieldException {
         if (this.offset == UNSET_OFFSET) {


### PR DESCRIPTION
## Summary
- add internal description for `VanillaFieldInfo`
- expand class and method javadoc for `UnsafeFieldInfo` and its subclasses
- document reflection-based getters and setters

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*