### PR TITLE
Clarify method parameters

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AbstractAnyWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractAnyWire.java
@@ -97,8 +97,8 @@ public abstract class AbstractAnyWire extends AbstractWire implements Wire {
 
     @Nullable
     @Override
-    public <K> K readEvent(Class<K> expectedClass) throws InvalidMarshallableException {
-        return wireAcquisition.acquireWire().readEvent(expectedClass);
+    public <K> K readEvent(Class<K> keyType) throws InvalidMarshallableException {
+        return wireAcquisition.acquireWire().readEvent(keyType);
     }
 
     @Override
@@ -181,13 +181,13 @@ public abstract class AbstractAnyWire extends AbstractWire implements Wire {
     }
 
     @Override
-    public ValueOut write(CharSequence key) {
-        return wireAcquisition.acquireWire().write(key);
+    public ValueOut write(CharSequence fieldName) {
+        return wireAcquisition.acquireWire().write(fieldName);
     }
 
     @Override
-    public ValueOut writeEvent(Class<?> expectedType, Object eventKey) throws InvalidMarshallableException {
-        return wireAcquisition.acquireWire().writeEvent(expectedType, eventKey);
+    public ValueOut writeEvent(Class<?> keyType, Object key) throws InvalidMarshallableException {
+        return wireAcquisition.acquireWire().writeEvent(keyType, key);
     }
 
     @NotNull
@@ -214,8 +214,8 @@ public abstract class AbstractAnyWire extends AbstractWire implements Wire {
     }
 
     @Override
-    public DocumentContext acquireWritingDocument(boolean metaData) {
-        return wireAcquisition.acquireWire().acquireWritingDocument(metaData);
+    public DocumentContext acquireWritingDocument(boolean includeMetaData) {
+        return wireAcquisition.acquireWire().acquireWritingDocument(includeMetaData);
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/wire/AbstractGeneratedMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractGeneratedMethodReader.java
@@ -162,7 +162,7 @@ public abstract class AbstractGeneratedMethodReader implements MethodReader {
             messageHistory = null;
         }
 
-        messageHistory().reset(context.sourceId(), context.index());
+        messageHistory().reset(context.sourceId(), context.lastReadIndex());
 
         try {
             wireIn.startEvent();

--- a/src/main/java/net/openhft/chronicle/wire/AbstractMethodWriterInvocationHandler.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractMethodWriterInvocationHandler.java
@@ -134,8 +134,8 @@ public abstract class AbstractMethodWriterInvocationHandler extends AbstractInvo
     }
 
     @Override
-    public void recordHistory(boolean recordHistory) {
-        this.recordHistory = recordHistory;
+    public void recordHistory(boolean enableHistory) {
+        this.recordHistory = enableHistory;
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -434,14 +434,14 @@ public abstract class AbstractWire implements Wire, InternalWire {
      * Uses CAS against {@code expectedHeader} to detect concurrent modification.
      */
     @Override
-    public void updateHeader(final long position, final boolean metaData, int expectedHeader) throws StreamCorruptedException {
-        if (position <= 0)
-            invalidPosition(position);
+    public void updateHeader(final long headerPos, final boolean isMetaData, int templateHeader) throws StreamCorruptedException {
+        if (headerPos <= 0)
+            invalidPosition(headerPos);
 
         // the reason we add padding is so that a message gets sent ( this is, mostly for queue as
         // it cant handle a zero len message )
         long pos = bytes.writePosition();
-        if (pos == position + 4) {
+        if (pos == headerPos + 4) {
             addPadding(1);
             pos = bytes.writePosition();
         }
@@ -459,9 +459,9 @@ public abstract class AbstractWire implements Wire, InternalWire {
                 bytesStore.writeByte(pos + i, 0);
         }
 
-        final long value = pos - position - 4;
+        final long value = pos - headerPos - 4;
         int header = (int) value;
-        if (metaData) header |= META_DATA;
+        if (isMetaData) header |= META_DATA;
         // shouldn't happen due to padding above.
 //        assert header == UNKNOWN_LENGTH;
 
@@ -470,13 +470,13 @@ public abstract class AbstractWire implements Wire, InternalWire {
 
         assert checkNoDataAfterEnd(pos);
 
-        if (!bytes.compareAndSwapInt(position, expectedHeader, header)) {
-            unexpectedValue(position, expectedHeader);
+        if (!bytes.compareAndSwapInt(headerPos, templateHeader, header)) {
+            unexpectedValue(headerPos, templateHeader);
         }
 
         bytes.writeLimit(bytes.capacity());
-        if (!metaData)
-            incrementHeaderNumber(position);
+        if (!isMetaData)
+            incrementHeaderNumber(headerPos);
     }
 
     /**
@@ -583,15 +583,15 @@ public abstract class AbstractWire implements Wire, InternalWire {
      * Writes an END_OF_DATA marker at the end of the wire if possible.
      */
     @Override
-    public boolean writeEndOfWire(long timeout, TimeUnit timeUnit, long lastPosition) {
-        return endOfWire(true, timeout, timeUnit, lastPosition) == EndOfWire.PRESENT_AFTER_UPDATE;
+    public boolean writeEndOfWire(long timeout, TimeUnit timeoutUnit, long lastPosition) {
+        return endOfWire(true, timeout, timeoutUnit, lastPosition) == EndOfWire.PRESENT_AFTER_UPDATE;
     }
 
     /**
      * Detects whether the wire has reached the END_OF_DATA marker, optionally writing one.
      */
     @Override
-    public EndOfWire endOfWire(boolean writeEOF, long timeout, TimeUnit timeUnit, long lastPosition) {
+    public EndOfWire endOfWire(boolean shouldWriteEof, long timeout, TimeUnit timeoutUnit, long lastPosition) {
 
         long pos = Math.max(lastPosition, bytes.writePosition());
         headerNumber = Long.MIN_VALUE;
@@ -603,7 +603,7 @@ public abstract class AbstractWire implements Wire, InternalWire {
 
                 if (MEMORY.safeAlignedInt(pos)) {
                     if (bytes.readVolatileInt(pos) == 0) {
-                        if (!writeEOF)
+                        if (!shouldWriteEof)
                             return EndOfWire.NOT_PRESENT;
 
                         if (bytes.compareAndSwapInt(pos, 0, END_OF_DATA)) {
@@ -617,7 +617,7 @@ public abstract class AbstractWire implements Wire, InternalWire {
                     // mis-aligned check, assume only one writer (best effort)
                     MEMORY.loadFence();
                     if (bytes.readInt(pos) == 0) {
-                        if (!writeEOF)
+                        if (!shouldWriteEof)
                             return EndOfWire.NOT_PRESENT;
 
                         bytes.writeInt(pos, END_OF_DATA);
@@ -632,11 +632,11 @@ public abstract class AbstractWire implements Wire, InternalWire {
                 if (header == END_OF_DATA)
                     return EndOfWire.PRESENT;
                 if (Wires.isNotComplete(header)) {
-                    if (!writeEOF)
-                        return EndOfWire.NOT_PRESENT;
+                        if (!shouldWriteEof)
+                            return EndOfWire.NOT_PRESENT;
 
                     try {
-                        acquireTimedParser().pause(timeout, timeUnit);
+                        acquireTimedParser().pause(timeout, timeoutUnit);
 
                     } catch (TimeoutException e) {
                         boolean success = bytes.compareAndSwapInt(pos, header, END_OF_DATA);

--- a/src/main/java/net/openhft/chronicle/wire/BinaryReadDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryReadDocumentContext.java
@@ -193,7 +193,7 @@ public class BinaryReadDocumentContext implements ReadDocumentContext {
     }
 
     @Override
-    public long index() {
+    public long lastReadIndex() {
         return readPosition;
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -319,10 +319,10 @@ public class BinaryWire extends AbstractWire implements Wire {
     }
 
     @Override
-    public DocumentContext acquireWritingDocument(boolean metaData) {
+    public DocumentContext acquireWritingDocument(boolean includeMetaData) {
         if (writeContext.isOpen() && writeContext.chainedElement())
             return writeContext;
-        return writingDocument(metaData);
+        return writingDocument(includeMetaData);
     }
 
     @NotNull
@@ -1609,36 +1609,36 @@ public class BinaryWire extends AbstractWire implements Wire {
     }
 
     @Override
-    public ValueOut writeEventId(int methodId) {
-        writeCode(FIELD_NUMBER).writeStopBit(methodId);
+    public ValueOut writeEventId(int eventId) {
+        writeCode(FIELD_NUMBER).writeStopBit(eventId);
         return valueOut;
     }
 
     @Override
-    public ValueOut writeEventId(String name, int methodId) {
+    public ValueOut writeEventId(String eventName, int eventId) {
         if (bytes.retainedHexDumpDescription()) {
-            writeEventIdDescription(name, methodId);
+            writeEventIdDescription(eventName, eventId);
         }
-        writeCode(FIELD_NUMBER).writeStopBit(methodId);
+        writeCode(FIELD_NUMBER).writeStopBit(eventId);
         return valueOut;
     }
 
     /**
      * Writes a description of an event ID which consists of the event name and its corresponding method ID.
      *
-     * @param name     The name of the event.
-     * @param methodId The ID of the method associated with the event.
+     * @param eventName The name of the event.
+     * @param eventId   The ID of the method associated with the event.
      */
-    private void writeEventIdDescription(String name, int methodId) {
+    private void writeEventIdDescription(String eventName, int eventId) {
         try (ScopedResource<StringBuilder> sbTl = SBP.get()) {
             final StringBuilder sb = sbTl.get();
-            sb.append(name).append(" (");
+            sb.append(eventName).append(" (");
 
-            // Check if the methodId falls within the printable ASCII character range.
-            if (' ' < methodId && methodId <= '~')
-                sb.append('\'').append((char) methodId).append('\''); // Represent methodId as a character.
+            // Check if the eventId falls within the printable ASCII character range.
+            if (' ' < eventId && eventId <= '~')
+                sb.append('\'').append((char) eventId).append('\''); // Represent eventId as a character.
             else
-                sb.append(methodId); // Use the integer representation.
+                sb.append(eventId); // Use the integer representation.
 
             sb.append(')');
 
@@ -1671,12 +1671,12 @@ public class BinaryWire extends AbstractWire implements Wire {
 
     @NotNull
     @Override
-    public ValueOut write(@NotNull CharSequence key) {
+    public ValueOut write(@NotNull CharSequence fieldName) {
         if (!fieldLess) {
             if (numericFields)
-                writeField(WireKey.toCode(key));
+                writeField(WireKey.toCode(fieldName));
             else
-                writeField(key);
+                writeField(fieldName);
         }
         return valueOut;
     }

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWriteDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWriteDocumentContext.java
@@ -180,7 +180,7 @@ public class BinaryWriteDocumentContext implements WriteDocumentContext {
     }
 
     @Override
-    public long index() {
+    public long lastReadIndex() {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/DocumentContextHolder.java
+++ b/src/main/java/net/openhft/chronicle/wire/DocumentContextHolder.java
@@ -92,8 +92,8 @@ public class DocumentContextHolder implements DocumentContext, WriteDocumentCont
     }
 
     @Override
-    public long index() throws IORuntimeException {
-        return dc.index();
+    public long lastReadIndex() throws IORuntimeException {
+        return dc.lastReadIndex();
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/DocumentWritten.java
+++ b/src/main/java/net/openhft/chronicle/wire/DocumentWritten.java
@@ -48,9 +48,9 @@ public interface DocumentWritten {
      * or reuses an existing one. Depending on the use case, calling the close() method
      * on the context might be optional.
      *
-     * @param metaData A boolean indicating if metadata should be included during writing.
+     * @param includeMetaData A boolean indicating if metadata should be included during writing.
      * @return An existing or new {@link DocumentContext} tailored to the metadata preference.
      * @throws UnrecoverableTimeoutException If the operation times out in an unrecoverable manner.
      */
-    DocumentContext acquireWritingDocument(boolean metaData) throws UnrecoverableTimeoutException;
+    DocumentContext acquireWritingDocument(boolean includeMetaData) throws UnrecoverableTimeoutException;
 }

--- a/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
@@ -146,7 +146,7 @@ public interface FieldInfo {
      * @return the value of the field represented by this {@code FieldInfo} object
      * as an {@code int} primitive.
      */
-    int getInt(Object object);
+    int getInt(Object instance);
 
     /**
      * Returns the value of the field represented by this {@code FieldInfo} object
@@ -173,21 +173,21 @@ public interface FieldInfo {
      * to the provided {@code value}. The provided {@code object} is used as a
      * target to the extract eh field from.
      */
-    void set(Object object, Object value) throws IllegalArgumentException;
+    void set(Object instance, Object value) throws IllegalArgumentException;
 
     /**
      * Sets the value of the field represented by this {@code FieldInfo} object
      * to the provided {@code value}. The provided {@code object} is used as a
      * target to the extract eh field from.
      */
-    void set(Object object, char value) throws IllegalArgumentException;
+    void set(Object instance, char value) throws IllegalArgumentException;
 
     /**
      * Sets the value of the field represented by this {@code FieldInfo} object
      * to the provided {@code value}. The provided {@code object} is used as a
      * target to the extract eh field from.
      */
-    void set(Object object, int value) throws IllegalArgumentException;
+    void set(Object instance, int value) throws IllegalArgumentException;
 
     /**
      * Sets the value of the field represented by this {@code FieldInfo} object
@@ -200,7 +200,7 @@ public interface FieldInfo {
      *                                  interface declaring the underlying field, or if an unwrapping
      *                                  conversion fails.
      */
-    void set(Object object, long value) throws IllegalArgumentException;
+    void set(Object instance, long value) throws IllegalArgumentException;
 
     /**
      * Sets the value of the field represented by this {@code FieldInfo} object
@@ -213,17 +213,17 @@ public interface FieldInfo {
      *                                  interface declaring the underlying field, or if an unwrapping
      *                                  conversion fails.
      */
-    void set(Object object, double value) throws IllegalArgumentException;
+    void set(Object instance, double value) throws IllegalArgumentException;
 
     /**
      * Retrieves the {@link Class} identifying the declared generic type of the
      * field represented by this {@code FieldInfo} object at the provided {@code index}.
      *
-     * @param index The index of the generic type to be retrieved.
+     * @param parameterIndex The index of the generic type to be retrieved.
      * @return a {@link Class} identifying the declared generic type of the field represented by
      * this {@code FieldInfo} object at the provided {@code index}.
      */
-    Class<?> genericType(int index);
+    Class<?> genericType(int parameterIndex);
 
     /**
      * Copies the value of the field represented by this {@code FieldInfo} object from

--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodWriter.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodWriter.java
@@ -100,8 +100,8 @@ public class GenerateMethodWriter {
                         "}\n"));
         List<Class<?>> dcBoolean = Stream.of(DocumentContext.class, boolean.class).collect(Collectors.toList());
         TEMPLATE_METHODS.put("acquireWritingDocument",
-                singletonMap(dcBoolean, "public " + DOCUMENT_CONTEXT + " acquireWritingDocument(boolean metaData){\n" +
-                        "    return out.get().acquireWritingDocument(metaData);\n" +
+                singletonMap(dcBoolean, "public " + DOCUMENT_CONTEXT + " acquireWritingDocument(boolean includeMetaData){\n" +
+                        "    return out.get().acquireWritingDocument(includeMetaData);\n" +
                         "}\n"));
         Map<List<Class<?>>, String> wd = new LinkedHashMap<>();
         wd.put(singletonList(DocumentContext.class), "public " + DOCUMENT_CONTEXT + " writingDocument(){\n" +

--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodWriter2.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodWriter2.java
@@ -67,8 +67,8 @@ public class GenerateMethodWriter2 extends AbstractClassGenerator<GenerateMethod
         List<Class<?>> dcBoolean = Stream.of(DocumentContext.class, boolean.class).collect(Collectors.toList());
         TEMPLATE_METHODS.put("acquireWritingDocument",
                 singletonMap(dcBoolean, "" +
-                        "public " + DOCUMENT_CONTEXT + " acquireWritingDocument(boolean metaData) {\n" +
-                        "    return this.outSupplier.get().acquireWritingDocument(metaData);\n" +
+                        "public " + DOCUMENT_CONTEXT + " acquireWritingDocument(boolean includeMetaData) {\n" +
+                        "    return this.outSupplier.get().acquireWritingDocument(includeMetaData);\n" +
                         "}\n"));
         Map<List<Class<?>>, String> wd = new LinkedHashMap<>();
         wd.put(singletonList(DocumentContext.class), "" +

--- a/src/main/java/net/openhft/chronicle/wire/HashWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/HashWire.java
@@ -201,15 +201,15 @@ public class HashWire implements WireOut, HexDumpBytesDescription {
 
     @NotNull
     @Override
-    public ValueOut write(@NotNull CharSequence name) {
-        hash += K0 + name.hashCode() * M0;
+    public ValueOut write(@NotNull CharSequence fieldName) {
+        hash += K0 + fieldName.hashCode() * M0;
         return valueOut;
     }
 
     @NotNull
     @Override
-    public ValueOut writeEvent(Class<?> ignored, @NotNull Object eventKey) {
-        hash += K0 + eventKey.hashCode() * M0;
+    public ValueOut writeEvent(Class<?> keyType, @NotNull Object key) {
+        hash += K0 + key.hashCode() * M0;
         return valueOut;
     }
 
@@ -265,7 +265,7 @@ public class HashWire implements WireOut, HexDumpBytesDescription {
     }
 
     @Override
-    public DocumentContext acquireWritingDocument(boolean metaData) {
+    public DocumentContext acquireWritingDocument(boolean includeMetaData) {
         throw new UnsupportedOperationException();
     }
 
@@ -295,7 +295,7 @@ public class HashWire implements WireOut, HexDumpBytesDescription {
     }
 
     @Override
-    public boolean writeEndOfWire(long timeout, TimeUnit timeUnit, long lastPosition) {
+    public boolean writeEndOfWire(long timeout, TimeUnit timeoutUnit, long lastPosition) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/JSONWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/JSONWire.java
@@ -705,8 +705,8 @@ public class JSONWire extends TextWire {
 
     @SuppressWarnings("rawtypes")
     @Override
-    public ValueOut writeEvent(Class<?> expectedType, Object eventKey) throws InvalidMarshallableException {
-        return super.writeEvent(String.class, "" + eventKey);
+    public ValueOut writeEvent(Class<?> keyType, Object key) throws InvalidMarshallableException {
+        return super.writeEvent(String.class, "" + key);
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/wire/MarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableOut.java
@@ -81,7 +81,7 @@ public interface MarshallableOut extends DocumentWritten, RollbackIfNotCompleteN
      * call opens the context and later calls share it. The context should be
      * closed once all messages are written.
      */
-    DocumentContext acquireWritingDocument(boolean metaData) throws UnrecoverableTimeoutException;
+    DocumentContext acquireWritingDocument(boolean includeMetaData) throws UnrecoverableTimeoutException;
 
     /**
      * @return {@code true} if callers are expected to record the history of each
@@ -276,20 +276,20 @@ public interface MarshallableOut extends DocumentWritten, RollbackIfNotCompleteN
      * recording. The builder exposes further configuration such as interceptors
      * and wire type before {@code build()} is invoked.
      *
-     * @param metaData write each call as metadata if true
+     * @param isMetaData write each call as metadata if true
      * @param tClass   primary interface
      * @return configurable builder
      */
     @NotNull
-    default <T> MethodWriterBuilder<T> methodWriterBuilder(boolean metaData, @NotNull Class<T> tClass) {
+    default <T> MethodWriterBuilder<T> methodWriterBuilder(boolean isMetaData, @NotNull Class<T> tClass) {
         // Creates a new builder instance with the specified WireType and InvocationHandler
         VanillaMethodWriterBuilder<T> builder = new VanillaMethodWriterBuilder<>(tClass,
                 WireType.BINARY_LIGHT,
-                () -> new BinaryMethodWriterInvocationHandler(tClass, metaData, this));
+                () -> new BinaryMethodWriterInvocationHandler(tClass, isMetaData, this));
 
         // Configure the builder
         builder.marshallableOut(this);
-        builder.metaData(metaData);
+        builder.metaData(isMetaData);
 
         // If the current instance can be closed, set its close behavior
         if (this instanceof Closeable)

--- a/src/main/java/net/openhft/chronicle/wire/MethodWriterInvocationHandlerSupplier.java
+++ b/src/main/java/net/openhft/chronicle/wire/MethodWriterInvocationHandlerSupplier.java
@@ -58,8 +58,8 @@ public class MethodWriterInvocationHandlerSupplier implements Supplier<MethodWri
      *
      * @param recordHistory Whether to enable history recording.
      */
-    public void recordHistory(boolean recordHistory) {
-        this.recordHistory = recordHistory;
+    public void recordHistory(boolean enableHistory) {
+        this.recordHistory = enableHistory;
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/NoDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/NoDocumentContext.java
@@ -54,7 +54,7 @@ public enum NoDocumentContext implements DocumentContext {
     }
 
     @Override
-    public long index() {
+    public long lastReadIndex() {
         return Long.MIN_VALUE;
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/QueryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/QueryWire.java
@@ -106,8 +106,8 @@ public class QueryWire extends TextWire {
 
     @NotNull
     @Override
-    public ValueOut write(@NotNull CharSequence name) {
-        return valueOut.write(name);
+    public ValueOut write(@NotNull CharSequence fieldName) {
+        return valueOut.write(fieldName);
     }
 
     @NotNull

--- a/src/main/java/net/openhft/chronicle/wire/RawWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/RawWire.java
@@ -97,10 +97,10 @@ public class RawWire extends AbstractWire implements Wire {
     }
 
     @Override
-    public DocumentContext acquireWritingDocument(boolean metaData) {
+    public DocumentContext acquireWritingDocument(boolean includeMetaData) {
         if (writeContext.isOpen())
             return writeContext;
-        return writingDocument(metaData);
+        return writingDocument(includeMetaData);
     }
 
     @NotNull
@@ -271,7 +271,7 @@ public class RawWire extends AbstractWire implements Wire {
 
     @NotNull
     @Override
-    public ValueOut write(@NotNull CharSequence name) {
+    public ValueOut write(@NotNull CharSequence fieldName) {
         return valueOut;
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/SourceContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/SourceContext.java
@@ -41,5 +41,5 @@ public interface SourceContext {
      * @return the position in implementation-defined units
      * @throws IORuntimeException if the position cannot be retrieved
      */
-    long index() throws IORuntimeException;
+    long lastReadIndex() throws IORuntimeException;
 }

--- a/src/main/java/net/openhft/chronicle/wire/TextReadDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextReadDocumentContext.java
@@ -217,7 +217,7 @@ public class TextReadDocumentContext implements ReadDocumentContext {
     }
 
     @Override
-    public long index() {
+    public long lastReadIndex() {
         return readPosition;
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -394,10 +394,10 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     @Override
-    public DocumentContext acquireWritingDocument(boolean metaData) {
+    public DocumentContext acquireWritingDocument(boolean includeMetaData) {
         if (writeContext != null && writeContext.isOpen() && writeContext.chainedElement())
             return writeContext;
-        return writingDocument(metaData);
+        return writingDocument(includeMetaData);
     }
 
     @NotNull

--- a/src/main/java/net/openhft/chronicle/wire/TextWriteDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWriteDocumentContext.java
@@ -164,7 +164,7 @@ public class TextWriteDocumentContext implements WriteDocumentContext {
     }
 
     @Override
-    public long index() {
+    public long lastReadIndex() {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/VanillaMessageHistory.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMessageHistory.java
@@ -233,7 +233,7 @@ public class VanillaMessageHistory extends SelfDescribingMarshallable implements
             @Nullable Object o = wire.parent();
             if (o instanceof SourceContext) {
                 @Nullable SourceContext dc = (SourceContext) o;
-                addSource(dc.sourceId(), dc.index());
+                addSource(dc.sourceId(), dc.lastReadIndex());
             }
 
             addTiming(nanoTime());

--- a/src/main/java/net/openhft/chronicle/wire/VanillaMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMethodReader.java
@@ -834,7 +834,7 @@ public class VanillaMethodReader implements MethodReader {
             assert context.isData();
 
             // Reset the message history with the current context's source ID and index
-            messageHistory().reset(context.sourceId(), context.index());
+            messageHistory().reset(context.sourceId(), context.lastReadIndex());
 
             // Parse the data message
             dataWireParser.accept(context.wire());

--- a/src/main/java/net/openhft/chronicle/wire/WireIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireIn.java
@@ -150,11 +150,11 @@ public interface WireIn extends WireCommon, MarshallableIn {
      * Commonly used when event names are enums.
      *
      * @param <K>           expected type of the event name
-     * @param expectedClass class of the expected type
+     * @param keyType class of the expected type
      * @return the converted name or {@code null} if absent
      * @throws InvalidMarshallableException if conversion fails
      */
-    @Nullable <K> K readEvent(Class<K> expectedClass) throws InvalidMarshallableException;
+    @Nullable <K> K readEvent(Class<K> keyType) throws InvalidMarshallableException;
 
     /**
      * Returns the {@link ValueIn} representing the value of the last field or event read.
@@ -246,10 +246,10 @@ public interface WireIn extends WireCommon, MarshallableIn {
      * @return {@code true} if a document was read
      * @throws InvalidMarshallableException if a marshalling error occurs
      */
-    default boolean readDocument(long position,
+    default boolean readDocument(long startPosition,
                                  @Nullable ReadMarshallable metaDataConsumer,
                                  @Nullable ReadMarshallable dataConsumer) throws InvalidMarshallableException {
-        return WireInternal.readData(position, this, metaDataConsumer, dataConsumer);
+        return WireInternal.readData(startPosition, this, metaDataConsumer, dataConsumer);
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -2569,13 +2569,13 @@ public class WireMarshaller<T> {
         }
 
         @Override
-        protected int getInt(Object o) {
-            return unsafeGetByte(o, offset) & 0xFF;
+        protected int getInt(Object instance) {
+            return unsafeGetByte(instance, offset) & 0xFF;
         }
 
         @Override
-        protected void putInt(Object o, int i) {
-            unsafePutByte(o, offset, (byte) i);
+        protected void putInt(Object instance, int i) {
+            unsafePutByte(instance, offset, (byte) i);
         }
     }
 
@@ -2593,13 +2593,13 @@ public class WireMarshaller<T> {
         }
 
         @Override
-        protected int getInt(Object o) {
-            return unsafeGetShort(o, offset) & 0xFFFF;
+        protected int getInt(Object instance) {
+            return unsafeGetShort(instance, offset) & 0xFFFF;
         }
 
         @Override
-        protected void putInt(Object o, int i) {
-            unsafePutShort(o, offset, (short) i);
+        protected void putInt(Object instance, int i) {
+            unsafePutShort(instance, offset, (short) i);
         }
     }
 
@@ -2835,8 +2835,8 @@ public class WireMarshaller<T> {
          * @param o The object containing the field
          * @return  The retrieved integer value
          */
-        protected int getInt(Object o) {
-            return unsafeGetInt(o, offset);
+        protected int getInt(Object instance) {
+            return unsafeGetInt(instance, offset);
         }
 
         @Override
@@ -2852,7 +2852,7 @@ public class WireMarshaller<T> {
                     i = converter.parse(sb);
                 }
             }
-            unsafePutLong(o, offset, i);
+            unsafePutLong(instance, offset, i);
         }
 
         /**
@@ -2861,8 +2861,8 @@ public class WireMarshaller<T> {
          * @param o The object to set the value on
          * @param i The integer value to set
          */
-        protected void putInt(Object o, int i) {
-            unsafePutInt(o, offset, i);
+        protected void putInt(Object instance, int i) {
+            unsafePutInt(instance, offset, i);
         }
 
         @Override

--- a/src/main/java/net/openhft/chronicle/wire/WireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireOut.java
@@ -76,19 +76,19 @@ public interface WireOut extends WireCommon, MarshallableOut {
      * Serialises an event where the key may be an {@code enum} or arbitrary
      * object. The {@code expectedType} hints how the key should be written.
      *
-     * @param expectedType expected class of {@code eventKey}
-     * @param eventKey     the key object to serialise
+     * @param keyType expected class of {@code key}
+     * @param key     the key object to serialise
      * @return interface used to serialise the value
      * @throws InvalidMarshallableException if the key cannot be written
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
-    default ValueOut writeEvent(Class<?> expectedType, Object eventKey) throws InvalidMarshallableException {
-        if (eventKey instanceof WireKey)
-            return writeEventName((WireKey) eventKey);
-        if (eventKey instanceof CharSequence)
-            return writeEventName((CharSequence) eventKey);
+    default ValueOut writeEvent(Class<?> keyType, Object key) throws InvalidMarshallableException {
+        if (key instanceof WireKey)
+            return writeEventName((WireKey) key);
+        if (key instanceof CharSequence)
+            return writeEventName((CharSequence) key);
         writeStartEvent();
-        getValueOut().object(expectedType, eventKey);
+        getValueOut().object(keyType, key);
         writeEndEvent();
         return getValueOut();
     }
@@ -96,23 +96,23 @@ public interface WireOut extends WireCommon, MarshallableOut {
     /**
      * Writes a numeric event identifier for compact binary formats.
      *
-     * @param methodId numeric id representing the method/event
+     * @param eventId numeric id representing the method/event
      * @return interface used to serialise the value
      */
-    default ValueOut writeEventId(int methodId) {
-        return write(new MethodWireKey(null, methodId));
+    default ValueOut writeEventId(int eventId) {
+        return write(new MethodWireKey(null, eventId));
     }
 
     /**
      * Writes a numeric event identifier and optional textual name. Useful for
      * debugging or human readable logs.
      *
-     * @param name     event name for diagnostic output
-     * @param methodId numeric id representing the method/event
+     * @param eventName event name for diagnostic output
+     * @param eventId numeric id representing the method/event
      * @return interface used to serialise the value
      */
-    default ValueOut writeEventId(String name, int methodId) {
-        return write(new MethodWireKey(name, methodId));
+    default ValueOut writeEventId(String eventName, int eventId) {
+        return write(new MethodWireKey(eventName, eventId));
     }
 
     /**
@@ -129,10 +129,10 @@ public interface WireOut extends WireCommon, MarshallableOut {
      * Writes a textual field name and returns a {@link ValueOut} for the
      * associated value.
      *
-     * @param key field identifier
+     * @param fieldName field identifier
      * @return interface used to serialise the value
      */
-    ValueOut write(CharSequence key);
+    ValueOut write(CharSequence fieldName);
 
     /**
      * Retrieves the interface for defining the output of a value
@@ -219,11 +219,11 @@ public interface WireOut extends WireCommon, MarshallableOut {
      * Convenience wrapper around {@link #writingDocument(boolean)} for one off
      * writes. The document is closed automatically.
      *
-     * @param metaData write metadata rather than data
-     * @param writer   callback used to write the document body
+     * @param isMetaData write metadata rather than data
+     * @param bodyWriter   callback used to write the document body
      */
-    default void writeDocument(boolean metaData, @NotNull WriteMarshallable writer) throws InvalidMarshallableException {
-        WireInternal.writeData(this, metaData, false, writer);
+    default void writeDocument(boolean isMetaData, @NotNull WriteMarshallable bodyWriter) throws InvalidMarshallableException {
+        WireInternal.writeData(this, isMetaData, false, bodyWriter);
     }
 
     /**
@@ -251,27 +251,27 @@ public interface WireOut extends WireCommon, MarshallableOut {
      * Acquire a document context, reusing any that may already be active.
      * Useful when writing multiple documents in a chain.
      *
-     * @param metaData if {@code true} a metadata document is required
+     * @param includeMetaData if {@code true} a metadata document is required
      * @return context controlling the document write
      */
-    DocumentContext acquireWritingDocument(boolean metaData);
+    DocumentContext acquireWritingDocument(boolean includeMetaData);
 
     /**
      * Write a document without the usual completion marker. Originally used for
      * streaming over TCP and seldom required now.
      *
-     * @param metaData write metadata rather than data
+     * @param isMetaData write metadata rather than data
      * @param writer   callback used to write the document body
      */
-    default void writeNotCompleteDocument(boolean metaData, @NotNull WriteMarshallable writer) throws InvalidMarshallableException {
-        WireInternal.writeData(this, metaData, true, writer);
+    default void writeNotCompleteDocument(boolean isMetaData, @NotNull WriteMarshallable writer) throws InvalidMarshallableException {
+        WireInternal.writeData(this, isMetaData, true, writer);
     }
 
     /**
      * INTERNAL METHOD used by {@link DocumentContext}. Updates the header when
      * a document is completed.
      */
-    void updateHeader(long position, boolean metaData, int expectedHeader) throws StreamCorruptedException;
+    void updateHeader(long headerPos, boolean isMetaData, int templateHeader) throws StreamCorruptedException;
 
     /**
      * INTERNAL METHOD used by {@link DocumentContext}. Begins a document
@@ -302,11 +302,11 @@ public interface WireOut extends WireCommon, MarshallableOut {
      * queue implementations to signal the last message.
      *
      * @param timeout      maximum time to wait
-     * @param timeUnit     unit of {@code timeout}
+     * @param timeoutUnit  unit of {@code timeout}
      * @param lastPosition position considered to be the end of the wire
      * @return {@code true} if a marker was written
      */
-    boolean writeEndOfWire(long timeout, TimeUnit timeUnit, long lastPosition);
+    boolean writeEndOfWire(long timeout, TimeUnit timeoutUnit, long lastPosition);
 
     /**
      * Tests for the end of wire marker and optionally writes one. Mainly used
@@ -318,7 +318,7 @@ public interface WireOut extends WireCommon, MarshallableOut {
      * @param lastPosition position considered to be the end of the wire
      * @return {@link EndOfWire} describing the marker status
      */
-    default EndOfWire endOfWire(boolean writeEOF, long timeout, TimeUnit timeUnit, long lastPosition) {
+    default EndOfWire endOfWire(boolean shouldWriteEof, long timeout, TimeUnit timeoutUnit, long lastPosition) {
         throw new UnsupportedOperationException("Optional operation, please use writeEndOfWire");
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/Wires.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wires.java
@@ -1958,47 +1958,47 @@ public enum Wires {
         }
 
         @Override
-        public int getInt(Object object) {
-            return ObjectUtils.convertTo(Integer.class, get(object));
+        public int getInt(Object instance) {
+            return ObjectUtils.convertTo(Integer.class, get(instance));
         }
 
         @Override
-        public char getChar(Object object) {
-            return ObjectUtils.convertTo(Character.class, get(object));
+        public char getChar(Object instance) {
+            return ObjectUtils.convertTo(Character.class, get(instance));
         }
 
         @Override
-        public double getDouble(Object object) {
-            return ObjectUtils.convertTo(Double.class, get(object));
+        public double getDouble(Object instance) {
+            return ObjectUtils.convertTo(Double.class, get(instance));
         }
 
         @Override
-        public void set(Object object, Object value) throws IllegalArgumentException {
-            getMap(object).put(name, value);
+        public void set(Object instance, Object value) throws IllegalArgumentException {
+            getMap(instance).put(name, value);
         }
 
         @Override
-        public void set(Object object, char value) throws IllegalArgumentException {
+        public void set(Object instance, char value) throws IllegalArgumentException {
             set(name, (Object) value);
         }
 
         @Override
-        public void set(Object object, int value) throws IllegalArgumentException {
+        public void set(Object instance, int value) throws IllegalArgumentException {
             set(name, (Object) value);
         }
 
         @Override
-        public void set(Object object, long value) throws IllegalArgumentException {
+        public void set(Object instance, long value) throws IllegalArgumentException {
             set(name, (Object) value);
         }
 
         @Override
-        public void set(Object object, double value) throws IllegalArgumentException {
+        public void set(Object instance, double value) throws IllegalArgumentException {
             set(name, (Object) value);
         }
 
         @Override
-        public Class<?> genericType(int index) {
+        public Class<?> genericType(int parameterIndex) {
             return Object.class;
         }
 

--- a/src/main/java/net/openhft/chronicle/wire/WrappedDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/WrappedDocumentContext.java
@@ -90,8 +90,8 @@ public abstract class WrappedDocumentContext implements DocumentContext {
     }
 
     @Override
-    public long index() throws IORuntimeException {
-        return dc.index();
+    public long lastReadIndex() throws IORuntimeException {
+        return dc.lastReadIndex();
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -427,10 +427,10 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     @Override
-    public DocumentContext acquireWritingDocument(boolean metaData) {
+    public DocumentContext acquireWritingDocument(boolean includeMetaData) {
         if (writeContext != null && writeContext.isOpen())
             return writeContext;
-        return writingDocument(metaData);
+        return writingDocument(includeMetaData);
     }
 
     @NotNull
@@ -1148,9 +1148,9 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     @Override
-    public boolean readDocument(long position, @Nullable ReadMarshallable metaDataConsumer, @Nullable ReadMarshallable dataConsumer) throws InvalidMarshallableException {
+    public boolean readDocument(long startPosition, @Nullable ReadMarshallable metaDataConsumer, @Nullable ReadMarshallable dataConsumer) throws InvalidMarshallableException {
         valueIn.resetState();
-        return super.readDocument(position, metaDataConsumer, dataConsumer);
+        return super.readDocument(startPosition, metaDataConsumer, dataConsumer);
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
@@ -162,27 +162,27 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
 
     @NotNull
     @Override
-    public ValueOut write(@NotNull CharSequence name) {
-        return valueOut.write(name);
+    public ValueOut write(@NotNull CharSequence fieldName) {
+        return valueOut.write(fieldName);
     }
 
     @Override
-    public ValueOut writeEvent(Class<?> expectedType, Object eventKey) throws InvalidMarshallableException {
-        if (eventKey instanceof WireKey)
-            return writeEventName((WireKey) eventKey);
-        if (eventKey instanceof CharSequence)
-            return writeEventName((CharSequence) eventKey);
-        if (expectedType != null && expectedType.isInstance(eventKey)) {
-            if (eventKey instanceof Enum)
-                return writeEventName(((Enum) eventKey).name());
-            if (eventKey instanceof DynamicEnum)
-                return writeEventName(((DynamicEnum) eventKey).name());
-            if (eventKey instanceof Boolean)
-                return writeEventName(eventKey.toString());
+    public ValueOut writeEvent(Class<?> keyType, Object key) throws InvalidMarshallableException {
+        if (key instanceof WireKey)
+            return writeEventName((WireKey) key);
+        if (key instanceof CharSequence)
+            return writeEventName((CharSequence) key);
+        if (keyType != null && keyType.isInstance(key)) {
+            if (key instanceof Enum)
+                return writeEventName(((Enum) key).name());
+            if (key instanceof DynamicEnum)
+                return writeEventName(((DynamicEnum) key).name());
+            if (key instanceof Boolean)
+                return writeEventName(key.toString());
         }
         boolean wasLeft = valueOut.swapLeaf(true);
         try {
-            return valueOut.write(expectedType, eventKey);
+            return valueOut.write(keyType, key);
         } finally {
             valueOut.swapLeaf(wasLeft);
         }

--- a/src/main/java/net/openhft/chronicle/wire/internal/FileMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/FileMarshallableOut.java
@@ -101,14 +101,14 @@ public class FileMarshallableOut implements MarshallableOut {
     }
 
     @Override
-    public DocumentContext writingDocument(boolean metaData) throws UnrecoverableTimeoutException {
-        dcHolder.documentContext(wire.writingDocument(metaData));
+    public DocumentContext writingDocument(boolean isMetaData) throws UnrecoverableTimeoutException {
+        dcHolder.documentContext(wire.writingDocument(isMetaData));
         return dcHolder;
     }
 
     @Override
-    public DocumentContext acquireWritingDocument(boolean metaData) throws UnrecoverableTimeoutException {
-        dcHolder.documentContext(wire.acquireWritingDocument(metaData));
+    public DocumentContext acquireWritingDocument(boolean includeMetaData) throws UnrecoverableTimeoutException {
+        dcHolder.documentContext(wire.acquireWritingDocument(includeMetaData));
         return dcHolder;
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
@@ -121,14 +121,14 @@ public class HTTPMarshallableOut implements MarshallableOut {
     }
 
     @Override
-    public DocumentContext writingDocument(boolean metaData) throws UnrecoverableTimeoutException {
-        dcHolder.documentContext(wire.writingDocument(metaData));
+    public DocumentContext writingDocument(boolean isMetaData) throws UnrecoverableTimeoutException {
+        dcHolder.documentContext(wire.writingDocument(isMetaData));
         return dcHolder;
     }
 
     @Override
-    public DocumentContext acquireWritingDocument(boolean metaData) throws UnrecoverableTimeoutException {
-        dcHolder.documentContext(wire.acquireWritingDocument(metaData));
+    public DocumentContext acquireWritingDocument(boolean includeMetaData) throws UnrecoverableTimeoutException {
+        dcHolder.documentContext(wire.acquireWritingDocument(includeMetaData));
         return dcHolder;
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/internal/StringConsumerMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/StringConsumerMarshallableOut.java
@@ -63,14 +63,14 @@ public class StringConsumerMarshallableOut implements MarshallableOut {
     }
 
     @Override
-    public DocumentContext writingDocument(boolean metaData) throws UnrecoverableTimeoutException {
-        dcHolder.documentContext(wire.writingDocument(metaData));
+    public DocumentContext writingDocument(boolean isMetaData) throws UnrecoverableTimeoutException {
+        dcHolder.documentContext(wire.writingDocument(isMetaData));
         return dcHolder;
     }
 
     @Override
-    public DocumentContext acquireWritingDocument(boolean metaData) throws UnrecoverableTimeoutException {
-        dcHolder.documentContext(wire.acquireWritingDocument(metaData));
+    public DocumentContext acquireWritingDocument(boolean includeMetaData) throws UnrecoverableTimeoutException {
+        dcHolder.documentContext(wire.acquireWritingDocument(includeMetaData));
         return dcHolder;
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/internal/VanillaFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/VanillaFieldInfo.java
@@ -62,9 +62,9 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
     }
 
     @Override
-    public int getInt(Object object) {
+    public int getInt(Object instance) {
         try {
-            return getField().getInt(object);
+            return getField().getInt(instance);
         } catch (@NotNull NoSuchFieldException | IllegalAccessException e) {
             Jvm.debug().on(VanillaFieldInfo.class, e);
             return Integer.MIN_VALUE;
@@ -72,9 +72,9 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
     }
 
     @Override
-    public char getChar(Object object) {
+    public char getChar(Object instance) {
         try {
-            return getField().getChar(object);
+            return getField().getChar(instance);
         } catch (@NotNull NoSuchFieldException | IllegalAccessException e) {
             Jvm.debug().on(VanillaFieldInfo.class, e);
             return Character.MAX_VALUE;
@@ -93,46 +93,46 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
 
     @SuppressWarnings("unchecked")
     @Override
-    public void set(Object object, Object value) throws IllegalArgumentException {
+    public void set(Object instance, Object value) throws IllegalArgumentException {
         Object value2 = ObjectUtils.convertTo(type, value);
         try {
-            getField().set(object, value2);
+            getField().set(instance, value2);
         } catch (@NotNull NoSuchFieldException | IllegalAccessException e) {
             throw new IllegalArgumentException(e);
         }
     }
 
     @Override
-    public void set(Object object, int value) throws IllegalArgumentException {
+    public void set(Object instance, int value) throws IllegalArgumentException {
         try {
-            getField().setInt(object, value);
+            getField().setInt(instance, value);
         } catch (@NotNull NoSuchFieldException | IllegalAccessException e) {
             throw new IllegalArgumentException(e);
         }
     }
 
     @Override
-    public void set(Object object, char value) throws IllegalArgumentException {
+    public void set(Object instance, char value) throws IllegalArgumentException {
         try {
-            getField().setChar(object, value);
+            getField().setChar(instance, value);
         } catch (@NotNull NoSuchFieldException | IllegalAccessException e) {
             throw new IllegalArgumentException(e);
         }
     }
 
     @Override
-    public void set(Object object, long value) throws IllegalArgumentException {
+    public void set(Object instance, long value) throws IllegalArgumentException {
         try {
-            getField().setLong(object, value);
+            getField().setLong(instance, value);
         } catch (@NotNull NoSuchFieldException | IllegalAccessException e) {
             throw new IllegalArgumentException(e);
         }
     }
 
     @Override
-    public void set(Object object, double value) throws IllegalArgumentException {
+    public void set(Object instance, double value) throws IllegalArgumentException {
         try {
-            getField().setDouble(object, value);
+            getField().setDouble(instance, value);
         } catch (@NotNull NoSuchFieldException | IllegalAccessException e) {
             throw new IllegalArgumentException(e);
         }
@@ -147,9 +147,9 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
     }
 
     @Override
-    public Class<?> genericType(int index) {
+    public Class<?> genericType(int parameterIndex) {
         ParameterizedType genericType = (ParameterizedType) field.getGenericType();
-        Type type = genericType.getActualTypeArguments()[index];
+        Type type = genericType.getActualTypeArguments()[parameterIndex];
         return (Class) type;
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/IntFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/IntFieldInfo.java
@@ -43,9 +43,9 @@ public final class IntFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
-    public int getInt(Object object) {
+    public int getInt(Object instance) {
         try {
-            return UnsafeMemory.unsafeGetInt(object, getOffset());
+            return UnsafeMemory.unsafeGetInt(instance, getOffset());
         } catch (@NotNull NoSuchFieldException e) {
             Jvm.debug().on(IntFieldInfo.class, e);
             return Integer.MIN_VALUE;
@@ -53,9 +53,9 @@ public final class IntFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
-    public void set(Object object, int value) throws IllegalArgumentException {
+    public void set(Object instance, int value) throws IllegalArgumentException {
         try {
-            UnsafeMemory.unsafePutInt(object, getOffset(), value);
+            UnsafeMemory.unsafePutInt(instance, getOffset(), value);
         } catch (@NotNull NoSuchFieldException e) {
             throw new IllegalArgumentException(e);
         }

--- a/src/main/java/net/openhft/chronicle/wire/internal/reduction/ReductionUtil.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/reduction/ReductionUtil.java
@@ -62,7 +62,7 @@ public final class ReductionUtil {
             try (final DocumentContext dc = tailer.readingDocument()) {
                 final Wire wire = dc.wire();
                 if (dc.isPresent() && wire != null) {
-                    lastIndex = dc.index();
+                    lastIndex = dc.lastReadIndex();
                     excerptListener.onExcerpt(wire, lastIndex);
                 } else {
                     end = true;

--- a/src/main/java/net/openhft/chronicle/wire/internal/stream/StreamsUtil.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/stream/StreamsUtil.java
@@ -323,7 +323,7 @@ public final class StreamsUtil {
                 try (final DocumentContext dc = tailer.readingDocument()) {
                     final Wire wire = dc.wire();
                     if (dc.isPresent() && wire != null) {
-                        lastIndex = dc.index();
+                        lastIndex = dc.lastReadIndex();
                         next = extractor.extract(wire, lastIndex);
                         if (next != null) {
                             return true;
@@ -388,7 +388,7 @@ public final class StreamsUtil {
                 try (final DocumentContext dc = tailer.readingDocument()) {
                     final Wire wire = dc.wire();
                     if (dc.isPresent() && wire != null) {
-                        lastIndex = dc.index();
+                        lastIndex = dc.lastReadIndex();
                         next = extractor.extractAsLong(wire, lastIndex);
                         if (next != Long.MIN_VALUE) {
                             return true;
@@ -453,7 +453,7 @@ public final class StreamsUtil {
                 try (final DocumentContext dc = tailer.readingDocument()) {
                     final Wire wire = dc.wire();
                     if (dc.isPresent() && wire != null) {
-                        lastIndex = dc.index();
+                        lastIndex = dc.lastReadIndex();
                         next = extractor.extractAsDouble(wire, lastIndex);
                         if (!Double.isNaN(next)) {
                             return true;


### PR DESCRIPTION
## Summary
- rename ambiguous parameters across the write/read APIs
- expose `lastReadIndex()` from `SourceContext`
- clean up method writer builder names
- adjust document-writing helpers

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*