### PR TITLE
Improve YamlWireOut javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
@@ -49,27 +49,41 @@ import java.util.function.BiConsumer;
 import static net.openhft.chronicle.bytes.BytesStore.empty;
 
 /**
- * Provides functionality for writing data in a YAML-based wire format.
- * This class encapsulates methods and attributes to handle data serialization into YAML format.
+ * Abstract base class for {@link WireOut} implementations that serialise data
+ * into a YAML-like textual format. It manages indentation, separators,
+ * quoting and character escaping according to YAML conventions. Concrete
+ * subclasses such as {@link TextWire} and {@link YamlWire} build upon this.
  *
- * @param <T> The type that extends YamlWireOut
+ * @param <T> the type that extends {@code YamlWireOut}
  */
 @SuppressWarnings({"rawtypes", "unchecked", "this-escape", "deprecation"})
 public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire {
     @Deprecated(/* to remove in x.28 */)
     private static final boolean APPEND_0 = Jvm.getBoolean("bytes.append.0", true);
 
+    /** Marker prefix used when writing type information. */
     public static final BytesStore<?, ?> TYPE = BytesStore.from("!type ");
+    /** YAML representation for a {@code null} value. */
     static final String NULL = "!null \"\"";
+    /** Characters that require quoting when found at the start of a string. */
     static final BitSet STARTS_QUOTE_CHARS = new BitSet();
+    /** Characters that force quoting wherever they appear. */
     static final BitSet QUOTE_CHARS = new BitSet();
+    /** Separator consisting of a comma followed by a space. */
     static final BytesStore<?, ?> COMMA_SPACE = BytesStore.from(", ");
+    /** Separator consisting of a comma followed by a newline. */
     static final BytesStore<?, ?> COMMA_NEW_LINE = BytesStore.from(",\n");
+    /** A newline sequence. */
     static final BytesStore<?, ?> NEW_LINE = BytesStore.from("\n");
-    static final BytesStore<?, ?> EMPTY_AFTER_COMMENT = BytesStore.wrap(new byte[0]); // not the same as EMPTY, so we can check this value.
+    /** Placeholder for an empty value when preceded by a comment. */
+    static final BytesStore<?, ?> EMPTY_AFTER_COMMENT = BytesStore.wrap(new byte[0]);
+    /** Shared empty bytes instance. */
     static final BytesStore<?, ?> EMPTY = BytesStore.from("");
+    /** Single space bytes. */
     static final BytesStore<?, ?> SPACE = BytesStore.from(" ");
+    /** Default end-of-field marker. */
     static final BytesStore<?, ?> END_FIELD = NEW_LINE;
+    /** Hex digits used for escape sequences. */
     static final char[] HEXADECIMAL = "0123456789ABCDEF".toCharArray();
 
     // Static initializer block to configure quote characters for the YAML writer
@@ -83,9 +97,17 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         WireInternal.INTERNER.valueCount();
     }
 
+    /** The primary {@link YamlValueOut} used to serialise values. */
     protected final YamlValueOut valueOut = createValueOut();
+    /** Reusable {@link StringBuilder} for temporary conversions. */
     protected final StringBuilder sb = new StringBuilder();
+    /**
+     * If true, append a readable timestamp comment after numeric epoch values.
+     */
     private boolean addTimeStamps = false;
