### PR TITLE
Improve parameter names

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/ScalarStrategy.java
+++ b/src/main/java/net/openhft/chronicle/wire/ScalarStrategy.java
@@ -45,11 +45,11 @@ class ScalarStrategy<E> implements SerializationStrategy {
     /**
      * Constructs a new {@code ScalarStrategy} with the given type and read function.
      *
-     * @param type The class type of the scalar value.
-     * @param read The function used to read the scalar value.
+     * @param scalarType The class type of the scalar value.
+     * @param read       The function used to read the scalar value.
      */
-    ScalarStrategy(Class<E> type, @NotNull BiFunction<? super E, ValueIn, E> read) {
-        this.type = type;
+    ScalarStrategy(Class<E> scalarType, @NotNull BiFunction<? super E, ValueIn, E> read) {
+        this.type = scalarType;
         this.read = read;
     }
 
@@ -72,16 +72,16 @@ class ScalarStrategy<E> implements SerializationStrategy {
      * for text data. This strategy reads text and applies the provided function
      * to convert the text into the desired scalar type.
      *
-     * @param clazz The class type of the scalar value.
-     * @param func  The function used to convert text into the scalar value.
+     * @param targetType The class type of the scalar value.
+     * @param resolver   The function used to convert text into the scalar value.
      * @param <E>   The type of the scalar value.
      * @return A new instance of {@code ScalarStrategy} for text.
      */
     @Nullable
-    static <E > ScalarStrategy< E > text(Class< E > clazz, @NotNull Function<String, E > func) {
-        return new ScalarStrategy<>(clazz, (Object o, ValueIn in) -> {
+    static <E > ScalarStrategy< E > text(Class< E > targetType, @NotNull Function<String, E > resolver) {
+        return new ScalarStrategy<>(targetType, (Object o, ValueIn in) -> {
             @Nullable String text = in.text();
-            return text == null ? null : func.apply(text);
+            return text == null ? null : resolver.apply(text);
         });
     }
 
@@ -102,7 +102,7 @@ class ScalarStrategy<E> implements SerializationStrategy {
     @SuppressWarnings("rawtypes")
     @NotNull
     @Override
-    public <T> T newInstanceOrNull(Class<T>type) {
+    public <T> T newInstanceOrNull(Class<T> targetType) {
         return Jvm.uncheckedCast(ObjectUtils.newInstance(this.type));
     }
 
@@ -121,11 +121,11 @@ class ScalarStrategy<E> implements SerializationStrategy {
     @SuppressWarnings("unchecked")
     @Nullable
     @Override
-    public <T> T readUsing(Class<?> clazz, T using, @NotNull ValueIn in, BracketType bracketType) {
-        if (in.isNull())
+    public <T> T readUsing(Class<?> declaredType, T target, @NotNull ValueIn valueIn, BracketType structure) {
+        if (valueIn.isNull())
             return null;
 
-        return (T) read.apply((E) using, in);
+        return (T) read.apply((E) target, valueIn);
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
+++ b/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
@@ -57,14 +57,14 @@ public enum SerializationStrategies implements SerializationStrategy {
          */
         @NotNull
         @Override
-        public Object readUsing(Class clazz, @NotNull Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
-            WireIn wireIn = in.wireIn();
-            if (wireIn.useSelfDescribingMessage((CommonMarshallable) o) && o instanceof ReadMarshallable) {
-                ((ReadMarshallable) o).readMarshallable(wireIn);
+        public Object readUsing(Class expectedType, @NotNull Object target, @NotNull ValueIn valueIn, BracketType structure) throws InvalidMarshallableException {
+            WireIn wireIn = valueIn.wireIn();
+            if (wireIn.useSelfDescribingMessage((CommonMarshallable) target) && target instanceof ReadMarshallable) {
+                ((ReadMarshallable) target).readMarshallable(wireIn);
             } else {
-                ((ReadBytesMarshallable) o).readMarshallable(wireIn.bytes());
+                ((ReadBytesMarshallable) target).readMarshallable(wireIn.bytes());
             }
-            return o;
+            return target;
         }
 
         /**
@@ -99,8 +99,8 @@ public enum SerializationStrategies implements SerializationStrategy {
          */
         @Nullable
         @Override
-        public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
-            return in.objectWithInferredType(o, ANY_NESTED, null);
+        public Object readUsing(Class expectedType, Object target, @NotNull ValueIn valueIn, BracketType structure) throws InvalidMarshallableException {
+            return valueIn.objectWithInferredType(target, ANY_NESTED, null);
         }
 
         /**
@@ -136,8 +136,8 @@ public enum SerializationStrategies implements SerializationStrategy {
          */
         @Nullable
         @Override
-        public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
-            return in.objectWithInferredType(o, ANY_NESTED, null);
+        public Object readUsing(Class expectedType, Object target, @NotNull ValueIn valueIn, BracketType structure) throws InvalidMarshallableException {
+            return valueIn.objectWithInferredType(target, ANY_NESTED, null);
         }
 
         /**
@@ -172,8 +172,8 @@ public enum SerializationStrategies implements SerializationStrategy {
          */
         @Nullable
         @Override
-        public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) {
-            return in.text();
+        public Object readUsing(Class expectedType, Object target, @NotNull ValueIn valueIn, BracketType structure) {
+            return valueIn.text();
         }
 
         /**
@@ -215,20 +215,20 @@ public enum SerializationStrategies implements SerializationStrategy {
          */
         @Nullable
         @Override
-        public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
-            if (bracketType != BracketType.MAP || !(o instanceof ReadMarshallable)) {
-                String text = in.text();
-                if (o != null) {
-                    EnumCache<?> cache = EnumCache.of(o.getClass());
+        public Object readUsing(Class expectedType, Object target, @NotNull ValueIn valueIn, BracketType structure) throws InvalidMarshallableException {
+            if (structure != BracketType.MAP || !(target instanceof ReadMarshallable)) {
+                String text = valueIn.text();
+                if (target != null) {
+                    EnumCache<?> cache = EnumCache.of(target.getClass());
                     Object ret = cache.valueOf(text);
                     if (ret == null)
-                        throw new IORuntimeException("No enum value '" + text + "' defined for " + o.getClass());
+                        throw new IORuntimeException("No enum value '" + text + "' defined for " + target.getClass());
                     return ret;
                 }
                 return text;
             }
-            ((ReadMarshallable) o).readMarshallable(in.wireIn());
-            return o;
+            ((ReadMarshallable) target).readMarshallable(valueIn.wireIn());
+            return target;
         }
 
         /**
@@ -284,14 +284,14 @@ public enum SerializationStrategies implements SerializationStrategy {
          * Reads a nested object or returns {@code null} if the input is null.
          */
         @Override
-        public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
-            if (in.isNull()) {
+        public Object readUsing(Class expectedType, Object target, @NotNull ValueIn valueIn, BracketType structure) throws InvalidMarshallableException {
+            if (valueIn.isNull()) {
                 return null;
             }
-            if (o == null)
-                o = ObjectUtils.newInstance(clazz);
-            Wires.readMarshallable(clazz, o, in.wireIn(), true);
-            return o;
+            if (target == null)
+                target = ObjectUtils.newInstance(expectedType);
+            Wires.readMarshallable(expectedType, target, valueIn.wireIn(), true);
+            return target;
         }
 
         /**
@@ -329,15 +329,15 @@ public enum SerializationStrategies implements SerializationStrategy {
          */
         @NotNull
         @Override
-        public Object readUsing(Class clazz, Object using, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
-            if (using instanceof DemarshallableWrapper) {
-                @NotNull final DemarshallableWrapper wrapper = (DemarshallableWrapper) using;
-                wrapper.demarshallable = Demarshallable.newInstance(wrapper.type, in.wireIn());
+        public Object readUsing(Class expectedType, Object target, @NotNull ValueIn valueIn, BracketType structure) throws InvalidMarshallableException {
+            if (target instanceof DemarshallableWrapper) {
+                @NotNull final DemarshallableWrapper wrapper = (DemarshallableWrapper) target;
+                wrapper.demarshallable = Demarshallable.newInstance(wrapper.type, valueIn.wireIn());
                 return wrapper;
-            } else if (using instanceof ReadMarshallable) {
-                return in.object(using, Object.class);
+            } else if (target instanceof ReadMarshallable) {
+                return valueIn.object(target, Object.class);
             } else {
-                return Demarshallable.newInstance((Class) using.getClass(), in.wireIn());
+                return Demarshallable.newInstance((Class) target.getClass(), valueIn.wireIn());
             }
         }
 
@@ -375,10 +375,10 @@ public enum SerializationStrategies implements SerializationStrategy {
          * {@link #ANY_OBJECT}.
          */
         @Override
-        public Object readUsing(Class clazz, Object o, ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
-            SerializationStrategies strategies = o instanceof Externalizable ? EXTERNALIZABLE : ANY_OBJECT;
-            strategies.readUsing(clazz, o, in, bracketType);
-            return o;
+        public Object readUsing(Class expectedType, Object target, ValueIn valueIn, BracketType structure) throws InvalidMarshallableException {
+            SerializationStrategies strategies = target instanceof Externalizable ? EXTERNALIZABLE : ANY_OBJECT;
+            strategies.readUsing(expectedType, target, valueIn, structure);
+            return target;
         }
 
         /**
@@ -406,13 +406,13 @@ public enum SerializationStrategies implements SerializationStrategy {
          */
         @NotNull
         @Override
-        public Object readUsing(Class clazz, @NotNull Object o, @NotNull ValueIn in, BracketType bracketType) {
+        public Object readUsing(Class expectedType, @NotNull Object target, @NotNull ValueIn valueIn, BracketType structure) {
             try {
-                ((Externalizable) o).readExternal(in.wireIn().objectInput());
+                ((Externalizable) target).readExternal(valueIn.wireIn().objectInput());
             } catch (@NotNull IOException | ClassNotFoundException e) {
                 throw new IORuntimeException(e);
             }
-            return o;
+            return target;
         }
 
         /**
@@ -449,13 +449,13 @@ public enum SerializationStrategies implements SerializationStrategy {
          * map context.
          */
         @Override
-        public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
-            @NotNull Map<Object, Object> map = (o == null ? new LinkedHashMap<>() : (Map<Object, Object>) o);
-            @NotNull final WireIn wireIn = in.wireIn();
+        public Object readUsing(Class expectedType, Object target, @NotNull ValueIn valueIn, BracketType structure) throws InvalidMarshallableException {
+            @NotNull Map<Object, Object> map = (target == null ? new LinkedHashMap<>() : (Map<Object, Object>) target);
+            @NotNull final WireIn wireIn = valueIn.wireIn();
             long pos = wireIn.bytes().readPosition();
-            while (in.hasNext()) {
+            while (valueIn.hasNext()) {
                 Object key = wireIn.readEvent(Object.class);
-                map.put(key, in.object());
+                map.put(key, valueIn.object());
 
                 // make sure we are progressing.
                 long pos2 = wireIn.bytes().readPosition();
@@ -505,13 +505,13 @@ public enum SerializationStrategies implements SerializationStrategy {
          * one if necessary.
          */
         @Override
-        public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
-            @NotNull Set<Object> set = (o == null ? new LinkedHashSet<>() : (Set<Object>) o);
-            @NotNull final WireIn wireIn = in.wireIn();
+        public Object readUsing(Class expectedType, Object target, @NotNull ValueIn valueIn, BracketType structure) throws InvalidMarshallableException {
+            @NotNull Set<Object> set = (target == null ? new LinkedHashSet<>() : (Set<Object>) target);
+            @NotNull final WireIn wireIn = valueIn.wireIn();
             @NotNull final Bytes<?> bytes = wireIn.bytes();
             long pos = bytes.readPosition();
-            while (in.hasNextSequenceItem()) {
-                @Nullable final Object object = in.object();
+            while (valueIn.hasNextSequenceItem()) {
+                @Nullable final Object object = valueIn.object();
                 // make sure we are progressing.
                 long pos2 = bytes.readPosition();
                 if (pos2 <= pos && !Jvm.isDebug())
@@ -568,16 +568,16 @@ public enum SerializationStrategies implements SerializationStrategy {
          * possible; surplus entries are removed.
          */
         @Override
-        public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
-            @NotNull List<Object> list = (o == null ? new ArrayList<>() : (List<Object>) o);
-            @NotNull final WireIn wireIn = in.wireIn();
+        public Object readUsing(Class expectedType, Object target, @NotNull ValueIn valueIn, BracketType structure) throws InvalidMarshallableException {
+            @NotNull List<Object> list = (target == null ? new ArrayList<>() : (List<Object>) target);
+            @NotNull final WireIn wireIn = valueIn.wireIn();
             long pos = wireIn.bytes().readPosition();
             int count = 0;
-            while (in.hasNextSequenceItem()) {
+            while (valueIn.hasNextSequenceItem()) {
                 if (list.size() > count) {
-                    list.set(count, in.object(list.get(count), Object.class));
+                    list.set(count, valueIn.object(list.get(count), Object.class));
                 } else {
-                    list.add(in.object());
+                    list.add(valueIn.object());
                 }
                 count++;
                 // make sure we are progressing.
@@ -638,19 +638,19 @@ public enum SerializationStrategies implements SerializationStrategy {
          */
         @NotNull
         @Override
-        public Object readUsing(Class clazz, Object using, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
-            if (using instanceof ArrayWrapper) {
-                @NotNull ArrayWrapper wrapper = (ArrayWrapper) using;
+        public Object readUsing(Class expectedType, Object target, @NotNull ValueIn valueIn, BracketType structure) throws InvalidMarshallableException {
+            if (target instanceof ArrayWrapper) {
+                @NotNull ArrayWrapper wrapper = (ArrayWrapper) target;
                 final Class componentType = wrapper.type.getComponentType();
                 @NotNull List list = new ArrayList<>();
-                while (in.hasNextSequenceItem())
-                    list.add(in.object(componentType));
+                while (valueIn.hasNextSequenceItem())
+                    list.add(valueIn.object(componentType));
                 wrapper.array = list.toArray((Object[]) Array.newInstance(componentType, list.size()));
                 return wrapper;
             } else {
                 @NotNull List list = new ArrayList<>();
-                while (in.hasNextSequenceItem())
-                    list.add(in.object());
+                while (valueIn.hasNextSequenceItem())
+                    list.add(valueIn.object());
                 return list.toArray();
             }
         }
@@ -703,13 +703,13 @@ public enum SerializationStrategies implements SerializationStrategy {
          */
         @NotNull
         @Override
-        public Object readUsing(Class clazz, Object using, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
-            @NotNull PrimArrayWrapper wrapper = (PrimArrayWrapper) using;
+        public Object readUsing(Class expectedType, Object target, @NotNull ValueIn valueIn, BracketType structure) throws InvalidMarshallableException {
+            @NotNull PrimArrayWrapper wrapper = (PrimArrayWrapper) target;
             final Class<?> componentType = wrapper.type.getComponentType();
             int i = 0;
             int len = 0;
             Object array = Array.newInstance(componentType, 0);
-            while (in.hasNextSequenceItem()) {
+            while (valueIn.hasNextSequenceItem()) {
                 if (i >= len) {
                     int len2 = len * 2 + 2;
                     Object array2 = Array.newInstance(componentType, len2);
@@ -717,7 +717,7 @@ public enum SerializationStrategies implements SerializationStrategy {
                     len = len2;
                     array = array2;
                 }
-                Array.set(array, i++, in.object(componentType));
+                Array.set(array, i++, valueIn.object(componentType));
             }
             if (i < len) {
                 Object array2 = Array.newInstance(componentType, i);
@@ -771,13 +771,13 @@ public enum SerializationStrategies implements SerializationStrategy {
      * <p>
      * Attempts to create a new instance of the given class.
      *
-     * @param type The class for which a new instance is to be created.
+     * @param targetType The class for which a new instance is to be created.
      * @return A new instance of the given class or {@code null} if the instantiation fails.
      */
     @Nullable
     @Override
-    public Object newInstanceOrNull(Class type) {
-        return ObjectUtils.newInstanceOrNull(type);
+    public Object newInstanceOrNull(Class targetType) {
+        return ObjectUtils.newInstanceOrNull(targetType);
     }
 
     /**
@@ -811,10 +811,10 @@ public enum SerializationStrategies implements SerializationStrategy {
         /**
          * Constructs an ArrayWrapper for a specified type.
          *
-         * @param type The class type of the elements in the array.
+         * @param componentType The class type of the elements in the array.
          */
-        ArrayWrapper(@NotNull Class type) {
-            this.type = type;
+        ArrayWrapper(@NotNull Class componentType) {
+            this.type = componentType;
         }
 
         /**
@@ -846,10 +846,10 @@ public enum SerializationStrategies implements SerializationStrategy {
         /**
          * Constructs a PrimArrayWrapper for a specified type.
          *
-         * @param type The class type of the elements in the primitive array.
+         * @param componentType The class type of the elements in the primitive array.
          */
-        PrimArrayWrapper(@NotNull Class type) {
-            this.type = type;
+        PrimArrayWrapper(@NotNull Class componentType) {
+            this.type = componentType;
         }
 
         /**

--- a/src/main/java/net/openhft/chronicle/wire/SerializationStrategy.java
+++ b/src/main/java/net/openhft/chronicle/wire/SerializationStrategy.java
@@ -33,32 +33,32 @@ public interface SerializationStrategy {
     /**
      * Reads an object of type {@code T} from the supplied input.
      *
-     * @param clazz       expected class of the object, or {@code null} to infer
-     *                    from the wire or {@code using} instance
-     * @param using       optional instance to populate; if {@code null} this
+     * @param declaredType expected class of the object, or {@code null} to infer
+     *                    from the wire or {@code target} instance
+     * @param target       optional instance to populate; if {@code null} this
      *                    method may call {@link #newInstanceOrNull(Class)}. If
      *                    that also returns {@code null} the strategy decides
      *                    whether to return {@code null} or throw
      *                    {@link InvalidMarshallableException}
-     * @param in          source of the wire data
-     * @param bracketType hint about the expected structure such as map, sequence
+     * @param valueIn      source of the wire data
+     * @param structure   hint about the expected structure such as map, sequence
      *                    or none
      * @return the populated or newly created object, or {@code null} if no
      * instance could be obtained
      * @throws InvalidMarshallableException if the deserialisation fails
      */
     @Nullable
-    <T> T readUsing(Class<?> clazz, T using, ValueIn in, BracketType bracketType) throws InvalidMarshallableException;
+    <T> T readUsing(Class<?> declaredType, T target, ValueIn valueIn, BracketType structure) throws InvalidMarshallableException;
 
     /**
      * Attempts to create a new instance of the given type.
      * Called when {@link #readUsing} needs an object but none was supplied.
      *
-     * @param type class of object to be created
+     * @param targetType class of object to be created
      * @return newly created instance or {@code null} if construction failed
      */
     @Nullable
-    <T> T newInstanceOrNull(Class<T> type);
+    <T> T newInstanceOrNull(Class<T> targetType);
 
     /**
      * Returns the primary Java {@link Class} that this strategy deals with.


### PR DESCRIPTION
## Summary
- rename parameters in `SerializationStrategy` and `ScalarStrategy`
- rename parameters for `readUsing` implementations in `SerializationStrategies`
- rename `ArrayWrapper` constructor argument

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*