### PR TITLE
Improve ValueIn javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/ValueIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueIn.java
@@ -41,27 +41,28 @@ import java.util.function.*;
 import static net.openhft.chronicle.wire.SerializationStrategies.MARSHALLABLE;
 
 /**
- * Represents an interface for reading values in various formats from a serialized data source.
- * This interface is part of the Chronicle Wire library, which is designed for high-performance
- * serialization and deserialization of data. It provides methods to read data types like text,
- * binary, numeric, and temporal values, as well as support for more complex types like collections
- * and marshallable objects.
+ * Represents the value component of a key–value pair being read from a wire.
+ * After a field name is consumed via {@link WireIn#read()}, a {@code ValueIn}
+ * instance is used to deserialize that field’s value.  A {@code ValueIn}
+ * instance is normally consumed once for a single field; the next field will
+ * supply a fresh instance from the parent {@link WireIn}.
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public interface ValueIn {
-    /** A constant consumer that does nothing when accepting a {@link ValueIn}. */
+    /**
+     * A {@link Consumer} that ignores the supplied {@code ValueIn}.  Useful as a
+     * no-op placeholder.
+     */
     @Deprecated(/* remove in x.29 as unused */)
     Consumer<ValueIn> DISCARD = v -> {};
 
     // ---- Text / Strings section ----
 
     /**
-     * Reads text data and applies a given bi-consumer to the text data and the provided object.
+     * Deserialises the current value as text and passes it to {@code ts} along
+     * with the supplied object.
      *
-     * @param t  The target object.
-     * @param ts The bi-consumer that accepts the target object and the read text.
-     * @param <T> Type of the target object.
-     * @return The current WireIn instance.
+     * @return the parent {@link WireIn}
      */
     @NotNull
     default <T> WireIn text(T t, @NotNull BiConsumer<T, String> ts) {
@@ -71,10 +72,9 @@ public interface ValueIn {
     }
 
     /**
-     * Reads text data and appends it to the given StringBuilder. If the data is null, the StringBuilder is cleared.
-     *
-     * @param sb The StringBuilder to append the text data to.
-     * @return The current WireIn instance.
+     * Reads the value as text and appends it to {@code sb}.  If the wire value
+     * is {@code null}, {@code sb} is cleared.  Using a reusable
+     * {@link StringBuilder} can reduce allocation.
      */
     @NotNull
     default WireIn text(@NotNull StringBuilder sb) {
@@ -84,9 +84,8 @@ public interface ValueIn {
     }
 
     /**
-     * Reads text data and returns the first character. If the data is null or empty, a null character is returned.
-     *
-     * @return The first character of the text data or '\u0000' if none.
+     * Reads the value as text and returns its first character.  Returns the null
+     * character ({@code '\u0000'}) if the text is absent or empty.
      */
     default char character() {
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
@@ -99,10 +98,7 @@ public interface ValueIn {
     }
 
     /**
-     * Reads text data into the provided Bytes object, which is then cleared.
-     *
-     * @param sdo The Bytes object to store the text data.
-     * @return The current WireIn instance.
+     * Reads the value as text into {@code sdo}, clearing it first.
      */
     @NotNull
     default WireIn text(@NotNull Bytes<?> sdo) {
@@ -112,46 +108,37 @@ public interface ValueIn {
     }
 
     /**
-     * Reads and returns the text data.
-     *
-     * @return The text data or null.
+     * Reads and returns the value as a {@link String}.  May return
+     * {@code null} if the wire representation is null.
      */
     @Nullable
     String text();
 
     /**
-     * Reads text data and appends it to the given StringBuilder.
+     * Populates {@code sb} with the text form of the value.
      *
-     * @param sb The StringBuilder to append the text data to.
-     * @return The StringBuilder with appended text or null.
+     * @return {@code sb}, or {@code null} if the value is null on the wire
      */
     @Nullable
     StringBuilder textTo(@NotNull StringBuilder sb);
 
     /**
-     * Reads text data into the provided Bytes object.
+     * Writes the value’s textual form to {@code bytes}, which is cleared first.
      *
-     * @param bytes The Bytes object to store the text data.
-     * @return The Bytes object with the text data or null.
+     * @return {@code bytes}, or {@code null} if the value is null
      */
     @Nullable
     Bytes<?> textTo(@NotNull Bytes<?> bytes);
 
     /**
-     * Reads byte data into the provided BytesOut object.
-     *
-     * @param toBytes The BytesOut object to store the byte data.
-     * @return The current WireIn instance.
+     * Reads the value as a sequence of bytes into {@code toBytes}.
      */
     @NotNull
     WireIn bytes(@NotNull BytesOut<?> toBytes);
 
     /**
-     * Reads byte data into the provided BytesOut object with an option to clear the BytesOut before reading.
-     *
-     * @param toBytes The BytesOut object to store the byte data.
-     * @param clearBytes If true, the BytesOut object will be cleared before reading.
-     * @return The current WireIn instance.
+     * Variant of {@link #bytes(BytesOut)} that clears {@code toBytes} first when
+     * {@code clearBytes} is {@code true}.
      */
     default WireIn bytes(@NotNull BytesOut<?> toBytes, boolean clearBytes) {
         if (clearBytes)
@@ -160,11 +147,8 @@ public interface ValueIn {
     }
 
     /**
-     * Reads byte data into the provided BytesOut object.
-     * This method acts as a semantic alias for {@link #bytes(BytesOut)} method.
-     *
-     * @param toBytes The BytesOut object to store the byte data.
-     * @return The current WireIn instance.
+     * Reads the raw byte sequence for this value into {@code toBytes}.  This is
+     * an alias of {@link #bytes(BytesOut)}.
      */
     @NotNull
     default WireIn bytesLiteral(@NotNull BytesOut<?> toBytes) {
@@ -172,10 +156,7 @@ public interface ValueIn {
     }
 
     /**
-     * Retrieves the byte data as a BytesStore object.
-     * This method acts as a semantic alias for {@link #bytesStore()} method.
-     *
-     * @return The BytesStore object or null.
+     * Returns the raw byte sequence for this value as a new {@link BytesStore}.
      */
     @Nullable
     default BytesStore<?, ?> bytesLiteral() {
@@ -183,54 +164,43 @@ public interface ValueIn {
     }
 
     /**
-     * Sets byte data to the provided PointerBytesStore.
-     *
-     * @param toBytes The PointerBytesStore to set the byte data.
-     * @return The current WireIn instance.
+     * Sets {@code toBytes} to point directly at the underlying data for this
+     * value when supported, avoiding a copy.
      */
     @Nullable
     WireIn bytesSet(@NotNull PointerBytesStore toBytes);
 
     /**
-     * Compares byte data with the provided BytesStore and uses the given BooleanConsumer based on the result.
-     *
-     * @param compareBytes The BytesStore to compare with.
-     * @param consumer     The BooleanConsumer to be called based on the comparison result.
-     * @return The current WireIn instance.
+     * Compares the value’s bytes with {@code compareBytes} and passes the match
+     * result to {@code consumer}.
      */
     @NotNull
     WireIn bytesMatch(@NotNull BytesStore<?, ?> compareBytes, BooleanConsumer consumer);
 
     /**
-     * Reads byte data using the provided ReadBytesMarshallable.
-     *
-     * @param bytesMarshallable The ReadBytesMarshallable to read the byte data.
-     * @return The current WireIn instance.
+     * Supplies the byte stream to {@code bytesMarshallable#readMarshallable} for
+     * custom deserialisation.
      */
     @NotNull
     WireIn bytes(@NotNull ReadBytesMarshallable bytesMarshallable);
 
     /**
-     * Retrieves the byte data as an array.
-     *
-     * @return The byte data as an array or null.
+     * Returns the value’s bytes as a new array, or {@code null} when the wire
+     * representation is null.
      */
     default byte @Nullable [] bytes() {
         return bytes((byte[]) null);
     }
 
     /**
-     * Retrieves the byte data as an array with the option to reuse an existing byte array.
-     *
-     * @param using The existing byte array to use or null.
-     * @return The byte data as an array or null.
+     * Populates {@code using} with the value’s bytes when possible to avoid
+     * allocation.  Returns the array containing the data, or {@code null} if the
+     * value is null.
      */
     byte @Nullable [] bytes(byte[] using);
 
     /**
-     * Retrieves the byte data as a BytesStore object.
-     *
-     * @return The BytesStore object or null.
+     * Wraps the value’s byte array in a new {@link BytesStore}.
      */
     @Nullable
     default BytesStore<?, ?> bytesStore() {
@@ -239,134 +209,89 @@ public interface ValueIn {
     }
 
     /**
-     * Puts the byte data into the provided ByteBuffer.
-     *
-     * @param bb The ByteBuffer to put the byte data.
+     * Copies the value’s bytes into {@code bb}.
      */
     default void byteBuffer(@NotNull ByteBuffer bb) {
         bb.put(bytes());
     }
 
     /**
-     * Provides the current WireIn instance.
-     *
-     * @return The current WireIn instance.
+     * Returns the parent {@link WireIn} that provided this instance.
      */
     @NotNull
     WireIn wireIn();
 
     /**
-     * Retrieves the length of the field in bytes, inclusive of any encoding and header character.
-     *
-     * @return The length of the field in bytes.
+     * Returns the length in bytes of this value as it appears on the wire,
+     * including any type or length prefix.
      */
     long readLength();
 
     /**
-     * Skips the current value while reading.
-     *
-     * @return The current WireIn instance.
+     * Consumes and discards the current value, advancing the read position.
      */
     @NotNull
     WireIn skipValue();
 
     /**
-     * Reads a boolean value and applies it to the provided consumer.
+     * Reads the value as a {@code boolean} and passes it, together with
+     * {@code t}, to {@code tFlag}.
      *
-     * @param t     The target object.
-     * @param tFlag The consumer that accepts the target object and the read boolean value.
-     * @return The current WireIn instance.
-     * @param <T>   The type of the target object.
+     * @param <T> type of the context object
+     * @return the parent {@link WireIn}
      */
     @NotNull <T> WireIn bool(T t, @NotNull ObjBooleanConsumer<T> tFlag);
 
     /**
-     * Reads an 8-bit integer (byte) value and applies an ObjByteConsumer with the provided object and the read value.
-     *
-     * @param <T> The type of object to be passed to the ObjByteConsumer.
-     * @param t   The object to be passed to the ObjByteConsumer.
-     * @param tb  The ObjByteConsumer that accepts the object and the read 8-bit integer value.
-     * @return The WireIn instance for method chaining.
+     * Reads the value as a signed byte and passes it to {@code tb} together with
+     * {@code t}.
      */
     @NotNull <T> WireIn int8(@NotNull T t, @NotNull ObjByteConsumer<T> tb);
 
     /**
-     * Reads an unsigned 8-bit integer (short) value and applies an ObjShortConsumer with the provided object and the read value.
-     *
-     * @param <T> The type of object to be passed to the ObjShortConsumer.
-     * @param t   The object to be passed to the ObjShortConsumer.
-     * @param ti  The ObjShortConsumer that accepts the object and the read unsigned 8-bit integer value.
-     * @return The WireIn instance for method chaining.
+     * Reads the value as an unsigned byte and passes it to {@code ti} with
+     * {@code t}.
      */
     @NotNull <T> WireIn uint8(@NotNull T t, @NotNull ObjShortConsumer<T> ti);
 
     /**
-     * Reads a 16-bit integer (short) value and applies an ObjShortConsumer with the provided object and the read value.
-     *
-     * @param <T> The type of object to be passed to the ObjShortConsumer.
-     * @param t   The object to be passed to the ObjShortConsumer.
-     * @param ti  The ObjShortConsumer that accepts the object and the read 16-bit integer value.
-     * @return The WireIn instance for method chaining.
+     * Reads the value as a short and passes it to {@code ti} with {@code t}.
      */
     @NotNull <T> WireIn int16(@NotNull T t, @NotNull ObjShortConsumer<T> ti);
 
     /**
-     * Reads an unsigned 16-bit integer (int) value and applies an ObjIntConsumer with the provided object and the read value.
-     *
-     * @param <T> The type of object to be passed to the ObjIntConsumer.
-     * @param t   The object to be passed to the ObjIntConsumer.
-     * @param ti  The ObjIntConsumer that accepts the object and the read unsigned 16-bit integer value.
-     * @return The WireIn instance for method chaining.
+     * Reads the value as an unsigned short and passes it to {@code ti} with
+     * {@code t}.
      */
     @NotNull <T> WireIn uint16(@NotNull T t, @NotNull ObjIntConsumer<T> ti);
 
     /**
-     * Reads a 32-bit integer (int) value and applies an ObjIntConsumer with the provided object and the read value.
-     *
-     * @param <T> The type of object to be passed to the ObjIntConsumer.
-     * @param t   The object to be passed to the ObjIntConsumer.
-     * @param ti  The ObjIntConsumer that accepts the object and the read 32-bit integer value.
-     * @return The WireIn instance for method chaining.
+     * Reads the value as an {@code int} and passes it to {@code ti} with
+     * {@code t}.
      */
     @NotNull <T> WireIn int32(@NotNull T t, @NotNull ObjIntConsumer<T> ti);
 
     /**
-     * Reads an unsigned 32-bit integer (long) value and applies an ObjLongConsumer with the provided object and the read value.
-     *
-     * @param <T> The type of object to be passed to the ObjLongConsumer.
-     * @param t   The object to be passed to the ObjLongConsumer.
-     * @param tl  The ObjLongConsumer that accepts the object and the read unsigned 32-bit integer value.
-     * @return The WireIn instance for method chaining.
+     * Reads the value as an unsigned int and passes it to {@code tl} with
+     * {@code t}.
      */
     @NotNull <T> WireIn uint32(@NotNull T t, @NotNull ObjLongConsumer<T> tl);
 
     /**
-     * Reads a 64-bit integer (long) value and applies an ObjLongConsumer with the provided object and the read value.
-     *
-     * @param <T> The type of object to be passed to the ObjLongConsumer.
-     * @param t   The object to be passed to the ObjLongConsumer.
-     * @param tl  The ObjLongConsumer that accepts the object and the read 64-bit integer value.
-     * @return The WireIn instance for method chaining.
+     * Reads the value as a {@code long} and passes it to {@code tl} with
+     * {@code t}.
      */
     @NotNull <T> WireIn int64(@NotNull T t, @NotNull ObjLongConsumer<T> tl);
 
     /**
-     * Reads a 32-bit floating-point (float) value and applies an ObjFloatConsumer with the provided object and the read value.
-     *
-     * @param <T> The type of object to be passed to the ObjFloatConsumer.
-     * @param t   The object to be passed to the ObjFloatConsumer.
-     * @param tf  The ObjFloatConsumer that accepts the object and the read 32-bit floating-point value.
-     * @return The WireIn instance for method chaining.
+     * Reads the value as a {@code float} and passes it to {@code tf} with
+     * {@code t}.
      */
     @NotNull <T> WireIn float32(@NotNull T t, @NotNull ObjFloatConsumer<T> tf);
 
     /**
-     * Reads a 64-bit floating-point (double) value and applies an ObjDoubleConsumer with the provided object and the read value.
-     *
-     * @param <T> The type of object to be passed to the ObjDoubleConsumer.
-     * @param t   The object to be passed to the ObjDoubleConsumer.
-     * @param td  The ObjDoubleConsumer that accepts the object and the read 64-bit floating-point value.
-     * @return The WireIn instance for method chaining.
+     * Reads the value as a {@code double} and passes it to {@code td} with
+     * {@code t}.
      */
     @NotNull <T> WireIn float64(@NotNull T t, @NotNull ObjDoubleConsumer<T> td);
 


### PR DESCRIPTION
## Summary
- clarify ValueIn purpose and usage
- note DISCARD constant is a no-op
- refine text and byte read method docs
- shorten primitive consumer docs

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*