### PR TITLE
Javadoc Field Info

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AbstractFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractFieldInfo.java
@@ -24,21 +24,27 @@ import static net.openhft.chronicle.wire.WireType.TEXT;
 @SuppressWarnings("rawtypes")
 public abstract class AbstractFieldInfo implements FieldInfo {
 
-    // The name of the field
+    /**
+     * The name of the field this {@code FieldInfo} instance represents.
+     */
     protected final String name;
 
-    // The type of the field
+    /**
+     * The Java type declared for the field.
+     */
     protected final Class<?> type;
 
-    // The bracket type associated with the field
+    /**
+     * How the field is bracketed when serialised.
+     */
     protected final BracketType bracketType;
 
     /**
-     * Constructs a new AbstractFieldInfo with the provided type, bracket type, and name.
+     * Creates a description of a field.
      *
-     * @param type         The class type of the field
-     * @param bracketType  The bracket type associated with the field
-     * @param name         The name of the field
+     * @param type        class used for marshalling
+     * @param bracketType placement of start and end brackets in the wire text
+     * @param name        identifier of the field
      */
     protected AbstractFieldInfo(Class<?> type, BracketType bracketType, String name) {
         this.type = type;
@@ -46,32 +52,50 @@ public abstract class AbstractFieldInfo implements FieldInfo {
         this.name = name;
     }
 
+    /**
+     * Returns the field name.
+     */
     @Override
     public String name() {
         return name;
     }
 
+    /**
+     * Returns the declared type.
+     */
     @Override
     public Class<?> type() {
         return type;
     }
 
+    /**
+     * Returns the bracket placement style.
+     */
     @Override
     public BracketType bracketType() {
         return bracketType;
     }
 
+    /**
+     * Generates a 32-bit hash of the serialised form.
+     */
     @Override
     public int hashCode() {
         return HashWire.hash32(this);
     }
 
+    /**
+     * Compares the serialised content for equality.
+     */
     @Override
     public boolean equals(Object obj) {
         if (obj == null) return false;
         return (this == obj || Wires.isEquals(this, obj));
     }
 
+    /**
+     * Returns a YAML style representation of this field information.
+     */
     @Override
     public String toString() {
         return TEXT.asString(this);

--- a/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
@@ -31,10 +31,23 @@ import static net.openhft.chronicle.wire.Wires.*;
 
 /**
  * Represents an abstraction for the meta-information of a field within a class or interface.
- * Implementations should provide more specific details about the type, nature, and characteristics of the field.
+ * This metadata is used by {@link WireMarshaller} and related serialisation components to read
+ * and write field values. It provides a consistent way to access properties such as the field
+ * name, type and how it is represented in the wire format.
  */
 public interface FieldInfo {
 
+    /**
+     * Creates an appropriate {@code FieldInfo} implementation for the supplied field.
+     * Primitive types are mapped to specialised variants such as {@link IntFieldInfo}.
+     * Other types fall back to {@link ObjectFieldInfo} or a generic implementation.
+     *
+     * @param name        the field's name
+     * @param type        the declared type
+     * @param bracketType the wire {@link BracketType}
+     * @param field       the reflective field instance
+     * @return a concrete {@code FieldInfo} for the field
+     */
     static FieldInfo createForField(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
         // Choose the FieldInfo type based on the field's type.
         if (!type.isPrimitive()) {
@@ -53,11 +66,13 @@ public interface FieldInfo {
     }
 
     /**
-     * Looks up the meta-information of the fields associated with the provided class and returns
-     * a pair of information encapsulated in {@link FieldInfoPair}.
+     * Analyses the supplied class using reflection and builds a {@link FieldInfoPair}
+     * describing its marshallable fields. The pair contains an unmodifiable list of
+     * {@code FieldInfo} objects and a map keyed by field name. Each field's
+     * {@link BracketType} is derived from its {@link SerializationStrategy}.
      *
-     * @param aClass The class for which field info needs to be retrieved.
-     * @return A {@link FieldInfoPair} representing the field information of the class.
+     * @param aClass the class to inspect
+     * @return an immutable {@link FieldInfoPair} describing the fields
      */
     @NotNull
     static FieldInfoPair lookupClass(@NotNull Class<?> aClass) {
@@ -120,109 +135,101 @@ public interface FieldInfo {
 
     /**
      * Returns the value of the field represented by this {@code FieldInfo} object
-     * as an {@link Object}. The provided {@code object} is used as a target to
-     * extract the field from.
-     *
-     * @return the value of the field represented by this {@code FieldInfo} object
      * as an {@link Object}.
+     *
+     * @param object the instance from which to read the field
+     * @return the field value or {@code null} if it cannot be obtained
      */
     @Nullable
     Object get(Object object);
 
     /**
      * Returns the value of the field represented by this {@code FieldInfo} object
-     * as a {@code long} primitive. The provided {@code object} is used as a target
-     * to extract the field from.
-     *
-     * @return the value of the field represented by this {@code FieldInfo} object
      * as a {@code long} primitive.
+     *
+     * @param object the instance from which to read the field
+     * @return the field value, converted to {@code long} if required
      */
     long getLong(Object object);
 
     /**
      * Returns the value of the field represented by this {@code FieldInfo} object
-     * as an {@code int} primitive. The provided {@code object} is used as a target
-     * to extract the field from.
-     *
-     * @return the value of the field represented by this {@code FieldInfo} object
      * as an {@code int} primitive.
+     *
+     * @param object the instance from which to read the field
+     * @return the field value, converted to {@code int} if required
      */
     int getInt(Object object);
 
     /**
      * Returns the value of the field represented by this {@code FieldInfo} object
-     * as a {@code char} primitive. The provided {@code object} is used as a target
-     * to extract the field from.
-     *
-     * @return the value of the field represented by this {@code FieldInfo} object
      * as a {@code char} primitive.
+     *
+     * @param object the instance from which to read the field
+     * @return the field value, converted to {@code char} if required
      */
     char getChar(Object object);
 
     /**
      * Returns the value of the field represented by this {@code FieldInfo} object
-     * as a {@code double} primitive. The provided {@code object} is used as a target
-     * to extract the field from.
-     *
-     * @return the value of the field represented by this {@code FieldInfo} object
      * as a {@code double} primitive.
+     *
+     * @param object the instance from which to read the field
+     * @return the field value, converted to {@code double} if required
      */
     double getDouble(Object object);
 
     /**
-     * Sets the value of the field represented by this {@code FieldInfo} object
-     * to the provided {@code value}. The provided {@code object} is used as a
-     * target to the extract eh field from.
+     * Sets the value of the field represented by this {@code FieldInfo} object.
+     *
+     * @param object the instance on which to set the field
+     * @param value  the new value; conversions may occur if the types differ
+     * @throws IllegalArgumentException if the assignment fails
      */
     void set(Object object, Object value) throws IllegalArgumentException;
 
     /**
-     * Sets the value of the field represented by this {@code FieldInfo} object
-     * to the provided {@code value}. The provided {@code object} is used as a
-     * target to the extract eh field from.
+     * Sets the value of the field represented by this {@code FieldInfo} object.
+     *
+     * @param object the instance on which to set the field
+     * @param value  the new {@code char} value
+     * @throws IllegalArgumentException if the assignment fails
      */
     void set(Object object, char value) throws IllegalArgumentException;
 
     /**
-     * Sets the value of the field represented by this {@code FieldInfo} object
-     * to the provided {@code value}. The provided {@code object} is used as a
-     * target to the extract eh field from.
+     * Sets the value of the field represented by this {@code FieldInfo} object.
+     *
+     * @param object the instance on which to set the field
+     * @param value  the new {@code int} value
+     * @throws IllegalArgumentException if the assignment fails
      */
     void set(Object object, int value) throws IllegalArgumentException;
 
     /**
-     * Sets the value of the field represented by this {@code FieldInfo} object
-     * to the provided {@code value} of type {@code long}. The provided {@code object} is used as a
-     * target from which the field is extracted.
+     * Sets the value of the field represented by this {@code FieldInfo} object.
      *
-     * @param object The object containing the field to be set.
-     * @param value  The value to set the field to.
-     * @throws IllegalArgumentException if the specified object is not an instance of the class or
-     *                                  interface declaring the underlying field, or if an unwrapping
-     *                                  conversion fails.
+     * @param object the instance on which to set the field
+     * @param value  the new {@code long} value
+     * @throws IllegalArgumentException if the assignment fails
      */
     void set(Object object, long value) throws IllegalArgumentException;
 
     /**
-     * Sets the value of the field represented by this {@code FieldInfo} object
-     * to the provided {@code value} of type {@code double}. The provided {@code object} is used as a
-     * target from which the field is extracted.
+     * Sets the value of the field represented by this {@code FieldInfo} object.
      *
-     * @param object The object containing the field to be set.
-     * @param value  The value to set the field to.
-     * @throws IllegalArgumentException if the specified object is not an instance of the class or
-     *                                  interface declaring the underlying field, or if an unwrapping
-     *                                  conversion fails.
+     * @param object the instance on which to set the field
+     * @param value  the new {@code double} value
+     * @throws IllegalArgumentException if the assignment fails
      */
     void set(Object object, double value) throws IllegalArgumentException;
 
     /**
-     * Retrieves the {@link Class} identifying the declared generic type of the
-     * field represented by this {@code FieldInfo} object at the provided {@code index}.
+     * Returns the declared generic type of the field, for example the
+     * element type of a {@code List<T>}.
      *
-     * @param index The index of the generic type to be retrieved.
-     * @return a {@link Class} identifying the declared generic type of the field represented by
-     * this {@code FieldInfo} object at the provided {@code index}.
+     * @param index the position of the generic parameter
+     * @return the generic argument {@link Class}
      */
     Class<?> genericType(int index);
 
@@ -239,12 +246,13 @@ public interface FieldInfo {
     }
 
     /**
-     * Compares the value of the field represented by this {@code FieldInfo} in both provided
-     * objects {@code a} and {@code b} and determines if they are equal.
+     * Compares the value of this field in two objects.
+     * Implementations may use type-specific equality checks, such as
+     * {@code Double.compare} for {@code double} fields.
      *
-     * @param a First object to compare the field's value.
-     * @param b Second object to compare the field's value.
-     * @return {@code true} if the values are equal, {@code false} otherwise.
+     * @param a first object to compare
+     * @param b second object to compare
+     * @return {@code true} if the values are considered equal
      */
     boolean isEqual(Object a, Object b);
 }

--- a/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static net.openhft.chronicle.wire.WireMarshaller.WIRE_MARSHALLER_CL;
+import static net.openhft.chronicle.wire.Wires.*;
 
 /**
  * Represents an abstraction for the meta-information of a field within a class or interface.
@@ -53,18 +54,18 @@ public interface FieldInfo {
 
     /**
      * Looks up the meta-information of the fields associated with the provided class and returns
-     * a pair of information encapsulated in {@link Wires.FieldInfoPair}.
+     * a pair of information encapsulated in {@link FieldInfoPair}.
      *
      * @param aClass The class for which field info needs to be retrieved.
-     * @return A {@link Wires.FieldInfoPair} representing the field information of the class.
+     * @return A {@link FieldInfoPair} representing the field information of the class.
      */
     @NotNull
-    static Wires.FieldInfoPair lookupClass(@NotNull Class<?> aClass) {
-        final SerializationStrategy ss = Wires.CLASS_STRATEGY.get(aClass);
+    static FieldInfoPair lookupClass(@NotNull Class<?> aClass) {
+        final SerializationStrategy ss = CLASS_STRATEGY.get(aClass);
         switch (ss.bracketType()) {
             case NONE:
             case SEQ:
-                return Wires.FieldInfoPair.EMPTY;
+                return FieldInfoPair.EMPTY;
             case MAP:
                 break;
             case HISTORY_MESSAGE:
@@ -81,13 +82,13 @@ public interface FieldInfo {
         for (@NotNull WireMarshaller.FieldAccess fa : marshaller.fields) {
             final String name = fa.field.getName();
             final Class<?> type = fa.field.getType();
-            final SerializationStrategy ss2 = Wires.CLASS_STRATEGY.get(type);
+            final SerializationStrategy ss2 = CLASS_STRATEGY.get(type);
             final BracketType bracketType = ss2.bracketType();
             fields.add(createForField(name, type, bracketType, fa.field));
         }
 
         // Return a pair of unmodifiable list of fields and a map of field names to their FieldInfo.
-        return new Wires.FieldInfoPair(
+        return new FieldInfoPair(
                 Collections.unmodifiableList(fields),
                 fields.stream().collect(Collectors.toMap(FieldInfo::name, f -> f)));
     }

--- a/src/main/java/net/openhft/chronicle/wire/internal/VanillaFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/VanillaFieldInfo.java
@@ -28,18 +28,45 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Objects;
 
+/**
+ * Standard reflection-backed implementation of {@link AbstractFieldInfo}.
+ * The associated {@link Field} is recreated on demand so that instances
+ * remain functional after deserialisation. Intended for internal marshalling
+ * tasks where unsafe access is not required.
+ */
 @SuppressWarnings("rawtypes")
 public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
 
+    /**
+     * Declaring class of the target field. Used to re-acquire the
+     * {@link #field} instance if needed.
+     */
     private final Class<?> parent;
+
+    /**
+     * Reflection handle to the actual field. Marked transient and looked up
+     * lazily via {@link #getField()}.
+     */
     private transient Field field;
 
+    /**
+     * Creates an instance for a specific field.
+     *
+     * @param name         textual name of the field
+     * @param type         runtime type of the field
+     * @param bracketType  bracket style used when writing
+     * @param field        reflection field for direct access
+     */
     public VanillaFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
         super(type, bracketType, name);
         parent = field.getDeclaringClass();
         this.field = field;
     }
 
+    /**
+     * Retrieves the value of this field from {@code object}. The method logs
+     * and returns {@code null} if reflection fails.
+     */
     @Nullable
     @Override
     public Object get(Object object) {
@@ -51,6 +78,11 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         }
     }
 
+    /**
+     * Reads the primitive {@code long} value.
+     *
+     * @return the field value or {@code Long.MIN_VALUE} on error
+     */
     @Override
     public long getLong(Object object) {
         try {
@@ -61,6 +93,11 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         }
     }
 
+    /**
+     * Reads the primitive {@code int} value.
+     *
+     * @return the field value or {@code Integer.MIN_VALUE} on error
+     */
     @Override
     public int getInt(Object object) {
         try {
@@ -71,6 +108,11 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         }
     }
 
+    /**
+     * Reads the primitive {@code char} value.
+     *
+     * @return the field value or {@code Character.MAX_VALUE} on error
+     */
     @Override
     public char getChar(Object object) {
         try {
@@ -81,6 +123,11 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         }
     }
 
+    /**
+     * Reads the primitive {@code double} value.
+     *
+     * @return the field value or {@code Double.NaN} on error
+     */
     @Override
     public double getDouble(Object object) {
         try {
@@ -92,6 +139,11 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
     }
 
     @SuppressWarnings("unchecked")
+    /**
+     * Converts {@code value} to the field type and writes it using reflection.
+     *
+     * @throws IllegalArgumentException if the field cannot be accessed
+     */
     @Override
     public void set(Object object, Object value) throws IllegalArgumentException {
         Object value2 = ObjectUtils.convertTo(type, value);
@@ -102,6 +154,11 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         }
     }
 
+    /**
+     * Writes an {@code int} value to the field.
+     *
+     * @throws IllegalArgumentException if reflection fails
+     */
     @Override
     public void set(Object object, int value) throws IllegalArgumentException {
         try {
@@ -111,6 +168,11 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         }
     }
 
+    /**
+     * Writes a {@code char} value to the field.
+     *
+     * @throws IllegalArgumentException if reflection fails
+     */
     @Override
     public void set(Object object, char value) throws IllegalArgumentException {
         try {
@@ -120,6 +182,11 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         }
     }
 
+    /**
+     * Writes a {@code long} value to the field.
+     *
+     * @throws IllegalArgumentException if reflection fails
+     */
     @Override
     public void set(Object object, long value) throws IllegalArgumentException {
         try {
@@ -129,6 +196,11 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         }
     }
 
+    /**
+     * Writes a {@code double} value to the field.
+     *
+     * @throws IllegalArgumentException if reflection fails
+     */
     @Override
     public void set(Object object, double value) throws IllegalArgumentException {
         try {
@@ -138,6 +210,12 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         }
     }
 
+    /**
+     * Lazily retrieves the underlying {@link Field}, re-acquiring it from
+     * {@link #parent} when required.
+     *
+     * @throws NoSuchFieldException if the field does not exist on the parent
+     */
     public Field getField() throws NoSuchFieldException {
         if (field == null) {
             field = parent.getDeclaredField(name);
@@ -146,6 +224,10 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         return field;
     }
 
+    /**
+     * Returns the {@link Class} of the generic argument at the given index if
+     * this field is parameterised.
+     */
     @Override
     public Class<?> genericType(int index) {
         ParameterizedType genericType = (ParameterizedType) field.getGenericType();
@@ -153,6 +235,11 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
         return (Class) type;
     }
 
+    /**
+     * Compares the value of this field in two objects. Primitive types are
+     * compared directly, otherwise {@link Objects#deepEquals(Object, Object)}
+     * is used.
+     */
     @Override
     public boolean isEqual(Object a, Object b) {
         if (type.isPrimitive()) {

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/CharFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/CharFieldInfo.java
@@ -24,25 +24,26 @@ import org.jetbrains.annotations.NotNull;
 import java.lang.reflect.Field;
 
 /**
- * Represents field information for character fields, extending the generic field information capabilities
- * provided by {@link UnsafeFieldInfo}. It offers direct memory access functionality to get and set
- * character values in objects, leveraging unsafe operations for performance.
+ * Internal {@link net.openhft.chronicle.wire.FieldInfo} for {@code char} fields
+ * using {@link UnsafeMemory} to read and write values via memory offsets.
  */
 public final class CharFieldInfo extends UnsafeFieldInfo {
 
     /**
-     * Constructs an instance of CharFieldInfo with the provided details about a character field.
-     *
-     * @param name        The name of the field.
-     * @param type        The type of the field.
-     * @param bracketType The bracket type associated with the field.
-     * @param field       The field object representation.
+     * @param name        field name used in text form
+     * @param type        runtime type
+     * @param bracketType formatting hint when writing
+     * @param field       reflection field used for unsafe access
      */
     public CharFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
         super(name, type, bracketType, field);
     }
 
     @Override
+    /**
+     * @return the {@code char} value or {@link Character#MAX_VALUE} if the
+     * offset could not be determined
+     */
     public char getChar(Object object) {
         try {
             return UnsafeMemory.unsafeGetChar(object, getOffset());
@@ -53,6 +54,7 @@ public final class CharFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
+    /** Writes the value using {@link UnsafeMemory}. */
     public void set(Object object, char value) throws IllegalArgumentException {
         try {
             UnsafeMemory.unsafePutChar(object, getOffset(), value);
@@ -62,11 +64,13 @@ public final class CharFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
+    /** Compares the character values in {@code a} and {@code b}. */
     public boolean isEqual(Object a, Object b) {
         return getChar(a) == getChar(b);
     }
 
     @Override
+    /** Copies the character value from {@code source} to {@code destination}. */
     public void copy(Object source, Object destination) {
         set(destination, getChar(source));
     }

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/DoubleFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/DoubleFieldInfo.java
@@ -24,25 +24,25 @@ import org.jetbrains.annotations.NotNull;
 import java.lang.reflect.Field;
 
 /**
- * Represents field information for double fields, extending the generic field information capabilities
- * provided by {@link UnsafeFieldInfo}. It offers direct memory access functionality to get and set
- * double values in objects, leveraging unsafe operations for enhanced performance.
+ * Internal {@link net.openhft.chronicle.wire.FieldInfo} for {@code double}
+ * fields using {@link UnsafeMemory} for direct access.
  */
 public final class DoubleFieldInfo extends UnsafeFieldInfo {
 
     /**
-     * Constructs an instance of DoubleFieldInfo with the provided details about a double field.
-     *
-     * @param name        The name of the field.
-     * @param type        The type of the field.
-     * @param bracketType The bracket type associated with the field.
-     * @param field       The field object representation.
+     * @param name        field name used in text form
+     * @param type        runtime type
+     * @param bracketType formatting hint when writing
+     * @param field       reflection field used for unsafe access
      */
     public DoubleFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
         super(name, type, bracketType, field);
     }
 
     @Override
+    /**
+     * @return the field value or {@code Double.NaN} if the offset is unavailable
+     */
     public double getDouble(Object object) {
         try {
             return UnsafeMemory.unsafeGetDouble(object, getOffset());
@@ -53,6 +53,7 @@ public final class DoubleFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
+    /** Writes the value using {@link UnsafeMemory}. */
     public void set(Object object, double value) throws IllegalArgumentException {
         try {
             UnsafeMemory.unsafePutDouble(object, getOffset(), value);
@@ -62,11 +63,13 @@ public final class DoubleFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
+    /** Compares the double values in {@code a} and {@code b}. */
     public boolean isEqual(Object a, Object b) {
         return getDouble(a) == getDouble(b);
     }
 
     @Override
+    /** Copies the double value from {@code source} to {@code destination}. */
     public void copy(Object source, Object destination) {
         set(destination, getDouble(source));
     }

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/IntFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/IntFieldInfo.java
@@ -24,25 +24,25 @@ import org.jetbrains.annotations.NotNull;
 import java.lang.reflect.Field;
 
 /**
- * Represents field information for integer fields, extending the generic field information capabilities
- * provided by {@link UnsafeFieldInfo}. It offers direct memory access functionality to get and set
- * integer values in objects, leveraging unsafe operations for enhanced performance.
+ * Internal {@link net.openhft.chronicle.wire.FieldInfo} for {@code int} fields
+ * using {@link UnsafeMemory} for direct access.
  */
 public final class IntFieldInfo extends UnsafeFieldInfo {
 
     /**
-     * Constructs an instance of IntFieldInfo with the provided details about an integer field.
-     *
-     * @param name        The name of the field.
-     * @param type        The type of the field.
-     * @param bracketType The bracket type associated with the field.
-     * @param field       The field object representation.
+     * @param name        field name used in text form
+     * @param type        runtime type
+     * @param bracketType formatting hint when writing
+     * @param field       reflection field used for unsafe access
      */
     public IntFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
         super(name, type, bracketType, field);
     }
 
     @Override
+    /**
+     * @return the field value or {@code Integer.MIN_VALUE} if the offset is unavailable
+     */
     public int getInt(Object object) {
         try {
             return UnsafeMemory.unsafeGetInt(object, getOffset());
@@ -53,6 +53,7 @@ public final class IntFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
+    /** Writes the value using {@link UnsafeMemory}. */
     public void set(Object object, int value) throws IllegalArgumentException {
         try {
             UnsafeMemory.unsafePutInt(object, getOffset(), value);
@@ -62,11 +63,13 @@ public final class IntFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
+    /** Compares the int values in {@code a} and {@code b}. */
     public boolean isEqual(Object a, Object b) {
         return getInt(a) == getInt(b);
     }
 
     @Override
+    /** Copies the int value from {@code source} to {@code destination}. */
     public void copy(Object source, Object destination) {
         set(destination, getInt(source));
     }

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/LongFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/LongFieldInfo.java
@@ -24,25 +24,25 @@ import org.jetbrains.annotations.NotNull;
 import java.lang.reflect.Field;
 
 /**
- * Represents field information for long fields, extending the generic field information capabilities
- * provided by {@link UnsafeFieldInfo}. This class offers direct memory access functionality to get and set
- * long values in objects, leveraging unsafe operations for performance enhancement.
+ * Internal {@link net.openhft.chronicle.wire.FieldInfo} for {@code long} fields
+ * using {@link UnsafeMemory} for direct access.
  */
 public final class LongFieldInfo extends UnsafeFieldInfo {
 
     /**
-     * Constructs an instance of LongFieldInfo with the provided details about a long field.
-     *
-     * @param name        The name of the field.
-     * @param type        The type of the field.
-     * @param bracketType The bracket type associated with the field.
-     * @param field       The actual field representation.
+     * @param name        field name used in text form
+     * @param type        runtime type
+     * @param bracketType formatting hint when writing
+     * @param field       reflection field used for unsafe access
      */
     public LongFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
         super(name, type, bracketType, field);
     }
 
     @Override
+    /**
+     * @return the field value or {@code Long.MIN_VALUE} if the offset is unavailable
+     */
     public long getLong(Object object) {
         try {
             return UnsafeMemory.unsafeGetLong(object, getOffset());
@@ -53,6 +53,7 @@ public final class LongFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
+    /** Writes the value using {@link UnsafeMemory}. */
     public void set(Object object, long value) throws IllegalArgumentException {
         try {
             UnsafeMemory.unsafePutLong(object, getOffset(), value);
@@ -62,11 +63,13 @@ public final class LongFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
+    /** Compares the long values in {@code a} and {@code b}. */
     public boolean isEqual(Object a, Object b) {
         return getLong(a) == getLong(b);
     }
 
     @Override
+    /** Copies the long value from {@code source} to {@code destination}. */
     public void copy(Object source, Object destination) {
         set(destination, getLong(source));
     }

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/ObjectFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/ObjectFieldInfo.java
@@ -27,25 +27,25 @@ import java.lang.reflect.Field;
 import java.util.Objects;
 
 /**
- * Represents field information for object fields, extending the generic field information capabilities
- * provided by {@link UnsafeFieldInfo}. This class offers direct memory access functionality to get and set
- * object values in objects, leveraging unsafe operations for performance enhancement.
+ * Internal {@link net.openhft.chronicle.wire.FieldInfo} for reference fields
+ * using {@link UnsafeMemory} for direct access.
  */
 public final class ObjectFieldInfo extends UnsafeFieldInfo {
 
     /**
-     * Constructs an instance of ObjectFieldInfo with the provided details about an object field.
-     *
-     * @param name        The name of the field.
-     * @param type        The type of the field.
-     * @param bracketType The bracket type associated with the field.
-     * @param field       The actual field representation.
+     * @param name        field name used in text form
+     * @param type        runtime type
+     * @param bracketType formatting hint when writing
+     * @param field       reflection field used for unsafe access
      */
     public ObjectFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
         super(name, type, bracketType, field);
     }
 
     @Override
+    /**
+     * @return the field value or {@code null} if the offset could not be determined
+     */
     public @Nullable Object get(Object object) {
         try {
             return UnsafeMemory.unsafeGetObject(object, getOffset());
@@ -56,6 +56,7 @@ public final class ObjectFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
+    /** Writes the value using {@link UnsafeMemory}, converting as required. */
     public void set(Object object, Object value) throws IllegalArgumentException {
         Object value2 = ObjectUtils.convertTo(type, value);
         try {
@@ -66,11 +67,13 @@ public final class ObjectFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
+    /** Compares the object values in {@code a} and {@code b}. */
     public boolean isEqual(Object a, Object b) {
         return Objects.deepEquals(get(a), get(b));
     }
 
     @Override
+    /** Copies the object value from {@code source} to {@code destination}. */
     public void copy(Object source, Object destination) {
         set(destination, get(source));
     }

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/UnsafeFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/UnsafeFieldInfo.java
@@ -23,33 +23,39 @@ import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Field;
 
+/**
+ * Base class for field access using {@link UnsafeMemory}. It resolves the
+ * memory offset of the underlying field and stores it for direct operations.
+ */
 @SuppressWarnings("deprecation" /* The parent class will either be moved to internal or cease to exist in x.26 */)
 class UnsafeFieldInfo extends VanillaFieldInfo {
-    // Offset value to indicate that it hasn't been set yet.
+    /** Offset value to indicate that it has not been set yet. */
     private static final long UNSET_OFFSET = Long.MAX_VALUE;
 
-    // Offset in memory where the value for this field can be found.
+    /**
+     * Memory offset of this field within its declaring class. Calculated on
+     * first use and cached. Marked transient as it is JVM specific.
+     */
     private transient long offset = UNSET_OFFSET;
 
     /**
-     * Constructs an instance of UnsafeFieldInfo with the provided details about a field.
+     * Creates an instance linked to a particular field.
      *
-     * @param name        The name of the field.
-     * @param type        The type of the field.
-     * @param bracketType The bracket type associated with the field.
-     * @param field       The actual field representation.
+     * @param name        textual field name
+     * @param type        runtime type of the field
+     * @param bracketType formatting hint used when writing
+     * @param field       reflection field from which the offset will be derived
      */
     public UnsafeFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
         super(name, type, bracketType, field);
     }
 
     /**
-     * Retrieves the memory offset where the value for this field is stored.
-     * If the offset hasn't been retrieved before, it leverages unsafe operations
-     * to get it and then caches the result.
+     * Obtains the memory offset of this field using {@link UnsafeMemory} on the
+     * first call and caches it for subsequent access.
      *
-     * @return The memory offset for this field.
-     * @throws NoSuchFieldException if there's a field access issue.
+     * @return the memory offset for direct field operations
+     * @throws NoSuchFieldException if {@link #getField()} fails
      */
     protected long getOffset() throws NoSuchFieldException {
         if (this.offset == UNSET_OFFSET) {


### PR DESCRIPTION
## 📝 Pull-request summary

*Aim: modernise and document the **field-metadata layer** (`FieldInfo` and friends) 

---

### 1. API & type housekeeping

| Change                            | Details                                                                                                                                                                                                |
| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| **Static import rationalisation** | Added `import static net.openhft.chronicle.wire.Wires.*;` in `FieldInfo.java` to remove repetitive qualifiers. No behavioural impact.                                                                  |

### 2. Documentation lift

* **`FieldInfo` interface**

  * Full Javadoc rewrite: clearer contract, param/return docs for every method, examples of bracket semantics.
  * Detailed explanation of `lookupClass` reflection path.

* **`AbstractFieldInfo`**

  * Added field-level Javadoc, ctor explanations and hash/equals clarifications.

* **Unsafe / reflection subclasses**

  * `VanillaFieldInfo`, `UnsafeFieldInfo` and the primitive specialisations (`IntFieldInfo`, `LongFieldInfo`, `CharFieldInfo`, `DoubleFieldInfo`, `ObjectFieldInfo`) now all include:

    * purpose + behaviour summary
    * param docs for ctors
    * notes on error handling and equality semantics.
