### PR TITLE
Improve Javadoc for YAML utilities

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/YamlKeys.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlKeys.java
@@ -18,26 +18,23 @@ package net.openhft.chronicle.wire;
 import java.util.Arrays;
 
 /**
- * Represents a collection of offsets used in a YAML structure.
- * The class provides mechanisms to add, retrieve, and manipulate the offsets,
- * which can be useful for various YAML parsing and generation tasks.
- *
- * <p>Internally, this class employs a dynamic array resizing strategy to accommodate
- * varying numbers of offsets without a significant overhead in space.
+ * Internal helper class for {@link YamlTokeniser} to manage a list of byte offsets.
+ * <p>
+ * These offsets mark the starting positions of YAML keys skipped during an initial
+ * parse pass. They can then be revisited without rescanning the stream.
  */
 public class YamlKeys {
+    /** A shared, empty array instance. */
     private static final long[] NO_OFFSETS = {};
 
-    // The current number of offsets stored
+    /** The number of valid offsets in {@link #offsets}. */
     int count = 0;
 
-    // The dynamic array of offsets
+    /** Array storing the offset values; resized as required. */
     long[] offsets = NO_OFFSETS;
 
     /**
-     * Adds a new offset to the collection.
-     *
-     * @param offset The offset value to be added.
+     * Adds {@code offset} to the end of the list, resizing if needed.
      */
     public void push(long offset) {
         if (count == offsets.length) {
@@ -48,37 +45,29 @@ public class YamlKeys {
     }
 
     /**
-     * Returns the current number of offsets stored in the collection.
-     *
-     * @return The count of offsets.
+     * Returns the number of stored offsets.
      */
     public int count() {
         return count;
     }
 
     /**
-     * Retrieves all the stored offsets.
-     *
-     * @return An array of stored offsets.
+     * Returns the internal array of offsets. Only the first {@link #count} values
+     * are valid.
      */
     public long[] offsets() {
         return offsets;
     }
 
     /**
-     * Resets the count of offsets to zero.
-     * This method does not clear the offset data but allows for reuse of the storage.
+     * Clears the list while retaining the underlying array for reuse.
      */
     public void reset() {
         count = 0;
     }
 
     /**
-     * Removes the offset at the specified index.
-     *
-     * <p>Subsequent offsets are shifted to the left (their indices decrease by one).
-     *
-     * @param i The index of the offset to be removed.
+     * Removes the offset at {@code i}, shifting remaining values left.
      */
     public void removeIndex(int i) {
         count--;

--- a/src/main/java/net/openhft/chronicle/wire/YamlLogging.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlLogging.java
@@ -19,96 +19,104 @@ import net.openhft.chronicle.core.Jvm;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Provides utility functions to control the logging of Yaml messages, which can be
- * useful for debugging or generating documentation. The logging settings can be toggled
- * using system properties or programmatically through this class's static methods.
+ * Utility to control YAML message logging.
+ * <p>
+ * The behaviour can be toggled via system properties or at runtime through this
+ * class's static methods, which aids debugging and documentation generation.
  */
 // Used in Chronicle Services
 public enum YamlLogging {
     ; // No enum instances are intended for this utility enum.
 
-    // The title for logging (can be changed during runtime).
+    /**
+     * Global title prepended to YAML messages. May be changed at runtime.
+     */
     @NotNull
     public static volatile String title = "";
 
-    // Flag indicating whether server writes should be shown.
-    // TODO Doesn't show all writes. Use clientReads instead.
+    /**
+     * Whether server write operations are logged as YAML. Initialised from the
+     * {@code yaml.logging} system property. Modifiable at runtime.
+     * TODO Doesn't show all writes. Use clientReads instead.
+     */
     private static volatile boolean showServerWrites = Jvm.getBoolean("yaml.logging");
 
-    // Flag indicating whether client writes should be shown.
+    /**
+     * Whether client write operations are logged as YAML. Initialised from the
+     * {@code yaml.logging} system property. Modifiable at runtime.
+     */
     private static volatile boolean clientWrites = Jvm.getBoolean("yaml.logging");
 
-    // A message associated with a write operation.
+    /**
+     * Message associated with write operations that may appear in logs.
+     */
     @NotNull
     private static volatile String writeMessage = "";
 
-    // Flag indicating whether client reads should be shown.
+    /**
+     * Whether client read operations are logged as YAML. Initialised from the
+     * {@code yaml.logging} system property. Modifiable at runtime.
+     */
     private static volatile boolean clientReads = Jvm.getBoolean("yaml.logging");
 
-    // Flag indicating whether server reads should be shown.
+    /**
+     * Whether server read operations are logged as YAML. Initialised from the
+     * {@code yaml.logging} system property. Modifiable at runtime.
+     */
     private static volatile boolean showServerReads = Jvm.getBoolean("yaml.logging");
 
-    // Flag indicating whether heartbeat messages should be shown.
+    /**
+     * Whether heartbeat messages are logged as YAML. Defaults to {@code false}.
+     * Modifiable at runtime.
+     */
     private static volatile boolean showHeartBeats = false;
 
     /**
-     * Sets the logging flags for all message types (reads/writes for both client and server).
+     * Enable or disable logging for all message types.
      *
-     * @param flag The boolean value to set for all logging flags.
+     * @param flag {@code true} to enable, {@code false} to disable.
      */
     public static void setAll(boolean flag) {
         showServerReads = showServerWrites = clientWrites = clientReads = flag;
     }
 
     /**
-     * Sets the logging flags for all message types based on the provided {@link YamlLoggingLevel}.
-     *
-     * @param level The {@link YamlLoggingLevel} determining whether to set or unset the logging flags.
+     * Set logging flags for all message types according to the level.
      */
     public static void setAll(@NotNull YamlLoggingLevel level) {
         showServerReads = showServerWrites = clientWrites = clientReads = level.isSet();
     }
 
     /**
-     * Checks whether logging for client reads is enabled.
-     *
-     * @return {@code true} if logging for client reads is enabled; {@code false} otherwise.
+     * Returns {@code true} if client read logging is enabled.
      */
     public static boolean showClientReads() {
         return clientReads;
     }
 
     /**
-     * Updates the message associated with a write operation.
-     *
-     * @param s The new message to be set.
+     * Associate a message with subsequent write operations.
      */
     public static void writeMessage(@NotNull String s) {
         writeMessage = s;
     }
 
     /**
-     * Sets the flag to determine whether server writes should be logged.
-     *
-     * @param logging {@code true} to enable logging for server writes; {@code false} to disable.
+     * Enable or disable logging of server writes.
      */
     public static void showServerWrites(boolean logging) {
         showServerWrites = logging;
     }
 
     /**
-     * Checks whether logging for client writes is enabled.
-     *
-     * @return {@code true} if logging for client writes is enabled; {@code false} otherwise.
+     * Returns {@code true} if client write logging is enabled.
      */
     public static boolean showClientWrites() {
         return clientWrites;
     }
 
     /**
-     * Retrieves the current message associated with a write operation.
-     *
-     * @return The message currently associated with a write operation.
+     * Returns the message associated with write operations.
      */
     @NotNull
     public static String writeMessage() {
@@ -116,85 +124,73 @@ public enum YamlLogging {
     }
 
     /**
-     * Checks whether heartbeat logging is enabled.
-     *
-     * @return {@code true} if heartbeat logging is enabled; {@code false} otherwise.
+     * Returns {@code true} if heartbeat logging is enabled.
      */
     public static boolean showHeartBeats() {
         return showHeartBeats;
     }
 
     /**
-     * Checks whether logging for server reads is enabled.
-     *
-     * @return {@code true} if logging for server reads is enabled; {@code false} otherwise.
+     * Returns {@code true} if server read logging is enabled.
      */
     public static boolean showServerReads() {
         return showServerReads;
     }
 
     /**
-     * Sets the flag to determine whether heartbeats should be logged.
-     *
-     * @param log {@code true} to enable heartbeat logging; {@code false} to disable.
+     * Enable or disable logging of heartbeats.
      */
     public static void showHeartBeats(boolean log) {
         showHeartBeats = log;
     }
 
     /**
-     * Sets the flag to determine whether client writes should be logged.
-     *
-     * @param logging {@code true} to enable logging for client writes; {@code false} to disable.
+     * Enable or disable logging of client writes.
      */
     public static void showClientWrites(boolean logging) {
         clientWrites = logging;
     }
 
     /**
-     * Sets the flag to determine whether client reads should be logged.
-     *
-     * @param logging {@code true} to enable logging for client reads; {@code false} to disable.
+     * Enable or disable logging of client reads.
      */
     public static void showClientReads(boolean logging) {
         clientReads = logging;
     }
 
     /**
-     * Checks whether logging for server writes is enabled.
-     *
-     * @return {@code true} if logging for server writes is enabled; {@code false} otherwise.
+     * Returns {@code true} if server write logging is enabled.
      */
     public static boolean showServerWrites() {
         return showServerWrites;
     }
 
     /**
-     * Sets the flag to determine whether server reads should be logged.
-     *
-     * @param logging {@code true} to enable logging for server reads; {@code false} to disable.
+     * Enable or disable logging of server reads.
      */
     public static void showServerReads(boolean logging) {
         showServerReads = logging;
     }
 
     /**
-     * Enum representing the various logging levels for Yaml.
-     * The levels include OFF (no logging), DEBUG_ONLY (logs only when in debug mode), and ON (always logs).
+     * Levels controlling when YAML logging is active.
      */
     public enum YamlLoggingLevel {
+        /** Logging is disabled. */
         OFF {
             @Override
             public boolean isSet() {
                 return false;
             }
         },
+        /** Logging enabled only when {@link Jvm#isDebug()} is {@code true}. */
         DEBUG_ONLY {
             @Override
             public boolean isSet() {
                 return Jvm.isDebug();
             }
         },
+        /** Logging is always enabled. */
         ON {
             @Override
             public boolean isSet() {
@@ -203,9 +199,7 @@ public enum YamlLogging {
         };
 
         /**
-         * Checks if the current logging level is set (enabled).
-         *
-         * @return {@code true} if the current logging level is enabled; {@code false} otherwise.
+         * Returns {@code true} if this level currently enables logging.
          */
         public abstract boolean isSet();
     }


### PR DESCRIPTION
## Summary
- clarify YAML logging flags and usage in `YamlLogging`
- document how `YamlKeys` manages byte offsets

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*