### PR TITLE
Improve parameter names for clarity

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AbstractFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractFieldInfo.java
@@ -42,12 +42,12 @@ public abstract class AbstractFieldInfo implements FieldInfo {
     /**
      * Creates a description of a field.
      *
-     * @param type        class used for marshalling
+     * @param fieldType   class used for marshalling
      * @param bracketType placement of start and end brackets in the wire text
      * @param name        identifier of the field
      */
-    protected AbstractFieldInfo(Class<?> type, BracketType bracketType, String name) {
-        this.type = type;
+    protected AbstractFieldInfo(Class<?> fieldType, BracketType bracketType, String name) {
+        this.type = fieldType;
         this.bracketType = bracketType;
         this.name = name;
     }

--- a/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
@@ -32,7 +32,7 @@ import static net.openhft.chronicle.wire.Wires.*;
 /**
  * Represents an abstraction for the meta-information of a field within a class or interface.
  * This metadata is used by {@link WireMarshaller} and related serialisation components to read
- * and write field values. It provides a consistent way to access properties such as the field
+ * and write field newValues. It provides a consistent way to access properties such as the field
  * name, type and how it is represented in the wire format.
  */
 public interface FieldInfo {
@@ -43,40 +43,40 @@ public interface FieldInfo {
      * Other types fall back to {@link ObjectFieldInfo} or a generic implementation.
      *
      * @param name        the field's name
-     * @param type        the declared type
+     * @param fieldType   the declared type
      * @param bracketType the wire {@link BracketType}
-     * @param field       the reflective field instance
+     * @param reflectField the reflective field instance
      * @return a concrete {@code FieldInfo} for the field
      */
-    static FieldInfo createForField(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
+    static FieldInfo createForField(String name, Class<?> fieldType, BracketType bracketType, @NotNull Field reflectField) {
         // Choose the FieldInfo type based on the field's type.
-        if (!type.isPrimitive()) {
-            return new ObjectFieldInfo(name, type, bracketType, field);
-        } else if (type == int.class) {
-            return new IntFieldInfo(name, type, bracketType, field);
-        } else if (type == double.class) {
-            return new DoubleFieldInfo(name, type, bracketType, field);
-        } else if (type == long.class) {
-            return new LongFieldInfo(name, type, bracketType, field);
-        } else if (type == char.class) {
-            return new CharFieldInfo(name, type, bracketType, field);
+        if (!fieldType.isPrimitive()) {
+            return new ObjectFieldInfo(name, fieldType, bracketType, reflectField);
+        } else if (fieldType == int.class) {
+            return new IntFieldInfo(name, fieldType, bracketType, reflectField);
+        } else if (fieldType == double.class) {
+            return new DoubleFieldInfo(name, fieldType, bracketType, reflectField);
+        } else if (fieldType == long.class) {
+            return new LongFieldInfo(name, fieldType, bracketType, reflectField);
+        } else if (fieldType == char.class) {
+            return new CharFieldInfo(name, fieldType, bracketType, reflectField);
         }
         // Default case for other primitive types.
-        return new VanillaFieldInfo(name, type, bracketType, field);
+        return new VanillaFieldInfo(name, fieldType, bracketType, reflectField);
     }
 
     /**
      * Analyses the supplied class using reflection and builds a {@link FieldInfoPair}
      * describing its marshallable fields. The pair contains an unmodifiable list of
-     * {@code FieldInfo} objects and a map keyed by field name. Each field's
+     * {@code FieldInfo} targets and a map keyed by field name. Each field's
      * {@link BracketType} is derived from its {@link SerializationStrategy}.
      *
-     * @param aClass the class to inspect
+     * @param targetClass the class to inspect
      * @return an immutable {@link FieldInfoPair} describing the fields
      */
     @NotNull
-    static FieldInfoPair lookupClass(@NotNull Class<?> aClass) {
-        final SerializationStrategy ss = CLASS_STRATEGY.get(aClass);
+    static FieldInfoPair lookupClass(@NotNull Class<?> targetClass) {
+        final SerializationStrategy ss = CLASS_STRATEGY.get(targetClass);
         switch (ss.bracketType()) {
             case NONE:
             case SEQ:
@@ -91,7 +91,7 @@ public interface FieldInfo {
         }
 
         @NotNull List<FieldInfo> fields = new ArrayList<>();
-        final WireMarshaller<?> marshaller = WIRE_MARSHALLER_CL.get(aClass);
+        final WireMarshaller<?> marshaller = WIRE_MARSHALLER_CL.get(targetClass);
 
         // Process each field of the class to create its FieldInfo.
         for (@NotNull WireMarshaller.FieldAccess fa : marshaller.fields) {
@@ -109,120 +109,120 @@ public interface FieldInfo {
     }
 
     /**
-     * Returns the name of the field represented by this {@code FieldInfo} object.
+     * Returns the name of the field represented by this {@code FieldInfo} target.
      *
-     * @return the name of the field represented by this {@code FieldInfo} object.
+     * @return the name of the field represented by this {@code FieldInfo} target.
      */
     String name();
 
     /**
      * Returns a {@link Class} identifying the declared type of the field
-     * represented by this {@code FieldInfo} object.
+     * represented by this {@code FieldInfo} target.
      *
      * @return a {@link Class} identifying the declared type of the field
-     * represented by this {@code FieldInfo} object.
+     * represented by this {@code FieldInfo} target.
      */
     Class<?> type();
 
     /**
      * Returns the {@link BracketType} used by the serialization strategy associated
-     * with this {@code FieldInfo} object.
+     * with this {@code FieldInfo} target.
      *
      * @return the {@link BracketType} used by the serialization strategy associated
-     * with this {@code FieldInfo} object.
+     * with this {@code FieldInfo} target.
      */
     BracketType bracketType();
 
     /**
-     * Returns the value of the field represented by this {@code FieldInfo} object
+     * Returns the newValue of the field represented by this {@code FieldInfo} target
      * as an {@link Object}.
      *
-     * @param object the instance from which to read the field
+     * @param target the instance from which to read the field
      * @return the field value or {@code null} if it cannot be obtained
      */
     @Nullable
-    Object get(Object object);
+    Object get(Object target);
 
     /**
-     * Returns the value of the field represented by this {@code FieldInfo} object
+     * Returns the value of the field represented by this {@code FieldInfo} target
      * as a {@code long} primitive.
      *
-     * @param object the instance from which to read the field
+     * @param target the instance from which to read the field
      * @return the field value, converted to {@code long} if required
      */
-    long getLong(Object object);
+    long getLong(Object target);
 
     /**
-     * Returns the value of the field represented by this {@code FieldInfo} object
+     * Returns the value of the field represented by this {@code FieldInfo} target
      * as an {@code int} primitive.
      *
-     * @param object the instance from which to read the field
+     * @param target the instance from which to read the field
      * @return the field value, converted to {@code int} if required
      */
-    int getInt(Object object);
+    int getInt(Object target);
 
     /**
-     * Returns the value of the field represented by this {@code FieldInfo} object
+     * Returns the value of the field represented by this {@code FieldInfo} target
      * as a {@code char} primitive.
      *
-     * @param object the instance from which to read the field
+     * @param target the instance from which to read the field
      * @return the field value, converted to {@code char} if required
      */
-    char getChar(Object object);
+    char getChar(Object target);
 
     /**
-     * Returns the value of the field represented by this {@code FieldInfo} object
+     * Returns the value of the field represented by this {@code FieldInfo} target
      * as a {@code double} primitive.
      *
-     * @param object the instance from which to read the field
+     * @param target the instance from which to read the field
      * @return the field value, converted to {@code double} if required
      */
-    double getDouble(Object object);
+    double getDouble(Object target);
 
     /**
-     * Sets the value of the field represented by this {@code FieldInfo} object.
+     * Sets the value of the field represented by this {@code FieldInfo} target.
      *
-     * @param object the instance on which to set the field
-     * @param value  the new value; conversions may occur if the types differ
+     * @param target the instance on which to set the field
+     * @param newValue  the new value; conversions may occur if the types differ
      * @throws IllegalArgumentException if the assignment fails
      */
-    void set(Object object, Object value) throws IllegalArgumentException;
+    void set(Object target, Object newValue) throws IllegalArgumentException;
 
     /**
-     * Sets the value of the field represented by this {@code FieldInfo} object.
+     * Sets the value of the field represented by this {@code FieldInfo} target.
      *
-     * @param object the instance on which to set the field
+     * @param target the instance on which to set the field
      * @param value  the new {@code char} value
      * @throws IllegalArgumentException if the assignment fails
      */
-    void set(Object object, char value) throws IllegalArgumentException;
+    void set(Object target, char value) throws IllegalArgumentException;
 
     /**
-     * Sets the value of the field represented by this {@code FieldInfo} object.
+     * Sets the value of the field represented by this {@code FieldInfo} target.
      *
-     * @param object the instance on which to set the field
+     * @param target the instance on which to set the field
      * @param value  the new {@code int} value
      * @throws IllegalArgumentException if the assignment fails
      */
-    void set(Object object, int value) throws IllegalArgumentException;
+    void set(Object target, int value) throws IllegalArgumentException;
 
     /**
-     * Sets the value of the field represented by this {@code FieldInfo} object.
+     * Sets the value of the field represented by this {@code FieldInfo} target.
      *
-     * @param object the instance on which to set the field
+     * @param target the instance on which to set the field
      * @param value  the new {@code long} value
      * @throws IllegalArgumentException if the assignment fails
      */
-    void set(Object object, long value) throws IllegalArgumentException;
+    void set(Object target, long value) throws IllegalArgumentException;
 
     /**
-     * Sets the value of the field represented by this {@code FieldInfo} object.
+     * Sets the value of the field represented by this {@code FieldInfo} target.
      *
-     * @param object the instance on which to set the field
+     * @param target the instance on which to set the field
      * @param value  the new {@code double} value
      * @throws IllegalArgumentException if the assignment fails
      */
-    void set(Object object, double value) throws IllegalArgumentException;
+    void set(Object target, double value) throws IllegalArgumentException;
 
     /**
      * Returns the declared generic type of the field, for example the
@@ -234,24 +234,24 @@ public interface FieldInfo {
     Class<?> genericType(int index);
 
     /**
-     * Copies the value of the field represented by this {@code FieldInfo} object from
-     * the source object to the destination object. It's a shallow copy, so objects will be
+     * Copies the value of the field represented by this {@code FieldInfo} target from
+     * the source target to the destination target. It's a shallow copy, so targets will be
      * copied by reference.
      *
-     * @param source      The object from which the field value is to be copied.
-     * @param destination The object to which the field value is to be copied.
+     * @param src The target from which the field value is to be copied.
+     * @param dst The target to which the field value is to be copied.
      */
-    default void copy(Object source, Object destination) {
-        set(destination, get(source));
+    default void copy(Object src, Object dst) {
+        set(dst, get(src));
     }
 
     /**
-     * Compares the value of this field in two objects.
+     * Compares the value of this field in two targets.
      * Implementations may use type-specific equality checks, such as
      * {@code Double.compare} for {@code double} fields.
      *
-     * @param a first object to compare
-     * @param b second object to compare
+     * @param a first target to compare
+     * @param b second target to compare
      * @return {@code true} if the values are considered equal
      */
     boolean isEqual(Object a, Object b);

--- a/src/main/java/net/openhft/chronicle/wire/Wires.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wires.java
@@ -1941,59 +1941,59 @@ public enum Wires {
          * @param o The object whose fields map needs to be fetched.
          * @return The map of fields corresponding to the object.
          */
-        private Map<String, Object> getMap(Object o) {
-            TupleInvocationHandler invocationHandler = (TupleInvocationHandler) Proxy.getInvocationHandler(o);
+        private Map<String, Object> getMap(Object target) {
+            TupleInvocationHandler invocationHandler = (TupleInvocationHandler) Proxy.getInvocationHandler(target);
             return invocationHandler.fields;
         }
 
         @Nullable
         @Override
-        public Object get(Object object) {
-            return getMap(object).get(name);
+        public Object get(Object target) {
+            return getMap(target).get(name);
         }
 
         @Override
-        public long getLong(Object object) {
-            return ObjectUtils.convertTo(Long.class, get(object));
+        public long getLong(Object target) {
+            return ObjectUtils.convertTo(Long.class, get(target));
         }
 
         @Override
-        public int getInt(Object object) {
-            return ObjectUtils.convertTo(Integer.class, get(object));
+        public int getInt(Object target) {
+            return ObjectUtils.convertTo(Integer.class, get(target));
         }
 
         @Override
-        public char getChar(Object object) {
-            return ObjectUtils.convertTo(Character.class, get(object));
+        public char getChar(Object target) {
+            return ObjectUtils.convertTo(Character.class, get(target));
         }
 
         @Override
-        public double getDouble(Object object) {
-            return ObjectUtils.convertTo(Double.class, get(object));
+        public double getDouble(Object target) {
+            return ObjectUtils.convertTo(Double.class, get(target));
         }
 
         @Override
-        public void set(Object object, Object value) throws IllegalArgumentException {
-            getMap(object).put(name, value);
+        public void set(Object target, Object newValue) throws IllegalArgumentException {
+            getMap(target).put(name, newValue);
         }
 
         @Override
-        public void set(Object object, char value) throws IllegalArgumentException {
+        public void set(Object target, char value) throws IllegalArgumentException {
             set(name, (Object) value);
         }
 
         @Override
-        public void set(Object object, int value) throws IllegalArgumentException {
+        public void set(Object target, int value) throws IllegalArgumentException {
             set(name, (Object) value);
         }
 
         @Override
-        public void set(Object object, long value) throws IllegalArgumentException {
+        public void set(Object target, long value) throws IllegalArgumentException {
             set(name, (Object) value);
         }
 
         @Override
-        public void set(Object object, double value) throws IllegalArgumentException {
+        public void set(Object target, double value) throws IllegalArgumentException {
             set(name, (Object) value);
         }
 

--- a/src/main/java/net/openhft/chronicle/wire/internal/VanillaFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/VanillaFieldInfo.java
@@ -55,23 +55,23 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
      * @param name         textual name of the field
      * @param type         runtime type of the field
      * @param bracketType  bracket style used when writing
-     * @param field        reflection field for direct access
+     * @param reflectField reflection field for direct access
      */
-    public VanillaFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
+    public VanillaFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field reflectField) {
         super(type, bracketType, name);
-        parent = field.getDeclaringClass();
-        this.field = field;
+        parent = reflectField.getDeclaringClass();
+        this.field = reflectField;
     }
 
     /**
-     * Retrieves the value of this field from {@code object}. The method logs
+     * Retrieves the value of this field from {@code target}. The method logs
      * and returns {@code null} if reflection fails.
      */
     @Nullable
     @Override
-    public Object get(Object object) {
+    public Object get(Object target) {
         try {
-            return getField().get(object);
+            return getField().get(target);
         } catch (@NotNull NoSuchFieldException | IllegalAccessException e) {
             Jvm.debug().on(VanillaFieldInfo.class, e);
             return null;
@@ -84,9 +84,9 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
      * @return the field value or {@code Long.MIN_VALUE} on error
      */
     @Override
-    public long getLong(Object object) {
+    public long getLong(Object target) {
         try {
-            return getField().getLong(object);
+            return getField().getLong(target);
         } catch (@NotNull NoSuchFieldException | IllegalAccessException e) {
             Jvm.debug().on(VanillaFieldInfo.class, e);
             return Long.MIN_VALUE;
@@ -99,9 +99,9 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
      * @return the field value or {@code Integer.MIN_VALUE} on error
      */
     @Override
-    public int getInt(Object object) {
+    public int getInt(Object target) {
         try {
-            return getField().getInt(object);
+            return getField().getInt(target);
         } catch (@NotNull NoSuchFieldException | IllegalAccessException e) {
             Jvm.debug().on(VanillaFieldInfo.class, e);
             return Integer.MIN_VALUE;
@@ -114,9 +114,9 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
      * @return the field value or {@code Character.MAX_VALUE} on error
      */
     @Override
-    public char getChar(Object object) {
+    public char getChar(Object target) {
         try {
-            return getField().getChar(object);
+            return getField().getChar(target);
         } catch (@NotNull NoSuchFieldException | IllegalAccessException e) {
             Jvm.debug().on(VanillaFieldInfo.class, e);
             return Character.MAX_VALUE;
@@ -129,9 +129,9 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
      * @return the field value or {@code Double.NaN} on error
      */
     @Override
-    public double getDouble(Object object) {
+    public double getDouble(Object target) {
         try {
-            return getField().getDouble(object);
+            return getField().getDouble(target);
         } catch (@NotNull NoSuchFieldException | IllegalAccessException e) {
             Jvm.debug().on(VanillaFieldInfo.class, e);
             return Double.NaN;
@@ -145,10 +145,10 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
      * @throws IllegalArgumentException if the field cannot be accessed
      */
     @Override
-    public void set(Object object, Object value) throws IllegalArgumentException {
-        Object value2 = ObjectUtils.convertTo(type, value);
+    public void set(Object target, Object newValue) throws IllegalArgumentException {
+        Object value2 = ObjectUtils.convertTo(type, newValue);
         try {
-            getField().set(object, value2);
+            getField().set(target, value2);
         } catch (@NotNull NoSuchFieldException | IllegalAccessException e) {
             throw new IllegalArgumentException(e);
         }
@@ -160,9 +160,9 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
      * @throws IllegalArgumentException if reflection fails
      */
     @Override
-    public void set(Object object, int value) throws IllegalArgumentException {
+    public void set(Object target, int value) throws IllegalArgumentException {
         try {
-            getField().setInt(object, value);
+            getField().setInt(target, value);
         } catch (@NotNull NoSuchFieldException | IllegalAccessException e) {
             throw new IllegalArgumentException(e);
         }
@@ -174,9 +174,9 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
      * @throws IllegalArgumentException if reflection fails
      */
     @Override
-    public void set(Object object, char value) throws IllegalArgumentException {
+    public void set(Object target, char value) throws IllegalArgumentException {
         try {
-            getField().setChar(object, value);
+            getField().setChar(target, value);
         } catch (@NotNull NoSuchFieldException | IllegalAccessException e) {
             throw new IllegalArgumentException(e);
         }
@@ -188,9 +188,9 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
      * @throws IllegalArgumentException if reflection fails
      */
     @Override
-    public void set(Object object, long value) throws IllegalArgumentException {
+    public void set(Object target, long value) throws IllegalArgumentException {
         try {
-            getField().setLong(object, value);
+            getField().setLong(target, value);
         } catch (@NotNull NoSuchFieldException | IllegalAccessException e) {
             throw new IllegalArgumentException(e);
         }
@@ -202,9 +202,9 @@ public class VanillaFieldInfo extends AbstractFieldInfo implements FieldInfo {
      * @throws IllegalArgumentException if reflection fails
      */
     @Override
-    public void set(Object object, double value) throws IllegalArgumentException {
+    public void set(Object target, double value) throws IllegalArgumentException {
         try {
-            getField().setDouble(object, value);
+            getField().setDouble(target, value);
         } catch (@NotNull NoSuchFieldException | IllegalAccessException e) {
             throw new IllegalArgumentException(e);
         }

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/CharFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/CharFieldInfo.java
@@ -33,10 +33,10 @@ public final class CharFieldInfo extends UnsafeFieldInfo {
      * @param name        field name used in text form
      * @param type        runtime type
      * @param bracketType formatting hint when writing
-     * @param field       reflection field used for unsafe access
+     * @param reflectField reflection field used for unsafe access
      */
-    public CharFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
-        super(name, type, bracketType, field);
+    public CharFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field reflectField) {
+        super(name, type, bracketType, reflectField);
     }
 
     @Override
@@ -44,7 +44,7 @@ public final class CharFieldInfo extends UnsafeFieldInfo {
      * @return the {@code char} value or {@link Character#MAX_VALUE} if the
      * offset could not be determined
      */
-    public char getChar(Object object) {
+    public char getChar(Object target) {
         try {
             return UnsafeMemory.unsafeGetChar(object, getOffset());
         } catch (@NotNull NoSuchFieldException e) {
@@ -55,9 +55,9 @@ public final class CharFieldInfo extends UnsafeFieldInfo {
 
     @Override
     /** Writes the value using {@link UnsafeMemory}. */
-    public void set(Object object, char value) throws IllegalArgumentException {
+    public void set(Object target, char value) throws IllegalArgumentException {
         try {
-            UnsafeMemory.unsafePutChar(object, getOffset(), value);
+            UnsafeMemory.unsafePutChar(target, getOffset(), value);
         } catch (@NotNull NoSuchFieldException e) {
             throw new IllegalArgumentException(e);
         }
@@ -70,8 +70,8 @@ public final class CharFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
-    /** Copies the character value from {@code source} to {@code destination}. */
-    public void copy(Object source, Object destination) {
-        set(destination, getChar(source));
+    /** Copies the character value from {@code src} to {@code dst}. */
+    public void copy(Object src, Object dst) {
+        set(dst, getChar(src));
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/DoubleFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/DoubleFieldInfo.java
@@ -33,17 +33,17 @@ public final class DoubleFieldInfo extends UnsafeFieldInfo {
      * @param name        field name used in text form
      * @param type        runtime type
      * @param bracketType formatting hint when writing
-     * @param field       reflection field used for unsafe access
+     * @param reflectField reflection field used for unsafe access
      */
-    public DoubleFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
-        super(name, type, bracketType, field);
+    public DoubleFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field reflectField) {
+        super(name, type, bracketType, reflectField);
     }
 
     @Override
     /**
      * @return the field value or {@code Double.NaN} if the offset is unavailable
      */
-    public double getDouble(Object object) {
+    public double getDouble(Object target) {
         try {
             return UnsafeMemory.unsafeGetDouble(object, getOffset());
         } catch (@NotNull NoSuchFieldException e) {
@@ -54,9 +54,9 @@ public final class DoubleFieldInfo extends UnsafeFieldInfo {
 
     @Override
     /** Writes the value using {@link UnsafeMemory}. */
-    public void set(Object object, double value) throws IllegalArgumentException {
+    public void set(Object target, double value) throws IllegalArgumentException {
         try {
-            UnsafeMemory.unsafePutDouble(object, getOffset(), value);
+            UnsafeMemory.unsafePutDouble(target, getOffset(), value);
         } catch (@NotNull NoSuchFieldException e) {
             throw new IllegalArgumentException(e);
         }
@@ -69,8 +69,8 @@ public final class DoubleFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
-    /** Copies the double value from {@code source} to {@code destination}. */
-    public void copy(Object source, Object destination) {
-        set(destination, getDouble(source));
+    /** Copies the double value from {@code src} to {@code dst}. */
+    public void copy(Object src, Object dst) {
+        set(dst, getDouble(src));
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/IntFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/IntFieldInfo.java
@@ -33,17 +33,17 @@ public final class IntFieldInfo extends UnsafeFieldInfo {
      * @param name        field name used in text form
      * @param type        runtime type
      * @param bracketType formatting hint when writing
-     * @param field       reflection field used for unsafe access
+     * @param reflectField reflection field used for unsafe access
      */
-    public IntFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
-        super(name, type, bracketType, field);
+    public IntFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field reflectField) {
+        super(name, type, bracketType, reflectField);
     }
 
     @Override
     /**
      * @return the field value or {@code Integer.MIN_VALUE} if the offset is unavailable
      */
-    public int getInt(Object object) {
+    public int getInt(Object target) {
         try {
             return UnsafeMemory.unsafeGetInt(object, getOffset());
         } catch (@NotNull NoSuchFieldException e) {
@@ -54,9 +54,9 @@ public final class IntFieldInfo extends UnsafeFieldInfo {
 
     @Override
     /** Writes the value using {@link UnsafeMemory}. */
-    public void set(Object object, int value) throws IllegalArgumentException {
+    public void set(Object target, int value) throws IllegalArgumentException {
         try {
-            UnsafeMemory.unsafePutInt(object, getOffset(), value);
+            UnsafeMemory.unsafePutInt(target, getOffset(), value);
         } catch (@NotNull NoSuchFieldException e) {
             throw new IllegalArgumentException(e);
         }
@@ -69,8 +69,8 @@ public final class IntFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
-    /** Copies the int value from {@code source} to {@code destination}. */
-    public void copy(Object source, Object destination) {
-        set(destination, getInt(source));
+    /** Copies the int value from {@code src} to {@code dst}. */
+    public void copy(Object src, Object dst) {
+        set(dst, getInt(src));
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/LongFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/LongFieldInfo.java
@@ -33,17 +33,17 @@ public final class LongFieldInfo extends UnsafeFieldInfo {
      * @param name        field name used in text form
      * @param type        runtime type
      * @param bracketType formatting hint when writing
-     * @param field       reflection field used for unsafe access
+     * @param reflectField reflection field used for unsafe access
      */
-    public LongFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
-        super(name, type, bracketType, field);
+    public LongFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field reflectField) {
+        super(name, type, bracketType, reflectField);
     }
 
     @Override
     /**
      * @return the field value or {@code Long.MIN_VALUE} if the offset is unavailable
      */
-    public long getLong(Object object) {
+    public long getLong(Object target) {
         try {
             return UnsafeMemory.unsafeGetLong(object, getOffset());
         } catch (@NotNull NoSuchFieldException e) {
@@ -54,9 +54,9 @@ public final class LongFieldInfo extends UnsafeFieldInfo {
 
     @Override
     /** Writes the value using {@link UnsafeMemory}. */
-    public void set(Object object, long value) throws IllegalArgumentException {
+    public void set(Object target, long value) throws IllegalArgumentException {
         try {
-            UnsafeMemory.unsafePutLong(object, getOffset(), value);
+            UnsafeMemory.unsafePutLong(target, getOffset(), value);
         } catch (@NotNull NoSuchFieldException e) {
             throw new IllegalArgumentException(e);
         }
@@ -69,8 +69,8 @@ public final class LongFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
-    /** Copies the long value from {@code source} to {@code destination}. */
-    public void copy(Object source, Object destination) {
-        set(destination, getLong(source));
+    /** Copies the long value from {@code src} to {@code dst}. */
+    public void copy(Object src, Object dst) {
+        set(dst, getLong(src));
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/ObjectFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/ObjectFieldInfo.java
@@ -36,17 +36,17 @@ public final class ObjectFieldInfo extends UnsafeFieldInfo {
      * @param name        field name used in text form
      * @param type        runtime type
      * @param bracketType formatting hint when writing
-     * @param field       reflection field used for unsafe access
+     * @param reflectField reflection field used for unsafe access
      */
-    public ObjectFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
-        super(name, type, bracketType, field);
+    public ObjectFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field reflectField) {
+        super(name, type, bracketType, reflectField);
     }
 
     @Override
     /**
      * @return the field value or {@code null} if the offset could not be determined
      */
-    public @Nullable Object get(Object object) {
+    public @Nullable Object get(Object target) {
         try {
             return UnsafeMemory.unsafeGetObject(object, getOffset());
         } catch (@NotNull NoSuchFieldException e) {
@@ -57,10 +57,10 @@ public final class ObjectFieldInfo extends UnsafeFieldInfo {
 
     @Override
     /** Writes the value using {@link UnsafeMemory}, converting as required. */
-    public void set(Object object, Object value) throws IllegalArgumentException {
-        Object value2 = ObjectUtils.convertTo(type, value);
+    public void set(Object target, Object newValue) throws IllegalArgumentException {
+        Object value2 = ObjectUtils.convertTo(type, newValue);
         try {
-            UnsafeMemory.unsafePutObject(object, getOffset(), value2);
+            UnsafeMemory.unsafePutObject(target, getOffset(), value2);
         } catch (@NotNull NoSuchFieldException e) {
             throw new IllegalArgumentException(e);
         }
@@ -73,8 +73,8 @@ public final class ObjectFieldInfo extends UnsafeFieldInfo {
     }
 
     @Override
-    /** Copies the object value from {@code source} to {@code destination}. */
-    public void copy(Object source, Object destination) {
-        set(destination, get(source));
+    /** Copies the object value from {@code src} to {@code dst}. */
+    public void copy(Object src, Object dst) {
+        set(dst, get(src));
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/UnsafeFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/UnsafeFieldInfo.java
@@ -44,10 +44,10 @@ class UnsafeFieldInfo extends VanillaFieldInfo {
      * @param name        textual field name
      * @param type        runtime type of the field
      * @param bracketType formatting hint used when writing
-     * @param field       reflection field from which the offset will be derived
+     * @param reflectField reflection field from which the offset will be derived
      */
-    public UnsafeFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field field) {
-        super(name, type, bracketType, field);
+    public UnsafeFieldInfo(String name, Class<?> type, BracketType bracketType, @NotNull Field reflectField) {
+        super(name, type, bracketType, reflectField);
     }
 
     /**


### PR DESCRIPTION
## Summary
- rename parameters in `FieldInfo` API
- update constructors in field info classes
- rename parameters in `Wires` tuple helper
- adjust documentation accordingly

## Testing
- `mvn -q verify` *(fails: mvn not found)*