### PR TITLE
Improve Javadoc for YAML enums

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/Quotes.java
+++ b/src/main/java/net/openhft/chronicle/wire/Quotes.java
@@ -17,8 +17,9 @@ package net.openhft.chronicle.wire;
 
 /**
  * Enumerates the types of quotation marks.
- * This enum represents the most common quotation marks: none, single, and double.
+ * This enum represents the most common quotation marks: none, single and double.
  * Each enumeration value is associated with its corresponding character representation.
+ * Used by {@link YamlWireOut} to determine how to quote and escape strings.
  */
 enum Quotes {
 
@@ -31,7 +32,10 @@ enum Quotes {
     /** Represents a double quotation mark. */
     DOUBLE('"');
 
-    // The character representation of the quotation mark
+    /**
+     * The character representation of the quote (for example {@code '} for
+     * SINGLE, {@code "} for DOUBLE or a space for NONE).
+     */
     final char q;
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/TextStopCharTesters.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextStopCharTesters.java
@@ -25,15 +25,17 @@ import java.util.BitSet;
  * character based on various parsing contexts.
  * <p>
  * This enum primarily caters to text parsing scenarios, especially when
- * determining the end of specific types or textual blocks.
+ * determining the end of specific types or textual blocks. These are typically
+ * used with methods like
+ * {@link net.openhft.chronicle.bytes.BytesIn#parseUtf8(Appendable, StopCharTester)}.
  */
 enum TextStopCharTesters implements StopCharTester {
 
     /**
-     * Tester for determining the end of a type.
-     * <p>
-     * This tester checks if a character is considered to be a termination
-     * point based on Java identifier rules, but with a few exceptions.
+     * A {@link StopCharTester} that stops parsing when a character is not a
+     * valid part of a Java identifier. Some YAML-specific characters such as
+     * {@code !}, {@code .}, {@code -}, {@code [} and {@code ]} are treated as
+     * valid within type tags.
      */
     END_OF_TYPE {
         @NotNull
@@ -45,6 +47,10 @@ enum TextStopCharTesters implements StopCharTester {
             return ch >= eowLength || eow.get(ch);
         }
     },
+    /**
+     * A {@link StopCharTester} that stops parsing at structural characters such
+     * as quotes, hash, newline, closing braces, colon or comma.
+     */
     END_OF_TEXT {
         @Override
         public boolean isStopChar(int ch) throws IllegalStateException {
@@ -67,13 +73,11 @@ enum TextStopCharTesters implements StopCharTester {
     };
 
     /**
-     * Constructs a BitSet representing characters that mark
-     * the end of a type.
-     * <p>
-     * By default, it considers all non-Java identifier characters as stop chars
-     * but makes exceptions for certain characters.
+     * Internal helper to create the {@link BitSet} used by {@link #END_OF_TYPE}.
+     * By default, it considers all non-Java identifier characters as stop
+     * characters but makes exceptions for a few YAML tag symbols.
      *
-     * @return A BitSet representing the stop characters for a type.
+     * @return a BitSet representing the stop characters for a type
      */
     private static BitSet endOfTypeBitSet() {
         final BitSet eow = new BitSet();

--- a/src/main/java/net/openhft/chronicle/wire/YamlToken.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlToken.java
@@ -18,34 +18,76 @@ package net.openhft.chronicle.wire;
 /**
  * Enumerates the different types of tokens that can be found in a YAML document.
  * Each token represents a distinct construct or symbol in YAML, which can be used
- * for tasks such as parsing or tokenization of YAML documents.
+ * for tasks such as parsing or tokenisation of YAML documents.
  */
 public enum YamlToken {
+    /**
+     * Represents no specific token, often used as a sentinel or when parsing
+     * reaches an ambiguous state.
+     */
     NONE,
+
+    /** A YAML comment line (starts with '#'). */
     COMMENT,
+
+    /** A YAML tag such as {@code !str} or {@code !!map}. */
     TAG,
+
+    /** A YAML directive like {@code %YAML 1.2}. */
     DIRECTIVE,
+
+    /** The end of a YAML document marker ({@code ...}). */
     DOCUMENT_END(),
-    /** Represents the end of the directives in a YAML document. */
+
+    /** The end of the directives section marker ({@code ---}). */
     DIRECTIVES_END(DOCUMENT_END),
+
+    /** Indicates that the following token is a key in a YAML mapping. */
     MAPPING_KEY(NONE),
+
+    /** The end of a YAML mapping (<code>}</code>). */
     MAPPING_END(),
-    /** Represents the start of a key-value mapping in a YAML document. */
+
+    /** The start of a YAML mapping (<code>{</code>). */
     MAPPING_START(MAPPING_END),
+
+    /** The end of a YAML sequence ({@code ]}). */
     SEQUENCE_END(),
+
+    /** Indicates a new entry in a YAML sequence. */
     SEQUENCE_ENTRY,
-    /** Represents the start of a sequence in a YAML document. */
+
+    /** The start of a YAML sequence (<code>[</code> or indicated by <code>-</code>). */
     SEQUENCE_START(SEQUENCE_END),
+
+    /** A scalar textual value (string, number or boolean). */
     TEXT,
+
+    /** A literal block scalar introduced by {@code |} or {@code >}. */
     LITERAL,
+
+    /** A YAML anchor such as {@code &anchor_name}. */
     ANCHOR,
+
+    /** A YAML alias such as {@code *anchor_name}. */
     ALIAS,
+
+    /** A reserved YAML indicator, for example {@code @} or {@code `}. */
     RESERVED,
+
+    /** The end of a YAML stream. */
     STREAM_END,
-    /** Represents the start of a YAML document stream. */
+
+    /** The start of a YAML stream, implicit before any content. */
     STREAM_START(STREAM_END);
 
-    /** The corresponding end token for certain start tokens. */
+    /**
+     * For tokens that represent the start of a block structure (for example
+     * {@link #MAPPING_START}, {@link #SEQUENCE_START} or {@link #STREAM_START}),
+     * this field holds the token that marks the end of that block, such as
+     * {@link #MAPPING_END}. It is {@code null} when the token does not start a
+     * block.
+     */
     public final YamlToken toEnd;
 
     /**


### PR DESCRIPTION
## Summary
- clarify YamlToken enum documentation
- expand Quotes enum docs
- describe TextStopCharTesters enum constants and helper

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*