### PR TITLE
Javadoc value in out

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/DefaultValueIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/DefaultValueIn.java
@@ -39,28 +39,30 @@ import java.util.List;
 import java.util.UUID;
 import java.util.function.*;
 /**
- * This class provides the default implementation for the {@link ValueIn} interface. It's primarily designed
- * to handle default values, converting them into various formats such as text and bytes.
- * The default value is retrieved from an underlying {@link WireIn} source.
+ * An implementation of {@link ValueIn} used when a requested field is not
+ * present on the wire. It returns either {@code null}, a primitive zero or the
+ * value configured by the {@link WireMarshaller}. This allows optional fields
+ * to be skipped without breaking deserialisation.
  */
 @SuppressWarnings("rawtypes")
 public class DefaultValueIn implements ValueIn {
 
-    // The underlying WireIn source for fetching default values
+    /** The parent {@link WireIn} this instance belongs to. */
     private final WireIn wireIn;
 
-    // The stored default value, fetched from the WireIn source
+    /** Value returned by the read methods when no field is present. */
     Object defaultValue;
 
     /**
-     * Constructs a new instance of DefaultValueIn with a given {@link WireIn} source.
-     *
-     * @param wireIn The WireIn source to fetch default values from.
+     * Creates a {@code DefaultValueIn} bound to the supplied wire.
      */
     DefaultValueIn(WireIn wireIn) {
         this.wireIn = wireIn;
     }
 
+    /**
+     * Returns {@link #defaultValue} as a string.
+     */
     @Nullable
     @Override
     public String text() {
@@ -68,6 +70,10 @@ public class DefaultValueIn implements ValueIn {
         return o == null ? null : o.toString();
     }
 
+    /**
+     * Appends the string form of {@link #defaultValue} to {@code sb}.
+     * Returns {@code null} if no value is configured.
+     */
     @Nullable
     @Override
     public StringBuilder textTo(@NotNull StringBuilder sb) {
@@ -78,6 +84,10 @@ public class DefaultValueIn implements ValueIn {
         return sb;
     }
 
+    /**
+     * Writes the string form of {@link #defaultValue} to the supplied bytes.
+     * Returns {@code null} when the value is absent.
+     */
     @Nullable
     @Override
     public Bytes<?> textTo(@NotNull Bytes<?> bytes) {
@@ -88,6 +98,10 @@ public class DefaultValueIn implements ValueIn {
         return bytes;
     }
 
+    /**
+     * Writes {@link #defaultValue} to {@code toBytes} and returns the parent
+     * wire.
+     */
     @NotNull
     @Override
     public WireIn bytes(@NotNull BytesOut<?> toBytes) {
@@ -99,6 +113,10 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Copies {@link #defaultValue} into a {@link PointerBytesStore}. If absent
+     * an empty store is set.
+     */
     @Nullable
     @Override
     public WireIn bytesSet(@NotNull PointerBytesStore toBytes) {
@@ -112,6 +130,10 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Compares {@link #defaultValue} with {@code compareBytes} and passes the
+     * result to {@code consumer}.
+     */
     @NotNull
     @Override
     public WireIn bytesMatch(@NotNull BytesStore<?, ?> compareBytes, @NotNull BooleanConsumer consumer) {
@@ -121,6 +143,9 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Supplies {@link #defaultValue} to a {@link ReadBytesMarshallable}.
+     */
     @NotNull
     @Override
     public WireIn bytes(@NotNull ReadBytesMarshallable wireInConsumer) {
@@ -134,28 +159,43 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Returns the backing byte array.
+     */
     @Override
     public byte @NotNull [] bytes(byte[] using) {
         return (byte[]) defaultValue;
     }
 
+    /**
+     * Returns the parent {@link WireIn}.
+     */
     @NotNull
     @Override
     public WireIn wireIn() {
         return wireIn;
     }
 
+    /**
+     * Always returns {@code 0} as no bytes are consumed.
+     */
     @Override
     public long readLength() {
         return 0;
     }
 
+    /**
+     * No value is read so the parent wire is returned.
+     */
     @NotNull
     @Override
     public WireIn skipValue() {
         return wireIn();
     }
 
+    /**
+     * Passes {@link #defaultValue} to {@code tFlag} and returns the parent wire.
+     */
     @NotNull
     @Override
     public <T> WireIn bool(T t, @NotNull ObjBooleanConsumer<T> tFlag) {
@@ -164,6 +204,9 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Supplies the byte value of {@link #defaultValue} to {@code tb}.
+     */
     @NotNull
     @Override
     public <T> WireIn int8(@NotNull T t, @NotNull ObjByteConsumer<T> tb) {
@@ -173,6 +216,9 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Supplies the unsigned byte value of {@link #defaultValue}.
+     */
     @NotNull
     @Override
     public <T> WireIn uint8(@NotNull T t, @NotNull ObjShortConsumer<T> ti) {
@@ -182,6 +228,9 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Supplies the short value of {@link #defaultValue}.
+     */
     @NotNull
     @Override
     public <T> WireIn int16(@NotNull T t, @NotNull ObjShortConsumer<T> ti) {
@@ -191,6 +240,9 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Supplies the unsigned short value of {@link #defaultValue}.
+     */
     @NotNull
     @Override
     public <T> WireIn uint16(@NotNull T t, @NotNull ObjIntConsumer<T> ti) {
@@ -200,6 +252,9 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Supplies the int value of {@link #defaultValue}.
+     */
     @NotNull
     @Override
     public <T> WireIn int32(@NotNull T t, @NotNull ObjIntConsumer<T> ti) {
@@ -209,6 +264,9 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Supplies the unsigned int value of {@link #defaultValue}.
+     */
     @NotNull
     @Override
     public <T> WireIn uint32(@NotNull T t, @NotNull ObjLongConsumer<T> tl) {
@@ -218,6 +276,9 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Supplies the long value of {@link #defaultValue}.
+     */
     @NotNull
     @Override
     public <T> WireIn int64(@NotNull T t, @NotNull ObjLongConsumer<T> tl) {
@@ -227,6 +288,9 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Supplies the float value of {@link #defaultValue}.
+     */
     @NotNull
     @Override
     public <T> WireIn float32(@NotNull T t, @NotNull ObjFloatConsumer<T> tf) {
@@ -236,6 +300,9 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Supplies the double value of {@link #defaultValue}.
+     */
     @NotNull
     @Override
     public <T> WireIn float64(@NotNull T t, @NotNull ObjDoubleConsumer<T> td) {
@@ -245,6 +312,9 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Passes the {@link LocalTime} held in {@link #defaultValue}.
+     */
     @NotNull
     @Override
     public <T> WireIn time(@NotNull T t, @NotNull BiConsumer<T, LocalTime> setLocalTime) {
@@ -253,6 +323,9 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Passes the {@link ZonedDateTime} held in {@link #defaultValue}.
+     */
     @NotNull
     @Override
     public <T> WireIn zonedDateTime(@NotNull T t, @NotNull BiConsumer<T, ZonedDateTime> tZonedDateTime) {
@@ -261,6 +334,9 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Passes the {@link LocalDate} held in {@link #defaultValue}.
+     */
     @NotNull
     @Override
     public <T> WireIn date(@NotNull T t, @NotNull BiConsumer<T, LocalDate> tLocalDate) {
@@ -269,16 +345,25 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Always {@code false} as no sequence exists.
+     */
     @Override
     public boolean hasNext() {
         return false;
     }
 
+    /**
+     * Always {@code false} as no sequence exists.
+     */
     @Override
     public boolean hasNextSequenceItem() {
         return false;
     }
 
+    /**
+     * Supplies the {@link UUID} from {@link #defaultValue}.
+     */
     @NotNull
     @Override
     public <T> WireIn uuid(@NotNull T t, @NotNull BiConsumer<T, UUID> tuuid) {
@@ -287,12 +372,18 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Not implemented for default values.
+     */
     @NotNull
     @Override
     public <T> WireIn int64array(@Nullable LongArrayValues values, T t, @NotNull BiConsumer<T, LongArrayValues> setter) {
         throw new UnsupportedOperationException("todo");
     }
 
+    /**
+     * Sets {@code value} from {@link #defaultValue}.
+     */
     @NotNull
     @Override
     public WireIn int64(@NotNull LongValue value) {
@@ -302,6 +393,9 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Sets {@code value} from {@link #defaultValue}.
+     */
     @NotNull
     @Override
     public WireIn int32(@NotNull IntValue value) {
@@ -311,11 +405,17 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Not implemented for default values.
+     */
     @Override
     public WireIn bool(@NotNull final BooleanValue ret) {
         throw new UnsupportedOperationException("todo");
     }
 
+    /**
+     * Provides {@link #defaultValue} to {@code setter}.
+     */
     @NotNull
     @Override
     public <T> WireIn int64(@Nullable LongValue value, T t, @NotNull BiConsumer<T, LongValue> setter) {
@@ -326,6 +426,9 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Provides {@link #defaultValue} to {@code setter}.
+     */
     @NotNull
     @Override
     public <T> WireIn int32(@Nullable IntValue value, T t, @NotNull BiConsumer<T, IntValue> setter) {
@@ -336,16 +439,25 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Always returns {@code false} as there is no sequence.
+     */
     @Override
     public <T> boolean sequence(@NotNull T t, @NotNull BiConsumer<T, ValueIn> tReader) {
         return false;
     }
 
+    /**
+     * Always returns {@code false}; there is no data to read.
+     */
     @Override
     public <T> boolean sequence(List<T> list, @NotNull List<T> buffer, Supplier<T> bufferAdd, Reader reader0) {
         return false;
     }
 
+    /**
+     * Invokes {@code tReader} with {@code kls} and this instance.
+     */
     @NotNull
     @Override
     public <T, K> WireIn sequence(@NotNull T t, K kls, @NotNull TriConsumer<T, K, ValueIn> tReader) throws InvalidMarshallableException {
@@ -368,6 +480,9 @@ public class DefaultValueIn implements ValueIn {
         return (T) defaultValue;
     }
 
+    /**
+     * Supplies a {@code null} type prefix.
+     */
     @NotNull
     @Override
     public <T> ValueIn typePrefix(T t, @NotNull BiConsumer<T, CharSequence> ts) {
@@ -375,6 +490,9 @@ public class DefaultValueIn implements ValueIn {
         return this;
     }
 
+    /**
+     * Supplies a {@code null} type prefix to {@code ts} and returns the wire.
+     */
     @NotNull
     @Override
     public <T> WireIn typeLiteralAsText(T t, @NotNull BiConsumer<T, CharSequence> ts) throws IORuntimeException, BufferUnderflowException {
@@ -382,22 +500,34 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
+    /**
+     * Delegates to the parent wire.
+     */
     @Override
     public ClassLookup classLookup() {
         return wireIn.classLookup();
     }
 
+    /**
+     * Returns {@link #defaultValue} unchanged.
+     */
     @Nullable
     @Override
     public Object marshallable(@NotNull Object object, @NotNull SerializationStrategy strategy) throws BufferUnderflowException, IORuntimeException {
         return defaultValue;
     }
 
+    /**
+     * Returns {@code true} if {@link #defaultValue} is {@code Boolean.TRUE}.
+     */
     @Override
     public boolean bool() throws IORuntimeException {
         return defaultValue == Boolean.TRUE;
     }
 
+    /**
+     * Returns the byte value of {@link #defaultValue}.
+     */
     @Override
     public byte int8() {
         @Nullable Number o = (Number) defaultValue;
@@ -405,6 +535,9 @@ public class DefaultValueIn implements ValueIn {
         return o.byteValue();
     }
 
+    /**
+     * Returns the short value of {@link #defaultValue}.
+     */
     @Override
     public short int16() {
         @NotNull Number o = (Number) defaultValue;
@@ -412,6 +545,9 @@ public class DefaultValueIn implements ValueIn {
         return o.shortValue();
     }
 
+    /**
+     * Returns the unsigned short value of {@link #defaultValue}.
+     */
     @Override
     public int uint16() {
         @Nullable Number o = (Number) defaultValue;
@@ -419,6 +555,9 @@ public class DefaultValueIn implements ValueIn {
         return o.intValue();
     }
 
+    /**
+     * Returns the int value of {@link #defaultValue}.
+     */
     @Override
     public int int32() {
         @NotNull Number o = (Number) defaultValue;
@@ -426,6 +565,9 @@ public class DefaultValueIn implements ValueIn {
         return o.intValue();
     }
 
+    /**
+     * Returns the long value of {@link #defaultValue}.
+     */
     @Override
     public long int64() {
         @NotNull Number o = (Number) defaultValue;
@@ -433,6 +575,9 @@ public class DefaultValueIn implements ValueIn {
         return o.longValue();
     }
 
+    /**
+     * Returns the double value of {@link #defaultValue}.
+     */
     @Override
     public double float64() {
         @NotNull Number o = (Number) defaultValue;
@@ -440,6 +585,9 @@ public class DefaultValueIn implements ValueIn {
         return o.doubleValue();
     }
 
+    /**
+     * Returns the float value of {@link #defaultValue}.
+     */
     @Override
     public float float32() {
         @NotNull Number o = (Number) defaultValue;
@@ -447,37 +595,58 @@ public class DefaultValueIn implements ValueIn {
         return o.floatValue();
     }
 
+    /**
+     * Returns {@link #defaultValue} as a type literal.
+     */
     @Override
     public Type typeLiteral(BiFunction<CharSequence, ClassNotFoundException, Type> unresolvedHandler) {
         return (Type) defaultValue;
     }
 
+    /**
+     * Always {@link BracketType#NONE} as no value is read.
+     */
     @NotNull
     @Override
     public BracketType getBracketType() {
         return BracketType.NONE;
     }
 
+    /**
+     * Returns {@code true} when {@link #defaultValue} is {@code null}.
+     */
     @Override
     public boolean isNull() {
         return defaultValue == null;
     }
 
+    /**
+     * Returns {@link #defaultValue}.
+     */
     @Override
     public Object objectWithInferredType(Object using, SerializationStrategy strategy, Class<?> type) {
         return defaultValue;
     }
 
+    /**
+     * Always {@code false}; nothing was found on the wire.
+     */
     @Override
     public boolean isPresent() {
         return false;
     }
 
+    /**
+     * Always {@code false}.
+     */
     @Override
     public boolean isTyped() {
         return false;
     }
 
+    /**
+     * Returns the class of {@link #defaultValue} or {@code void.class}.
+     */
     @Override
     public Class<?> typePrefix() {
         @Nullable Object o = defaultValue;
@@ -485,6 +654,9 @@ public class DefaultValueIn implements ValueIn {
         return o.getClass();
     }
 
+    /**
+     * Nothing to reset.
+     */
     @Override
     public void resetState() {
         // Do nothing

--- a/src/main/java/net/openhft/chronicle/wire/DefaultValueIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/DefaultValueIn.java
@@ -39,10 +39,10 @@ import java.util.List;
 import java.util.UUID;
 import java.util.function.*;
 /**
- * An implementation of {@link ValueIn} used when a requested field is not
- * present on the wire. It returns either {@code null}, a primitive zero or the
- * value configured by the {@link WireMarshaller}. This allows optional fields
- * to be skipped without breaking deserialisation.
+ * This class provides the default implementation for the {@link ValueIn} interface. It's primarily designed
+ * to handle default values, converting them into various formats such as text and bytes.
+ * It returns either {@code null}, a primitive zero or the value configured by the {@link WireMarshaller}.
+ * This allows optional fields to be skipped without breaking deserialisation.
  */
 @SuppressWarnings("rawtypes")
 public class DefaultValueIn implements ValueIn {
@@ -60,9 +60,6 @@ public class DefaultValueIn implements ValueIn {
         this.wireIn = wireIn;
     }
 
-    /**
-     * Returns {@link #defaultValue} as a string.
-     */
     @Nullable
     @Override
     public String text() {
@@ -70,10 +67,6 @@ public class DefaultValueIn implements ValueIn {
         return o == null ? null : o.toString();
     }
 
-    /**
-     * Appends the string form of {@link #defaultValue} to {@code sb}.
-     * Returns {@code null} if no value is configured.
-     */
     @Nullable
     @Override
     public StringBuilder textTo(@NotNull StringBuilder sb) {
@@ -84,10 +77,6 @@ public class DefaultValueIn implements ValueIn {
         return sb;
     }
 
-    /**
-     * Writes the string form of {@link #defaultValue} to the supplied bytes.
-     * Returns {@code null} when the value is absent.
-     */
     @Nullable
     @Override
     public Bytes<?> textTo(@NotNull Bytes<?> bytes) {
@@ -98,10 +87,6 @@ public class DefaultValueIn implements ValueIn {
         return bytes;
     }
 
-    /**
-     * Writes {@link #defaultValue} to {@code toBytes} and returns the parent
-     * wire.
-     */
     @NotNull
     @Override
     public WireIn bytes(@NotNull BytesOut<?> toBytes) {
@@ -113,10 +98,6 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
-    /**
-     * Copies {@link #defaultValue} into a {@link PointerBytesStore}. If absent
-     * an empty store is set.
-     */
     @Nullable
     @Override
     public WireIn bytesSet(@NotNull PointerBytesStore toBytes) {
@@ -130,10 +111,6 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
-    /**
-     * Compares {@link #defaultValue} with {@code compareBytes} and passes the
-     * result to {@code consumer}.
-     */
     @NotNull
     @Override
     public WireIn bytesMatch(@NotNull BytesStore<?, ?> compareBytes, @NotNull BooleanConsumer consumer) {
@@ -143,9 +120,6 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
-    /**
-     * Supplies {@link #defaultValue} to a {@link ReadBytesMarshallable}.
-     */
     @NotNull
     @Override
     public WireIn bytes(@NotNull ReadBytesMarshallable wireInConsumer) {
@@ -159,17 +133,11 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
-    /**
-     * Returns the backing byte array.
-     */
     @Override
     public byte @NotNull [] bytes(byte[] using) {
         return (byte[]) defaultValue;
     }
 
-    /**
-     * Returns the parent {@link WireIn}.
-     */
     @NotNull
     @Override
     public WireIn wireIn() {
@@ -184,18 +152,12 @@ public class DefaultValueIn implements ValueIn {
         return 0;
     }
 
-    /**
-     * No value is read so the parent wire is returned.
-     */
     @NotNull
     @Override
     public WireIn skipValue() {
         return wireIn();
     }
 
-    /**
-     * Passes {@link #defaultValue} to {@code tFlag} and returns the parent wire.
-     */
     @NotNull
     @Override
     public <T> WireIn bool(T t, @NotNull ObjBooleanConsumer<T> tFlag) {
@@ -204,9 +166,6 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
-    /**
-     * Supplies the byte value of {@link #defaultValue} to {@code tb}.
-     */
     @NotNull
     @Override
     public <T> WireIn int8(@NotNull T t, @NotNull ObjByteConsumer<T> tb) {
@@ -216,9 +175,6 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
-    /**
-     * Supplies the unsigned byte value of {@link #defaultValue}.
-     */
     @NotNull
     @Override
     public <T> WireIn uint8(@NotNull T t, @NotNull ObjShortConsumer<T> ti) {
@@ -228,9 +184,6 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
-    /**
-     * Supplies the short value of {@link #defaultValue}.
-     */
     @NotNull
     @Override
     public <T> WireIn int16(@NotNull T t, @NotNull ObjShortConsumer<T> ti) {
@@ -240,9 +193,6 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
-    /**
-     * Supplies the unsigned short value of {@link #defaultValue}.
-     */
     @NotNull
     @Override
     public <T> WireIn uint16(@NotNull T t, @NotNull ObjIntConsumer<T> ti) {
@@ -252,9 +202,6 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
-    /**
-     * Supplies the int value of {@link #defaultValue}.
-     */
     @NotNull
     @Override
     public <T> WireIn int32(@NotNull T t, @NotNull ObjIntConsumer<T> ti) {
@@ -264,9 +211,6 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
-    /**
-     * Supplies the unsigned int value of {@link #defaultValue}.
-     */
     @NotNull
     @Override
     public <T> WireIn uint32(@NotNull T t, @NotNull ObjLongConsumer<T> tl) {
@@ -276,9 +220,6 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
-    /**
-     * Supplies the long value of {@link #defaultValue}.
-     */
     @NotNull
     @Override
     public <T> WireIn int64(@NotNull T t, @NotNull ObjLongConsumer<T> tl) {
@@ -288,9 +229,6 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
-    /**
-     * Supplies the float value of {@link #defaultValue}.
-     */
     @NotNull
     @Override
     public <T> WireIn float32(@NotNull T t, @NotNull ObjFloatConsumer<T> tf) {
@@ -300,9 +238,6 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
-    /**
-     * Supplies the double value of {@link #defaultValue}.
-     */
     @NotNull
     @Override
     public <T> WireIn float64(@NotNull T t, @NotNull ObjDoubleConsumer<T> td) {
@@ -312,9 +247,6 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
-    /**
-     * Passes the {@link LocalTime} held in {@link #defaultValue}.
-     */
     @NotNull
     @Override
     public <T> WireIn time(@NotNull T t, @NotNull BiConsumer<T, LocalTime> setLocalTime) {
@@ -323,9 +255,6 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
-    /**
-     * Passes the {@link ZonedDateTime} held in {@link #defaultValue}.
-     */
     @NotNull
     @Override
     public <T> WireIn zonedDateTime(@NotNull T t, @NotNull BiConsumer<T, ZonedDateTime> tZonedDateTime) {
@@ -334,9 +263,6 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
-    /**
-     * Passes the {@link LocalDate} held in {@link #defaultValue}.
-     */
     @NotNull
     @Override
     public <T> WireIn date(@NotNull T t, @NotNull BiConsumer<T, LocalDate> tLocalDate) {
@@ -361,9 +287,6 @@ public class DefaultValueIn implements ValueIn {
         return false;
     }
 
-    /**
-     * Supplies the {@link UUID} from {@link #defaultValue}.
-     */
     @NotNull
     @Override
     public <T> WireIn uuid(@NotNull T t, @NotNull BiConsumer<T, UUID> tuuid) {
@@ -381,9 +304,6 @@ public class DefaultValueIn implements ValueIn {
         throw new UnsupportedOperationException("todo");
     }
 
-    /**
-     * Sets {@code value} from {@link #defaultValue}.
-     */
     @NotNull
     @Override
     public WireIn int64(@NotNull LongValue value) {
@@ -393,9 +313,6 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
-    /**
-     * Sets {@code value} from {@link #defaultValue}.
-     */
     @NotNull
     @Override
     public WireIn int32(@NotNull IntValue value) {
@@ -413,9 +330,6 @@ public class DefaultValueIn implements ValueIn {
         throw new UnsupportedOperationException("todo");
     }
 
-    /**
-     * Provides {@link #defaultValue} to {@code setter}.
-     */
     @NotNull
     @Override
     public <T> WireIn int64(@Nullable LongValue value, T t, @NotNull BiConsumer<T, LongValue> setter) {
@@ -426,9 +340,6 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
-    /**
-     * Provides {@link #defaultValue} to {@code setter}.
-     */
     @NotNull
     @Override
     public <T> WireIn int32(@Nullable IntValue value, T t, @NotNull BiConsumer<T, IntValue> setter) {
@@ -455,9 +366,6 @@ public class DefaultValueIn implements ValueIn {
         return false;
     }
 
-    /**
-     * Invokes {@code tReader} with {@code kls} and this instance.
-     */
     @NotNull
     @Override
     public <T, K> WireIn sequence(@NotNull T t, K kls, @NotNull TriConsumer<T, K, ValueIn> tReader) throws InvalidMarshallableException {
@@ -500,9 +408,6 @@ public class DefaultValueIn implements ValueIn {
         return wireIn();
     }
 
-    /**
-     * Delegates to the parent wire.
-     */
     @Override
     public ClassLookup classLookup() {
         return wireIn.classLookup();
@@ -517,17 +422,11 @@ public class DefaultValueIn implements ValueIn {
         return defaultValue;
     }
 
-    /**
-     * Returns {@code true} if {@link #defaultValue} is {@code Boolean.TRUE}.
-     */
     @Override
     public boolean bool() throws IORuntimeException {
         return defaultValue == Boolean.TRUE;
     }
 
-    /**
-     * Returns the byte value of {@link #defaultValue}.
-     */
     @Override
     public byte int8() {
         @Nullable Number o = (Number) defaultValue;
@@ -535,9 +434,6 @@ public class DefaultValueIn implements ValueIn {
         return o.byteValue();
     }
 
-    /**
-     * Returns the short value of {@link #defaultValue}.
-     */
     @Override
     public short int16() {
         @NotNull Number o = (Number) defaultValue;
@@ -545,9 +441,6 @@ public class DefaultValueIn implements ValueIn {
         return o.shortValue();
     }
 
-    /**
-     * Returns the unsigned short value of {@link #defaultValue}.
-     */
     @Override
     public int uint16() {
         @Nullable Number o = (Number) defaultValue;
@@ -555,9 +448,6 @@ public class DefaultValueIn implements ValueIn {
         return o.intValue();
     }
 
-    /**
-     * Returns the int value of {@link #defaultValue}.
-     */
     @Override
     public int int32() {
         @NotNull Number o = (Number) defaultValue;
@@ -565,9 +455,6 @@ public class DefaultValueIn implements ValueIn {
         return o.intValue();
     }
 
-    /**
-     * Returns the long value of {@link #defaultValue}.
-     */
     @Override
     public long int64() {
         @NotNull Number o = (Number) defaultValue;
@@ -575,9 +462,6 @@ public class DefaultValueIn implements ValueIn {
         return o.longValue();
     }
 
-    /**
-     * Returns the double value of {@link #defaultValue}.
-     */
     @Override
     public double float64() {
         @NotNull Number o = (Number) defaultValue;
@@ -585,9 +469,6 @@ public class DefaultValueIn implements ValueIn {
         return o.doubleValue();
     }
 
-    /**
-     * Returns the float value of {@link #defaultValue}.
-     */
     @Override
     public float float32() {
         @NotNull Number o = (Number) defaultValue;
@@ -595,9 +476,6 @@ public class DefaultValueIn implements ValueIn {
         return o.floatValue();
     }
 
-    /**
-     * Returns {@link #defaultValue} as a type literal.
-     */
     @Override
     public Type typeLiteral(BiFunction<CharSequence, ClassNotFoundException, Type> unresolvedHandler) {
         return (Type) defaultValue;
@@ -612,9 +490,6 @@ public class DefaultValueIn implements ValueIn {
         return BracketType.NONE;
     }
 
-    /**
-     * Returns {@code true} when {@link #defaultValue} is {@code null}.
-     */
     @Override
     public boolean isNull() {
         return defaultValue == null;
@@ -644,9 +519,6 @@ public class DefaultValueIn implements ValueIn {
         return false;
     }
 
-    /**
-     * Returns the class of {@link #defaultValue} or {@code void.class}.
-     */
     @Override
     public Class<?> typePrefix() {
         @Nullable Object o = defaultValue;
@@ -654,9 +526,6 @@ public class DefaultValueIn implements ValueIn {
         return o.getClass();
     }
 
-    /**
-     * Nothing to reset.
-     */
     @Override
     public void resetState() {
         // Do nothing

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -3111,3 +3111,4 @@ public class TextWire extends YamlWireOut<TextWire> {
         writeContext.rollbackIfNotComplete();
     }
 }
+

--- a/src/main/java/net/openhft/chronicle/wire/ValueIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueIn.java
@@ -43,27 +43,28 @@ import java.util.function.*;
 import static net.openhft.chronicle.wire.SerializationStrategies.MARSHALLABLE;
 
 /**
- * Represents an interface for reading values in various formats from a serialized data source.
- * This interface is part of the Chronicle Wire library, which is designed for high-performance
- * serialization and deserialization of data. It provides methods to read data types like text,
- * binary, numeric, and temporal values, as well as support for more complex types like collections
- * and marshallable objects.
+ * Represents the value component of a key–value pair being read from a wire.
+ * After a field name is consumed via {@link WireIn#read()}, a {@code ValueIn}
+ * instance is used to deserialize that field’s value.  A {@code ValueIn}
+ * instance is normally consumed once for a single field; the next field will
+ * supply a fresh instance from the parent {@link WireIn}.
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public interface ValueIn {
-    /** A constant consumer that does nothing when accepting a {@link ValueIn}. */
+    /**
+     * A {@link Consumer} that ignores the supplied {@code ValueIn}.  Useful as a
+     * no-op placeholder.
+     */
     @Deprecated(/* remove in x.29 as unused */)
     Consumer<ValueIn> DISCARD = v -> {};
 
     // ---- Text / Strings section ----
 
     /**
-     * Reads text data and applies a given bi-consumer to the text data and the provided object.
+     * Deserialises the current value as text and passes it to {@code ts} along
+     * with the supplied object.
      *
-     * @param t  The target object.
-     * @param ts The bi-consumer that accepts the target object and the read text.
-     * @param <T> Type of the target object.
-     * @return The current WireIn instance.
+     * @return the parent {@link WireIn}
      */
     @NotNull
     default <T> WireIn text(T t, @NotNull BiConsumer<T, String> ts) {
@@ -73,10 +74,9 @@ public interface ValueIn {
     }
 
     /**
-     * Reads text data and appends it to the given StringBuilder. If the data is null, the StringBuilder is cleared.
-     *
-     * @param sb The StringBuilder to append the text data to.
-     * @return The current WireIn instance.
+     * Reads the value as text and appends it to {@code sb}.  If the wire value
+     * is {@code null}, {@code sb} is cleared.  Using a reusable
+     * {@link StringBuilder} can reduce allocation.
      */
     @NotNull
     default WireIn text(@NotNull StringBuilder sb) {
@@ -86,9 +86,8 @@ public interface ValueIn {
     }
 
     /**
-     * Reads text data and returns the first character. If the data is null or empty, a null character is returned.
-     *
-     * @return The first character of the text data or '\u0000' if none.
+     * Reads the value as text and returns its first character.  Returns the null
+     * character ({@code '\u0000'}) if the text is absent or empty.
      */
     default char character() {
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
@@ -101,10 +100,7 @@ public interface ValueIn {
     }
 
     /**
-     * Reads text data into the provided Bytes object, which is then cleared.
-     *
-     * @param sdo The Bytes object to store the text data.
-     * @return The current WireIn instance.
+     * Reads the value as text into {@code sdo}, clearing it first.
      */
     @NotNull
     default WireIn text(@NotNull Bytes<?> sdo) {
@@ -114,46 +110,37 @@ public interface ValueIn {
     }
 
     /**
-     * Reads and returns the text data.
-     *
-     * @return The text data or null.
+     * Reads and returns the value as a {@link String}.  May return
+     * {@code null} if the wire representation is null.
      */
     @Nullable
     String text();
 
     /**
-     * Reads text data and appends it to the given StringBuilder.
+     * Populates {@code sb} with the text form of the value.
      *
-     * @param sb The StringBuilder to append the text data to.
-     * @return The StringBuilder with appended text or null.
+     * @return {@code sb}, or {@code null} if the value is null on the wire
      */
     @Nullable
     StringBuilder textTo(@NotNull StringBuilder sb);
 
     /**
-     * Reads text data into the provided Bytes object.
+     * Writes the value’s textual form to {@code bytes}, which is cleared first.
      *
-     * @param bytes The Bytes object to store the text data.
-     * @return The Bytes object with the text data or null.
+     * @return {@code bytes}, or {@code null} if the value is null
      */
     @Nullable
     Bytes<?> textTo(@NotNull Bytes<?> bytes);
 
     /**
-     * Reads byte data into the provided BytesOut object.
-     *
-     * @param toBytes The BytesOut object to store the byte data.
-     * @return The current WireIn instance.
+     * Reads the value as a sequence of bytes into {@code toBytes}.
      */
     @NotNull
     WireIn bytes(@NotNull BytesOut<?> toBytes);
 
     /**
-     * Reads byte data into the provided BytesOut object with an option to clear the BytesOut before reading.
-     *
-     * @param toBytes The BytesOut object to store the byte data.
-     * @param clearBytes If true, the BytesOut object will be cleared before reading.
-     * @return The current WireIn instance.
+     * Variant of {@link #bytes(BytesOut)} that clears {@code toBytes} first when
+     * {@code clearBytes} is {@code true}.
      */
     default WireIn bytes(@NotNull BytesOut<?> toBytes, boolean clearBytes) {
         if (clearBytes)
@@ -162,11 +149,8 @@ public interface ValueIn {
     }
 
     /**
-     * Reads byte data into the provided BytesOut object.
-     * This method acts as a semantic alias for {@link #bytes(BytesOut)} method.
-     *
-     * @param toBytes The BytesOut object to store the byte data.
-     * @return The current WireIn instance.
+     * Reads the raw byte sequence for this value into {@code toBytes}.  This is
+     * an alias of {@link #bytes(BytesOut)}.
      */
     @NotNull
     default WireIn bytesLiteral(@NotNull BytesOut<?> toBytes) {
@@ -174,10 +158,7 @@ public interface ValueIn {
     }
 
     /**
-     * Retrieves the byte data as a BytesStore object.
-     * This method acts as a semantic alias for {@link #bytesStore()} method.
-     *
-     * @return The BytesStore object or null.
+     * Returns the raw byte sequence for this value as a new {@link BytesStore}.
      */
     @Nullable
     default BytesStore<?, ?> bytesLiteral() {
@@ -185,54 +166,43 @@ public interface ValueIn {
     }
 
     /**
-     * Sets byte data to the provided PointerBytesStore.
-     *
-     * @param toBytes The PointerBytesStore to set the byte data.
-     * @return The current WireIn instance.
+     * Sets {@code toBytes} to point directly at the underlying data for this
+     * value when supported, avoiding a copy.
      */
     @Nullable
     WireIn bytesSet(@NotNull PointerBytesStore toBytes);
 
     /**
-     * Compares byte data with the provided BytesStore and uses the given BooleanConsumer based on the result.
-     *
-     * @param compareBytes The BytesStore to compare with.
-     * @param consumer     The BooleanConsumer to be called based on the comparison result.
-     * @return The current WireIn instance.
+     * Compares the value’s bytes with {@code compareBytes} and passes the match
+     * result to {@code consumer}.
      */
     @NotNull
     WireIn bytesMatch(@NotNull BytesStore<?, ?> compareBytes, BooleanConsumer consumer);
 
     /**
-     * Reads byte data using the provided ReadBytesMarshallable.
-     *
-     * @param bytesMarshallable The ReadBytesMarshallable to read the byte data.
-     * @return The current WireIn instance.
+     * Supplies the byte stream to {@code bytesMarshallable#readMarshallable} for
+     * custom deserialisation.
      */
     @NotNull
     WireIn bytes(@NotNull ReadBytesMarshallable bytesMarshallable);
 
     /**
-     * Retrieves the byte data as an array.
-     *
-     * @return The byte data as an array or null.
+     * Returns the value’s bytes as a new array, or {@code null} when the wire
+     * representation is null.
      */
     default byte @Nullable [] bytes() {
         return bytes((byte[]) null);
     }
 
     /**
-     * Retrieves the byte data as an array with the option to reuse an existing byte array.
-     *
-     * @param using The existing byte array to use or null.
-     * @return The byte data as an array or null.
+     * Populates {@code using} with the value’s bytes when possible to avoid
+     * allocation.  Returns the array containing the data, or {@code null} if the
+     * value is null.
      */
     byte @Nullable [] bytes(byte[] using);
 
     /**
-     * Retrieves the byte data as a BytesStore object.
-     *
-     * @return The BytesStore object or null.
+     * Wraps the value’s byte array in a new {@link BytesStore}.
      */
     @Nullable
     default BytesStore<?, ?> bytesStore() {
@@ -241,134 +211,89 @@ public interface ValueIn {
     }
 
     /**
-     * Puts the byte data into the provided ByteBuffer.
-     *
-     * @param bb The ByteBuffer to put the byte data.
+     * Copies the value’s bytes into {@code bb}.
      */
     default void byteBuffer(@NotNull ByteBuffer bb) {
         bb.put(bytes());
     }
 
     /**
-     * Provides the current WireIn instance.
-     *
-     * @return The current WireIn instance.
+     * Returns the parent {@link WireIn} that provided this instance.
      */
     @NotNull
     WireIn wireIn();
 
     /**
-     * Retrieves the length of the field in bytes, inclusive of any encoding and header character.
-     *
-     * @return The length of the field in bytes.
+     * Returns the length in bytes of this value as it appears on the wire,
+     * including any type or length prefix.
      */
     long readLength();
 
     /**
-     * Skips the current value while reading.
-     *
-     * @return The current WireIn instance.
+     * Consumes and discards the current value, advancing the read position.
      */
     @NotNull
     WireIn skipValue();
 
     /**
-     * Reads a boolean value and applies it to the provided consumer.
+     * Reads the value as a {@code boolean} and passes it, together with
+     * {@code t}, to {@code tFlag}.
      *
-     * @param t     The target object.
-     * @param tFlag The consumer that accepts the target object and the read boolean value.
-     * @return The current WireIn instance.
-     * @param <T>   The type of the target object.
+     * @param <T> type of the context object
+     * @return the parent {@link WireIn}
      */
     @NotNull <T> WireIn bool(T t, @NotNull ObjBooleanConsumer<T> tFlag);
 
     /**
-     * Reads an 8-bit integer (byte) value and applies an ObjByteConsumer with the provided object and the read value.
-     *
-     * @param <T> The type of object to be passed to the ObjByteConsumer.
-     * @param t   The object to be passed to the ObjByteConsumer.
-     * @param tb  The ObjByteConsumer that accepts the object and the read 8-bit integer value.
-     * @return The WireIn instance for method chaining.
+     * Reads the value as a signed byte and passes it to {@code tb} together with
+     * {@code t}.
      */
     @NotNull <T> WireIn int8(@NotNull T t, @NotNull ObjByteConsumer<T> tb);
 
     /**
-     * Reads an unsigned 8-bit integer (short) value and applies an ObjShortConsumer with the provided object and the read value.
-     *
-     * @param <T> The type of object to be passed to the ObjShortConsumer.
-     * @param t   The object to be passed to the ObjShortConsumer.
-     * @param ti  The ObjShortConsumer that accepts the object and the read unsigned 8-bit integer value.
-     * @return The WireIn instance for method chaining.
+     * Reads the value as an unsigned byte and passes it to {@code ti} with
+     * {@code t}.
      */
     @NotNull <T> WireIn uint8(@NotNull T t, @NotNull ObjShortConsumer<T> ti);
 
     /**
-     * Reads a 16-bit integer (short) value and applies an ObjShortConsumer with the provided object and the read value.
-     *
-     * @param <T> The type of object to be passed to the ObjShortConsumer.
-     * @param t   The object to be passed to the ObjShortConsumer.
-     * @param ti  The ObjShortConsumer that accepts the object and the read 16-bit integer value.
-     * @return The WireIn instance for method chaining.
+     * Reads the value as a short and passes it to {@code ti} with {@code t}.
      */
     @NotNull <T> WireIn int16(@NotNull T t, @NotNull ObjShortConsumer<T> ti);
 
     /**
-     * Reads an unsigned 16-bit integer (int) value and applies an ObjIntConsumer with the provided object and the read value.
-     *
-     * @param <T> The type of object to be passed to the ObjIntConsumer.
-     * @param t   The object to be passed to the ObjIntConsumer.
-     * @param ti  The ObjIntConsumer that accepts the object and the read unsigned 16-bit integer value.
-     * @return The WireIn instance for method chaining.
+     * Reads the value as an unsigned short and passes it to {@code ti} with
+     * {@code t}.
      */
     @NotNull <T> WireIn uint16(@NotNull T t, @NotNull ObjIntConsumer<T> ti);
 
     /**
-     * Reads a 32-bit integer (int) value and applies an ObjIntConsumer with the provided object and the read value.
-     *
-     * @param <T> The type of object to be passed to the ObjIntConsumer.
-     * @param t   The object to be passed to the ObjIntConsumer.
-     * @param ti  The ObjIntConsumer that accepts the object and the read 32-bit integer value.
-     * @return The WireIn instance for method chaining.
+     * Reads the value as an {@code int} and passes it to {@code ti} with
+     * {@code t}.
      */
     @NotNull <T> WireIn int32(@NotNull T t, @NotNull ObjIntConsumer<T> ti);
 
     /**
-     * Reads an unsigned 32-bit integer (long) value and applies an ObjLongConsumer with the provided object and the read value.
-     *
-     * @param <T> The type of object to be passed to the ObjLongConsumer.
-     * @param t   The object to be passed to the ObjLongConsumer.
-     * @param tl  The ObjLongConsumer that accepts the object and the read unsigned 32-bit integer value.
-     * @return The WireIn instance for method chaining.
+     * Reads the value as an unsigned int and passes it to {@code tl} with
+     * {@code t}.
      */
     @NotNull <T> WireIn uint32(@NotNull T t, @NotNull ObjLongConsumer<T> tl);
 
     /**
-     * Reads a 64-bit integer (long) value and applies an ObjLongConsumer with the provided object and the read value.
-     *
-     * @param <T> The type of object to be passed to the ObjLongConsumer.
-     * @param t   The object to be passed to the ObjLongConsumer.
-     * @param tl  The ObjLongConsumer that accepts the object and the read 64-bit integer value.
-     * @return The WireIn instance for method chaining.
+     * Reads the value as a {@code long} and passes it to {@code tl} with
+     * {@code t}.
      */
     @NotNull <T> WireIn int64(@NotNull T t, @NotNull ObjLongConsumer<T> tl);
 
     /**
-     * Reads a 32-bit floating-point (float) value and applies an ObjFloatConsumer with the provided object and the read value.
-     *
-     * @param <T> The type of object to be passed to the ObjFloatConsumer.
-     * @param t   The object to be passed to the ObjFloatConsumer.
-     * @param tf  The ObjFloatConsumer that accepts the object and the read 32-bit floating-point value.
-     * @return The WireIn instance for method chaining.
+     * Reads the value as a {@code float} and passes it to {@code tf} with
+     * {@code t}.
      */
     @NotNull <T> WireIn float32(@NotNull T t, @NotNull ObjFloatConsumer<T> tf);
 
     /**
-     * Reads a 64-bit floating-point (double) value and applies an ObjDoubleConsumer with the provided object and the read value.
-     *
-     * @param <T> The type of object to be passed to the ObjDoubleConsumer.
-     * @param t   The object to be passed to the ObjDoubleConsumer.
-     * @param td  The ObjDoubleConsumer that accepts the object and the read 64-bit floating-point value.
-     * @return The WireIn instance for method chaining.
+     * Reads the value as a {@code double} and passes it to {@code td} with
+     * {@code t}.
      */
     @NotNull <T> WireIn float64(@NotNull T t, @NotNull ObjDoubleConsumer<T> td);
 

--- a/src/main/java/net/openhft/chronicle/wire/ValueIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueIn.java
@@ -43,11 +43,11 @@ import java.util.function.*;
 import static net.openhft.chronicle.wire.SerializationStrategies.MARSHALLABLE;
 
 /**
- * Represents the value component of a key–value pair being read from a wire.
- * After a field name is consumed via {@link WireIn#read()}, a {@code ValueIn}
- * instance is used to deserialize that field’s value.  A {@code ValueIn}
- * instance is normally consumed once for a single field; the next field will
- * supply a fresh instance from the parent {@link WireIn}.
+ * Represents an interface for reading values in various formats from a serialized data source.
+ * This interface is part of the Chronicle Wire library, which is designed for high-performance
+ * serialization and deserialization of data. It provides methods to read data types like text,
+ * binary, numeric, and temporal values, as well as support for more complex types like collections
+ * and marshallable objects.
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public interface ValueIn {
@@ -74,9 +74,10 @@ public interface ValueIn {
     }
 
     /**
-     * Reads the value as text and appends it to {@code sb}.  If the wire value
-     * is {@code null}, {@code sb} is cleared.  Using a reusable
-     * {@link StringBuilder} can reduce allocation.
+     * Reads text data and appends it to the given StringBuilder. If the data is null, the StringBuilder is cleared.
+     *
+     * @param sb The StringBuilder to append the text data to.
+     * @return The current WireIn instance.
      */
     @NotNull
     default WireIn text(@NotNull StringBuilder sb) {
@@ -86,8 +87,9 @@ public interface ValueIn {
     }
 
     /**
-     * Reads the value as text and returns its first character.  Returns the null
-     * character ({@code '\u0000'}) if the text is absent or empty.
+     * Reads text data and returns the first character. If the data is null or empty, a null character is returned.
+     *
+     * @return The first character of the text data or '\u0000' if none.
      */
     default char character() {
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
@@ -100,7 +102,10 @@ public interface ValueIn {
     }
 
     /**
-     * Reads the value as text into {@code sdo}, clearing it first.
+     * Reads text data into the provided Bytes object, which is then cleared.
+     *
+     * @param sdo The Bytes object to store the text data.
+     * @return The current WireIn instance.
      */
     @NotNull
     default WireIn text(@NotNull Bytes<?> sdo) {
@@ -110,37 +115,46 @@ public interface ValueIn {
     }
 
     /**
-     * Reads and returns the value as a {@link String}.  May return
-     * {@code null} if the wire representation is null.
+     * Reads and returns the text data.
+     *
+     * @return The text data or null.
      */
     @Nullable
     String text();
 
     /**
-     * Populates {@code sb} with the text form of the value.
+     * Reads text data and appends it to the given StringBuilder.
      *
-     * @return {@code sb}, or {@code null} if the value is null on the wire
+     * @param sb The StringBuilder to append the text data to.
+     * @return The StringBuilder with appended text or null.
      */
     @Nullable
     StringBuilder textTo(@NotNull StringBuilder sb);
 
     /**
-     * Writes the value’s textual form to {@code bytes}, which is cleared first.
+     * Reads text data into the provided Bytes object.
      *
-     * @return {@code bytes}, or {@code null} if the value is null
+     * @param bytes The Bytes object to store the text data.
+     * @return The Bytes object with the text data or null.
      */
     @Nullable
     Bytes<?> textTo(@NotNull Bytes<?> bytes);
 
     /**
-     * Reads the value as a sequence of bytes into {@code toBytes}.
+     * Reads byte data into the provided BytesOut object.
+     *
+     * @param toBytes The BytesOut object to store the byte data.
+     * @return The current WireIn instance.
      */
     @NotNull
     WireIn bytes(@NotNull BytesOut<?> toBytes);
 
     /**
-     * Variant of {@link #bytes(BytesOut)} that clears {@code toBytes} first when
-     * {@code clearBytes} is {@code true}.
+     * Reads byte data into the provided BytesOut object with an option to clear the BytesOut before reading.
+     *
+     * @param toBytes The BytesOut object to store the byte data.
+     * @param clearBytes If true, the BytesOut object will be cleared before reading.
+     * @return The current WireIn instance.
      */
     default WireIn bytes(@NotNull BytesOut<?> toBytes, boolean clearBytes) {
         if (clearBytes)
@@ -149,8 +163,11 @@ public interface ValueIn {
     }
 
     /**
-     * Reads the raw byte sequence for this value into {@code toBytes}.  This is
-     * an alias of {@link #bytes(BytesOut)}.
+     * Reads byte data into the provided BytesOut object.
+     * This method acts as a semantic alias for {@link #bytes(BytesOut)} method.
+     *
+     * @param toBytes The BytesOut object to store the byte data.
+     * @return The current WireIn instance.
      */
     @NotNull
     default WireIn bytesLiteral(@NotNull BytesOut<?> toBytes) {
@@ -158,7 +175,10 @@ public interface ValueIn {
     }
 
     /**
-     * Returns the raw byte sequence for this value as a new {@link BytesStore}.
+     * Retrieves the byte data as a BytesStore object.
+     * This method acts as a semantic alias for {@link #bytesStore()} method.
+     *
+     * @return The BytesStore object or null.
      */
     @Nullable
     default BytesStore<?, ?> bytesLiteral() {
@@ -166,18 +186,23 @@ public interface ValueIn {
     }
 
     /**
-     * Sets {@code toBytes} to point directly at the underlying data for this
-     * value when supported, avoiding a copy.
+     * Sets byte data to the provided PointerBytesStore.
+     *
+     * @param toBytes The PointerBytesStore to set the byte data.
+     * @return The current WireIn instance.
      */
     @Nullable
     WireIn bytesSet(@NotNull PointerBytesStore toBytes);
 
     /**
-     * Compares the value’s bytes with {@code compareBytes} and passes the match
-     * result to {@code matchResult}.
+     * Compares byte data with the provided BytesStore and uses the given BooleanConsumer based on the result.
+     *
+     * @param compareBytes The BytesStore to compare with.
+     * @param consumer     The BooleanConsumer to be called based on the comparison result.
+     * @return The current WireIn instance.
      */
     @NotNull
-    WireIn bytesMatch(@NotNull BytesStore<?, ?> compareBytes, BooleanConsumer matchResult);
+    WireIn bytesMatch(@NotNull BytesStore<?, ?> compareBytes, BooleanConsumer consumer);
 
     /**
      * Supplies the byte stream to {@code bytesMarshallable#readMarshallable} for
@@ -187,8 +212,9 @@ public interface ValueIn {
     WireIn bytes(@NotNull ReadBytesMarshallable bytesMarshallable);
 
     /**
-     * Returns the value’s bytes as a new array, or {@code null} when the wire
-     * representation is null.
+     * Retrieves the byte data as an array.
+     *
+     * @return The byte data as an array or null.
      */
     default byte @Nullable [] bytes() {
         return bytes((byte[]) null);
@@ -211,26 +237,33 @@ public interface ValueIn {
     }
 
     /**
-     * Copies the value’s bytes into {@code bb}.
+     * Puts the byte data into the provided ByteBuffer.
+     *
+     * @param bb The ByteBuffer to put the byte data.
      */
     default void byteBuffer(@NotNull ByteBuffer bb) {
         bb.put(bytes());
     }
 
     /**
-     * Returns the parent {@link WireIn} that provided this instance.
+     * Provides the current WireIn instance.
+     *
+     * @return The current WireIn instance.
      */
     @NotNull
     WireIn wireIn();
 
     /**
-     * Returns the length in bytes of this value as it appears on the wire,
-     * including any type or length prefix.
+     * Retrieves the length of the field in bytes, inclusive of any encoding and header character.
+     *
+     * @return The length of the field in bytes.
      */
     long readLength();
 
     /**
-     * Consumes and discards the current value, advancing the read position.
+     * Skips the current value while reading.
+     *
+     * @return The current WireIn instance.
      */
     @NotNull
     WireIn skipValue();

--- a/src/main/java/net/openhft/chronicle/wire/ValueIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueIn.java
@@ -52,6 +52,7 @@ import static net.openhft.chronicle.wire.SerializationStrategies.MARSHALLABLE;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public interface ValueIn {
     /** A constant consumer that does nothing when accepting a {@link ValueIn}. */
+    @Deprecated(/* remove in x.29 as unused */)
     Consumer<ValueIn> DISCARD = v -> {};
 
     // ---- Text / Strings section ----

--- a/src/main/java/net/openhft/chronicle/wire/ValueIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueIn.java
@@ -61,15 +61,15 @@ public interface ValueIn {
     // ---- Text / Strings section ----
 
     /**
-     * Deserialises the current value as text and passes it to {@code ts} along
+     * Deserialises the current value as text and passes it to {@code consumer} along
      * with the supplied object.
      *
      * @return the parent {@link WireIn}
      */
     @NotNull
-    default <T> WireIn text(T t, @NotNull BiConsumer<T, String> ts) {
+    default <T> WireIn text(T target, @NotNull BiConsumer<T, String> consumer) {
         @Nullable final String text = text();
-        ts.accept(t, text);
+        consumer.accept(target, text);
         return wireIn();
     }
 
@@ -174,10 +174,10 @@ public interface ValueIn {
 
     /**
      * Compares the value’s bytes with {@code compareBytes} and passes the match
-     * result to {@code consumer}.
+     * result to {@code matchResult}.
      */
     @NotNull
-    WireIn bytesMatch(@NotNull BytesStore<?, ?> compareBytes, BooleanConsumer consumer);
+    WireIn bytesMatch(@NotNull BytesStore<?, ?> compareBytes, BooleanConsumer matchResult);
 
     /**
      * Supplies the byte stream to {@code bytesMarshallable#readMarshallable} for
@@ -237,65 +237,65 @@ public interface ValueIn {
 
     /**
      * Reads the value as a {@code boolean} and passes it, together with
-     * {@code t}, to {@code tFlag}.
+     * {@code target}, to {@code flagConsumer}.
      *
      * @param <T> type of the context object
      * @return the parent {@link WireIn}
      */
-    @NotNull <T> WireIn bool(T t, @NotNull ObjBooleanConsumer<T> tFlag);
+    @NotNull <T> WireIn bool(T target, @NotNull ObjBooleanConsumer<T> flagConsumer);
 
     /**
-     * Reads the value as a signed byte and passes it to {@code tb} together with
-     * {@code t}.
+     * Reads the value as a signed byte and passes it to {@code byteConsumer} together with
+     * {@code target}.
      */
-    @NotNull <T> WireIn int8(@NotNull T t, @NotNull ObjByteConsumer<T> tb);
+    @NotNull <T> WireIn int8(@NotNull T target, @NotNull ObjByteConsumer<T> byteConsumer);
 
     /**
-     * Reads the value as an unsigned byte and passes it to {@code ti} with
-     * {@code t}.
+     * Reads the value as an unsigned byte and passes it to {@code shortConsumer} with
+     * {@code target}.
      */
-    @NotNull <T> WireIn uint8(@NotNull T t, @NotNull ObjShortConsumer<T> ti);
+    @NotNull <T> WireIn uint8(@NotNull T target, @NotNull ObjShortConsumer<T> shortConsumer);
 
     /**
-     * Reads the value as a short and passes it to {@code ti} with {@code t}.
+     * Reads the value as a short and passes it to {@code shortConsumer} with {@code target}.
      */
-    @NotNull <T> WireIn int16(@NotNull T t, @NotNull ObjShortConsumer<T> ti);
+    @NotNull <T> WireIn int16(@NotNull T target, @NotNull ObjShortConsumer<T> shortConsumer);
 
     /**
-     * Reads the value as an unsigned short and passes it to {@code ti} with
-     * {@code t}.
+     * Reads the value as an unsigned short and passes it to {@code intConsumer} with
+     * {@code target}.
      */
-    @NotNull <T> WireIn uint16(@NotNull T t, @NotNull ObjIntConsumer<T> ti);
+    @NotNull <T> WireIn uint16(@NotNull T target, @NotNull ObjIntConsumer<T> intConsumer);
 
     /**
-     * Reads the value as an {@code int} and passes it to {@code ti} with
-     * {@code t}.
+     * Reads the value as an {@code int} and passes it to {@code intConsumer} with
+     * {@code target}.
      */
-    @NotNull <T> WireIn int32(@NotNull T t, @NotNull ObjIntConsumer<T> ti);
+    @NotNull <T> WireIn int32(@NotNull T target, @NotNull ObjIntConsumer<T> intConsumer);
 
     /**
-     * Reads the value as an unsigned int and passes it to {@code tl} with
-     * {@code t}.
+     * Reads the value as an unsigned int and passes it to {@code longConsumer} with
+     * {@code target}.
      */
-    @NotNull <T> WireIn uint32(@NotNull T t, @NotNull ObjLongConsumer<T> tl);
+    @NotNull <T> WireIn uint32(@NotNull T target, @NotNull ObjLongConsumer<T> longConsumer);
 
     /**
-     * Reads the value as a {@code long} and passes it to {@code tl} with
-     * {@code t}.
+     * Reads the value as a {@code long} and passes it to {@code longConsumer} with
+     * {@code target}.
      */
-    @NotNull <T> WireIn int64(@NotNull T t, @NotNull ObjLongConsumer<T> tl);
+    @NotNull <T> WireIn int64(@NotNull T target, @NotNull ObjLongConsumer<T> longConsumer);
 
     /**
-     * Reads the value as a {@code float} and passes it to {@code tf} with
-     * {@code t}.
+     * Reads the value as a {@code float} and passes it to {@code floatConsumer} with
+     * {@code target}.
      */
-    @NotNull <T> WireIn float32(@NotNull T t, @NotNull ObjFloatConsumer<T> tf);
+    @NotNull <T> WireIn float32(@NotNull T target, @NotNull ObjFloatConsumer<T> floatConsumer);
 
     /**
-     * Reads the value as a {@code double} and passes it to {@code td} with
-     * {@code t}.
+     * Reads the value as a {@code double} and passes it to {@code doubleConsumer} with
+     * {@code target}.
      */
-    @NotNull <T> WireIn float64(@NotNull T t, @NotNull ObjDoubleConsumer<T> td);
+    @NotNull <T> WireIn float64(@NotNull T target, @NotNull ObjDoubleConsumer<T> doubleConsumer);
 
     @NotNull <T> WireIn time(@NotNull T t, @NotNull BiConsumer<T, LocalTime> setLocalTime);
 

--- a/src/main/java/net/openhft/chronicle/wire/ValueInStack.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueInStack.java
@@ -21,8 +21,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Package-private class that manages a stack of {@link ValueInState} objects.
- * Used by {@link ValueIn} implementations when reading nested data structures.
+ * Represents a stack structure specifically designed to manage {@link ValueInState} instances.
+ * The primary purpose of this class is to provide an organized way to manage and retrieve states
+ * at different levels, and efficiently reuse them without constant instantiation.
  */
 class ValueInStack {
 
@@ -32,19 +33,18 @@ class ValueInStack {
      */
     final List<ValueInState> freeList = new ArrayList<>();
 
-    /** The current depth or level of the stack. {@code level = 0} is the base. */
+    // Represents the current level of the stack
     int level = 0;
 
     /**
-     * Initialises the stack and pre-allocates the first {@link ValueInState} at level 0.
+     * Constructs a new ValueInStack and adds the first ValueInState to the free list.
      */
     public ValueInStack() {
         addOne();
     }
 
     /**
-     * Resets the stack to its initial state: {@link #level} is set to 0 and the
-     * root {@link ValueInState} is reset.
+     * Resets the current level to the initial state and clears the state of the first ValueInState.
      */
     public void reset() {
         level = 0;
@@ -73,8 +73,9 @@ class ValueInStack {
     }
 
     /**
-     * Returns the {@link ValueInState} for the current {@link #level}. Extra
-     * entries are added to {@link #freeList} if needed.
+     * Retrieves the {@link ValueInState} at the current level. If none exists, new instances are added until one does.
+     *
+     * @return The ValueInState at the current stack level
      */
     public ValueInState curr() {
         while (freeList.size() <= level)

--- a/src/main/java/net/openhft/chronicle/wire/ValueInStack.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueInStack.java
@@ -21,27 +21,30 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Represents a stack structure specifically designed to manage {@link ValueInState} instances.
- * The primary purpose of this class is to provide an organized way to manage and retrieve states
- * at different levels, and efficiently reuse them without constant instantiation.
+ * Package-private class that manages a stack of {@link ValueInState} objects.
+ * Used by {@link ValueIn} implementations when reading nested data structures.
  */
 class ValueInStack {
 
-    // A list to hold ValueInState instances that can be reused
+    /**
+     * A list of {@link ValueInState} objects that can be reused to reduce
+     * allocation. Acts as the underlying storage for the stack.
+     */
     final List<ValueInState> freeList = new ArrayList<>();
 
-    // Represents the current level of the stack
+    /** The current depth or level of the stack. {@code level = 0} is the base. */
     int level = 0;
 
     /**
-     * Constructs a new ValueInStack and adds the first ValueInState to the free list.
+     * Initialises the stack and pre-allocates the first {@link ValueInState} at level 0.
      */
     public ValueInStack() {
         addOne();
     }
 
     /**
-     * Resets the current level to the initial state and clears the state of the first ValueInState.
+     * Resets the stack to its initial state: {@link #level} is set to 0 and the
+     * root {@link ValueInState} is reset.
      */
     public void reset() {
         level = 0;
@@ -49,7 +52,8 @@ class ValueInStack {
     }
 
     /**
-     * Increases the current level of the stack. If the free list has a state at this new level, it is reset.
+     * Increments {@link #level}. If a state object already exists at the new
+     * level it is reset for reuse.
      */
     public void push() {
         level++;
@@ -59,9 +63,8 @@ class ValueInStack {
     }
 
     /**
-     * Decreases the current level of the stack. If the level would become negative, an exception is thrown.
-     *
-     * @throws IllegalStateException if trying to pop below the bottom of the stack.
+     * Decrements {@link #level}. Throws {@link IllegalStateException} if called
+     * below level&nbsp;0.
      */
     public void pop() {
         if (level < 0)
@@ -70,9 +73,8 @@ class ValueInStack {
     }
 
     /**
-     * Retrieves the {@link ValueInState} at the current level. If none exists, new instances are added until one does.
-     *
-     * @return The ValueInState at the current stack level
+     * Returns the {@link ValueInState} for the current {@link #level}. Extra
+     * entries are added to {@link #freeList} if needed.
      */
     public ValueInState curr() {
         while (freeList.size() <= level)
@@ -81,7 +83,7 @@ class ValueInStack {
     }
 
     /**
-     * Adds a new {@link ValueInState} instance to the free list.
+     * Adds a new, default-initialised {@link ValueInState} to the free list.
      */
     private void addOne() {
         freeList.add(new ValueInState());

--- a/src/main/java/net/openhft/chronicle/wire/ValueInState.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueInState.java
@@ -20,26 +20,31 @@ package net.openhft.chronicle.wire;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Represents the state associated with a particular input value.
- * This class is primarily designed to manage unexpected inputs and the position of these unexpected values.
+ * Package-private helper used by {@link ValueIn} implementations to keep track of a
+ * single value or nested structure as it is read from a wire. Any fields that appear
+ * out of order can be stored for later processing.
  */
 class ValueInState {
 
-    // A constant representing an empty array of long values
+    /** A shared, empty {@code long} array instance used as the initial state for {@link #unexpected}. */
     private static final long[] EMPTY_ARRAY = {};
 
-    // The saved position for the current state
+    /** Stores a position in the wire to return to later. */
     private long savedPosition;
 
-    // Size of the unexpected values
+    /** The number of valid entries currently in the {@link #unexpected} array. */
     private int unexpectedSize;
 
-    // An array to hold unexpected values
+    /**
+     * An array storing the starting positions of fields that were encountered in the
+     * input wire but not immediately processed.
+     */
     @NotNull
     private long[] unexpected = EMPTY_ARRAY;
 
     /**
-     * Resets the saved position and the unexpected values to their initial states.
+     * Resets this state, clearing {@link #savedPosition} and removing all
+     * recorded unexpected positions.
      */
     public void reset() {
         savedPosition = 0;
@@ -47,9 +52,10 @@ class ValueInState {
     }
 
     /**
-     * Adds an unexpected position to the list of unexpected values.
+     * Adds the given {@code position} to the list of unexpected field starts.
+     * Grows the internal array if required.
      *
-     * @param position The unexpected position to be added
+     * @param position position of an unexpected field
      */
     public void addUnexpected(long position) {
         if (unexpectedSize >= unexpected.length) {
@@ -62,46 +68,38 @@ class ValueInState {
     }
 
     /**
-     * Sets the saved position for the current state.
+     * Stores the given position for later retrieval.
      *
-     * @param savedPosition The position to be saved
+     * @param savedPosition position to save
      */
     public void savedPosition(long savedPosition) {
         this.savedPosition = savedPosition;
     }
 
     /**
-     * Retrieves the saved position for the current state.
-     *
-     * @return The saved position
+     * Returns the last saved position.
      */
     public long savedPosition() {
         return savedPosition;
     }
 
     /**
-     * Retrieves the number of unexpected positions stored.
-     *
-     * @return The size of unexpected positions
+     * Returns the current count of unexpected field positions recorded.
      */
     public int unexpectedSize() {
         return unexpectedSize;
     }
 
     /**
-     * Retrieves a specific unexpected position based on its index.
-     *
-     * @param index The index of the unexpected position
-     * @return The unexpected position at the given index
+     * Returns the wire position of the unexpected field at {@code index}.
      */
     public long unexpected(int index) {
         return unexpected[index];
     }
 
     /**
-     * Removes an unexpected position from the list based on its index.
-     *
-     * @param i The index of the unexpected position to be removed
+     * Removes the unexpected field position at index {@code i}, shifting the
+     * remaining elements down.
      */
     public void removeUnexpected(int i) {
         int length = unexpectedSize - i - 1;

--- a/src/main/java/net/openhft/chronicle/wire/ValueInState.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueInState.java
@@ -52,19 +52,19 @@ class ValueInState {
     }
 
     /**
-     * Adds the given {@code position} to the list of unexpected field starts.
+     * Adds the given {@code wirePosition} to the list of unexpected field starts.
      * Grows the internal array if required.
      *
-     * @param position position of an unexpected field
+     * @param wirePosition position of an unexpected field
      */
-    public void addUnexpected(long position) {
+    public void addUnexpected(long wirePosition) {
         if (unexpectedSize >= unexpected.length) {
             int newSize = unexpected.length * 3 / 2 + 8;
             @NotNull long[] unexpected2 = new long[newSize];
             System.arraycopy(unexpected, 0, unexpected2, 0, unexpected.length);
             unexpected = unexpected2;
         }
-        unexpected[unexpectedSize++] = position;
+        unexpected[unexpectedSize++] = wirePosition;
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/ValueInState.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueInState.java
@@ -20,9 +20,8 @@ package net.openhft.chronicle.wire;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Package-private helper used by {@link ValueIn} implementations to keep track of a
- * single value or nested structure as it is read from a wire. Any fields that appear
- * out of order can be stored for later processing.
+ * Represents the state associated with a particular input value.
+ * This class is primarily designed to manage unexpected inputs and the position of these unexpected values.
  */
 class ValueInState {
 
@@ -77,29 +76,37 @@ class ValueInState {
     }
 
     /**
-     * Returns the last saved position.
+     * Retrieves the saved position for the current state.
+     *
+     * @return The saved position
      */
     public long savedPosition() {
         return savedPosition;
     }
 
     /**
-     * Returns the current count of unexpected field positions recorded.
+     * Retrieves the number of unexpected positions stored.
+     *
+     * @return The size of unexpected positions
      */
     public int unexpectedSize() {
         return unexpectedSize;
     }
 
     /**
-     * Returns the wire position of the unexpected field at {@code index}.
+     * Retrieves a specific unexpected position based on its index.
+     *
+     * @param index The index of the unexpected position
+     * @return The unexpected position at the given index
      */
     public long unexpected(int index) {
         return unexpected[index];
     }
 
     /**
-     * Removes the unexpected field position at index {@code i}, shifting the
-     * remaining elements down.
+     * Removes an unexpected position from the list based on its index.
+     *
+     * @param i The index of the unexpected position to be removed
      */
     public void removeUnexpected(int i) {
         int length = unexpectedSize - i - 1;

--- a/src/main/java/net/openhft/chronicle/wire/ValueOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueOut.java
@@ -54,32 +54,30 @@ import java.util.stream.Stream;
 import static net.openhft.chronicle.wire.Wires.isScalar;
 
 /**
- * Defines an interface for writing out values after writing a field.
- * Implementations of this interface should provide methods to handle writing various data types.
+ * After a field name is written by {@link WireOut#write(CharSequence)}, a
+ * {@code ValueOut} serialises the value.  Implementations usually write a
+ * single value and support many primitive and object types.
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public interface ValueOut {
 
     /**
-     * Thread local instance for MapMarshaller to support thread-safe marshalling operations.
+     * Thread-local {@link MapMarshaller} for efficient, thread-safe map serialisation.
      */
     ThreadLocal<MapMarshaller> MM_TL = ThreadLocal.withInitial(MapMarshaller::new);
 
     /**
-     * Defines a threshold for small messages.
+     * Threshold in bytes below which {@link #compress(String, Bytes)} may skip compression.
      */
     int SMALL_MESSAGE = 64;
 
     /**
-     * Represents a 64-character sequence of zeros.
+     * Utility string of sixty-four zeros, often used when commenting binary output.
      */
     String ZEROS_64 = "0000000000000000000000000000000000000000000000000000000000000000";
 
     /**
-     * Checks if the provided object is an instance of Enum or DynamicEnum.
-     *
-     * @param v Object to be checked.
-     * @return {@code true} if the object is an instance of Enum or DynamicEnum; {@code false} otherwise.
+     * Utility to check whether {@code v} is a standard {@link Enum} or a {@link DynamicEnum}.
      */
     @SuppressWarnings("deprecation")
     static boolean isAnEnum(Object v) {
@@ -87,28 +85,25 @@ public interface ValueOut {
     }
 
     /**
-     * Write a boolean value.
+     * Writes {@code flag} as this field's boolean value.
      *
-     * @param flag The boolean value to be written.
-     * @return The WireOut instance for chained calls.
+     * @param flag value to write
+     * @return parent wire for chaining
      */
     @NotNull
     WireOut bool(Boolean flag);
 
     /**
-     * Write a text value.
+     * Writes the text value {@code s}.
      *
-     * @param s The CharSequence containing the text to be written.
-     * @return The WireOut instance for chained calls.
+     * @param s text to write
+     * @return parent wire for chaining
      */
     @NotNull
     WireOut text(@Nullable CharSequence s);
 
     /**
-     * Write a text value. This method delegates the writing to {@link #text(CharSequence)}.
-     *
-     * @param s The String containing the text to be written.
-     * @return The WireOut instance for chained calls.
+     * Convenience overload for {@link #text(CharSequence)}.
      */
     @NotNull
     default WireOut text(@Nullable String s) {
@@ -116,9 +111,9 @@ public interface ValueOut {
     }
 
     /**
-     * Write a null value.
+     * Writes a null representation for this field.
      *
-     * @return The WireOut instance for chained calls.
+     * @return parent wire for chaining
      */
     @NotNull
     default WireOut nu11() {
@@ -126,10 +121,10 @@ public interface ValueOut {
     }
 
     /**
-     * Write a text value that's made up of a single character.
+     * Writes the single character {@code c} as text.
      *
-     * @param c The character to be written as text.
-     * @return The WireOut instance for chained calls.
+     * @param c character to write
+     * @return parent wire for chaining
      */
     @NotNull
     default WireOut text(char c) {
@@ -139,10 +134,7 @@ public interface ValueOut {
     }
 
     /**
-     * Write a character value as text. This method delegates its functionality to {@link #text(char)}.
-     *
-     * @param c The character to be written.
-     * @return The WireOut instance for chained calls.
+     * Alias for {@link #text(char)}.
      */
     @NotNull
     default WireOut character(char c) {
@@ -150,11 +142,10 @@ public interface ValueOut {
     }
 
     /**
-     * Write a text value based on the contents of a {@link BytesStore} object.
-     * The method casts the BytesStore to a CharSequence for processing.
+     * Writes the content of {@code s} as text.
      *
-     * @param s The BytesStore whose contents are to be written as text.
-     * @return The WireOut instance for chained calls.
+     * @param s bytes to write
+     * @return parent wire for chaining
      */
     @NotNull
     default WireOut text(@Nullable BytesStore<?, ?> s) {
@@ -162,12 +153,11 @@ public interface ValueOut {
     }
 
     /**
-     * Write a signed 8-bit integer value. The provided long value is first checked
-     * to ensure it fits within the bounds of a signed 8-bit integer.
+     * Writes {@code x} as a signed 8‑bit value, checking the range.
      *
-     * @param x The long value to be written as an 8-bit integer.
-     * @return The WireOut instance for chained calls.
-     * @throws ArithmeticException if the supplied argument does not fit in an unsigned 8-bit integer.
+     * @param x value to write
+     * @return parent wire for chaining
+     * @throws ArithmeticException if {@code x} does not fit in a byte
      */
     @NotNull
     default WireOut int8(long x) {
@@ -175,29 +165,29 @@ public interface ValueOut {
     }
 
     /**
-     * Write a signed 8-bit integer value.
+     * Writes the byte {@code i8} as the current value.
      *
-     * @param i8 The byte value representing the 8-bit integer to be written.
-     * @return The WireOut instance for chained calls.
+     * @param i8 byte to write
+     * @return parent wire for chaining
      */
     @NotNull
     WireOut int8(byte i8);
 
     /**
-     * Write a sequence of bytes based on the content of a {@link BytesStore} object.
+     * Writes the content of {@code fromBytes} as bytes.
      *
-     * @param fromBytes The BytesStore containing the byte sequence to be written.
-     * @return The WireOut instance for chained calls.
+     * @param fromBytes bytes to write
+     * @return parent wire for chaining
      */
     @NotNull
     WireOut bytes(@Nullable BytesStore<?, ?> fromBytes);
 
     /**
-     * Write a sequence of bytes from a {@link BytesStore} object as a literal value,
-     * if supported by the wire type. If not supported, this method defaults to {@link #bytes(BytesStore)}.
+     * Writes {@code fromBytes} as a literal byte sequence when the wire supports it.
+     * Falls back to {@link #bytes(BytesStore)} otherwise.
      *
-     * @param fromBytes The BytesStore containing the byte sequence to be written as a literal.
-     * @return The WireOut instance for chained calls.
+     * @param fromBytes bytes to write
+     * @return parent wire for chaining
      */
     @NotNull
     default WireOut bytesLiteral(@Nullable BytesStore<?, ?> fromBytes) {
@@ -205,30 +195,29 @@ public interface ValueOut {
     }
 
     /**
-     * Write a typed sequence of bytes based on the content of a {@link BytesStore} object.
+     * Writes a typed byte sequence using {@code type} as the type name.
      *
-     * @param type       The string representing the type of byte sequence.
-     * @param fromBytes  The BytesStore containing the byte sequence to be written.
-     * @return The WireOut instance for chained calls.
+     * @param type      type identifier
+     * @param fromBytes bytes to write
+     * @return parent wire for chaining
      */
     @NotNull
     WireOut bytes(String type, @Nullable BytesStore<?, ?> fromBytes);
 
     /**
-     * Write a raw sequence of bytes. The exact behavior of this method depends on the implementation.
+     * Writes {@code value} directly with minimal encoding.
      *
-     * @param value  The array of bytes to be written.
-     * @return The WireOut instance for chained calls.
+     * @param value bytes to write
+     * @return parent wire for chaining
      */
     @NotNull
     WireOut rawBytes(byte[] value);
 
     /**
-     * Write a raw text value. The exact behavior of this method depends on the implementation.
-     * If not supported, this method defaults to {@link #text(CharSequence)}.
+     * Writes {@code value} with minimal encoding, falling back to {@link #text(CharSequence)} if unsupported.
      *
-     * @param value  The CharSequence representing the text to be written.
-     * @return The WireOut instance for chained calls.
+     * @param value text to write
+     * @return parent wire for chaining
      */
     @NotNull
     default WireOut rawText(CharSequence value) {
@@ -236,40 +225,40 @@ public interface ValueOut {
     }
 
     /**
-     * Write the length of a value if supported by the implementing class.
+     * Writes a length prefix and returns this {@code ValueOut} to continue writing
+     * the content.
      *
-     * @param remaining  The length of the value to be written.
-     * @return A ValueOut instance for chained calls.
+     * @param remaining number of bytes or elements to follow
+     * @return this instance for chaining
      */
     @NotNull
     ValueOut writeLength(long remaining);
 
     /**
-     * Write a sequence of bytes.
+     * Writes the byte array {@code fromBytes}.
      *
-     * @param fromBytes  The array of bytes to be written.
-     * @return The WireOut instance for chained calls.
+     * @param fromBytes bytes to write
+     * @return parent wire for chaining
      */
     @NotNull
     WireOut bytes(byte[] fromBytes);
 
     /**
-     * Write a typed sequence of bytes.
+     * Writes the byte array {@code fromBytes} with a type identifier.
      *
-     * @param type       The string representing the type of byte sequence.
-     * @param fromBytes  The array of bytes to be written.
-     * @return The WireOut instance for chained calls.
+     * @param type      type identifier
+     * @param fromBytes bytes to write
+     * @return parent wire for chaining
      */
     @NotNull
     WireOut bytes(String type, byte[] fromBytes);
 
     /**
-     * Write an unsigned 8-bit integer value. The provided integer value is first checked
-     * to ensure it fits within the bounds of an unsigned 8-bit integer.
+     * Writes {@code x} as an unsigned 8‑bit integer, checking the range.
      *
-     * @param x  The integer value to be written as an unsigned 8-bit integer.
-     * @return The WireOut instance for chained calls.
-     * @throws ArithmeticException if the supplied argument does not fit in an unsigned 8-bit integer.
+     * @param x value to write
+     * @return parent wire for chaining
+     * @throws ArithmeticException if {@code x} is out of range
      */
     @NotNull
     default WireOut uint8(int x) {
@@ -277,22 +266,17 @@ public interface ValueOut {
     }
 
     /**
-     * Write an unsigned 8-bit integer value. This method assumes the argument is within the
-     * correct bounds of an unsigned 8-bit integer and doesn't perform any additional checks.
-     *
-     * @param u8  The unsigned 8-bit integer value to be written.
-     * @return The WireOut instance for chained calls.
+     * Writes {@code u8} as an unsigned 8‑bit integer without additional checks.
      */
     @NotNull
     WireOut uint8checked(int u8);
 
     /**
-     * Write a signed 16-bit integer value. The provided long value is first checked
-     * to ensure it fits within the bounds of a signed 16-bit integer.
+     * Writes {@code x} as a signed 16‑bit integer, checking the range.
      *
-     * @param x  The long value to be written as a signed 16-bit integer.
-     * @return The WireOut instance for chained calls.
-     * @throws ArithmeticException if the supplied argument does not fit in a signed 16-bit integer.
+     * @param x value to write
+     * @return parent wire for chaining
+     * @throws ArithmeticException if {@code x} is out of range
      */
     @NotNull
     default WireOut int16(long x) {
@@ -300,21 +284,13 @@ public interface ValueOut {
     }
 
     /**
-     * Write a signed 16-bit integer value. This method assumes the argument is within the
-     * correct bounds of a signed 16-bit integer and doesn't perform any additional checks.
-     *
-     * @param i16  The signed 16-bit integer value to be written.
-     * @return The WireOut instance for chained calls.
+     * Writes the short {@code i16} without extra range checking.
      */
     @NotNull
     WireOut int16(short i16);
 
     /**
-     * Write an unsigned 16-bit integer value. The provided long value is directly cast to an integer
-     * and passed to {@link #uint16checked(int)} without additional range checks.
-     *
-     * @param x  The long value to be written as an unsigned 16-bit integer.
-     * @return The WireOut instance for chained calls.
+     * Writes {@code x} as an unsigned 16‑bit integer.
      */
     @NotNull
     default WireOut uint16(long x) {
@@ -322,31 +298,23 @@ public interface ValueOut {
     }
 
     /**
-     * Write an unsigned 16-bit integer value. This method assumes the argument is within the
-     * correct bounds of an unsigned 16-bit integer and doesn't perform any additional checks.
-     *
-     * @param u16  The unsigned 16-bit integer value to be written.
-     * @return The WireOut instance for chained calls.
+     * Writes {@code u16} as an unsigned 16‑bit integer without extra checks.
      */
     @NotNull
     WireOut uint16checked(int u16);
 
     /**
-     * Write a single 16-bit Unicode codepoint as UTF-8. The exact behavior of this method depends on the implementation.
-     *
-     * @param codepoint  The 16-bit Unicode codepoint to be written as UTF-8.
-     * @return The WireOut instance for chained calls.
+     * Writes a single Unicode code point as UTF-8.
      */
     @NotNull
     WireOut utf8(int codepoint);
 
     /**
-     * Write a signed 32-bit integer value. The provided long value is first checked
-     * to ensure it fits within the bounds of a signed 32-bit integer.
+     * Writes {@code x} as a signed 32‑bit integer, checking the range.
      *
-     * @param x The long value to be written as a signed 32-bit integer.
-     * @return The WireOut instance for chained calls.
-     * @throws ArithmeticException if the supplied argument does not fit in a signed 32-bit integer.
+     * @param x value to write
+     * @return parent wire for chaining
+     * @throws ArithmeticException if {@code x} is out of range
      */
     @NotNull
     default WireOut int32(long x) {
@@ -354,22 +322,13 @@ public interface ValueOut {
     }
 
     /**
-     * Write a signed 32-bit integer value. This method assumes the argument is within the
-     * correct bounds of a signed 32-bit integer and doesn't perform any additional checks.
-     *
-     * @param i32 The signed 32-bit integer value to be written.
-     * @return The WireOut instance for chained calls.
+     * Writes the int {@code i32} without extra range checking.
      */
     @NotNull
     WireOut int32(int i32);
 
     /**
-     * Write a signed 32-bit integer value. This overloaded method accepts a previous value, but
-     * currently ignores it and delegates to the simpler {@link #int32(int)} method.
-     *
-     * @param i32 The signed 32-bit integer value to be written.
-     * @param previous The previous value, currently not used in this method.
-     * @return The WireOut instance for chained calls.
+     * Writes {@code i32}, ignoring {@code previous} unless the wire supports delta encoding.
      */
     @NotNull
     default WireOut int32(int i32, int previous) {
@@ -377,11 +336,7 @@ public interface ValueOut {
     }
 
     /**
-     * Write an unsigned 32-bit integer value. The provided long value is directly passed
-     * to {@link #uint32checked(long)} without additional range checks.
-     *
-     * @param x The long value to be written as an unsigned 32-bit integer.
-     * @return The WireOut instance for chained calls.
+     * Writes {@code x} as an unsigned 32‑bit integer.
      */
     @NotNull
     default WireOut uint32(long x) {
@@ -389,31 +344,19 @@ public interface ValueOut {
     }
 
     /**
-     * Write an unsigned 32-bit integer value. This method assumes the argument is within the
-     * correct bounds of an unsigned 32-bit integer and doesn't perform any additional checks.
-     *
-     * @param u32 The unsigned 32-bit integer value to be written.
-     * @return The WireOut instance for chained calls.
+     * Writes {@code u32} as an unsigned 32‑bit integer without extra checks.
      */
     @NotNull
     WireOut uint32checked(long u32);
 
     /**
-     * Write a signed 64-bit integer value.
-     *
-     * @param i64 The signed 64-bit integer value to be written.
-     * @return The WireOut instance for chained calls.
+     * Writes {@code i64} as a signed 64‑bit integer.
      */
     @NotNull
     WireOut int64(long i64);
 
     /**
-     * Write a signed 64-bit integer value. This overloaded method accepts a previous value, but
-     * currently ignores it and delegates to the simpler {@link #int64(long)} method.
-     *
-     * @param i64 The signed 64-bit integer value to be written.
-     * @param previous The previous value, currently not used in this method.
-     * @return The WireOut instance for chained calls.
+     * Writes {@code i64}, ignoring {@code previous} unless the wire supports delta encoding.
      */
     @NotNull
     default WireOut int64(long i64, long previous) {
@@ -421,72 +364,43 @@ public interface ValueOut {
     }
 
     /**
-     * Write two signed 64-bit integer values bound to a TwoLongValue object.
-     *
-     * @param i64x0 The first 64-bit integer value.
-     * @param i64x1 The second 64-bit integer value.
-     * @param value The TwoLongValue object to which the values are bound.
-     * @return The WireOut instance for chained calls.
+     * Writes two longs and binds them to {@code value} for direct access.
      */
     @NotNull
     WireOut int128forBinding(long i64x0, long i64x1, TwoLongValue value);
 
     /**
-     * Write a signed 64-bit integer value as a hexadecimal representation. The behavior
-     * of this method might differ based on the wire type in use.
-     *
-     * @param i64 The 64-bit integer value to be written in hexadecimal format.
-     * @return The WireOut instance for chained calls.
+     * Writes {@code i64} in hexadecimal form when the wire is textual.
      */
     @NotNull
     WireOut int64_0x(long i64);
 
     /**
-     * Allocate space for writing an array of 64-bit integers. The exact behavior might
-     * vary depending on the wire type or the underlying implementation.
-     *
-     * @param capacity The desired capacity of the 64-bit integer array.
-     * @return The WireOut instance for chained calls.
+     * Prepares space for a 64‑bit integer array of {@code capacity} elements.
      */
     @NotNull
     WireOut int64array(long capacity);
 
     /**
-     * Write a sequence of 64-bit integers into an array, using the provided LongArrayValues
-     * object as the source of the values.
-     *
-     * @param capacity The desired capacity of the 64-bit integer array.
-     * @param values The LongArrayValues object containing the 64-bit integers to be written.
-     * @return The WireOut instance for chained calls.
+     * Writes an array of longs bound to {@code values} for direct access.
      */
     @NotNull
     WireOut int64array(long capacity, LongArrayValues values);
 
     /**
-     * Write a 32-bit floating-point value.
-     *
-     * @param f The 32-bit float value to be written.
-     * @return The WireOut instance for chained calls.
+     * Writes {@code f} as a 32‑bit floating‑point number.
      */
     @NotNull
     WireOut float32(float f);
 
     /**
-     * Write a 64-bit floating-point value, also known as a double.
-     *
-     * @param d The 64-bit double value to be written.
-     * @return The WireOut instance for chained calls.
+     * Writes {@code d} as a 64‑bit floating‑point number.
      */
     @NotNull
     WireOut float64(double d);
 
     /**
-     * Write a 32-bit floating-point value. This overloaded method accepts a previous value,
-     * but currently ignores it and delegates to the simpler {@link #float32(float)} method.
-     *
-     * @param f The 32-bit float value to be written.
-     * @param previous The previous float value, currently not used in this method.
-     * @return The WireOut instance for chained calls.
+     * Writes {@code f}, ignoring {@code previous} unless the wire supports delta encoding.
      */
     @NotNull
     default WireOut float32(float f, float previous) {
@@ -494,12 +408,7 @@ public interface ValueOut {
     }
 
     /**
-     * Write a 64-bit floating-point value. This overloaded method accepts a previous value,
-     * but currently ignores it and delegates to the simpler {@link #float64(double)} method.
-     *
-     * @param d The 64-bit double value to be written.
-     * @param previous The previous double value, currently not used in this method.
-     * @return The WireOut instance for chained calls.
+     * Writes {@code d}, ignoring {@code previous} unless the wire supports delta encoding.
      */
     @NotNull
     default WireOut float64(double d, double previous) {
@@ -507,61 +416,37 @@ public interface ValueOut {
     }
 
     /**
-     * Write a local time value. The exact format and representation might vary depending
-     * on the wire type or the underlying implementation.
-     *
-     * @param localTime The LocalTime instance to be written.
-     * @return The WireOut instance for chained calls.
+     * Writes the {@link LocalTime} value.
      */
     @NotNull
     WireOut time(LocalTime localTime);
 
     /**
-     * Write a zoned date-time value, which includes information about date, time, and the
-     * associated time zone.
-     *
-     * @param zonedDateTime The ZonedDateTime instance to be written.
-     * @return The WireOut instance for chained calls.
+     * Writes the {@link ZonedDateTime} value.
      */
     @NotNull
     WireOut zonedDateTime(ZonedDateTime zonedDateTime);
 
     /**
-     * Write a date value. The exact format and representation might vary depending on the
-     * wire type or the underlying implementation.
-     *
-     * @param localDate The LocalDate instance to be written.
-     * @return The WireOut instance for chained calls.
+     * Writes the {@link LocalDate} value.
      */
     @NotNull
     WireOut date(LocalDate localDate);
 
     /**
-     * Write a local date-time value, which represents both date and time without a time zone.
-     * The exact format and representation might vary depending on the wire type or the underlying implementation.
-     *
-     * @param localDateTime The LocalDateTime instance to be written.
-     * @return The WireOut instance for chained calls.
+     * Writes the {@link LocalDateTime} value.
      */
     @NotNull
     WireOut dateTime(LocalDateTime localDateTime);
 
     /**
-     * Write a prefix that denotes a type for the upcoming value. This is useful for
-     * wire formats that include type information, allowing for dynamic deserialization.
-     *
-     * @param typeName The name of the type as a CharSequence.
-     * @return The ValueOut instance for chained calls.
+     * Writes a type prefix such as {@code !com.acme.MyClass}.
      */
     @NotNull
     ValueOut typePrefix(CharSequence typeName);
 
     /**
-     * Write a type prefix for a specified {@link Class} object. If the class object is null,
-     * no action is taken; otherwise, it fetches the type name from a lookup method.
-     *
-     * @param type The Class object representing the type.
-     * @return The ValueOut instance for chained calls.
+     * Convenience overload for {@link #typePrefix(CharSequence)}.
      */
     @NotNull
     default ValueOut typePrefix(Class<?> type) {

--- a/src/main/java/net/openhft/chronicle/wire/ValueOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueOut.java
@@ -155,13 +155,13 @@ public interface ValueOut {
     /**
      * Writes {@code x} as a signed 8‑bit value, checking the range.
      *
-     * @param x value to write
+     * @param value value to write
      * @return parent wire for chaining
      * @throws ArithmeticException if {@code x} does not fit in a byte
      */
     @NotNull
-    default WireOut int8(long x) {
-        return int8(Maths.toInt8(x));
+    default WireOut int8(long value) {
+        return int8(Maths.toInt8(value));
     }
 
     /**
@@ -195,14 +195,14 @@ public interface ValueOut {
     }
 
     /**
-     * Writes a typed byte sequence using {@code type} as the type name.
+     * Writes a typed byte sequence using {@code typeName} as the type name.
      *
-     * @param type      type identifier
-     * @param fromBytes bytes to write
+     * @param typeName type identifier
+     * @param data bytes to write
      * @return parent wire for chaining
      */
     @NotNull
-    WireOut bytes(String type, @Nullable BytesStore<?, ?> fromBytes);
+    WireOut bytes(String typeName, @Nullable BytesStore<?, ?> data);
 
     /**
      * Writes {@code value} directly with minimal encoding.
@@ -244,14 +244,14 @@ public interface ValueOut {
     WireOut bytes(byte[] fromBytes);
 
     /**
-     * Writes the byte array {@code fromBytes} with a type identifier.
+     * Writes the byte array {@code data} with a type identifier.
      *
-     * @param type      type identifier
-     * @param fromBytes bytes to write
+     * @param typeName type identifier
+     * @param data bytes to write
      * @return parent wire for chaining
      */
     @NotNull
-    WireOut bytes(String type, byte[] fromBytes);
+    WireOut bytes(String typeName, byte[] data);
 
     /**
      * Writes {@code x} as an unsigned 8‑bit integer, checking the range.
@@ -266,10 +266,10 @@ public interface ValueOut {
     }
 
     /**
-     * Writes {@code u8} as an unsigned 8‑bit integer without additional checks.
+     * Writes {@code unsignedByte} as an unsigned 8‑bit integer without additional checks.
      */
     @NotNull
-    WireOut uint8checked(int u8);
+    WireOut uint8checked(int unsignedByte);
 
     /**
      * Writes {@code x} as a signed 16‑bit integer, checking the range.
@@ -307,7 +307,7 @@ public interface ValueOut {
      * Writes a single Unicode code point as UTF-8.
      */
     @NotNull
-    WireOut utf8(int codepoint);
+    WireOut utf8(int unicodeCodePoint);
 
     /**
      * Writes {@code x} as a signed 32‑bit integer, checking the range.
@@ -367,7 +367,7 @@ public interface ValueOut {
      * Writes two longs and binds them to {@code value} for direct access.
      */
     @NotNull
-    WireOut int128forBinding(long i64x0, long i64x1, TwoLongValue value);
+    WireOut int128forBinding(long highBits, long lowBits, TwoLongValue value);
 
     /**
      * Writes {@code i64} in hexadecimal form when the wire is textual.

--- a/src/main/java/net/openhft/chronicle/wire/ValueOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueOut.java
@@ -54,20 +54,19 @@ import java.util.stream.Stream;
 import static net.openhft.chronicle.wire.Wires.isScalar;
 
 /**
- * After a field name is written by {@link WireOut#write(CharSequence)}, a
- * {@code ValueOut} serialises the value.  Implementations usually write a
- * single value and support many primitive and object types.
+ * Defines an interface for writing out values after writing a field.
+ * Implementations of this interface should provide methods to handle writing various data types.
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public interface ValueOut {
 
     /**
-     * Thread-local {@link MapMarshaller} for efficient, thread-safe map serialisation.
+     * Thread-local {@link MapMarshaller} to support thread-safe marshalling operations.
      */
     ThreadLocal<MapMarshaller> MM_TL = ThreadLocal.withInitial(MapMarshaller::new);
 
     /**
-     * Threshold in bytes below which {@link #compress(String, Bytes)} may skip compression.
+     * Defines a threshold for small messages.
      */
     int SMALL_MESSAGE = 64;
 
@@ -85,7 +84,7 @@ public interface ValueOut {
     }
 
     /**
-     * Writes {@code flag} as this field's boolean value.
+     * Write a boolean value.
      *
      * @param flag value to write
      * @return parent wire for chaining
@@ -94,7 +93,7 @@ public interface ValueOut {
     WireOut bool(Boolean flag);
 
     /**
-     * Writes the text value {@code s}.
+     * Write a text value.
      *
      * @param s text to write
      * @return parent wire for chaining
@@ -111,9 +110,9 @@ public interface ValueOut {
     }
 
     /**
-     * Writes a null representation for this field.
+     * Write a null value.
      *
-     * @return parent wire for chaining
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     default WireOut nu11() {
@@ -121,10 +120,10 @@ public interface ValueOut {
     }
 
     /**
-     * Writes the single character {@code c} as text.
+     * Write a text value that's made up of a single character.
      *
-     * @param c character to write
-     * @return parent wire for chaining
+     * @param c The character to be written as text.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     default WireOut text(char c) {
@@ -142,10 +141,11 @@ public interface ValueOut {
     }
 
     /**
-     * Writes the content of {@code s} as text.
+     * Write a text value based on the contents of a {@link BytesStore} object.
+     * The method casts the BytesStore to a CharSequence for processing.
      *
-     * @param s bytes to write
-     * @return parent wire for chaining
+     * @param s The BytesStore whose contents are to be written as text.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     default WireOut text(@Nullable BytesStore<?, ?> s) {
@@ -153,7 +153,8 @@ public interface ValueOut {
     }
 
     /**
-     * Writes {@code x} as a signed 8‑bit value, checking the range.
+     * Write a signed 8-bit integer value. The provided long value is first checked
+     * to ensure it fits within the bounds of a signed 8-bit integer.
      *
      * @param value value to write
      * @return parent wire for chaining
@@ -165,29 +166,29 @@ public interface ValueOut {
     }
 
     /**
-     * Writes the byte {@code i8} as the current value.
+     * Write a signed 8-bit integer value.
      *
-     * @param i8 byte to write
-     * @return parent wire for chaining
+     * @param i8 The byte value representing the 8-bit integer to be written.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     WireOut int8(byte i8);
 
     /**
-     * Writes the content of {@code fromBytes} as bytes.
+     * Write a sequence of bytes based on the content of a {@link BytesStore} object.
      *
-     * @param fromBytes bytes to write
-     * @return parent wire for chaining
+     * @param fromBytes The BytesStore containing the byte sequence to be written.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     WireOut bytes(@Nullable BytesStore<?, ?> fromBytes);
 
     /**
-     * Writes {@code fromBytes} as a literal byte sequence when the wire supports it.
-     * Falls back to {@link #bytes(BytesStore)} otherwise.
+     * Write a sequence of bytes from a {@link BytesStore} object as a literal value,
+     * if supported by the wire type. If not supported, this method defaults to {@link #bytes(BytesStore)}.
      *
-     * @param fromBytes bytes to write
-     * @return parent wire for chaining
+     * @param fromBytes The BytesStore containing the byte sequence to be written as a literal.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     default WireOut bytesLiteral(@Nullable BytesStore<?, ?> fromBytes) {
@@ -195,29 +196,30 @@ public interface ValueOut {
     }
 
     /**
-     * Writes a typed byte sequence using {@code typeName} as the type name.
+     * Write a typed sequence of bytes based on the content of a {@link BytesStore} object.
      *
-     * @param typeName type identifier
-     * @param data bytes to write
-     * @return parent wire for chaining
+     * @param type       The string representing the type of byte sequence.
+     * @param fromBytes  The BytesStore containing the byte sequence to be written.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
-    WireOut bytes(String typeName, @Nullable BytesStore<?, ?> data);
+    WireOut bytes(String type, @Nullable BytesStore<?, ?> fromBytes);
 
     /**
-     * Writes {@code value} directly with minimal encoding.
+     * Write a raw sequence of bytes. The exact behavior of this method depends on the implementation.
      *
-     * @param value bytes to write
-     * @return parent wire for chaining
+     * @param value  The array of bytes to be written.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     WireOut rawBytes(byte[] value);
 
     /**
-     * Writes {@code value} with minimal encoding, falling back to {@link #text(CharSequence)} if unsupported.
+     * Write a raw text value. The exact behavior of this method depends on the implementation.
+     * If not supported, this method defaults to {@link #text(CharSequence)}.
      *
-     * @param value text to write
-     * @return parent wire for chaining
+     * @param value  The CharSequence representing the text to be written.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     default WireOut rawText(CharSequence value) {
@@ -225,40 +227,40 @@ public interface ValueOut {
     }
 
     /**
-     * Writes a length prefix and returns this {@code ValueOut} to continue writing
-     * the content.
+     * Write the length of a value if supported by the implementing class.
      *
-     * @param remaining number of bytes or elements to follow
-     * @return this instance for chaining
+     * @param remaining  The length of the value to be written.
+     * @return A ValueOut instance for chained calls.
      */
     @NotNull
     ValueOut writeLength(long remaining);
 
     /**
-     * Writes the byte array {@code fromBytes}.
+     * Write a sequence of bytes.
      *
-     * @param fromBytes bytes to write
-     * @return parent wire for chaining
+     * @param fromBytes  The array of bytes to be written.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     WireOut bytes(byte[] fromBytes);
 
     /**
-     * Writes the byte array {@code data} with a type identifier.
+     * Write a typed sequence of bytes.
      *
-     * @param typeName type identifier
-     * @param data bytes to write
-     * @return parent wire for chaining
+     * @param type       The string representing the type of byte sequence.
+     * @param fromBytes  The array of bytes to be written.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
-    WireOut bytes(String typeName, byte[] data);
+    WireOut bytes(String type, byte[] fromBytes);
 
     /**
-     * Writes {@code x} as an unsigned 8‑bit integer, checking the range.
+     * Write an unsigned 8-bit integer value. The provided integer value is first checked
+     * to ensure it fits within the bounds of an unsigned 8-bit integer.
      *
-     * @param x value to write
-     * @return parent wire for chaining
-     * @throws ArithmeticException if {@code x} is out of range
+     * @param x  The integer value to be written as an unsigned 8-bit integer.
+     * @return The WireOut instance for chained calls.
+     * @throws ArithmeticException if the supplied argument does not fit in an unsigned 8-bit integer.
      */
     @NotNull
     default WireOut uint8(int x) {
@@ -266,17 +268,22 @@ public interface ValueOut {
     }
 
     /**
-     * Writes {@code unsignedByte} as an unsigned 8‑bit integer without additional checks.
+     * Write an unsigned 8-bit integer value. This method assumes the argument is within the
+     * correct bounds of an unsigned 8-bit integer and doesn't perform any additional checks.
+     *
+     * @param u8  The unsigned 8-bit integer value to be written.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
-    WireOut uint8checked(int unsignedByte);
+    WireOut uint8checked(int u8);
 
     /**
-     * Writes {@code x} as a signed 16‑bit integer, checking the range.
+     * Write a signed 16-bit integer value. The provided long value is first checked
+     * to ensure it fits within the bounds of a signed 16-bit integer.
      *
-     * @param x value to write
-     * @return parent wire for chaining
-     * @throws ArithmeticException if {@code x} is out of range
+     * @param x  The long value to be written as a signed 16-bit integer.
+     * @return The WireOut instance for chained calls.
+     * @throws ArithmeticException if the supplied argument does not fit in a signed 16-bit integer.
      */
     @NotNull
     default WireOut int16(long x) {
@@ -284,13 +291,21 @@ public interface ValueOut {
     }
 
     /**
-     * Writes the short {@code i16} without extra range checking.
+     * Write a signed 16-bit integer value. This method assumes the argument is within the
+     * correct bounds of a signed 16-bit integer and doesn't perform any additional checks.
+     *
+     * @param i16  The signed 16-bit integer value to be written.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     WireOut int16(short i16);
 
     /**
-     * Writes {@code x} as an unsigned 16‑bit integer.
+     * Write an unsigned 16-bit integer value. The provided long value is directly cast to an integer
+     * and passed to {@link #uint16checked(int)} without additional range checks.
+     *
+     * @param x  The long value to be written as an unsigned 16-bit integer.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     default WireOut uint16(long x) {
@@ -298,23 +313,31 @@ public interface ValueOut {
     }
 
     /**
-     * Writes {@code u16} as an unsigned 16‑bit integer without extra checks.
+     * Write an unsigned 16-bit integer value. This method assumes the argument is within the
+     * correct bounds of an unsigned 16-bit integer and doesn't perform any additional checks.
+     *
+     * @param u16  The unsigned 16-bit integer value to be written.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     WireOut uint16checked(int u16);
 
     /**
-     * Writes a single Unicode code point as UTF-8.
+     * Write a single 16-bit Unicode codepoint as UTF-8. The exact behavior of this method depends on the implementation.
+     *
+     * @param codepoint  The 16-bit Unicode codepoint to be written as UTF-8.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
-    WireOut utf8(int unicodeCodePoint);
+    WireOut utf8(int codepoint);
 
     /**
-     * Writes {@code x} as a signed 32‑bit integer, checking the range.
+     * Write a signed 32-bit integer value. The provided long value is first checked
+     * to ensure it fits within the bounds of a signed 32-bit integer.
      *
-     * @param x value to write
-     * @return parent wire for chaining
-     * @throws ArithmeticException if {@code x} is out of range
+     * @param x The long value to be written as a signed 32-bit integer.
+     * @return The WireOut instance for chained calls.
+     * @throws ArithmeticException if the supplied argument does not fit in a signed 32-bit integer.
      */
     @NotNull
     default WireOut int32(long x) {
@@ -322,13 +345,22 @@ public interface ValueOut {
     }
 
     /**
-     * Writes the int {@code i32} without extra range checking.
+     * Write a signed 32-bit integer value. This method assumes the argument is within the
+     * correct bounds of a signed 32-bit integer and doesn't perform any additional checks.
+     *
+     * @param i32 The signed 32-bit integer value to be written.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     WireOut int32(int i32);
 
     /**
-     * Writes {@code i32}, ignoring {@code previous} unless the wire supports delta encoding.
+     * Write a signed 32-bit integer value. This overloaded method accepts a previous value, but
+     * currently ignores it and delegates to the simpler {@link #int32(int)} method.
+     *
+     * @param i32 The signed 32-bit integer value to be written.
+     * @param previous The previous value, currently not used in this method.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     default WireOut int32(int i32, int previous) {
@@ -336,7 +368,11 @@ public interface ValueOut {
     }
 
     /**
-     * Writes {@code x} as an unsigned 32‑bit integer.
+     * Write an unsigned 32-bit integer value. The provided long value is directly passed
+     * to {@link #uint32checked(long)} without additional range checks.
+     *
+     * @param x The long value to be written as an unsigned 32-bit integer.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     default WireOut uint32(long x) {
@@ -344,19 +380,31 @@ public interface ValueOut {
     }
 
     /**
-     * Writes {@code u32} as an unsigned 32‑bit integer without extra checks.
+     * Write an unsigned 32-bit integer value. This method assumes the argument is within the
+     * correct bounds of an unsigned 32-bit integer and doesn't perform any additional checks.
+     *
+     * @param u32 The unsigned 32-bit integer value to be written.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     WireOut uint32checked(long u32);
 
     /**
-     * Writes {@code i64} as a signed 64‑bit integer.
+     * Write a signed 64-bit integer value.
+     *
+     * @param i64 The signed 64-bit integer value to be written.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     WireOut int64(long i64);
 
     /**
-     * Writes {@code i64}, ignoring {@code previous} unless the wire supports delta encoding.
+     * Write a signed 64-bit integer value. This overloaded method accepts a previous value, but
+     * currently ignores it and delegates to the simpler {@link #int64(long)} method.
+     *
+     * @param i64 The signed 64-bit integer value to be written.
+     * @param previous The previous value, currently not used in this method.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     default WireOut int64(long i64, long previous) {
@@ -364,43 +412,72 @@ public interface ValueOut {
     }
 
     /**
-     * Writes two longs and binds them to {@code value} for direct access.
+     * Write two signed 64-bit integer values bound to a TwoLongValue object.
+     *
+     * @param i64x0 The first 64-bit integer value.
+     * @param i64x1 The second 64-bit integer value.
+     * @param value The TwoLongValue object to which the values are bound.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
-    WireOut int128forBinding(long highBits, long lowBits, TwoLongValue value);
+    WireOut int128forBinding(long i64x0, long i64x1, TwoLongValue value);
 
     /**
-     * Writes {@code i64} in hexadecimal form when the wire is textual.
+     * Write a signed 64-bit integer value as a hexadecimal representation. The behavior
+     * of this method might differ based on the wire type in use.
+     *
+     * @param i64 The 64-bit integer value to be written in hexadecimal format.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     WireOut int64_0x(long i64);
 
     /**
-     * Prepares space for a 64‑bit integer array of {@code capacity} elements.
+     * Allocate space for writing an array of 64-bit integers. The exact behavior might
+     * vary depending on the wire type or the underlying implementation.
+     *
+     * @param capacity The desired capacity of the 64-bit integer array.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     WireOut int64array(long capacity);
 
     /**
-     * Writes an array of longs bound to {@code values} for direct access.
+     * Write a sequence of 64-bit integers into an array, using the provided LongArrayValues
+     * object as the source of the values.
+     *
+     * @param capacity The desired capacity of the 64-bit integer array.
+     * @param values The LongArrayValues object containing the 64-bit integers to be written.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     WireOut int64array(long capacity, LongArrayValues values);
 
     /**
-     * Writes {@code f} as a 32‑bit floating‑point number.
+     * Write a 32-bit floating-point value.
+     *
+     * @param f The 32-bit float value to be written.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     WireOut float32(float f);
 
     /**
-     * Writes {@code d} as a 64‑bit floating‑point number.
+     * Write a 64-bit floating-point value, also known as a double.
+     *
+     * @param d The 64-bit double value to be written.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     WireOut float64(double d);
 
     /**
-     * Writes {@code f}, ignoring {@code previous} unless the wire supports delta encoding.
+     * Write a 32-bit floating-point value. This overloaded method accepts a previous value,
+     * but currently ignores it and delegates to the simpler {@link #float32(float)} method.
+     *
+     * @param f The 32-bit float value to be written.
+     * @param previous The previous float value, currently not used in this method.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     default WireOut float32(float f, float previous) {
@@ -408,7 +485,12 @@ public interface ValueOut {
     }
 
     /**
-     * Writes {@code d}, ignoring {@code previous} unless the wire supports delta encoding.
+     * Write a 64-bit floating-point value. This overloaded method accepts a previous value,
+     * but currently ignores it and delegates to the simpler {@link #float64(double)} method.
+     *
+     * @param d The 64-bit double value to be written.
+     * @param previous The previous double value, currently not used in this method.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     default WireOut float64(double d, double previous) {
@@ -416,37 +498,61 @@ public interface ValueOut {
     }
 
     /**
-     * Writes the {@link LocalTime} value.
+     * Write a local time value. The exact format and representation might vary depending
+     * on the wire type or the underlying implementation.
+     *
+     * @param localTime The LocalTime instance to be written.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     WireOut time(LocalTime localTime);
 
     /**
-     * Writes the {@link ZonedDateTime} value.
+     * Write a zoned date-time value, which includes information about date, time, and the
+     * associated time zone.
+     *
+     * @param zonedDateTime The ZonedDateTime instance to be written.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     WireOut zonedDateTime(ZonedDateTime zonedDateTime);
 
     /**
-     * Writes the {@link LocalDate} value.
+     * Write a date value. The exact format and representation might vary depending on the
+     * wire type or the underlying implementation.
+     *
+     * @param localDate The LocalDate instance to be written.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     WireOut date(LocalDate localDate);
 
     /**
-     * Writes the {@link LocalDateTime} value.
+     * Write a local date-time value, which represents both date and time without a time zone.
+     * The exact format and representation might vary depending on the wire type or the underlying implementation.
+     *
+     * @param localDateTime The LocalDateTime instance to be written.
+     * @return The WireOut instance for chained calls.
      */
     @NotNull
     WireOut dateTime(LocalDateTime localDateTime);
 
     /**
-     * Writes a type prefix such as {@code !com.acme.MyClass}.
+     * Write a prefix that denotes a type for the upcoming value. This is useful for
+     * wire formats that include type information, allowing for dynamic deserialization.
+     *
+     * @param typeName The name of the type as a CharSequence.
+     * @return The ValueOut instance for chained calls.
      */
     @NotNull
     ValueOut typePrefix(CharSequence typeName);
 
     /**
-     * Convenience overload for {@link #typePrefix(CharSequence)}.
+     * Write a type prefix for a specified {@link Class} object. If the class object is null,
+     * no action is taken; otherwise, it fetches the type name from a lookup method.
+     *
+     * @param type The Class object representing the type.
+     * @return The ValueOut instance for chained calls.
      */
     @NotNull
     default ValueOut typePrefix(Class<?> type) {


### PR DESCRIPTION
### ✨ What’s inside this PR?

This bundle of 6 commits is a **pure-API-clarity sweep** over the `chronicle-wire` public surface. It **doesn’t change behaviour or binary signatures**; it focuses on naming, documentation and small deprecations so that IDE auto-completion and generated Javadoc are self-explanatory.

| Commit                                                      | Theme                                   | Key points                                                                                                                                                                                                                     |
| ----------------------------------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| **1/6** `Create branch`                                     | *House-keeping*                         | Creates topic branch; marks `ValueIn.DISCARD` as `@Deprecated` for removal in x.29.                                                                                                                                            |
| **2/6** `Improve ValueIn javadoc (#1053)`                   | Javadoc                                 | - Top-to-bottom rewrite of `ValueIn` docs.<br>- Explains lifecycle (`WireIn#read()` → `ValueIn`).<br>- Clarifies each method’s null/return behaviour.                                                                          |
| **3/6** `Improve ValueOut javadoc (#1054)`                  | Javadoc                                 | Same treatment for `ValueOut`; adds missing detail around compression thresholds, delta writes etc.                                                                                                                            |
| **4/6** `Improve DefaultValueIn javadoc (#1055)`            | Javadoc                                 | Makes it obvious this class surfaces default values when a field is absent.                                                                                                                                                    |
| **5/6** `Improve Javadoc for ValueIn state helpers (#1056)` | Javadoc (internal)                      | Documents `ValueInStack` & `ValueInState`, aiding new contributors.                                                                                                                                                            |
| **6/7** `Rename parameters for clarity (#1063)`             | **Parameter-name polish (source only)** | • Renames cryptic one-letter params (`t`, `ts`, `tb`…) to expressive names (`target`, `consumer`, `byteConsumer`, …).<br>• Updates docs accordingly.<br>• Adjusts internal helpers (`wirePosition`, `highBits/lowBits`, etc.). |
