### PR TITLE
Refactor parameter names for clarity

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/ValueIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueIn.java
@@ -59,15 +59,15 @@ public interface ValueIn {
     // ---- Text / Strings section ----
 
     /**
-     * Deserialises the current value as text and passes it to {@code ts} along
+     * Deserialises the current value as text and passes it to {@code consumer} along
      * with the supplied object.
      *
      * @return the parent {@link WireIn}
      */
     @NotNull
-    default <T> WireIn text(T t, @NotNull BiConsumer<T, String> ts) {
+    default <T> WireIn text(T target, @NotNull BiConsumer<T, String> consumer) {
         @Nullable final String text = text();
-        ts.accept(t, text);
+        consumer.accept(target, text);
         return wireIn();
     }
 
@@ -172,10 +172,10 @@ public interface ValueIn {
 
     /**
      * Compares the value’s bytes with {@code compareBytes} and passes the match
-     * result to {@code consumer}.
+     * result to {@code matchResult}.
      */
     @NotNull
-    WireIn bytesMatch(@NotNull BytesStore<?, ?> compareBytes, BooleanConsumer consumer);
+    WireIn bytesMatch(@NotNull BytesStore<?, ?> compareBytes, BooleanConsumer matchResult);
 
     /**
      * Supplies the byte stream to {@code bytesMarshallable#readMarshallable} for
@@ -235,65 +235,65 @@ public interface ValueIn {
 
     /**
      * Reads the value as a {@code boolean} and passes it, together with
-     * {@code t}, to {@code tFlag}.
+     * {@code target}, to {@code flagConsumer}.
      *
      * @param <T> type of the context object
      * @return the parent {@link WireIn}
      */
-    @NotNull <T> WireIn bool(T t, @NotNull ObjBooleanConsumer<T> tFlag);
+    @NotNull <T> WireIn bool(T target, @NotNull ObjBooleanConsumer<T> flagConsumer);
 
     /**
-     * Reads the value as a signed byte and passes it to {@code tb} together with
-     * {@code t}.
+     * Reads the value as a signed byte and passes it to {@code byteConsumer} together with
+     * {@code target}.
      */
-    @NotNull <T> WireIn int8(@NotNull T t, @NotNull ObjByteConsumer<T> tb);
+    @NotNull <T> WireIn int8(@NotNull T target, @NotNull ObjByteConsumer<T> byteConsumer);
 
     /**
-     * Reads the value as an unsigned byte and passes it to {@code ti} with
-     * {@code t}.
+     * Reads the value as an unsigned byte and passes it to {@code shortConsumer} with
+     * {@code target}.
      */
-    @NotNull <T> WireIn uint8(@NotNull T t, @NotNull ObjShortConsumer<T> ti);
+    @NotNull <T> WireIn uint8(@NotNull T target, @NotNull ObjShortConsumer<T> shortConsumer);
 
     /**
-     * Reads the value as a short and passes it to {@code ti} with {@code t}.
+     * Reads the value as a short and passes it to {@code shortConsumer} with {@code target}.
      */
-    @NotNull <T> WireIn int16(@NotNull T t, @NotNull ObjShortConsumer<T> ti);
+    @NotNull <T> WireIn int16(@NotNull T target, @NotNull ObjShortConsumer<T> shortConsumer);
 
     /**
-     * Reads the value as an unsigned short and passes it to {@code ti} with
-     * {@code t}.
+     * Reads the value as an unsigned short and passes it to {@code intConsumer} with
+     * {@code target}.
      */
-    @NotNull <T> WireIn uint16(@NotNull T t, @NotNull ObjIntConsumer<T> ti);
+    @NotNull <T> WireIn uint16(@NotNull T target, @NotNull ObjIntConsumer<T> intConsumer);
 
     /**
-     * Reads the value as an {@code int} and passes it to {@code ti} with
-     * {@code t}.
+     * Reads the value as an {@code int} and passes it to {@code intConsumer} with
+     * {@code target}.
      */
-    @NotNull <T> WireIn int32(@NotNull T t, @NotNull ObjIntConsumer<T> ti);
+    @NotNull <T> WireIn int32(@NotNull T target, @NotNull ObjIntConsumer<T> intConsumer);
 
     /**
-     * Reads the value as an unsigned int and passes it to {@code tl} with
-     * {@code t}.
+     * Reads the value as an unsigned int and passes it to {@code longConsumer} with
+     * {@code target}.
      */
-    @NotNull <T> WireIn uint32(@NotNull T t, @NotNull ObjLongConsumer<T> tl);
+    @NotNull <T> WireIn uint32(@NotNull T target, @NotNull ObjLongConsumer<T> longConsumer);
 
     /**
-     * Reads the value as a {@code long} and passes it to {@code tl} with
-     * {@code t}.
+     * Reads the value as a {@code long} and passes it to {@code longConsumer} with
+     * {@code target}.
      */
-    @NotNull <T> WireIn int64(@NotNull T t, @NotNull ObjLongConsumer<T> tl);
+    @NotNull <T> WireIn int64(@NotNull T target, @NotNull ObjLongConsumer<T> longConsumer);
 
     /**
-     * Reads the value as a {@code float} and passes it to {@code tf} with
-     * {@code t}.
+     * Reads the value as a {@code float} and passes it to {@code floatConsumer} with
+     * {@code target}.
      */
-    @NotNull <T> WireIn float32(@NotNull T t, @NotNull ObjFloatConsumer<T> tf);
+    @NotNull <T> WireIn float32(@NotNull T target, @NotNull ObjFloatConsumer<T> floatConsumer);
 
     /**
-     * Reads the value as a {@code double} and passes it to {@code td} with
-     * {@code t}.
+     * Reads the value as a {@code double} and passes it to {@code doubleConsumer} with
+     * {@code target}.
      */
-    @NotNull <T> WireIn float64(@NotNull T t, @NotNull ObjDoubleConsumer<T> td);
+    @NotNull <T> WireIn float64(@NotNull T target, @NotNull ObjDoubleConsumer<T> doubleConsumer);
 
     @NotNull <T> WireIn time(@NotNull T t, @NotNull BiConsumer<T, LocalTime> setLocalTime);
 

--- a/src/main/java/net/openhft/chronicle/wire/ValueInState.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueInState.java
@@ -50,19 +50,19 @@ class ValueInState {
     }
 
     /**
-     * Adds the given {@code position} to the list of unexpected field starts.
+     * Adds the given {@code wirePosition} to the list of unexpected field starts.
      * Grows the internal array if required.
      *
-     * @param position position of an unexpected field
+     * @param wirePosition position of an unexpected field
      */
-    public void addUnexpected(long position) {
+    public void addUnexpected(long wirePosition) {
         if (unexpectedSize >= unexpected.length) {
             int newSize = unexpected.length * 3 / 2 + 8;
             @NotNull long[] unexpected2 = new long[newSize];
             System.arraycopy(unexpected, 0, unexpected2, 0, unexpected.length);
             unexpected = unexpected2;
         }
-        unexpected[unexpectedSize++] = position;
+        unexpected[unexpectedSize++] = wirePosition;
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/ValueOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueOut.java
@@ -153,13 +153,13 @@ public interface ValueOut {
     /**
      * Writes {@code x} as a signed 8‑bit value, checking the range.
      *
-     * @param x value to write
+     * @param value value to write
      * @return parent wire for chaining
      * @throws ArithmeticException if {@code x} does not fit in a byte
      */
     @NotNull
-    default WireOut int8(long x) {
-        return int8(Maths.toInt8(x));
+    default WireOut int8(long value) {
+        return int8(Maths.toInt8(value));
     }
 
     /**
@@ -193,14 +193,14 @@ public interface ValueOut {
     }
 
     /**
-     * Writes a typed byte sequence using {@code type} as the type name.
+     * Writes a typed byte sequence using {@code typeName} as the type name.
      *
-     * @param type      type identifier
-     * @param fromBytes bytes to write
+     * @param typeName type identifier
+     * @param data bytes to write
      * @return parent wire for chaining
      */
     @NotNull
-    WireOut bytes(String type, @Nullable BytesStore<?, ?> fromBytes);
+    WireOut bytes(String typeName, @Nullable BytesStore<?, ?> data);
 
     /**
      * Writes {@code value} directly with minimal encoding.
@@ -242,14 +242,14 @@ public interface ValueOut {
     WireOut bytes(byte[] fromBytes);
 
     /**
-     * Writes the byte array {@code fromBytes} with a type identifier.
+     * Writes the byte array {@code data} with a type identifier.
      *
-     * @param type      type identifier
-     * @param fromBytes bytes to write
+     * @param typeName type identifier
+     * @param data bytes to write
      * @return parent wire for chaining
      */
     @NotNull
-    WireOut bytes(String type, byte[] fromBytes);
+    WireOut bytes(String typeName, byte[] data);
 
     /**
      * Writes {@code x} as an unsigned 8‑bit integer, checking the range.
@@ -264,10 +264,10 @@ public interface ValueOut {
     }
 
     /**
-     * Writes {@code u8} as an unsigned 8‑bit integer without additional checks.
+     * Writes {@code unsignedByte} as an unsigned 8‑bit integer without additional checks.
      */
     @NotNull
-    WireOut uint8checked(int u8);
+    WireOut uint8checked(int unsignedByte);
 
     /**
      * Writes {@code x} as a signed 16‑bit integer, checking the range.
@@ -305,7 +305,7 @@ public interface ValueOut {
      * Writes a single Unicode code point as UTF-8.
      */
     @NotNull
-    WireOut utf8(int codepoint);
+    WireOut utf8(int unicodeCodePoint);
 
     /**
      * Writes {@code x} as a signed 32‑bit integer, checking the range.
@@ -365,7 +365,7 @@ public interface ValueOut {
      * Writes two longs and binds them to {@code value} for direct access.
      */
     @NotNull
-    WireOut int128forBinding(long i64x0, long i64x1, TwoLongValue value);
+    WireOut int128forBinding(long highBits, long lowBits, TwoLongValue value);
 
     /**
      * Writes {@code i64} in hexadecimal form when the wire is textual.


### PR DESCRIPTION
## Summary
- adopt descriptive parameter names in `ValueIn` public interface
- rename matching parameters in `ValueOut`
- update `ValueInState.addUnexpected` to use `wirePosition`
- adjust Javadoc to match new identifiers

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*