+    /**
+     * If true the outermost curly braces for a top level object may be omitted.
+     */
     private boolean trimFirstCurly = true;
 
     /**
@@ -100,20 +122,20 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Checks if timestamps should be added during serialization.
+     * Returns whether human readable timestamp comments are emitted.
      *
-     * @return True if timestamps should be added, otherwise false.
+     * @return true if timestamp comments should be added
      */
     public boolean addTimeStamps() {
         return addTimeStamps;
     }
 
     /**
-     * Configures whether to add timestamps during serialization.
-     * This method follows the builder pattern allowing chained method calls.
+     * Controls whether human readable timestamp comments are added after long
+     * values that look like epoch times.
      *
-     * @param addTimeStamps Boolean indicating whether to add timestamps.
-     * @return The current instance of YamlWireOut.
+     * @param addTimeStamps set to true to enable timestamp comments
+     * @return this instance for chaining
      */
     public T addTimeStamps(boolean addTimeStamps) {
         this.addTimeStamps = addTimeStamps;
@@ -121,9 +143,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Creates and returns a new instance of {@link YamlValueOut}.
-     *
-     * @return A new YamlValueOut instance.
+     * Factory method used to obtain the main {@link YamlValueOut}. Subclasses
+     * may override if a specialised implementation is required.
      */
     @NotNull
     protected YamlValueOut createValueOut() {
@@ -131,10 +152,7 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Acquires and clears the internal StringBuilder {@code sb} for use.
-     * The method ensures the StringBuilder's count is reset to 0 before returning.
-     *
-     * @return The internal StringBuilder after it has been cleared.
+     * Returns the reusable {@link #sb} after clearing its contents.
      */
     @NotNull
     protected StringBuilder acquireStringBuilder() {
@@ -217,11 +235,10 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Escapes the given CharSequence {@code s} based on the requirements of the YAML format.
-     * If the sequence requires quotes, it will be enclosed with the appropriate quote character;
-     * otherwise, the sequence will be escaped without quotes.
+     * Escapes {@code s} according to YAML rules. If quoting is required the
+     * chosen quote character is written around the escaped text.
      *
-     * @param s The CharSequence to be escaped.
+     * @param s text to escape
      */
     void escape(@NotNull CharSequence s) {
         @NotNull Quotes quotes = needsQuotes(s);
@@ -236,11 +253,12 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
 
     // https://yaml.org/spec/1.2.2/#escaped-characters
     /**
-     * Helper method to escape special characters in the given CharSequence {@code s} based on the requirements of the YAML format.
-     * The method handles the specific escaping requirements for various control and special characters.
+     * Core logic used by {@link #escape(CharSequence)} to write escape
+     * sequences for control characters and Unicode using the supplied quote
+     * style.
      *
-     * @param s The CharSequence to be escaped.
-     * @param quotes The type of quotes used to determine how certain characters are escaped.
+     * @param s      text to escape
+     * @param quotes quoting strategy
      */
     protected void escape0(@NotNull CharSequence s, @NotNull Quotes quotes) {
         for (int i = 0; i < s.length(); i++) {
@@ -318,10 +336,10 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Appends a 2-character hexadecimal representation of the given character {@code ch} to the output bytes.
-     * This is used for character escaping.
+     * Helper for {@link #escape0(CharSequence, Quotes)} that writes a \xHH
+     * escape.
      *
-     * @param ch The character to be converted to hexadecimal.
+     * @param ch character to convert
      */
     private void appendX2(char ch) {
         bytes.append('\\');
@@ -331,10 +349,10 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Appends a 4-character hexadecimal Unicode representation of the given character {@code ch} to the output bytes.
-     * This is used for character escaping.
+     * Helper for {@link #escape0(CharSequence, Quotes)} that writes a \uHHHH
+     * Unicode escape.
      *
-     * @param ch The character to be converted to hexadecimal Unicode representation.
+     * @param ch character to convert
      */
     protected void appendU4(char ch) {
         bytes.append('\\');
@@ -346,11 +364,12 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Determines the type of quotes (if any) required for the given CharSequence {@code s} based on the YAML format's escaping requirements.
-     * This method decides between using no quotes, single quotes, or double quotes.
+     * Determines whether {@code s} needs quoting to be a valid YAML scalar.
+     * Considers leading characters, trailing whitespace and characters with
+     * special meaning.
      *
-     * @param s The CharSequence to be analyzed.
-     * @return The type of quotes required.
+     * @param s candidate text
+     * @return the quote style to use
      */
     @NotNull
     protected Quotes needsQuotes(@NotNull CharSequence s) {
@@ -391,9 +410,10 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Appends the given CharSequence {@code cs} to the output bytes using either an 8-bit or UTF-8 encoding, depending on {@code use8bit}.
+     * Append {@code cs} to the underlying {@link Bytes} using 8‑bit or UTF‑8
+     * encoding depending on {@link #use8bit}.
      *
-     * @param cs CharSequence to be appended.
+     * @param cs text to append
      */
     public void append(@NotNull CharSequence cs) {
         if (use8bit)
@@ -403,11 +423,11 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Appends a subsequence of the given CharSequence {@code cs} to the output bytes using either an 8-bit or UTF-8 encoding.
+     * Append part of {@code cs} using either 8‑bit or UTF‑8 encoding.
      *
-     * @param cs     CharSequence from which a subsequence will be appended.
-     * @param offset Starting index of the subsequence.
-     * @param length Length of the subsequence.
+     * @param cs     source text
+     * @param offset starting index
+     * @param length number of characters
      */
     public void append(@NotNull CharSequence cs, int offset, int length) {
         if (use8bit)
@@ -417,10 +437,12 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Writes the representation of the object {@code o} to the output. Differentiates the serialization logic based on the type of the object.
+     * Serialises a generic object. Iterables and maps are expanded, while other
+     * types delegate to {@link ValueOut#object(Object)} or
+     * {@link ValueOut#typedMarshallable(WriteMarshallable)} as appropriate.
      *
-     * @param o The object to be serialized.
-     * @throws InvalidMarshallableException if an error occurs during serialization.
+     * @param o object to serialise
+     * @throws InvalidMarshallableException if marshalling fails
      */
     public void writeObject(Object o) throws InvalidMarshallableException {
         if (o instanceof Iterable) {
@@ -440,11 +462,11 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Writes the representation of the object {@code o} to the output with a specified indentation level.
+     * Serialises {@code o} as a list item using the provided indentation.
      *
-     * @param o           The object to be serialized.
-     * @param indentation The number of spaces to use for indentation.
-     * @throws InvalidMarshallableException if an error occurs during serialization.
+     * @param o           object to serialise
+     * @param indentation indentation level in spaces
+     * @throws InvalidMarshallableException if marshalling fails
      */
     private void writeObject(Object o, int indentation) throws InvalidMarshallableException {
         writeTwo('-', ' ');
@@ -453,9 +475,7 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Inserts the specified number of spaces into the output bytes for indentation.
-     *
-     * @param indentation The number of spaces to insert.
+     * Writes {@code indentation} spaces to the output.
      */
     private void indentation(int indentation) {
         while (indentation-- > 0)
@@ -474,10 +494,10 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Writes two characters to the 'bytes' object sequentially.
+     * Helper to append two characters to the output buffer.
      *
-     * @param ch1 First character to write.
-     * @param ch2 Second character to write.
+     * @param ch1 first character
+     * @param ch2 second character
      */
     void writeTwo(char ch1, char ch2) {
         bytes.writeUnsignedByte(ch1);
@@ -485,19 +505,18 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Returns a flag indicating if the top-level curly brackets in the serialized YAML should be dropped.
-     *
-     * @return {@code true} if the top-level curly brackets should be dropped; {@code false} otherwise.
+     * Whether the outermost braces for a top level object are omitted.
      */
     public boolean trimFirstCurly() {
         return trimFirstCurly;
     }
 
     /**
-     * Sets whether the top-level curly brackets in the serialized YAML should be dropped.
+     * Controls whether the outermost curly braces are written for the top level
+     * object.
      *
-     * @param trimFirstCurly {@code true} to drop the top-level curly brackets; {@code false} to include them.
-     * @return The current instance of {@code YamlWireOut} (fluent API style).
+     * @param trimFirstCurly set to true to omit the braces
+     * @return this instance for chaining
      */
     public T trimFirstCurly(boolean trimFirstCurly) {
         this.trimFirstCurly = trimFirstCurly;


### PR DESCRIPTION
## Summary
- refine class-level description of `YamlWireOut`
- document constant fields and state fields
- clarify behaviour of timestamp options
- describe string escaping helpers
- update append and writeObject method comments

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*