### PR TITLE
Improve public-API parameter names

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AbstractAnyWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractAnyWire.java
@@ -181,13 +181,13 @@ public abstract class AbstractAnyWire extends AbstractWire implements Wire {
     }
 
     @Override
-    public ValueOut write(CharSequence key) {
-        return wireAcquisition.acquireWire().write(key);
+    public ValueOut write(CharSequence fieldName) {
+        return wireAcquisition.acquireWire().write(fieldName);
     }
 
     @Override
-    public ValueOut writeEvent(Class<?> expectedType, Object eventKey) throws InvalidMarshallableException {
-        return wireAcquisition.acquireWire().writeEvent(expectedType, eventKey);
+    public ValueOut writeEvent(Class<?> keyType, Object key) throws InvalidMarshallableException {
+        return wireAcquisition.acquireWire().writeEvent(keyType, key);
     }
 
     @NotNull

--- a/src/main/java/net/openhft/chronicle/wire/BinaryReadDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryReadDocumentContext.java
@@ -106,13 +106,13 @@ public class BinaryReadDocumentContext implements ReadDocumentContext {
     }
 
     @Override
-    public void closeReadPosition(long readPosition) {
-        this.readPosition = readPosition;
+    public void closeReadPosition(long savedReadPosition) {
+        this.readPosition = savedReadPosition;
     }
 
     @Override
-    public void closeReadLimit(long readLimit) {
-        this.readLimit = readLimit;
+    public void closeReadLimit(long savedReadLimit) {
+        this.readLimit = savedReadLimit;
     }
 
     @Nullable

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -1609,17 +1609,17 @@ public class BinaryWire extends AbstractWire implements Wire {
     }
 
     @Override
-    public ValueOut writeEventId(int methodId) {
-        writeCode(FIELD_NUMBER).writeStopBit(methodId);
+    public ValueOut writeEventId(int eventId) {
+        writeCode(FIELD_NUMBER).writeStopBit(eventId);
         return valueOut;
     }
 
     @Override
-    public ValueOut writeEventId(String name, int methodId) {
+    public ValueOut writeEventId(String name, int eventId) {
         if (bytes.retainedHexDumpDescription()) {
-            writeEventIdDescription(name, methodId);
+            writeEventIdDescription(name, eventId);
         }
-        writeCode(FIELD_NUMBER).writeStopBit(methodId);
+        writeCode(FIELD_NUMBER).writeStopBit(eventId);
         return valueOut;
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWriteDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWriteDocumentContext.java
@@ -64,21 +64,21 @@ public class BinaryWriteDocumentContext implements WriteDocumentContext {
      * {@link #close()}.  The {@code metaData} argument determines if the
      * metadata bit is set.
      *
-     * @param metaData true if the document carries metadata rather than user
-     *                 data
+     * @param isMetaData true if the document carries metadata rather than user
+     *                   data
      */
-    public void start(boolean metaData) {
+    public void start(boolean isMetaData) {
         count++;
         // If start() was called more than once, validate the metadata flag.
         if (count > 1) {
-            assert metaData == isMetaData();
+            assert isMetaData == isMetaData();
             return;
         }
         @NotNull Bytes<?> bytes = wire().bytes();
         bytes.writePositionForHeader(wire.usePadding());
         bytes.writeHexDumpDescription("msg-length");
         this.position = bytes.writePosition();
-        metaDataBit = metaData ? Wires.META_DATA : 0;
+        metaDataBit = isMetaData ? Wires.META_DATA : 0;
         tmpHeader = metaDataBit | Wires.NOT_COMPLETE | Wires.UNKNOWN_LENGTH;
         bytes.writeInt(tmpHeader);
         rollback = false;
@@ -181,8 +181,8 @@ public class BinaryWriteDocumentContext implements WriteDocumentContext {
     }
 
     @Override
-    public void chainedElement(boolean chainedElement) {
-        this.chainedElement = chainedElement;
+    public void chainedElement(boolean isChained) {
+        this.chainedElement = isChained;
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/wire/DocumentContextHolder.java
+++ b/src/main/java/net/openhft/chronicle/wire/DocumentContextHolder.java
@@ -60,8 +60,8 @@ public class DocumentContextHolder implements DocumentContext, WriteDocumentCont
     /**
      * Replaces the wrapped {@link DocumentContext}.
      */
-    public void documentContext(DocumentContext dc) {
-        this.dc = dc;
+    public void documentContext(DocumentContext context) {
+        this.dc = context;
     }
 
     /**
@@ -107,8 +107,8 @@ public class DocumentContextHolder implements DocumentContext, WriteDocumentCont
     }
 
     @Override
-    public void start(boolean metaData) {
-        ((WriteDocumentContext) dc).start(metaData);
+    public void start(boolean isMetaData) {
+        ((WriteDocumentContext) dc).start(isMetaData);
     }
 
     @Override
@@ -117,8 +117,8 @@ public class DocumentContextHolder implements DocumentContext, WriteDocumentCont
     }
 
     @Override
-    public void chainedElement(boolean chainedElement) {
-        ((WriteDocumentContext) dc).chainedElement(chainedElement);
+    public void chainedElement(boolean isChained) {
+        ((WriteDocumentContext) dc).chainedElement(isChained);
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/wire/HashWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/HashWire.java
@@ -208,8 +208,8 @@ public class HashWire implements WireOut, HexDumpBytesDescription {
 
     @NotNull
     @Override
-    public ValueOut writeEvent(Class<?> ignored, @NotNull Object eventKey) {
-        hash += K0 + eventKey.hashCode() * M0;
+    public ValueOut writeEvent(Class<?> ignoredType, @NotNull Object key) {
+        hash += K0 + key.hashCode() * M0;
         return valueOut;
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/JSONWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/JSONWire.java
@@ -705,8 +705,8 @@ public class JSONWire extends TextWire {
 
     @SuppressWarnings("rawtypes")
     @Override
-    public ValueOut writeEvent(Class<?> expectedType, Object eventKey) throws InvalidMarshallableException {
-        return super.writeEvent(String.class, "" + eventKey);
+    public ValueOut writeEvent(Class<?> keyType, Object key) throws InvalidMarshallableException {
+        return super.writeEvent(String.class, "" + key);
     }
 
     @Override
@@ -795,9 +795,9 @@ public class JSONWire extends TextWire {
         }
 
         @Override
-        public void start(boolean metaData) {
+        public void start(boolean isMetaData) {
             int count = this.count;
-            super.start(metaData);
+            super.start(isMetaData);
             if (count == 0) {
                 bytes.append('{');
                 start = bytes.writePosition();

--- a/src/main/java/net/openhft/chronicle/wire/ReadDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/ReadDocumentContext.java
@@ -36,9 +36,9 @@ public interface ReadDocumentContext extends DocumentContext {
      * underlying bytes if it was temporarily changed for reading the current document.
      * Not usually intended for external use.
      *
-     * @param readLimit the read limit to restore
+     * @param savedReadLimit the read limit to restore
      */
-    void closeReadLimit(long readLimit);
+    void closeReadLimit(long savedReadLimit);
 
     /**
      * Sets the read position for this {@code ReadDocumentContext}. Implementations typically
@@ -46,7 +46,7 @@ public interface ReadDocumentContext extends DocumentContext {
      * {@link net.openhft.chronicle.bytes.Bytes} object if it was advanced past the current
      * document.
      *
-     * @param readPosition the read position to restore
+     * @param savedReadPosition the read position to restore
      */
-    void closeReadPosition(long readPosition);
+    void closeReadPosition(long savedReadPosition);
 }

--- a/src/main/java/net/openhft/chronicle/wire/TextReadDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextReadDocumentContext.java
@@ -117,13 +117,13 @@ public class TextReadDocumentContext implements ReadDocumentContext {
     }
 
     @Override
-    public void closeReadPosition(long readPosition) {
-        this.readPosition = readPosition;
+    public void closeReadPosition(long savedReadPosition) {
+        this.readPosition = savedReadPosition;
     }
 
     @Override
-    public void closeReadLimit(long readLimit) {
-        this.readLimit = readLimit;
+    public void closeReadLimit(long savedReadLimit) {
+        this.readLimit = savedReadLimit;
     }
 
     @Nullable

--- a/src/main/java/net/openhft/chronicle/wire/TextWriteDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWriteDocumentContext.java
@@ -57,20 +57,20 @@ public class TextWriteDocumentContext implements WriteDocumentContext {
     }
 
     /**
-     * Prepares for writing a new text document. If {@code metaData} is true a
+     * Prepares for writing a new text document. If {@code isMetaData} is true a
      * {@code "meta-data"} comment is written. Nested calls are allowed but only
      * the outermost call performs full initialisation.
      *
-     * @param metaData true if the document represents meta-data
+     * @param isMetaData true if the document represents meta-data
      */
-    public void start(boolean metaData) {
+    public void start(boolean isMetaData) {
         count++;
         if (count > 1) {
-            assert metaData == isMetaData();
+            assert isMetaData == isMetaData();
             return;
         }
-        this.metaData = metaData;
-        if (metaData)
+        this.metaData = isMetaData;
+        if (isMetaData)
             wire().writeComment("meta-data");
         notComplete = true;
         chainedElement = false;
@@ -176,8 +176,8 @@ public class TextWriteDocumentContext implements WriteDocumentContext {
     /**
      * Sets whether this context is chained to the previous document.
      */
-    public void chainedElement(boolean chainedElement) {
-        this.chainedElement = chainedElement;
+    public void chainedElement(boolean isChained) {
+        this.chainedElement = isChained;
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/wire/WireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireOut.java
@@ -53,7 +53,7 @@ public interface WireOut extends WireCommon, MarshallableOut {
     /**
      * Writes a CharSequence key to the stream.
      *
-     * @param key The CharSequence key to write to the stream.
+     * @param fieldName The CharSequence key to write to the stream.
      * @return An interface to further define the output for the written value.
      */
     default ValueOut writeEventName(CharSequence key) {
@@ -63,19 +63,19 @@ public interface WireOut extends WireCommon, MarshallableOut {
     /**
      * Writes an event to the stream based on the type and event key.
      *
-     * @param expectedType The expected type of the event to write.
-     * @param eventKey The key of the event.
+     * @param keyType The expected type of the event key.
+     * @param key The key of the event.
      * @return An interface to further define the output for the written value.
      * @throws InvalidMarshallableException if there's an error marshalling the event.
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
-    default ValueOut writeEvent(Class<?> expectedType, Object eventKey) throws InvalidMarshallableException {
-        if (eventKey instanceof WireKey)
-            return writeEventName((WireKey) eventKey);
-        if (eventKey instanceof CharSequence)
-            return writeEventName((CharSequence) eventKey);
+    default ValueOut writeEvent(Class<?> keyType, Object key) throws InvalidMarshallableException {
+        if (key instanceof WireKey)
+            return writeEventName((WireKey) key);
+        if (key instanceof CharSequence)
+            return writeEventName((CharSequence) key);
         writeStartEvent();
-        getValueOut().object(expectedType, eventKey);
+        getValueOut().object(keyType, key);
         writeEndEvent();
         return getValueOut();
     }
@@ -83,22 +83,22 @@ public interface WireOut extends WireCommon, MarshallableOut {
     /**
      * Writes an event identifier to the stream.
      *
-     * @param methodId The ID of the method representing the event.
+     * @param eventId The ID of the event.
      * @return An interface to further define the output for the written value.
      */
-    default ValueOut writeEventId(int methodId) {
-        return write(new MethodWireKey(null, methodId));
+    default ValueOut writeEventId(int eventId) {
+        return write(new MethodWireKey(null, eventId));
     }
 
     /**
      * Writes an event identifier with a name to the stream.
      *
      * @param name The name of the event.
-     * @param methodId The ID of the method representing the event.
+     * @param eventId The ID of the event.
      * @return An interface to further define the output for the written value.
      */
-    default ValueOut writeEventId(String name, int methodId) {
-        return write(new MethodWireKey(name, methodId));
+    default ValueOut writeEventId(String name, int eventId) {
+        return write(new MethodWireKey(name, eventId));
     }
 
     /**
@@ -118,7 +118,7 @@ public interface WireOut extends WireCommon, MarshallableOut {
      * @param key The CharSequence key to write to the stream.
      * @return An interface to further define the output for the written value.
      */
-    ValueOut write(CharSequence key);
+    ValueOut write(CharSequence fieldName);
 
     /**
      * Retrieves the interface for defining the output of a value

--- a/src/main/java/net/openhft/chronicle/wire/WriteDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/WriteDocumentContext.java
@@ -25,13 +25,13 @@ public interface WriteDocumentContext extends DocumentContext {
 
     /**
      * Prepares the context to write a new document or message.
-     * If {@code metaData} is {@code true} the entry is marked as metadata,
+     * If {@code isMetaData} is {@code true} the entry is marked as metadata,
      * otherwise it is data. Implementations typically call this from
      * {@link MarshallableOut} before any bytes are written to the wire.
      *
-     * @param metaData {@code true} to mark the entry as metadata
+     * @param isMetaData {@code true} to mark the entry as metadata
      */
-    void start(boolean metaData);
+    void start(boolean isMetaData);
 
     /**
      * Indicates whether this write is part of a chained sequence.
@@ -47,9 +47,9 @@ public interface WriteDocumentContext extends DocumentContext {
      * When set to {@code true} additional writes may follow before the
      * document is finalised.
      *
-     * @param chainedElement {@code true} to enable chaining
+     * @param isChained {@code true} to enable chaining
      */
-    void chainedElement(boolean chainedElement);
+    void chainedElement(boolean isChained);
 
     /**
      * Returns {@code true} if no data has been written since

--- a/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
@@ -167,22 +167,22 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     @Override
-    public ValueOut writeEvent(Class<?> expectedType, Object eventKey) throws InvalidMarshallableException {
-        if (eventKey instanceof WireKey)
-            return writeEventName((WireKey) eventKey);
-        if (eventKey instanceof CharSequence)
-            return writeEventName((CharSequence) eventKey);
-        if (expectedType != null && expectedType.isInstance(eventKey)) {
-            if (eventKey instanceof Enum)
-                return writeEventName(((Enum) eventKey).name());
-            if (eventKey instanceof DynamicEnum)
-                return writeEventName(((DynamicEnum) eventKey).name());
-            if (eventKey instanceof Boolean)
-                return writeEventName(eventKey.toString());
+    public ValueOut writeEvent(Class<?> keyType, Object key) throws InvalidMarshallableException {
+        if (key instanceof WireKey)
+            return writeEventName((WireKey) key);
+        if (key instanceof CharSequence)
+            return writeEventName((CharSequence) key);
+        if (keyType != null && keyType.isInstance(key)) {
+            if (key instanceof Enum)
+                return writeEventName(((Enum) key).name());
+            if (key instanceof DynamicEnum)
+                return writeEventName(((DynamicEnum) key).name());
+            if (key instanceof Boolean)
+                return writeEventName(key.toString());
         }
         boolean wasLeft = valueOut.swapLeaf(true);
         try {
-            return valueOut.write(expectedType, eventKey);
+            return valueOut.write(keyType, key);
         } finally {
             valueOut.swapLeaf(wasLeft);
         }


### PR DESCRIPTION
## Summary
- rename start() boolean parameter to `isMetaData`
- rename chainedElement() boolean parameter to `isChained`
- rename read restoration parameters to `savedReadLimit` and `savedReadPosition`
- rename writeEvent* parameters and update implementations
- rename WireOut.write(CharSequence) parameter to `fieldName`
- adjust DocumentContextHolder to take `context`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*