### PR TITLE
Javadoc text yaml wire v2

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/BitSetUtil.java
+++ b/src/main/java/net/openhft/chronicle/wire/BitSetUtil.java
@@ -24,30 +24,24 @@ import java.util.BitSet;
 
 /**
  * Utility class to access and manipulate the internals of the {@link BitSet} class.
- *
  * This class provides methods to directly interact with the underlying word storage
- * and related metadata of a BitSet. It leverages reflection to access private fields.
- * <b>This class relies on reflection of private fields of {@link java.util.BitSet}
- * and may break with different Java versions or JDK implementations. Use with extreme
- * caution and only when direct access to {@code BitSet} internals is absolutely necessary.</b>
+ * and related metadata of a BitSet. It leverages reflection to access private fields
+ * and therefore, should be used with caution.
  */
 final class BitSetUtil {
 
-    /** Private static final {@link Field} reference for the 'words' field within
-     * {@link java.util.BitSet}. Initialised reflectively and made accessible. */
+    // Reflective field reference to the 'words' field in BitSet
     private static final Field wordsField;
-    /** Private static final {@link Field} reference for the 'wordsInUse' field within
-     * {@link java.util.BitSet}. Initialised reflectively and made accessible. */
+    // Reflective field reference to the 'wordsInUse' field in BitSet
     private static final Field wordsInUse;
-    /** Private static final {@link Field} reference for the 'sizeIsSticky' field within
-     * {@link java.util.BitSet}. Initialised reflectively and made accessible. */
+    // Reflective field reference to the 'sizeIsSticky' field in BitSet
     private static final Field sizeIsSticky;
 
     // Private constructor to prevent instantiation of utility class
     private BitSetUtil() {
     }
 
-    // Static block to initialise reflective fields
+    // Static block to initialize reflective fields
     static {
         try {
             wordsField = BitSet.class.getDeclaredField("words");
@@ -66,10 +60,9 @@ final class BitSetUtil {
     /**
      * Retrieves the word from a {@link BitSet} at the given index.
      *
-     * @param bs    The {@link java.util.BitSet} instance from which to retrieve the word.
-     * @param index The zero-based index of the internal {@code long} word to retrieve.
-     * @return The {@code long} value of the word at the specified {@code index}.
-     * @throws RuntimeException wrapping {@link IllegalAccessException} if reflective access fails.
+     * @param bs    The target BitSet.
+     * @param index The index of the word to retrieve.
+     * @return The word (as a long value) at the given index in the BitSet.
      */
     static long getWord(BitSet bs, int index) {
         try {
@@ -82,14 +75,11 @@ final class BitSetUtil {
     }
 
     /**
-     * Directly sets the internal 'words' array of the {@code using} {@link java.util.BitSet}
-     * to the provided {@code words} array. Also updates the 'wordsInUse' field to
-     * {@code words.length} and 'sizeIsSticky' to {@code false} to reflect the change.
+     * Sets the underlying words of a {@link BitSet} and updates related metadata.
      *
-     * @param using  The {@link java.util.BitSet} instance to modify.
-     * @param words  The new {@code long[]} array to set as the internal bit storage.
-     * @return The modified {@code using} {@link java.util.BitSet} instance.
-     * @throws RuntimeException wrapping {@link IllegalAccessException} if reflective access fails.
+     * @param using The BitSet to modify.
+     * @param words The new words to set in the BitSet.
+     * @return The modified BitSet.
      */
     static BitSet set(final BitSet using, final long[] words) {
         try {

--- a/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
@@ -196,7 +196,7 @@ public interface FieldInfo {
      * to the provided {@code value} of type {@code long}. The provided {@code object} is used as a
      * target from which the field is extracted.
      *
-     * @param object The object containing the field to be set.
+     * @param instance The object containing the field to be set.
      * @param value  The value to set the field to.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or
      *                                  interface declaring the underlying field, or if an unwrapping
@@ -209,7 +209,7 @@ public interface FieldInfo {
      * to the provided {@code value} of type {@code double}. The provided {@code object} is used as a
      * target from which the field is extracted.
      *
-     * @param object The object containing the field to be set.
+     * @param instance The object containing the field to be set.
      * @param value  The value to set the field to.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or
      *                                  interface declaring the underlying field, or if an unwrapping
@@ -243,8 +243,8 @@ public interface FieldInfo {
      * Compares the value of the field represented by this {@code FieldInfo} in both provided
      * objects {@code a} and {@code b} and determines if they are equal.
      *
-     * @param a First object to compare the field's value.
-     * @param b Second object to compare the field's value.
+     * @param instanceA First object to compare the field's value.
+     * @param instanceB Second object to compare the field's value.
      * @return {@code true} if the values are equal, {@code false} otherwise.
      */
     boolean isEqual(Object instanceA, Object instanceB);

--- a/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
@@ -128,7 +128,7 @@ public interface FieldInfo {
      * as an {@link Object}.
      */
     @Nullable
-    Object get(Object instance);
+    Object get(Object object);
 
     /**
      * Returns the value of the field represented by this {@code FieldInfo} object
@@ -138,7 +138,7 @@ public interface FieldInfo {
      * @return the value of the field represented by this {@code FieldInfo} object
      * as a {@code long} primitive.
      */
-    long getLong(Object instance);
+    long getLong(Object object);
 
     /**
      * Returns the value of the field represented by this {@code FieldInfo} object
@@ -148,7 +148,7 @@ public interface FieldInfo {
      * @return the value of the field represented by this {@code FieldInfo} object
      * as an {@code int} primitive.
      */
-    int getInt(Object instance);
+    int getInt(Object object);
 
     /**
      * Returns the value of the field represented by this {@code FieldInfo} object
@@ -158,7 +158,7 @@ public interface FieldInfo {
      * @return the value of the field represented by this {@code FieldInfo} object
      * as a {@code char} primitive.
      */
-    char getChar(Object instance);
+    char getChar(Object object);
 
     /**
      * Returns the value of the field represented by this {@code FieldInfo} object
@@ -168,54 +168,54 @@ public interface FieldInfo {
      * @return the value of the field represented by this {@code FieldInfo} object
      * as a {@code double} primitive.
      */
-    double getDouble(Object instance);
+    double getDouble(Object object);
 
     /**
      * Sets the value of the field represented by this {@code FieldInfo} object
      * to the provided {@code value}. The provided {@code object} is used as a
      * target to the extract eh field from.
      */
-    void set(Object instance, Object value) throws IllegalArgumentException;
+    void set(Object object, Object value) throws IllegalArgumentException;
 
     /**
      * Sets the value of the field represented by this {@code FieldInfo} object
      * to the provided {@code value}. The provided {@code object} is used as a
      * target to the extract eh field from.
      */
-    void set(Object instance, char value) throws IllegalArgumentException;
+    void set(Object object, char value) throws IllegalArgumentException;
 
     /**
      * Sets the value of the field represented by this {@code FieldInfo} object
      * to the provided {@code value}. The provided {@code object} is used as a
      * target to the extract eh field from.
      */
-    void set(Object instance, int value) throws IllegalArgumentException;
+    void set(Object object, int value) throws IllegalArgumentException;
 
     /**
      * Sets the value of the field represented by this {@code FieldInfo} object
      * to the provided {@code value} of type {@code long}. The provided {@code object} is used as a
      * target from which the field is extracted.
      *
-     * @param instance The object containing the field to be set.
+     * @param object The object containing the field to be set.
      * @param value  The value to set the field to.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or
      *                                  interface declaring the underlying field, or if an unwrapping
      *                                  conversion fails.
      */
-    void set(Object instance, long value) throws IllegalArgumentException;
+    void set(Object object, long value) throws IllegalArgumentException;
 
     /**
      * Sets the value of the field represented by this {@code FieldInfo} object
      * to the provided {@code value} of type {@code double}. The provided {@code object} is used as a
      * target from which the field is extracted.
      *
-     * @param instance The object containing the field to be set.
+     * @param object The object containing the field to be set.
      * @param value  The value to set the field to.
      * @throws IllegalArgumentException if the specified object is not an instance of the class or
      *                                  interface declaring the underlying field, or if an unwrapping
      *                                  conversion fails.
      */
-    void set(Object instance, double value) throws IllegalArgumentException;
+    void set(Object object, double value) throws IllegalArgumentException;
 
     /**
      * Retrieves the {@link Class} identifying the declared generic type of the
@@ -243,9 +243,9 @@ public interface FieldInfo {
      * Compares the value of the field represented by this {@code FieldInfo} in both provided
      * objects {@code a} and {@code b} and determines if they are equal.
      *
-     * @param instanceA First object to compare the field's value.
-     * @param instanceB Second object to compare the field's value.
+     * @param objectA First object to compare the field's value.
+     * @param objectB Second object to compare the field's value.
      * @return {@code true} if the values are equal, {@code false} otherwise.
      */
-    boolean isEqual(Object instanceA, Object instanceB);
+    boolean isEqual(Object objectA, Object objectB);
 }

--- a/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
@@ -128,7 +128,7 @@ public interface FieldInfo {
      * as an {@link Object}.
      */
     @Nullable
-    Object get(Object object);
+    Object get(Object instance);
 
     /**
      * Returns the value of the field represented by this {@code FieldInfo} object
@@ -138,7 +138,7 @@ public interface FieldInfo {
      * @return the value of the field represented by this {@code FieldInfo} object
      * as a {@code long} primitive.
      */
-    long getLong(Object object);
+    long getLong(Object instance);
 
     /**
      * Returns the value of the field represented by this {@code FieldInfo} object
@@ -148,7 +148,7 @@ public interface FieldInfo {
      * @return the value of the field represented by this {@code FieldInfo} object
      * as an {@code int} primitive.
      */
-    int getInt(Object object);
+    int getInt(Object instance);
 
     /**
      * Returns the value of the field represented by this {@code FieldInfo} object
@@ -158,7 +158,7 @@ public interface FieldInfo {
      * @return the value of the field represented by this {@code FieldInfo} object
      * as a {@code char} primitive.
      */
-    char getChar(Object object);
+    char getChar(Object instance);
 
     /**
      * Returns the value of the field represented by this {@code FieldInfo} object
@@ -168,28 +168,28 @@ public interface FieldInfo {
      * @return the value of the field represented by this {@code FieldInfo} object
      * as a {@code double} primitive.
      */
-    double getDouble(Object object);
+    double getDouble(Object instance);
 
     /**
      * Sets the value of the field represented by this {@code FieldInfo} object
      * to the provided {@code value}. The provided {@code object} is used as a
      * target to the extract eh field from.
      */
-    void set(Object object, Object value) throws IllegalArgumentException;
+    void set(Object instance, Object value) throws IllegalArgumentException;
 
     /**
      * Sets the value of the field represented by this {@code FieldInfo} object
      * to the provided {@code value}. The provided {@code object} is used as a
      * target to the extract eh field from.
      */
-    void set(Object object, char value) throws IllegalArgumentException;
+    void set(Object instance, char value) throws IllegalArgumentException;
 
     /**
      * Sets the value of the field represented by this {@code FieldInfo} object
      * to the provided {@code value}. The provided {@code object} is used as a
      * target to the extract eh field from.
      */
-    void set(Object object, int value) throws IllegalArgumentException;
+    void set(Object instance, int value) throws IllegalArgumentException;
 
     /**
      * Sets the value of the field represented by this {@code FieldInfo} object
@@ -202,7 +202,7 @@ public interface FieldInfo {
      *                                  interface declaring the underlying field, or if an unwrapping
      *                                  conversion fails.
      */
-    void set(Object object, long value) throws IllegalArgumentException;
+    void set(Object instance, long value) throws IllegalArgumentException;
 
     /**
      * Sets the value of the field represented by this {@code FieldInfo} object
@@ -215,7 +215,7 @@ public interface FieldInfo {
      *                                  interface declaring the underlying field, or if an unwrapping
      *                                  conversion fails.
      */
-    void set(Object object, double value) throws IllegalArgumentException;
+    void set(Object instance, double value) throws IllegalArgumentException;
 
     /**
      * Retrieves the {@link Class} identifying the declared generic type of the
@@ -247,5 +247,5 @@ public interface FieldInfo {
      * @param b Second object to compare the field's value.
      * @return {@code true} if the values are equal, {@code false} otherwise.
      */
-    boolean isEqual(Object a, Object b);
+    boolean isEqual(Object instanceA, Object instanceB);
 }

--- a/src/main/java/net/openhft/chronicle/wire/FieldNumberParselet.java
+++ b/src/main/java/net/openhft/chronicle/wire/FieldNumberParselet.java
@@ -20,22 +20,17 @@ package net.openhft.chronicle.wire;
 import net.openhft.chronicle.core.io.InvalidMarshallableException;
 
 /**
- * Parses fields identified by a numeric ID.
- * This is primarily used with binary wire formats where fields can be
- * identified by numeric IDs instead of string names, for compactness and
- * efficiency. It is typically registered with a {@link WireParser}
- * (e.g., {@link VanillaWireParser}) as a fallback or for specific
- * field numbers.
+ * Represents a parselet to process field numbers in a wire format.
+ * Implementations should provide logic to read data based on the field number from a wire input source.
  */
 public interface FieldNumberParselet {
 
     /**
-     * Invoked when a numeric field ID is parsed.
+     * Reads and processes data corresponding to the given field number (methodId) from the wire input.
      *
-     * @param methodId the numeric field ID read from the binary wire
-     * @param wire     the {@link WireIn} from which the value should be read;
-     *                 use {@code wire.getValueIn()} to access and deserialise the value
-     * @throws InvalidMarshallableException if the value cannot be processed
+     * @param methodId The field number or methodId that denotes which data to read.
+     * @param wire     The wire input source from which the data is read.
+     * @throws InvalidMarshallableException If there's an error in reading or processing the data.
      */
     void readOne(long methodId, WireIn wire) throws InvalidMarshallableException;
 }

--- a/src/main/java/net/openhft/chronicle/wire/LongArrayValueBitSet.java
+++ b/src/main/java/net/openhft/chronicle/wire/LongArrayValueBitSet.java
@@ -35,29 +35,27 @@ import java.util.stream.StreamSupport;
 import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
 
 /**
- * A {@link ChronicleBitSet} backed by a {@link net.openhft.chronicle.core.values.LongArrayValues}.
- * The backing array can reside off-heap, allowing multiple processes to share the same state.
- * All updates rely on compare‑and‑swap operations and therefore do not require explicit locks.
- * <b>Note:</b> the capacity is fixed when the instance is created and cannot later be expanded.
+ * This {@code ChronicleBitSet} is intended to be shared between processes. To minimize locking constraints, it is implemented as a lock-free solution
+ * without support for resizing.
  */
 @SuppressWarnings("this-escape")
 public class LongArrayValueBitSet extends AbstractCloseable implements Marshallable, ChronicleBitSet {
 
-    /** Internal constant used when masking partial words. */
+    /* Used to shift left or right for a partial word mask */
     private static final long WORD_MASK = ~0L;
 
-    /** Lazily created {@link Pauser} used during CAS spin loops. */
+    // Pauser object used for managing concurrent access (assuming based on its name, actual use needs context)
     private transient Pauser pauser;
 
     /**
-     * Holds the 64-bit words representing the bits. Each index is one word in the
-     * underlying {@link LongArrayValues} instance.
+     * The internal field corresponding to the serialField "bits".
      */
     private LongArrayValues words;
 
     /**
-     * Create a bit set capable of holding {@code maxNumberOfBits} bits.
-     * The backing {@link BinaryLongArrayReference} is sized once during construction.
+     * Constructs a new {@code LongArrayValueBitSet} with the given maximum number of bits.
+     *
+     * @param maxNumberOfBits Maximum number of bits that the bit set can handle.
      */
     public LongArrayValueBitSet(final long maxNumberOfBits) {
         words = new BinaryLongArrayReference((maxNumberOfBits + BITS_PER_WORD - 1) / BITS_PER_WORD);
@@ -65,9 +63,10 @@ public class LongArrayValueBitSet extends AbstractCloseable implements Marshalla
     }
 
     /**
-     * Create a bit set of {@code maxNumberOfBits} bits and immediately marshal its state
-     * to and from the provided {@link Wire}. The {@link #words} field is initialised using
-     * a {@link BinaryLongArrayReference} before marshalling occurs.
+     * Constructs a new {@code LongArrayValueBitSet} with the given maximum number of bits and initializes it with the given {@code Wire}.
+     *
+     * @param maxNumberOfBits Maximum number of bits that the bit set can handle.
+     * @param w               The {@code Wire} object to be used for initialization.
      */
     public LongArrayValueBitSet(final long maxNumberOfBits, Wire w) {
         this(maxNumberOfBits);
@@ -76,9 +75,11 @@ public class LongArrayValueBitSet extends AbstractCloseable implements Marshalla
     }
 
     /**
-     * Locate the word containing {@code bitIndex}.
+     * Calculates the word index in the internal storage corresponding to a given bit index.
      *
-     * @throws IndexOutOfBoundsException if {@code bitIndex} is negative
+     * @param bitIndex The bit index for which to find the word index.
+     * @return The word index containing the given bit index.
+     * @throws IndexOutOfBoundsException if the provided bitIndex is negative.
      */
     private static int wordIndex(int bitIndex) {
         if (bitIndex < 0)
@@ -88,14 +89,17 @@ public class LongArrayValueBitSet extends AbstractCloseable implements Marshalla
     }
 
     /**
-     * Utility method matching {@link BitSet#valueOf(byte[])} for convenience.
+     * Constructs and returns a new {@code BitSet} using the bits from the provided byte array.
+     *
+     * @param bytes The byte array to be used for constructing the {@code BitSet}.
+     * @return A new {@code BitSet} containing all bits from the given byte array.
      */
     public static BitSet valueOf(byte[] bytes) {
         return BitSet.valueOf(ByteBuffer.wrap(bytes));
     }
 
     /**
-     * Validate that {@code fromIndex}..{@code toIndex} forms a non‑empty range.
+     * Checks that fromIndex ... toIndex is a valid range of bit indices.
      */
     private static void checkRange(int fromIndex, int toIndex) {
         if (fromIndex < 0)
@@ -107,18 +111,11 @@ public class LongArrayValueBitSet extends AbstractCloseable implements Marshalla
                     " > toIndex: " + toIndex);
     }
 
-    /**
-     * Return the value of the word at {@code wordIndex} or zero if beyond {@link #getWordsInUse()}.
-     */
     @Override
     public long getWord(int wordIndex) {
         return wordIndex < getWordsInUse() ? words.getValueAt(wordIndex) : 0;
     }
 
-    /**
-     * Store {@code bits} at the given {@code wordIndex}. The backing {@link LongArrayValues}
-     * is expanded to the index if needed.
-     */
     @Override
     public void setWord(int wordIndex, long bits) {
         expandTo(wordIndex);
@@ -176,8 +173,11 @@ public class LongArrayValueBitSet extends AbstractCloseable implements Marshalla
     }
 
     /**
-     * Atomically set an external {@link LongValue} to {@code newValue}.
-     * This helper does not access {@link #words}; it is provided for convenience.
+     * Sets a new value for a given word in this bit set.
+     * This method is lock-free and uses CAS operations to safely set the new word value.
+     *
+     * @param word     The {@code LongValue} instance representing the word to set.
+     * @param newValue The new value to set for the word.
      */
     public void set(LongValue word, long newValue) {
         throwExceptionIfClosed();
@@ -209,8 +209,9 @@ public class LongArrayValueBitSet extends AbstractCloseable implements Marshalla
     }
 
     /**
-     * Ensure the backing store can address {@code wordIndex}. Throws if the requested index
-     * exceeds the initial capacity.
+     * Ensures that the ChronicleBitSet can accommodate a given wordIndex.
+     *
+     * @param wordIndex the index to be accommodated.
      */
     private void expandTo(int wordIndex) {
         int wordsRequired = wordIndex + 1;

--- a/src/main/java/net/openhft/chronicle/wire/LongValueBitSet.java
+++ b/src/main/java/net/openhft/chronicle/wire/LongValueBitSet.java
@@ -34,60 +34,47 @@ import java.util.stream.StreamSupport;
 import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
 
 /**
- * A {@link ChronicleBitSet} implementation backed by an array of
- * {@link net.openhft.chronicle.core.values.LongValue}s. The backing
- * words may reside in off-heap memory so the bit set can be shared
- * between processes. Operations are performed using compare-and-swap
- * loops rather than explicit locks.
- * <b>Note:</b> the capacity is fixed on construction and cannot be
- * expanded later.
+ * This is the LongValueBitSet class extending AbstractCloseable.
+ * This class represents a BitSet designed to be shared across processes without requiring locks.
+ * It has been implemented as a lock-free solution and does not support resizing.
  */
 @SuppressWarnings("this-escape")
 public class LongValueBitSet extends AbstractCloseable implements Marshallable, ChronicleBitSet {
 
-    /**
-     * Internal constant with all bits set ({@code 0xFFFF_FFFF_FFFF_FFFFL}) used
-     * when masking partial words.
-     */
+    // Mask used for operations on partial words.
     private static final long WORD_MASK = ~0L;
 
-    /**
-     * Transient {@link Pauser} used to back off in CAS loops. Lazily
-     * initialised on first use.
-     */
+    // Provides a pausing strategy for contention management.
     private transient Pauser pauser;
 
     /**
-     * The array of {@link LongValue} words storing the bits for this set.
-     * Each entry is a 64‑bit word that may be shared across processes.
+     * The internal field corresponding to the serialField "bits".
      */
     private LongValue[] words;
 
     /**
-     * Creates a bit set sized for {@code maxNumberOfBits} bits.
-     * The backing array is allocated but not bound to any {@link Wire}.
+     * Constructor that initializes a LongValueBitSet with a maximum number of bits provided as an integer.
      *
-     * @param maxNumberOfBits maximum number of bits this set can hold
+     * @param maxNumberOfBits The maximum number of bits this BitSet can accommodate.
      */
     public LongValueBitSet(final int maxNumberOfBits) {
         this((long) maxNumberOfBits);
     }
 
     /**
-     * Creates a bit set sized for {@code maxNumberOfBits} bits and immediately
-     * binds the backing array to the supplied {@link Wire} for serialisation.
+     * Constructor that initializes a LongValueBitSet with a maximum number of bits provided as an integer and associates it with a Wire.
      *
-     * @param maxNumberOfBits maximum number of bits this set can hold
-     * @param w               wire used to marshal the initial state
+     * @param maxNumberOfBits The maximum number of bits this BitSet can accommodate.
+     * @param w The Wire associated with this BitSet.
      */
     public LongValueBitSet(final int maxNumberOfBits, Wire w) {
         this((long) maxNumberOfBits, w);
     }
 
     /**
-     * Creates a bit set sized for {@code maxNumberOfBits} bits.
+     * Constructor that initializes a LongValueBitSet with a maximum number of bits provided as a long.
      *
-     * @param maxNumberOfBits maximum number of bits this set can hold
+     * @param maxNumberOfBits The maximum number of bits this BitSet can accommodate.
      */
     public LongValueBitSet(final long maxNumberOfBits) {
         int size = (int) ((maxNumberOfBits + BITS_PER_WORD - 1) / BITS_PER_WORD);
@@ -96,11 +83,10 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Creates a bit set sized for {@code maxNumberOfBits} bits and binds its
-     * storage to a {@link Wire} for marshalling.
+     * Constructor that initializes a LongValueBitSet with a maximum number of bits provided as a long and associates it with a Wire.
      *
-     * @param maxNumberOfBits maximum number of bits this set can hold
-     * @param w               wire used to marshal the initial state
+     * @param maxNumberOfBits The maximum number of bits this BitSet can accommodate.
+     * @param w The Wire associated with this BitSet.
      */
     public LongValueBitSet(final long maxNumberOfBits, Wire w) {
         this(maxNumberOfBits);
@@ -146,20 +132,11 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
                     " > toIndex: " + toIndex);
     }
 
-    /**
-     * Returns the raw word at {@code wordIndex}. If the index is beyond the
-     * backing array the value {@code 0} is returned.
-     */
     @Override
     public long getWord(int wordIndex) {
         return wordIndex < words.length ? words[wordIndex].getValue() : 0;
     }
 
-    /**
-     * Sets the raw word at {@code wordIndex} to {@code bits}. The array is
-     * not expanded; {@link #expandTo(int)} will throw if the index is beyond the
-     * configured capacity.
-     */
     @Override
     public void setWord(int wordIndex, long bits) {
         expandTo(wordIndex);
@@ -172,18 +149,21 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Returns the number of {@link LongValue} words available in the backing
-     * array. This is the fixed capacity rather than a logical size.
+     * Fetches the number of words currently in use in this BitSet.
+     *
+     * @return The number of words in use.
      */
     public int getWordsInUse() {
         return words.length;
     }
 
     /**
-     * Atomically updates {@code word} using a compare‑and‑swap loop. The
-     * {@code function} computes a new value from the current one and
-     * {@code param}. The {@link #pauser()} is used between failed CAS
-     * attempts to reduce contention.
+     * Atomically sets the value of a LongValue object based on a provided function and parameter.
+     * It uses a pausing strategy to deal with contention.
+     *
+     * @param word The LongValue object whose value needs to be set.
+     * @param param The parameter to pass to the function.
+     * @param function A function that takes the old value of the word and the provided parameter to produce a new value.
      */
     public void set(LongValue word, long param, LongFunction function) {
         throwExceptionIfClosed();
@@ -200,8 +180,10 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Returns the {@link Pauser} used for CAS backoff, creating it on first
-     * use. The default strategy is {@link Pauser#busy()}.
+     * Fetches the Pauser object for this bit set.
+     * If the Pauser object is not yet initialized, it initializes it to a busy pauser.
+     *
+     * @return The Pauser object associated with this bit set.
      */
     private Pauser pauser() {
         if (this.pauser == null)
@@ -210,8 +192,11 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Atomically sets {@code word} to {@code newValue}. A CAS loop is used
-     * with {@link #pauser()} invoked between attempts when contention occurs.
+     * Atomically sets the value of a LongValue object to a new value.
+     * It uses a pausing strategy to handle contention during the set operation.
+     *
+     * @param word The LongValue object whose value needs to be set.
+     * @param newValue The new value to be set.
      */
     public void set(LongValue word, long newValue) {
         throwExceptionIfClosed();
@@ -224,8 +209,10 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Returns a little‑endian byte array representing this set. Each word
-     * is written in sequence.
+     * Converts the bit set to a byte array representation.
+     * It serializes the bits into bytes in little-endian order.
+     *
+     * @return A byte array containing all the bits set in this bit set.
      */
     public byte[] toByteArray() {
         throwExceptionIfClosed();
@@ -246,9 +233,10 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Verifies that {@code wordIndex} is within the fixed capacity. This
-     * implementation never resizes and will throw
-     * {@link UnsupportedOperationException} if expansion would be required.
+     * Ensures that the current bit set can accommodate a specified word index.
+     * Throws an UnsupportedOperationException if the bit set cannot be expanded.
+     *
+     * @param wordIndex The word index that needs to be accommodated.
      */
     private void expandTo(int wordIndex) {
         int wordsRequired = wordIndex + 1;
@@ -260,7 +248,10 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Atomically toggles the bit at {@code bitIndex}.
+     * Flips the bit at the specified index, toggling it from its current value.
+     * If the bit is currently set to 0, it will become 1, and vice versa.
+     *
+     * @param bitIndex The index of the bit to flip.
      */
     public void flip(int bitIndex) {
         throwExceptionIfClosed();
@@ -274,21 +265,33 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Atomically performs {@code word ^= param}.
+     * Applies the bitwise XOR operation between the provided word and parameter.
+     * The result of this operation toggles the bits where they differ.
+     *
+     * @param word The LongValue object representing the word.
+     * @param param The parameter against which XOR operation needs to be performed.
      */
     private void caret(LongValue word, long param) {
         set(word, param, (x, y) -> x ^ y);
     }
 
     /**
-     * Atomically performs {@code word &= param}.
+     * Applies the bitwise AND operation between the provided word and parameter.
+     * The result of this operation retains the bits that are set in both the word and the parameter.
+     *
+     * @param word The LongValue object representing the word.
+     * @param param The parameter against which AND operation needs to be performed.
      */
     private void and(LongValue word, final long param) {
         set(word, param, (x, y) -> x & y);
     }
 
     /**
-     * Atomically flips bits in the range [{@code fromIndex}, {@code toIndex}).
+     * Flips a range of bits, toggling them from their current value.
+     * If a bit within the range is currently set to 0, it will become 1, and vice versa.
+     *
+     * @param fromIndex Index of the first bit to flip (inclusive).
+     * @param toIndex Index of the last bit to flip (exclusive).
      */
     public void flip(int fromIndex, int toIndex) {
         throwExceptionIfClosed();
@@ -325,7 +328,9 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Atomically sets the bit at {@code bitIndex}.
+     * Sets the bit at the specified index to {@code true}.
+     *
+     * @param bitIndex The index of the bit to be set to {@code true}.
      */
     public void set(int bitIndex) {
         // Check if the BitSet is closed, if so, throws an exception
@@ -343,7 +348,11 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Atomically performs {@code word |= param}.
+     * Performs a bitwise OR operation on the given word and parameter.
+     * This method is particularly used to set a specific bit to {@code true} within a word.
+     *
+     * @param word The word on which the operation will be performed.
+     * @param param The parameter value used in the OR operation.
      */
     private void pipe(LongValue word, long param) {
         // Set the desired bit by using the OR operation
@@ -351,7 +360,11 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Sets the bit at {@code bitIndex} to {@code value}.
+     * Sets the bit at the specified index to the specified value.
+     * If the value is {@code true}, the bit is set to 1, otherwise it is set to 0.
+     *
+     * @param bitIndex The index of the bit to be modified.
+     * @param value The new value for the specified bit.
      */
     public void set(int bitIndex, boolean value) {
         throwExceptionIfClosed();
@@ -363,7 +376,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Atomically sets all bits in the range [{@code fromIndex}, {@code toIndex}) to {@code true}.
+     * Sets the bits from the specified {@code fromIndex} (inclusive) to the specified {@code toIndex} (exclusive) to {@code true}.
      */
     public void set(int fromIndex, int toIndex) {
         throwExceptionIfClosed();
@@ -400,7 +413,13 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Atomically sets all bits in the range to {@code value}.
+     * Sets the bits from the specified {@code fromIndex} (inclusive) to the specified {@code toIndex} (exclusive) to the specified value.
+     *
+     * @param fromIndex index of the first bit to be set
+     * @param toIndex   index after the last bit to be set
+     * @param value     value to set the selected bits to
+     * @throws IndexOutOfBoundsException if {@code fromIndex} is negative, or {@code toIndex} is negative, or {@code fromIndex} is larger than {@code
+     *                                   toIndex}
      */
     public void set(int fromIndex, int toIndex, boolean value) {
         throwExceptionIfClosed();
@@ -412,7 +431,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Clears the bit at {@code bitIndex}.
+     * Sets the bit specified by the index to {@code false}.
      */
     public void clear(int bitIndex) {
         throwExceptionIfClosed();
@@ -428,7 +447,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Clears all bits in the range [{@code fromIndex}, {@code toIndex}).
+     * Sets the bits from the specified {@code fromIndex} (inclusive) to the specified {@code toIndex} (exclusive) to {@code false}.
      */
     public void clear(int fromIndex, int toIndex) {
         throwExceptionIfClosed();
@@ -473,7 +492,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Clears every bit in the set.
+     * Sets all of the bits in this ChronicleBitSet to {@code false}.
      */
     public void clear() {
         throwExceptionIfClosed();
@@ -484,7 +503,11 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Returns {@code true} if the bit at {@code bitIndex} is set.
+     * Returns the value of the bit with the specified index. The value is {@code true} if the bit with the index {@code bitIndex}
+     * is currently set in this {@code ChronicleBitSet}; otherwise, the result is {@code false}.
+     *
+     * @param bitIndex the index of the bit to check
+     * @return true if the bit at the specified index is set, false otherwise
      */
     public boolean get(int bitIndex) {
         throwExceptionIfClosed();
@@ -498,8 +521,11 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Returns the index of the next set bit on or after {@code fromIndex}.
-     * Uses volatile reads for cross-process visibility.
+     * Returns the index of the first bit that is set to {@code true} that occurs on or after the specified starting index.
+     * If no such bit exists then {@code -1} is returned.
+     *
+     * @param fromIndex the index to start checking from
+     * @return the index of the next set bit, or -1 if no such bit is found
      */
     public int nextSetBit(int fromIndex) {
         throwExceptionIfClosed();
@@ -532,7 +558,12 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Variant of {@link #nextSetBit(int)} that stops searching at {@code toIndex}.
+     * Returns the index of the first bit that is set to {@code true} that occurs on or after the specified starting index but before the toIndex.
+     * If no such bit exists then {@code -1} is returned.
+     *
+     * @param fromIndex the index to start checking from
+     * @param toIndex the index to stop checking (exclusive)
+     * @return the index of the next set bit within the specified range, or -1 if no such bit is found
      */
     public int nextSetBit(int fromIndex, int toIndex) {
         throwExceptionIfClosed();
@@ -566,8 +597,10 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Returns the index of the next clear bit on or after {@code fromIndex}.
-     * Uses volatile reads for visibility.
+     * Returns the index of the first bit that is set to {@code false} that occurs on or after the specified starting index.
+     *
+     * @param fromIndex the index to start checking from
+     * @return the index of the next unset bit, or the total length if all bits are set
      */
     public int nextClearBit(int fromIndex) {
         throwExceptionIfClosed();
@@ -603,7 +636,13 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Scans backwards for the previous set bit starting from {@code fromIndex}.
+     * This method searches for the closest bit set to {@code true} from the specified starting index moving backwards.
+     * If the bit at the specified starting index is set to {@code true}, it will return the index itself.
+     * If no such bit exists before the given index, or if {@code -1} is the specified index, then {@code -1} is returned.
+     *
+     * @param fromIndex The starting index to begin the search. The search moves towards the index 0 from this point.
+     * @return The index of the nearest set bit (with value {@code true}) before the specified starting index, or {@code -1} if none exists.
+     * @throws IndexOutOfBoundsException if {@code fromIndex} is less than {@code -1}
      */
     public int previousSetBit(int fromIndex) {
         throwExceptionIfClosed();
@@ -632,7 +671,13 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Scans backwards for the previous clear bit starting from {@code fromIndex}.
+     * This method searches for the closest bit set to {@code false} from the specified starting index moving backwards.
+     * If the bit at the specified starting index is set to {@code false}, it will return the index itself.
+     * If no such unset bit exists before the given index, or if {@code -1} is the specified index, then {@code -1} is returned.
+     *
+     * @param fromIndex The starting index to begin the search. The search moves towards the index 0 from this point.
+     * @return The index of the nearest unset bit (with value {@code false}) before the specified starting index, or {@code -1} if none exists.
+     * @throws IndexOutOfBoundsException if {@code fromIndex} is less than {@code -1}
      */
     public int previousClearBit(int fromIndex) {
         throwExceptionIfClosed();
@@ -689,8 +734,9 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Counts the bits set to {@code true}. Each word is read
-     * with {@link LongValue#getVolatileValue()} for visibility.
+     * Calculates and returns the number of bits set to {@code true} in this {@code ChronicleBitSet}.
+     *
+     * @return The number of bits currently set to {@code true}.
      */
     public int cardinality() {
         throwExceptionIfClosed();
@@ -840,8 +886,9 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Computes a hash code from the values of all words. A load fence is used
-     * before reading them.
+     * Computes the hash code for this {@code ChronicleBitSet}. The hash code is calculated based on the bit values that are set.
+     *
+     * @return The computed hash code.
      */
     public int hashCode() {
         long h = 1234;
@@ -853,15 +900,26 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Returns the maximum number of bits represented by this set.
+     * Retrieves the number of bits that are actually being used by this {@code ChronicleBitSet} to represent bit values.
+     * Essentially, this is the highest set bit plus one.
+     *
+     * @return The number of bits of space in use.
      */
     public int size() {
         return Math.toIntExact(words.length * BITS_PER_WORD);
     }
 
     /**
-     * Returns {@code true} if {@code obj} is a {@link ChronicleBitSet} with the
-     * same word values. A load fence is issued before comparison.
+     * Compares this {@code ChronicleBitSet} object against the specified object. The result is {@code true} if and only if:
+     * <ul>
+     *     <li>The provided object is not {@code null}.
+     *     <li>The provided object is an instance of {@code ChronicleBitSet}.
+     *     <li>Both {@code ChronicleBitSet} objects have the exact same set of bits set to {@code true}.
+     * </ul>
+     * In essence, for every non-negative {@code int} index {@code k}, the bits of both {@code ChronicleBitSet} objects at index {@code k} should be identical.
+     *
+     * @param obj The object to compare with.
+     * @return {@code true} if the objects are the same; {@code false} otherwise.
      */
     public boolean equals(Object obj) {
         throwExceptionIfClosed();
@@ -914,7 +972,8 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Streams the set bit indices in ascending order.
+     * Returns a stream of indices for which this {@code ChronicleBitSet} contains a bit in the set state. The indices are returned in order, from lowest to
+     * highest. The size of the stream is the number of bits in the set state, equal to the value returned by the {@link #cardinality()} method.
      */
     public IntStream stream() {
         throwExceptionIfClosed();
@@ -952,7 +1011,6 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
                 false);
     }
 
-    /** Serialises the backing words to {@code wire}. */
     @Override
     public void writeMarshallable(@NotNull final WireOut wire) {
         wire.write("numberOfLongValues").int32(words.length);
@@ -964,7 +1022,6 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
         }
     }
 
-    /** Deserialises the backing words from {@code wire}. */
     @Override
     public void readMarshallable(@NotNull final WireIn wire) throws IORuntimeException {
         singleThreadedCheckDisabled(true);
@@ -979,7 +1036,6 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
         }
     }
 
-    /** Copies the contents of {@code bitSet} into this instance. */
     @Override
     public void copyFrom(ChronicleBitSet bitSet) {
         OS.memory().loadFence();
@@ -994,14 +1050,28 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Function used for atomic updates on a {@code long} value. It accepts the
-     * current value and a parameter and returns the new value.
-     */
+     * Represents a function that accepts two long values (an old value and a parameter) and produces a long result.
+     * This is the {@code long}-consuming and {@code long}-producing primitive specialization for
+     * {@link java.util.function.Function}.
+     *
+     * <p>For example, this interface can be used to represent functions like addition:
+     * <pre>
+     * {@code
+     * LongFunction add = (oldValue, param) -> oldValue + param;
+     * long result = add.apply(2L, 3L);  // result will be 5
+     * }
+     * </pre>
+     *
+         */
     @FunctionalInterface
     interface LongFunction {
 
         /**
-         * Applies the function to {@code oldValue} and {@code param}.
+         * Applies this function to the given arguments.
+         *
+         * @param oldValue The old long value.
+         * @param param The long parameter.
+         * @return The function result.
          */
         long apply(long oldValue, long param);
     }

--- a/src/main/java/net/openhft/chronicle/wire/Quotes.java
+++ b/src/main/java/net/openhft/chronicle/wire/Quotes.java
@@ -43,9 +43,9 @@ enum Quotes {
     /**
      * Constructs a new instance of {@code Quotes} with the provided character representation.
      *
-     * @param q The character representation of the quotation mark.
+     * @param quoteCharacter The character representation of the quotation mark.
      */
-    Quotes(char q) {
-        this.q = q;
+    Quotes(char quoteCharacter) {
+        this.q = quoteCharacter;
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/Quotes.java
+++ b/src/main/java/net/openhft/chronicle/wire/Quotes.java
@@ -19,9 +19,8 @@ package net.openhft.chronicle.wire;
 
 /**
  * Enumerates the types of quotation marks.
- * This enum represents the most common quotation marks: none, single and double.
+ * This enum represents the most common quotation marks: none, single, and double.
  * Each enumeration value is associated with its corresponding character representation.
- * Used by {@link YamlWireOut} to determine how to quote and escape strings.
  */
 enum Quotes {
 
@@ -34,10 +33,7 @@ enum Quotes {
     /** Represents a double quotation mark. */
     DOUBLE('"');
 
-    /**
-     * The character representation of the quote (for example {@code '} for
-     * SINGLE, {@code "} for DOUBLE or a space for NONE).
-     */
+    // The character representation of the quotation mark
     final char q;
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/Quotes.java
+++ b/src/main/java/net/openhft/chronicle/wire/Quotes.java
@@ -19,8 +19,9 @@ package net.openhft.chronicle.wire;
 
 /**
  * Enumerates the types of quotation marks.
- * This enum represents the most common quotation marks: none, single, and double.
+ * This enum represents the most common quotation marks: none, single and double.
  * Each enumeration value is associated with its corresponding character representation.
+ * Used by {@link YamlWireOut} to determine how to quote and escape strings.
  */
 enum Quotes {
 
@@ -33,7 +34,10 @@ enum Quotes {
     /** Represents a double quotation mark. */
     DOUBLE('"');
 
-    // The character representation of the quotation mark
+    /**
+     * The character representation of the quote (for example {@code '} for
+     * SINGLE, {@code "} for DOUBLE or a space for NONE).
+     */
     final char q;
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/ScalarStrategy.java
+++ b/src/main/java/net/openhft/chronicle/wire/ScalarStrategy.java
@@ -28,13 +28,20 @@ import java.util.function.Function;
 /**
  * Implements the {@link SerializationStrategy} for scalar data types.
  * This strategy is designed for simple types and provides mechanisms for reading
- * them using provided functions.
+ * them using provided functions. It typically uses {@link BracketType#NONE} as
+ * scalar values are usually not enclosed in map or sequence brackets.
  *
  * @param <E> The type of the scalar value that this strategy handles.
  */
 class ScalarStrategy<E> implements SerializationStrategy {
+    /**
+     * The {@link BiFunction} used to deserialize the scalar value. It takes an
+     * optional existing object (or {@code null}) and the {@link ValueIn} source,
+     * and returns the deserialized value.
+     */
     final BiFunction<? super E, ValueIn, E> read;
-    // The class type of the scalar value
+
+    /** The class type of the scalar value. */
     private final Class<E> type;
 
     /**
@@ -80,12 +87,20 @@ class ScalarStrategy<E> implements SerializationStrategy {
         });
     }
 
+    /**
+     * Returns {@link BracketType#NONE}, as scalar values are typically not enclosed
+     * in structural brackets.
+     */
     @NotNull
     @Override
     public BracketType bracketType() {
         return BracketType.NONE;
     }
 
+    /**
+     * Creates a new instance of the scalar type using {@link ObjectUtils#newInstance(Class)}.
+     * This is used when no existing object is provided for deserialization.
+     */
     @SuppressWarnings("rawtypes")
     @NotNull
     @Override
@@ -93,11 +108,18 @@ class ScalarStrategy<E> implements SerializationStrategy {
         return Jvm.uncheckedCast(ObjectUtils.newInstance(this.type));
     }
 
+    /**
+     * Returns the {@link Class} of the scalar type this strategy handles.
+     */
     @Override
     public Class<E> type() {
         return type;
     }
 
+    /**
+     * Reads the scalar value using the configured {@link #read} function. Returns
+     * {@code null} if the input {@link ValueIn#isNull()}.
+     */
     @SuppressWarnings("unchecked")
     @Nullable
     @Override
@@ -108,6 +130,9 @@ class ScalarStrategy<E> implements SerializationStrategy {
         return (T) read.apply((E) using, in);
     }
 
+    /**
+     * @return A string representation of this strategy, including the scalar type name.
+     */
     @NotNull
     @Override
     public String toString() {

--- a/src/main/java/net/openhft/chronicle/wire/ScalarStrategy.java
+++ b/src/main/java/net/openhft/chronicle/wire/ScalarStrategy.java
@@ -28,8 +28,7 @@ import java.util.function.Function;
 /**
  * Implements the {@link SerializationStrategy} for scalar data types.
  * This strategy is designed for simple types and provides mechanisms for reading
- * them using provided functions. It typically uses {@link BracketType#NONE} as
- * scalar values are usually not enclosed in map or sequence brackets.
+ * them using provided functions.
  *
  * @param <E> The type of the scalar value that this strategy handles.
  */

--- a/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
+++ b/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
@@ -48,14 +48,16 @@ import static net.openhft.chronicle.wire.BracketType.UNKNOWN;
 public enum SerializationStrategies implements SerializationStrategy {
 
     /**
-     * Strategy for objects implementing {@link Marshallable}.
-     * Supports both self-describing and raw byte forms.
+     * A serialization strategy for objects implementing the {@link Marshallable} interface.
+     * This strategy supports both self-describing messages and raw byte data serialization.
      */
     MARSHALLABLE {
         /**
-         * Reads the object either via {@link ReadMarshallable#readMarshallable(WireIn)}
-         * or {@link ReadBytesMarshallable#readMarshallable(Bytes)}. The choice is
-         * governed by {@link WireIn#useSelfDescribingMessage(CommonMarshallable)}.
+         * Reads an object from the provided input source using a wire format.
+         * The object can be deserialized either as a self-describing message or as raw byte data,
+         * based on its type.
+         *
+         * @return The populated object.
          */
         @NotNull
         @Override
@@ -81,7 +83,10 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * Returns {@code null} for interfaces or abstract types.
+         * Creates a new instance of the specified type.
+         * If the type represents an interface or an abstract class, {@code null} is returned.
+         *
+         * @return A new instance of the provided type or {@code null} if the type is an interface or abstract.
          */
         @Nullable
         @Override
@@ -91,13 +96,15 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Handles objects of any type. The actual strategy is chosen at read time
-     * once the type has been inferred from the wire.
+     * A serialization strategy that supports any object type.
+     * This strategy infers the object type during deserialization.
      */
     ANY_OBJECT {
         /**
-         * Infers the type from the wire and then delegates to {@link #ANY_NESTED}
-         * or another appropriate strategy.
+         * Reads an object from the provided input source, inferring its type.
+         * The type is not explicitly described in the serialized data.
+         *
+         * @return The populated object with its type inferred from the input.
          */
         @Nullable
         @Override
@@ -129,12 +136,14 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Handles scalar values such as primitives and boxed types. Scalars are
-     * written without explicit map or list brackets.
+     * A serialization strategy that supports any scalar value.
+     * Scalar values are typically primitive types or their boxed equivalents.
      */
     ANY_SCALAR {
         /**
-         * Reads a scalar value and infers the target type from the wire.
+         * Reads a scalar object from the provided input source, inferring its type.
+         *
+         * @return The populated scalar object with its type inferred from the input.
          */
         @Nullable
         @Override
@@ -166,11 +175,13 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Strategy for standard {@link Enum} types. Values are written as their {@code name()}.
+     * A serialization strategy specifically designed for handling enumerations (enums).
      */
     ENUM {
         /**
-         * Reads an enum by consuming its textual name.
+         * Reads an enum value from the provided input source, represented as text.
+         *
+         * @return The textual representation of the enum value.
          */
         @Nullable
         @Override
@@ -202,18 +213,23 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Supports dynamic enums whose values may change at run time. Special logic
-     * deals with both simple text forms and map based representations.
+     * A serialization strategy designed for handling dynamic enumerations (enums).
+     * Dynamic enums are enums whose values can be altered or enhanced at runtime.
+     * This strategy incorporates custom handling to ensure proper deserialization
+     * of dynamic enums from the input source.
      */
     DYNAMIC_ENUM {
 
         // Reflective field access to the ordinal of the Enum class
-        private final Field ordinal = Jvm.getField(Enum.class, "ordinal");
+        private Field ordinal = Jvm.getField(Enum.class, "ordinal");
 
         /**
-         * Reads a dynamic enum. A plain text name is resolved via {@link EnumCache}.
-         * If {@code o} implements {@link ReadMarshallable} and a map is present,
-         * that map is read into the instance.
+         * Reads a dynamic enum value from the provided input source.
+         * This method accounts for multiple input representations,
+         * such as direct textual names or custom serialized formats
+         * for more complex dynamic enums.
+         *
+         * @return The deserialized dynamic enum object or its textual representation.
          */
         @Nullable
         @Override
@@ -277,13 +293,19 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Deserialises nested objects without knowing the target type. Data is
-     * typically encoded in a map style structure.
+     * A serialization strategy designed for handling nested objects.
+     * This strategy reads nested objects without explicitly knowing
+     * their exact type, treating them as generic objects and performing
+     * a generic deserialization.
      */
     ANY_NESTED {
 
         /**
-         * Reads a nested object or returns {@code null} if the input is null.
+         * Reads the nested object from the provided input source.
+         * If the input is null, it returns null. Otherwise, it
+         * deserializes the object and returns the constructed instance.
+         *
+         * @return The deserialized nested object.
          */
         @Override
         public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -319,15 +341,18 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Handles {@link Demarshallable} objects. A wrapper may be used during
-     * reading to defer construction until {@link #readUsing} is invoked.
+     * A serialization strategy specifically designed for handling
+     * {@link Demarshallable} objects. {@link Demarshallable} represents
+     * an object that can be deserialized from a wire format.
      */
     DEMARSHALLABLE {
 
         /**
-         * Reads a {@link Demarshallable}. If {@code using} is a
-         * {@link DemarshallableWrapper}, a new instance is created and stored in
-         * the wrapper. Otherwise the existing object is populated.
+         * Reads the {@link Demarshallable} object from the provided input source.
+         * This method has logic to handle multiple formats of input including
+         * wrapped objects and direct serialized formats.
+         *
+         * @return The deserialized {@link Demarshallable} object or wrapper.
          */
         @NotNull
         @Override
@@ -355,8 +380,9 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * Returns a {@link DemarshallableWrapper} used as a temporary holder
-         * until the real object is read.
+         * Constructs a new instance of a {@link Demarshallable} wrapped in a {@link DemarshallableWrapper}.
+         *
+         * @return The constructed {@link DemarshallableWrapper}.
          */
         @NotNull
         @Override
@@ -366,15 +392,20 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Handles {@link Serializable} objects. If an instance is also
-     * {@link Externalizable} its own read logic is used, otherwise the data is
-     * read via {@link #ANY_OBJECT}.
+     * A serialization strategy for handling objects that implement the
+     * {@link java.io.Serializable} interface. This strategy checks if the object
+     * is also an instance of {@link Externalizable}, and if so, uses the
+     * {@link #EXTERNALIZABLE} strategy. Otherwise, it defaults to the
+     * {@link #ANY_OBJECT} strategy.
      */
     SERIALIZABLE {
 
         /**
-         * Delegates to {@link #EXTERNALIZABLE} when required, otherwise to
-         * {@link #ANY_OBJECT}.
+         * Reads the {@link Serializable} object from the provided input source.
+         * Delegates the deserialization to the appropriate strategy based on
+         * whether the object is an instance of {@link Externalizable}.
+         *
+         * @return The deserialized {@link Serializable} object.
          */
         @Override
         public Object readUsing(Class clazz, Object o, ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -397,14 +428,17 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Handles {@link Externalizable} objects and calls their
-     * {@link java.io.Externalizable#readExternal(java.io.ObjectInput)} method.
+     * A serialization strategy specifically designed for handling
+     * {@link Externalizable} objects. Externalizable objects provide their
+     * own custom serialization mechanism that this strategy leverages.
      */
     EXTERNALIZABLE {
 
         /**
-         * Delegates to {@link java.io.Externalizable#readExternal(java.io.ObjectInput)}
-         * using an {@link java.io.ObjectInput} facade over the wire.
+         * Reads the {@link Externalizable} object from the provided input source
+         * using the object's custom serialization logic.
+         *
+         * @return The deserialized {@link Externalizable} object.
          */
         @NotNull
         @Override
@@ -442,13 +476,17 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Reads key value pairs into a {@link Map}.
+     * A serialization strategy for handling objects that implement the
+     * {@link java.util.Map} interface. This strategy deserializes a sequence
+     * of key-value pairs into a Map instance.
      */
     MAP {
 
         /**
-         * Consumes key value pairs until no more entries remain in the current
-         * map context.
+         * Reads the {@link Map} object from the provided input source, mapping
+         * each key-value pair in the sequence.
+         *
+         * @return The deserialized {@link Map} object.
          */
         @Override
         public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -498,13 +536,17 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Reads a sequence of items into a {@link Set} implementation.
+     * A serialization strategy for handling objects that implement the
+     * {@link java.util.Set} interface. This strategy deserializes a sequence
+     * of items into a Set instance.
      */
     SET {
 
         /**
-         * Consumes items from the wire and adds them to the given set, creating
-         * one if necessary.
+         * Reads the {@link Set} object from the provided input source, adding
+         * each item in the sequence to the set.
+         *
+         * @return The deserialized {@link Set} object.
          */
         @Override
         public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -561,13 +603,17 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Reads a sequence of items into a {@link List} implementation.
+     * A serialization strategy for handling objects that implement the
+     * {@link java.util.List} interface. This strategy deserializes a sequence
+     * of items into a List instance.
      */
     LIST {
 
         /**
-         * Populates the supplied list. Existing entries are reused where
-         * possible; surplus entries are removed.
+         * Reads the {@link List} object from the provided input source, adding
+         * each item in the sequence to the list.
+         *
+         * @return The deserialized {@link List} object.
          */
         @Override
         public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -629,14 +675,21 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Reads a sequence of items into an array. Uses {@link ArrayWrapper} when
-     * the target type is known at construction time.
+     * A serialization strategy for handling arrays. This strategy deserializes
+     * a sequence of items into an array instance.
      */
     ARRAY {
 
         /**
-         * Collects items into a list and then converts that list to an array or
-         * populates the supplied {@link ArrayWrapper}.
+         * Reads an array object from the provided input source, adding each
+         * item in the sequence to a list, which is then converted into an array.
+         * <p>
+         * If the 'using' parameter is an instance of ArrayWrapper, the method
+         * first deserializes items into a list and then wraps them into an array
+         * with the correct component type. Otherwise, it deserializes items into
+         * a list and then converts that list into an array.
+         *
+         * @return The deserialized array or an ArrayWrapper containing the array.
          */
         @NotNull
         @Override
@@ -694,14 +747,21 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * Reads primitive arrays using a {@link PrimArrayWrapper}. The array grows
-     * as items are read and is trimmed to size when complete.
+     * A serialization strategy for handling primitive arrays. This strategy
+     * deserializes a sequence of items into an array instance, dynamically
+     * resizing the array as required during deserialization.
      */
     PRIM_ARRAY {
 
         /**
-         * Reads items into the primitive array held by the wrapper, expanding the
-         * array when it becomes full and finally shrinking it to the exact length.
+         * Reads a primitive array object from the provided input source,
+         * dynamically resizing the array during the deserialization process.
+         * <p>
+         * The method starts with an empty array and doubles its size as needed
+         * to accommodate the incoming data. After all items have been read,
+         * the array is resized to fit the number of items that were read.
+         *
+         * @return The PrimArrayWrapper containing the deserialized primitive array.
          */
         @NotNull
         @Override
@@ -794,8 +854,8 @@ public enum SerializationStrategies implements SerializationStrategy {
     }
 
     /**
-     * Temporary holder for arrays during deserialization. {@link #readResolve()}
-     * returns the actual array so callers see only the final result.
+     * A wrapper class for arrays which provides a mechanism for deserialization
+     * by resolving the actual array when being read from a serialized source.
      */
     static class ArrayWrapper implements ReadResolvable<Object[]> {
 
@@ -820,7 +880,10 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * {@inheritDoc}
+         * Provides a deserialization mechanism which returns the actual array
+         * when this wrapper is being read from a serialized source.
+         *
+         * @return The actual array wrapped by this wrapper.
          */
         @NotNull
         @Override
@@ -830,7 +893,12 @@ public enum SerializationStrategies implements SerializationStrategy {
     }
 
     /**
-     * Temporary holder for primitive arrays during deserialization.
+     * The following classes are wrappers that facilitate deserialization processes for
+     * specific types of objects. They implement the ReadResolvable interface to define
+     * the deserialization mechanism.
+     * <p>
+     * A wrapper class for primitive arrays which provides a mechanism for deserialization
+     * by resolving the actual array when being read from a serialized source.
      */
     static class PrimArrayWrapper implements ReadResolvable<Object> {
 
@@ -855,7 +923,10 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * {@inheritDoc}
+         * Provides a deserialization mechanism which returns the actual primitive array
+         * when this wrapper is being read from a serialized source.
+         *
+         * @return The actual primitive array wrapped by this wrapper.
          */
         @NotNull
         @Override
@@ -865,7 +936,8 @@ public enum SerializationStrategies implements SerializationStrategy {
     }
 
     /**
-     * Wrapper used when reading {@link Demarshallable} objects lazily.
+     * A wrapper class for Demarshallable objects which provides a mechanism for deserialization
+     * by resolving the actual Demarshallable object when being read from a serialized source.
      */
     static class DemarshallableWrapper implements ReadResolvable<Demarshallable> {
 
@@ -890,7 +962,10 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * {@inheritDoc}
+         * Provides a deserialization mechanism which returns the actual Demarshallable object
+         * when this wrapper is being read from a serialized source.
+         *
+         * @return The actual Demarshallable object wrapped by this wrapper.
          */
         @NotNull
         @Override

--- a/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
+++ b/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
@@ -48,16 +48,14 @@ import static net.openhft.chronicle.wire.BracketType.UNKNOWN;
 public enum SerializationStrategies implements SerializationStrategy {
 
     /**
-     * A serialization strategy for objects implementing the {@link Marshallable} interface.
-     * This strategy supports both self-describing messages and raw byte data serialization.
+     * Strategy for objects implementing {@link Marshallable}.
+     * Supports both self-describing and raw byte forms.
      */
     MARSHALLABLE {
         /**
-         * Reads an object from the provided input source using a wire format.
-         * The object can be deserialized either as a self-describing message or as raw byte data,
-         * based on its type.
-         *
-         * @return The populated object.
+         * Reads the object either via {@link ReadMarshallable#readMarshallable(WireIn)}
+         * or {@link ReadBytesMarshallable#readMarshallable(Bytes)}. The choice is
+         * governed by {@link WireIn#useSelfDescribingMessage(CommonMarshallable)}.
          */
         @NotNull
         @Override
@@ -83,10 +81,7 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * Creates a new instance of the specified type.
-         * If the type represents an interface or an abstract class, {@code null} is returned.
-         *
-         * @return A new instance of the provided type or {@code null} if the type is an interface or abstract.
+         * Returns {@code null} for interfaces or abstract types.
          */
         @Nullable
         @Override
@@ -96,15 +91,13 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy that supports any object type.
-     * This strategy infers the object type during deserialization.
+     * Handles objects of any type. The actual strategy is chosen at read time
+     * once the type has been inferred from the wire.
      */
     ANY_OBJECT {
         /**
-         * Reads an object from the provided input source, inferring its type.
-         * The type is not explicitly described in the serialized data.
-         *
-         * @return The populated object with its type inferred from the input.
+         * Infers the type from the wire and then delegates to {@link #ANY_NESTED}
+         * or another appropriate strategy.
          */
         @Nullable
         @Override
@@ -136,14 +129,12 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy that supports any scalar value.
-     * Scalar values are typically primitive types or their boxed equivalents.
+     * Handles scalar values such as primitives and boxed types. Scalars are
+     * written without explicit map or list brackets.
      */
     ANY_SCALAR {
         /**
-         * Reads a scalar object from the provided input source, inferring its type.
-         *
-         * @return The populated scalar object with its type inferred from the input.
+         * Reads a scalar value and infers the target type from the wire.
          */
         @Nullable
         @Override
@@ -175,13 +166,11 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy specifically designed for handling enumerations (enums).
+     * Strategy for standard {@link Enum} types. Values are written as their {@code name()}.
      */
     ENUM {
         /**
-         * Reads an enum value from the provided input source, represented as text.
-         *
-         * @return The textual representation of the enum value.
+         * Reads an enum by consuming its textual name.
          */
         @Nullable
         @Override
@@ -213,10 +202,8 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy designed for handling dynamic enumerations (enums).
-     * Dynamic enums are enums whose values can be altered or enhanced at runtime.
-     * This strategy incorporates custom handling to ensure proper deserialization
-     * of dynamic enums from the input source.
+     * Supports dynamic enums whose values may change at run time. Special logic
+     * deals with both simple text forms and map based representations.
      */
     DYNAMIC_ENUM {
 
@@ -224,12 +211,9 @@ public enum SerializationStrategies implements SerializationStrategy {
         private final Field ordinal = Jvm.getField(Enum.class, "ordinal");
 
         /**
-         * Reads a dynamic enum value from the provided input source.
-         * This method accounts for multiple input representations,
-         * such as direct textual names or custom serialized formats
-         * for more complex dynamic enums.
-         *
-         * @return The deserialized dynamic enum object or its textual representation.
+         * Reads a dynamic enum. A plain text name is resolved via {@link EnumCache}.
+         * If {@code o} implements {@link ReadMarshallable} and a map is present,
+         * that map is read into the instance.
          */
         @Nullable
         @Override
@@ -293,19 +277,13 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy designed for handling nested objects.
-     * This strategy reads nested objects without explicitly knowing
-     * their exact type, treating them as generic objects and performing
-     * a generic deserialization.
+     * Deserialises nested objects without knowing the target type. Data is
+     * typically encoded in a map style structure.
      */
     ANY_NESTED {
 
         /**
-         * Reads the nested object from the provided input source.
-         * If the input is null, it returns null. Otherwise, it
-         * deserializes the object and returns the constructed instance.
-         *
-         * @return The deserialized nested object.
+         * Reads a nested object or returns {@code null} if the input is null.
          */
         @Override
         public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -341,18 +319,15 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy specifically designed for handling
-     * {@link Demarshallable} objects. {@link Demarshallable} represents
-     * an object that can be deserialized from a wire format.
+     * Handles {@link Demarshallable} objects. A wrapper may be used during
+     * reading to defer construction until {@link #readUsing} is invoked.
      */
     DEMARSHALLABLE {
 
         /**
-         * Reads the {@link Demarshallable} object from the provided input source.
-         * This method has logic to handle multiple formats of input including
-         * wrapped objects and direct serialized formats.
-         *
-         * @return The deserialized {@link Demarshallable} object or wrapper.
+         * Reads a {@link Demarshallable}. If {@code using} is a
+         * {@link DemarshallableWrapper}, a new instance is created and stored in
+         * the wrapper. Otherwise the existing object is populated.
          */
         @NotNull
         @Override
@@ -380,9 +355,8 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * Constructs a new instance of a {@link Demarshallable} wrapped in a {@link DemarshallableWrapper}.
-         *
-         * @return The constructed {@link DemarshallableWrapper}.
+         * Returns a {@link DemarshallableWrapper} used as a temporary holder
+         * until the real object is read.
          */
         @NotNull
         @Override
@@ -392,20 +366,15 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling objects that implement the
-     * {@link java.io.Serializable} interface. This strategy checks if the object
-     * is also an instance of {@link Externalizable}, and if so, uses the
-     * {@link #EXTERNALIZABLE} strategy. Otherwise, it defaults to the
-     * {@link #ANY_OBJECT} strategy.
+     * Handles {@link Serializable} objects. If an instance is also
+     * {@link Externalizable} its own read logic is used, otherwise the data is
+     * read via {@link #ANY_OBJECT}.
      */
     SERIALIZABLE {
 
         /**
-         * Reads the {@link Serializable} object from the provided input source.
-         * Delegates the deserialization to the appropriate strategy based on
-         * whether the object is an instance of {@link Externalizable}.
-         *
-         * @return The deserialized {@link Serializable} object.
+         * Delegates to {@link #EXTERNALIZABLE} when required, otherwise to
+         * {@link #ANY_OBJECT}.
          */
         @Override
         public Object readUsing(Class clazz, Object o, ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -428,17 +397,14 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy specifically designed for handling
-     * {@link Externalizable} objects. Externalizable objects provide their
-     * own custom serialization mechanism that this strategy leverages.
+     * Handles {@link Externalizable} objects and calls their
+     * {@link java.io.Externalizable#readExternal(java.io.ObjectInput)} method.
      */
     EXTERNALIZABLE {
 
         /**
-         * Reads the {@link Externalizable} object from the provided input source
-         * using the object's custom serialization logic.
-         *
-         * @return The deserialized {@link Externalizable} object.
+         * Delegates to {@link java.io.Externalizable#readExternal(java.io.ObjectInput)}
+         * using an {@link java.io.ObjectInput} facade over the wire.
          */
         @NotNull
         @Override
@@ -476,17 +442,13 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling objects that implement the
-     * {@link java.util.Map} interface. This strategy deserializes a sequence
-     * of key-value pairs into a Map instance.
+     * Reads key value pairs into a {@link Map}.
      */
     MAP {
 
         /**
-         * Reads the {@link Map} object from the provided input source, mapping
-         * each key-value pair in the sequence.
-         *
-         * @return The deserialized {@link Map} object.
+         * Consumes key value pairs until no more entries remain in the current
+         * map context.
          */
         @Override
         public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -536,17 +498,13 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling objects that implement the
-     * {@link java.util.Set} interface. This strategy deserializes a sequence
-     * of items into a Set instance.
+     * Reads a sequence of items into a {@link Set} implementation.
      */
     SET {
 
         /**
-         * Reads the {@link Set} object from the provided input source, adding
-         * each item in the sequence to the set.
-         *
-         * @return The deserialized {@link Set} object.
+         * Consumes items from the wire and adds them to the given set, creating
+         * one if necessary.
          */
         @Override
         public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -603,17 +561,13 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling objects that implement the
-     * {@link java.util.List} interface. This strategy deserializes a sequence
-     * of items into a List instance.
+     * Reads a sequence of items into a {@link List} implementation.
      */
     LIST {
 
         /**
-         * Reads the {@link List} object from the provided input source, adding
-         * each item in the sequence to the list.
-         *
-         * @return The deserialized {@link List} object.
+         * Populates the supplied list. Existing entries are reused where
+         * possible; surplus entries are removed.
          */
         @Override
         public Object readUsing(Class clazz, Object o, @NotNull ValueIn in, BracketType bracketType) throws InvalidMarshallableException {
@@ -675,21 +629,14 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling arrays. This strategy deserializes
-     * a sequence of items into an array instance.
+     * Reads a sequence of items into an array. Uses {@link ArrayWrapper} when
+     * the target type is known at construction time.
      */
     ARRAY {
 
         /**
-         * Reads an array object from the provided input source, adding each
-         * item in the sequence to a list, which is then converted into an array.
-         * <p>
-         * If the 'using' parameter is an instance of ArrayWrapper, the method
-         * first deserializes items into a list and then wraps them into an array
-         * with the correct component type. Otherwise, it deserializes items into
-         * a list and then converts that list into an array.
-         *
-         * @return The deserialized array or an ArrayWrapper containing the array.
+         * Collects items into a list and then converts that list to an array or
+         * populates the supplied {@link ArrayWrapper}.
          */
         @NotNull
         @Override
@@ -747,21 +694,14 @@ public enum SerializationStrategies implements SerializationStrategy {
     },
 
     /**
-     * A serialization strategy for handling primitive arrays. This strategy
-     * deserializes a sequence of items into an array instance, dynamically
-     * resizing the array as required during deserialization.
+     * Reads primitive arrays using a {@link PrimArrayWrapper}. The array grows
+     * as items are read and is trimmed to size when complete.
      */
     PRIM_ARRAY {
 
         /**
-         * Reads a primitive array object from the provided input source,
-         * dynamically resizing the array during the deserialization process.
-         * <p>
-         * The method starts with an empty array and doubles its size as needed
-         * to accommodate the incoming data. After all items have been read,
-         * the array is resized to fit the number of items that were read.
-         *
-         * @return The PrimArrayWrapper containing the deserialized primitive array.
+         * Reads items into the primitive array held by the wrapper, expanding the
+         * array when it becomes full and finally shrinking it to the exact length.
          */
         @NotNull
         @Override
@@ -854,8 +794,8 @@ public enum SerializationStrategies implements SerializationStrategy {
     }
 
     /**
-     * A wrapper class for arrays which provides a mechanism for deserialization
-     * by resolving the actual array when being read from a serialized source.
+     * Temporary holder for arrays during deserialization. {@link #readResolve()}
+     * returns the actual array so callers see only the final result.
      */
     static class ArrayWrapper implements ReadResolvable<Object[]> {
 
@@ -880,10 +820,7 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * Provides a deserialization mechanism which returns the actual array
-         * when this wrapper is being read from a serialized source.
-         *
-         * @return The actual array wrapped by this wrapper.
+         * {@inheritDoc}
          */
         @NotNull
         @Override
@@ -893,12 +830,7 @@ public enum SerializationStrategies implements SerializationStrategy {
     }
 
     /**
-     * The following classes are wrappers that facilitate deserialization processes for
-     * specific types of objects. They implement the ReadResolvable interface to define
-     * the deserialization mechanism.
-     * <p>
-     * A wrapper class for primitive arrays which provides a mechanism for deserialization
-     * by resolving the actual array when being read from a serialized source.
+     * Temporary holder for primitive arrays during deserialization.
      */
     static class PrimArrayWrapper implements ReadResolvable<Object> {
 
@@ -923,10 +855,7 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * Provides a deserialization mechanism which returns the actual primitive array
-         * when this wrapper is being read from a serialized source.
-         *
-         * @return The actual primitive array wrapped by this wrapper.
+         * {@inheritDoc}
          */
         @NotNull
         @Override
@@ -936,8 +865,7 @@ public enum SerializationStrategies implements SerializationStrategy {
     }
 
     /**
-     * A wrapper class for Demarshallable objects which provides a mechanism for deserialization
-     * by resolving the actual Demarshallable object when being read from a serialized source.
+     * Wrapper used when reading {@link Demarshallable} objects lazily.
      */
     static class DemarshallableWrapper implements ReadResolvable<Demarshallable> {
 
@@ -962,10 +890,7 @@ public enum SerializationStrategies implements SerializationStrategy {
         }
 
         /**
-         * Provides a deserialization mechanism which returns the actual Demarshallable object
-         * when this wrapper is being read from a serialized source.
-         *
-         * @return The actual Demarshallable object wrapped by this wrapper.
+         * {@inheritDoc}
          */
         @NotNull
         @Override

--- a/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
+++ b/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
@@ -221,7 +221,7 @@ public enum SerializationStrategies implements SerializationStrategy {
     DYNAMIC_ENUM {
 
         // Reflective field access to the ordinal of the Enum class
-        private Field ordinal = Jvm.getField(Enum.class, "ordinal");
+        private final Field ordinal = Jvm.getField(Enum.class, "ordinal");
 
         /**
          * Reads a dynamic enum value from the provided input source.

--- a/src/main/java/net/openhft/chronicle/wire/SerializationStrategy.java
+++ b/src/main/java/net/openhft/chronicle/wire/SerializationStrategy.java
@@ -33,15 +33,14 @@ import org.jetbrains.annotations.Nullable;
 public interface SerializationStrategy {
 
     /**
-     * Reads an object of type {@code T} from the supplied input.
+     * Reads an object of type {@code T} from the provided input source and populates
+     * the given 'using' object, if not null. The method uses the given {@link BracketType}
+     * to aid in the deserialization.
      *
      * @param clazz       expected class of the object, or {@code null} to infer
      *                    from the wire or {@code using} instance
-     * @param using       optional instance to populate; if {@code null} this
-     *                    method may call {@link #newInstanceOrNull(Class)}. If
-     *                    that also returns {@code null} the strategy decides
-     *                    whether to return {@code null} or throw
-     *                    {@link InvalidMarshallableException}
+     * @param using       An optional object of type {@code T} that can be populated with the read data.
+     *      *              If null, a new object will be created or an exception might be thrown depending on implementation.
      * @param in          source of the wire data
      * @param bracketType hint about the expected structure such as map, sequence
      *                    or none
@@ -53,11 +52,12 @@ public interface SerializationStrategy {
     <T> T readUsing(Class<?> clazz, T using, ValueIn in, BracketType bracketType) throws InvalidMarshallableException;
 
     /**
-     * Attempts to create a new instance of the given type.
-     * Called when {@link #readUsing} needs an object but none was supplied.
+     * Constructs and returns a new instance of the provided {@code type}
+     * as a reference. If the instance cannot be constructed for any reason,
+     * {@code null} is returned.
      *
-     * @param type class of object to be created
-     * @return newly created instance or {@code null} if construction failed
+     * @param type The class type for which a new instance is required.
+     * @return A new instance of the provided {@code type} or {@code null} if instantiation is not possible.
      */
     @Nullable
     <T> T newInstanceOrNull(Class<T> type);
@@ -70,12 +70,10 @@ public interface SerializationStrategy {
     Class<?> type();
 
     /**
-     * The bracket type expected in the wire representation.
-     * For example {@link BracketType#MAP} for key-value pairs,
-     * {@link BracketType#SEQ} for sequences or {@link BracketType#NONE} for
-     * scalar values.
+     * Provides the bracket type used in the serialized format, which might
+     * give hints or constraints on how the data is structured.
      *
-     * @return the {@link BracketType} used by this strategy
+     * @return the {@link BracketType} used by this serialization strategy.
      */
     @NotNull
     BracketType bracketType();

--- a/src/main/java/net/openhft/chronicle/wire/SerializationStrategy.java
+++ b/src/main/java/net/openhft/chronicle/wire/SerializationStrategy.java
@@ -22,51 +22,60 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Represents a strategy for serializing and deserializing objects of type {@code T}.
- * Implementations of this interface define methods for reading, instantiating,
- * and providing metadata about the serialized format.
+ * Strategy for serialising and deserialising objects of type {@code T}.
+ * Implementations read data from a {@link ValueIn}, create instances as
+ * required and describe the wire format used. A strategy usually targets a
+ * particular Java type or category such as enums, {@link Marshallable}
+ * objects or collections. It dictates how objects are converted to and from a
+ * wire representation. See {@link SerializationStrategies} for the common
+ * built-in strategies.
  */
 public interface SerializationStrategy {
 
     /**
-     * Reads an object of type {@code T} from the provided input source and populates
-     * the given 'using' object, if not null. The method uses the given {@link BracketType}
-     * to aid in the deserialization.
+     * Reads an object of type {@code T} from the supplied input.
      *
-     * @param clazz The class type to be deserialized.
-     * @param using An optional object of type {@code T} that can be populated with the read data.
-     *              If null, a new object will be created or an exception might be thrown depending on implementation.
-     * @param in The input source containing serialized data.
-     * @param bracketType The type of bracket used in the serialized format.
-     * @return The populated or newly created object of type {@code T}.
-     * @throws InvalidMarshallableException If an error occurs during the deserialization process.
+     * @param clazz       expected class of the object, or {@code null} to infer
+     *                    from the wire or {@code using} instance
+     * @param using       optional instance to populate; if {@code null} this
+     *                    method may call {@link #newInstanceOrNull(Class)}. If
+     *                    that also returns {@code null} the strategy decides
+     *                    whether to return {@code null} or throw
+     *                    {@link InvalidMarshallableException}
+     * @param in          source of the wire data
+     * @param bracketType hint about the expected structure such as map, sequence
+     *                    or none
+     * @return the populated or newly created object, or {@code null} if no
+     * instance could be obtained
+     * @throws InvalidMarshallableException if the deserialisation fails
      */
     @Nullable
     <T> T readUsing(Class<?> clazz, T using, ValueIn in, BracketType bracketType) throws InvalidMarshallableException;
 
     /**
-     * Constructs and returns a new instance of the provided {@code type}
-     * as a reference. If the instance cannot be constructed for any reason,
-     * {@code null} is returned.
+     * Attempts to create a new instance of the given type.
+     * Called when {@link #readUsing} needs an object but none was supplied.
      *
-     * @param type The class type for which a new instance is required.
-     * @return A new instance of the provided {@code type} or {@code null} if instantiation is not possible.
+     * @param type class of object to be created
+     * @return newly created instance or {@code null} if construction failed
      */
     @Nullable
     <T> T newInstanceOrNull(Class<T> type);
 
     /**
-     * Returns the class type of objects this serialization strategy is designed to handle.
-     *
-     * @return The class type of objects this strategy can serialize and deserialize.
+     * Returns the primary Java {@link Class} that this strategy deals with.
+     * It may be a concrete type, an interface or a broad category such as
+     * {@code java.lang.Enum}.
      */
     Class<?> type();
 
     /**
-     * Provides the bracket type used in the serialized format, which might
-     * give hints or constraints on how the data is structured.
+     * The bracket type expected in the wire representation.
+     * For example {@link BracketType#MAP} for key-value pairs,
+     * {@link BracketType#SEQ} for sequences or {@link BracketType#NONE} for
+     * scalar values.
      *
-     * @return the {@link BracketType} used by this serialization strategy.
+     * @return the {@link BracketType} used by this strategy
      */
     @NotNull
     BracketType bracketType();

--- a/src/main/java/net/openhft/chronicle/wire/TextStopCharTesters.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextStopCharTesters.java
@@ -27,17 +27,15 @@ import java.util.BitSet;
  * character based on various parsing contexts.
  * <p>
  * This enum primarily caters to text parsing scenarios, especially when
- * determining the end of specific types or textual blocks. These are typically
- * used with methods like
- * {@link net.openhft.chronicle.bytes.BytesIn#parseUtf8(Appendable, StopCharTester)}.
+ * determining the end of specific types or textual blocks.
  */
 enum TextStopCharTesters implements StopCharTester {
 
     /**
-     * A {@link StopCharTester} that stops parsing when a character is not a
-     * valid part of a Java identifier. Some YAML-specific characters such as
-     * {@code !}, {@code .}, {@code -}, {@code [} and {@code ]} are treated as
-     * valid within type tags.
+     * Tester for determining the end of a type.
+     * <p>
+     * This tester checks if a character is considered to be a termination
+     * point based on Java identifier rules, but with a few exceptions.
      */
     END_OF_TYPE {
         @NotNull
@@ -49,10 +47,6 @@ enum TextStopCharTesters implements StopCharTester {
             return characterCode >= eowLength || eow.get(characterCode);
         }
     },
-    /**
-     * A {@link StopCharTester} that stops parsing at structural characters such
-     * as quotes, hash, newline, closing braces, colon or comma.
-     */
     END_OF_TEXT {
         @Override
         public boolean isStopChar(int characterCode) throws IllegalStateException {
@@ -75,11 +69,13 @@ enum TextStopCharTesters implements StopCharTester {
     };
 
     /**
-     * Internal helper to create the {@link BitSet} used by {@link #END_OF_TYPE}.
-     * By default, it considers all non-Java identifier characters as stop
-     * characters but makes exceptions for a few YAML tag symbols.
+     * Constructs a BitSet representing characters that mark
+     * the end of a type.
+     * <p>
+     * By default, it considers all non-Java identifier characters as stop chars
+     * but makes exceptions for certain characters.
      *
-     * @return a BitSet representing the stop characters for a type
+     * @return A BitSet representing the stop characters for a type.
      */
     private static BitSet endOfTypeBitSet() {
         final BitSet eow = new BitSet();

--- a/src/main/java/net/openhft/chronicle/wire/TextStopCharTesters.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextStopCharTesters.java
@@ -45,8 +45,8 @@ enum TextStopCharTesters implements StopCharTester {
         private final int eowLength = eow.length();
 
         @Override
-        public boolean isStopChar(int ch) {
-            return ch >= eowLength || eow.get(ch);
+        public boolean isStopChar(int characterCode) {
+            return characterCode >= eowLength || eow.get(characterCode);
         }
     },
     /**
@@ -55,8 +55,8 @@ enum TextStopCharTesters implements StopCharTester {
      */
     END_OF_TEXT {
         @Override
-        public boolean isStopChar(int ch) throws IllegalStateException {
-            switch (ch) {
+        public boolean isStopChar(int characterCode) throws IllegalStateException {
+            switch (characterCode) {
                 // one character stop.
                 case '"':
                 case '#':

--- a/src/main/java/net/openhft/chronicle/wire/TextStopCharTesters.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextStopCharTesters.java
@@ -27,15 +27,17 @@ import java.util.BitSet;
  * character based on various parsing contexts.
  * <p>
  * This enum primarily caters to text parsing scenarios, especially when
- * determining the end of specific types or textual blocks.
+ * determining the end of specific types or textual blocks. These are typically
+ * used with methods like
+ * {@link net.openhft.chronicle.bytes.BytesIn#parseUtf8(Appendable, StopCharTester)}.
  */
 enum TextStopCharTesters implements StopCharTester {
 
     /**
-     * Tester for determining the end of a type.
-     * <p>
-     * This tester checks if a character is considered to be a termination
-     * point based on Java identifier rules, but with a few exceptions.
+     * A {@link StopCharTester} that stops parsing when a character is not a
+     * valid part of a Java identifier. Some YAML-specific characters such as
+     * {@code !}, {@code .}, {@code -}, {@code [} and {@code ]} are treated as
+     * valid within type tags.
      */
     END_OF_TYPE {
         @NotNull
@@ -47,6 +49,10 @@ enum TextStopCharTesters implements StopCharTester {
             return ch >= eowLength || eow.get(ch);
         }
     },
+    /**
+     * A {@link StopCharTester} that stops parsing at structural characters such
+     * as quotes, hash, newline, closing braces, colon or comma.
+     */
     END_OF_TEXT {
         @Override
         public boolean isStopChar(int ch) throws IllegalStateException {
@@ -69,13 +75,11 @@ enum TextStopCharTesters implements StopCharTester {
     };
 
     /**
-     * Constructs a BitSet representing characters that mark
-     * the end of a type.
-     * <p>
-     * By default, it considers all non-Java identifier characters as stop chars
-     * but makes exceptions for certain characters.
+     * Internal helper to create the {@link BitSet} used by {@link #END_OF_TYPE}.
+     * By default, it considers all non-Java identifier characters as stop
+     * characters but makes exceptions for a few YAML tag symbols.
      *
-     * @return A BitSet representing the stop characters for a type.
+     * @return a BitSet representing the stop characters for a type
      */
     private static BitSet endOfTypeBitSet() {
         final BitSet eow = new BitSet();

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -157,8 +157,8 @@ public class TextWire extends YamlWireOut<TextWire> {
      * @throws IOException if any I/O error occurs.
      */
     @NotNull
-    public static TextWire fromFile(String name) throws IOException {
-        return new TextWire(BytesUtil.readFile(name), true);
+    public static TextWire fromFile(String filePath) throws IOException {
+        return new TextWire(BytesUtil.readFile(filePath), true);
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -49,43 +49,62 @@ import static net.openhft.chronicle.wire.TextStopCharTesters.END_OF_TYPE;
 import static net.openhft.chronicle.wire.Wires.*;
 
 /**
- * A representation of the YAML-based wire format. `TextWire` provides functionalities
- * for reading and writing objects in a YAML-based format, and encapsulates various characteristics
- * of the YAML text format.
+ * A YAML-based wire format optimised for human readability. It supports reading
+ * and writing objects in a YAML-like form and encapsulates the
+ * peculiarities of that text format.
  *
- * <p>This class utilizes bit sets, thread locals, and regular expressions to efficiently handle
- * the YAML formatting nuances.
- *
- * <p><b>Important:</b> Some configurations and methods in this class are marked as deprecated
- * and are slated for removal in future versions, suggesting that its behavior might evolve in future releases.
+ * <p>It is often used for configuration, debugging and interoperability with
+ * systems that expect YAML. While compatibility is a goal, the
+ * implementation is tuned for performance within the Chronicle ecosystem.</p>
  */
 @SuppressWarnings({"rawtypes", "unchecked", "this-escape"})
 public class TextWire extends YamlWireOut<TextWire> {
 
-    // Constants representing specific textual constructs in YAML.
+    /** Prefix used when emitting binary data. */
     public static final BytesStore<?, ?> BINARY = BytesStore.from("!!binary");
+
+    /** Marker for explicit type information within the text wire. */
     public static final @NotNull Bytes<byte[]> TYPE_STR = Bytes.from("type ");
+
+    /** Keyword for representing a sequence as a map. */
     static final String SEQ_MAP = "!seqmap";
 
-    // A set of characters considered as "end characters" in this wire format.
+    /** Characters that terminate events or values when reading. */
     static final BitSet END_CHARS = new BitSet();
 
-    // Thread locals for stop char testers that might need escaping in specific contexts.
-    // They are weakly referenced to avoid potential memory leaks in multithreaded environments.
-    static final ThreadLocal<WeakReference<StopCharTester>> ESCAPED_QUOTES = new ThreadLocal<>();//ThreadLocal.withInitial(StopCharTesters.QUOTES::escaping);
-    static final ThreadLocal<WeakReference<StopCharTester>> ESCAPED_SINGLE_QUOTES = new ThreadLocal<>();//ThreadLocal.withInitial(() -> StopCharTesters.SINGLE_QUOTES.escaping());
-    static final ThreadLocal<WeakReference<StopCharTester>> ESCAPED_END_OF_TEXT = new ThreadLocal<>();// ThreadLocal.withInitial(() -> TextStopCharsTesters.END_OF_TEXT.escaping());
-    static final ThreadLocal<WeakReference<StopCharsTester>> STRICT_ESCAPED_END_OF_TEXT = new ThreadLocal<>();// ThreadLocal.withInitial(() -> TextStopCharsTesters.END_OF_TEXT.escaping());
+    /**
+     * Provides thread-local testers for escaping rules so allocations are
+     * avoided during parsing.
+     */
+    static final ThreadLocal<WeakReference<StopCharTester>> ESCAPED_QUOTES = new ThreadLocal<>();
+
+    /** Thread-local tester for text inside single quotes. */
+    static final ThreadLocal<WeakReference<StopCharTester>> ESCAPED_SINGLE_QUOTES = new ThreadLocal<>();
+
+    /** Thread-local tester for content that ends at the first terminator. */
+    static final ThreadLocal<WeakReference<StopCharTester>> ESCAPED_END_OF_TEXT = new ThreadLocal<>();
+
+    /** Thread-local tester enforcing strict end-of-text rules. */
+    static final ThreadLocal<WeakReference<StopCharsTester>> STRICT_ESCAPED_END_OF_TEXT = new ThreadLocal<>();
+    /** Pattern used when processing regular expression escapes. */
     static final Pattern REGX_PATTERN = Pattern.compile("\\.|\\$");
 
-    // Suppliers for various stop char testers.
+    /** Suppliers returning new stop char testers when thread locals are empty. */
     static final Supplier<StopCharTester> QUOTES_ESCAPING = StopCharTesters.QUOTES::escaping;
+
+    /** Supplier for a tester that escapes single quoted text. */
     static final Supplier<StopCharTester> SINGLE_QUOTES_ESCAPING = StopCharTesters.SINGLE_QUOTES::escaping;
+
+    /** Supplier for an end-of-text tester. */
     static final Supplier<StopCharTester> END_OF_TEXT_ESCAPING = TextStopCharTesters.END_OF_TEXT::escaping;
+
+    /** Supplier for a strict end-of-text tester. */
     static final Supplier<StopCharsTester> STRICT_END_OF_TEXT_ESCAPING = TextStopCharsTesters.STRICT_END_OF_TEXT::escaping;
+
+    /** Supplier for escaping event name delimiters. */
     static final Supplier<StopCharsTester> END_EVENT_NAME_ESCAPING = TextStopCharsTesters.END_EVENT_NAME::escaping;
 
-    // Metadata representation in bytes.
+    /** Marker used to denote meta-data documents. */
     static final Bytes<?> META_DATA = Bytes.from("!!meta-data");
 
     static {
@@ -99,62 +118,65 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Input value parser specifically for text-based wire format.
+     * Primary {@link TextValueIn} instance used when deserialising values from
+     * this wire.
      */
     protected final TextValueIn valueIn = createValueIn();
 
     /**
-     * Represents the start of the current line being processed in the wire format.
+     * Byte position of the start of the current line used when calculating
+     * indentation.
      */
     protected long lineStart = 0;
 
     /**
-     * Default value input utility.
+     * Supplies a fallback {@link ValueIn} when a field is absent.
      */
     private DefaultValueIn defaultValueIn;
 
     /**
-     * Context for writing documents in the wire format.
+     * The active {@link WriteDocumentContext} managing document boundaries.
      */
     protected WriteDocumentContext writeContext;
 
     /**
-     * Context for reading documents from the wire format.
+     * The active {@link ReadDocumentContext} managing document boundaries.
      */
     protected ReadDocumentContext readContext;
 
     /**
-     * Flag to determine if strict parsing rules are applied.
+     * If true, parsing adheres to strict YAML rules and is less forgiving of
+     * deviations.
      */
     private boolean strict = false;
 
     /**
-     * Constructor to initialize the `TextWire` with a specific bytes representation
-     * and a flag to determine if 8-bit encoding is to be used.
+     * Creates a wire backed by the provided bytes.
      *
-     * @param bytes   Bytes representation.
-     * @param use8bit Flag to determine if 8-bit encoding is to be used.
+     * @param bytes   underlying data store
+     * @param use8bit if true strings are read and written using ISO-8859-1
+     *                rather than UTF-8
      */
     public TextWire(@NotNull Bytes<?> bytes, boolean use8bit) {
         super(bytes, use8bit);
     }
 
     /**
-     * Constructor that initializes the `TextWire` with bytes representation
-     * with default 8-bit encoding turned off.
+     * Creates a UTF-8 based wire backed by the provided bytes.
      *
-     * @param bytes Bytes representation.
+     * @param bytes underlying data store
      */
     public TextWire(@NotNull Bytes<?> bytes) {
         this(bytes, false);
     }
 
     /**
-     * Factory method to create a `TextWire` from a file.
+     * Returns a new {@code TextWire} initialised with the contents of the named
+     * file.
      *
-     * @param name Name of the file.
-     * @return A new instance of `TextWire`.
-     * @throws IOException if any I/O error occurs.
+     * @param name file path
+     * @return wire over the file contents
+     * @throws IOException if the file cannot be read
      */
     @NotNull
     public static TextWire fromFile(String name) throws IOException {
@@ -162,10 +184,10 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Factory method to create a `TextWire` from a string representation.
+     * Returns a new wire over the supplied text.
      *
-     * @param text String representation of the wire format.
-     * @return A new instance of `TextWire`.
+     * @param text YAML-like string
+     * @return wire instance containing that text
      */
     @NotNull
     public static TextWire from(@NotNull String text) {
@@ -173,10 +195,11 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Converts any wire format into a text representation.
+     * Converts any given wire into its textual representation. Handy for
+     * debugging or logging.
      *
-     * @param wire The wire format to be converted.
-     * @return The text representation of the wire format.
+     * @param wire source wire
+     * @return YAML-style text
      */
     public static String asText(@NotNull Wire wire) {
         NativeBytes<Void> bytes = nativeBytes();
@@ -195,12 +218,10 @@ public class TextWire extends YamlWireOut<TextWire> {
 
     // https://yaml.org/spec/1.2.2/#escaped-characters
     /**
-     * Processes and unescapes the provided {@link CharSequence} containing escaped sequences.
-     * For instance, "\\n" is converted to a newline character, "\\t" to a tab, etc.
-     * This method modifies the given sequence directly and adjusts its length if needed.
+     * Unescapes YAML escape sequences in-place. See the YAML&nbsp;1.2.2 spec
+     * section&nbsp;5.7 for details.
      *
-     * @param sb A {@link CharSequence} that is also an {@link Appendable}, containing potentially escaped sequences.
-     *           This sequence will be modified directly.
+     * @param sb text to modify in-place
      */
     public static <ACS extends Appendable & CharSequence> void unescape(@NotNull ACS sb) {
         int end = 0;
@@ -277,11 +298,8 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Acquires a {@link StopCharTester} instance related to escaping single quotes.
-     * This method utilizes thread-local storage to ensure that the returned instance is thread-safe.
-     *
-     * @return A {@link StopCharTester} instance specifically designed for escaping single quotes,
-     *         or null if such an instance could not be acquired.
+     * Returns a thread-local {@link StopCharTester} for text inside single
+     * quotes.
      */
     @Nullable
     static StopCharTester getEscapingSingleQuotes() {

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -152,7 +152,7 @@ public class TextWire extends YamlWireOut<TextWire> {
     /**
      * Factory method to create a `TextWire` from a file.
      *
-     * @param name Name of the file.
+     * @param filePath Name of the file.
      * @return A new instance of `TextWire`.
      * @throws IOException if any I/O error occurs.
      */

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -311,12 +311,12 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Loads an Object from a file
+     * Static utility to load and deserialise an object from a YAML-formatted file.
      *
-     * @param filename the file-path containing the object
-     * @param <T>      the type of the object to load
-     * @return an instance of the object created from the data in the file
-     * @throws IOException if the file can not be found or read
+     * @param filename file-path containing the YAML representation
+     * @param <T>      the expected object type
+     * @return deserialised instance created from the file contents
+     * @throws IOException if the file can not be read
      */
     public static <T> T load(String filename) throws IOException, InvalidMarshallableException {
         return (T) TextWire.fromFile(filename).readObject();
@@ -328,26 +328,25 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Retrieves the current strict mode setting for this TextWire instance.
-     *
-     * @return A boolean indicating whether strict mode is enabled (true) or disabled (false).
+     * Returns whether strict parsing is enabled.
      */
     public boolean strict() {
         return strict;
     }
 
     /**
-     * Sets the strict mode for this TextWire instance.
-     * When strict mode is enabled, the instance may enforce stricter parsing or serialization rules.
-     *
-     * @param strict A boolean value to set the strict mode. True to enable, false to disable.
-     * @return The current TextWire instance, allowing for method chaining.
+     * Enables or disables strict parsing mode.
      */
     public TextWire strict(boolean strict) {
         this.strict = strict;
         return this;
     }
 
+    /**
+     * Creates a method writer proxy for the given interface(s). Method calls on
+     * the proxy will be serialised to this {@code TextWire} instance using
+     * {@link WireType#TEXT}.
+     */
     @Override
     @NotNull
     public <T> T methodWriter(@NotNull Class<T> tClass, Class<?>... additional) {
@@ -362,12 +361,8 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Creates a new textual method writer invocation handler based on provided interface(s).
-     * If any of the provided interfaces have a {@link Comment} annotation,
-     * the associated comment is written to the wire.
-     *
-     * @param interfaces One or more interfaces that the created handler should be aware of.
-     * @return A newly instantiated {@link TextMethodWriterInvocationHandler} for the provided interface(s).
+     * Internal factory for creating the invocation handler used by text based
+     * method writers.
      */
     @NotNull
     TextMethodWriterInvocationHandler newTextMethodWriterInvocationHandler(Class<?>... interfaces) {
@@ -379,6 +374,10 @@ public class TextWire extends YamlWireOut<TextWire> {
         return new TextMethodWriterInvocationHandler(interfaces[0], this);
     }
 
+    /**
+     * Creates a builder for a text-based method writer. The resulting writer
+     * will serialise method calls to this {@code TextWire} instance.
+     */
     @Override
     @NotNull
     public <T> MethodWriterBuilder<T> methodWriterBuilder(@NotNull Class<T> tClass) {
@@ -438,10 +437,8 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Configures this TextWire instance to use binary document contexts for reading and writing.
-     * This will replace the current read and write contexts with binary contexts.
-     *
-     * @return The current TextWire instance, allowing for method chaining.
+     * Switches to binary document mode where document boundaries are length
+     * prefixed and metadata is kept separate from data.
      */
     @NotNull
     public TextWire useBinaryDocuments() {
@@ -451,10 +448,8 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Configures this TextWire instance to use textual document contexts for reading and writing.
-     * This will replace the current read and write contexts with textual contexts.
-     *
-     * @return The current TextWire instance, allowing for method chaining.
+     * Switches to text document mode where documents are separated by the
+     * {@code ---} and {@code ...} markers.
      */
     @NotNull
     public TextWire useTextDocuments() {
@@ -476,10 +471,7 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Creates and returns a new instance of TextValueIn.
-     * This method is primarily intended for internal use to provide consistent access to TextValueIn instances.
-     *
-     * @return A new instance of TextValueIn.
+     * Protected factory method to create the {@link TextValueIn} used by this wire.
      */
     @NotNull
     protected TextValueIn createValueIn() {
@@ -487,10 +479,8 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Converts the underlying bytes of this TextWire to its string representation.
-     * For large byte sequences, only the initial part of the data is returned followed by "..".
-     *
-     * @return A string representation of the TextWire's underlying bytes.
+     * Returns the remaining readable content of the wire's buffer.
+     * If more than 1&nbsp;MiB remains only the first MiB is returned followed by "..".
      */
     public String toString() {
         if (bytes.readRemaining() > (1024 * 1024)) {
@@ -506,18 +496,14 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Converts the underlying bytes of this TextWire to its ISO-8859-1 string representation.
-     *
-     * @return A string representation of the TextWire's underlying bytes in ISO-8859-1 encoding.
+     * Returns the remaining readable content as an ISO-8859-1 string.
      */
     public String to8bitString() {
         return bytes.to8bitString();
     }
 
     /**
-     * Converts the underlying bytes of this TextWire to its UTF-8 string representation.
-     *
-     * @return A string representation of the TextWire's underlying bytes in UTF-8 encoding.
+     * Returns the remaining readable content as a UTF-8 string.
      */
     public String toUtf8String() {
         return bytes.toUtf8String();
@@ -555,11 +541,7 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Reads the field from the current position of the wire and appends it to the given StringBuilder.
-     * The method handles different encodings and escape sequences, and ensures correct parsing of field data.
-     *
-     * @param sb The StringBuilder to which the field value should be appended.
-     * @return The updated StringBuilder containing the field value.
+     * Reads the next field name and appends it to the provided {@code StringBuilder}.
      */
     @NotNull
     protected StringBuilder readField(@NotNull StringBuilder sb) {
@@ -617,16 +599,16 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Trims trailing whitespace from the end of the given StringBuilder.
-     * This utility method ensures that field values are read without trailing spaces.
-     *
-     * @param sb The StringBuilder to be trimmed.
+     * Internal utility to remove trailing whitespace from a {@code StringBuilder}.
      */
     private void trimTheEnd(@NotNull StringBuilder sb) {
         while (sb.length() > 0 && Character.isWhitespace(sb.charAt(sb.length() - 1)))
             sb.setLength(sb.length() - 1);
     }
 
+    /**
+     * Reads the next event key and attempts to convert it to {@code expectedClass}.
+     */
     @Nullable
     @Override
     public <K> K readEvent(@NotNull Class<K> expectedClass) throws InvalidMarshallableException {
@@ -686,10 +668,7 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Returns the default class to be used as a key.
-     * By default, this method returns the Object class.
-     *
-     * @return The default key class, which is {@link Object}.
+     * Specifies the default class to assume for map keys if not otherwise specified.
      */
     protected Class<?> defaultKeyClass() {
         return Object.class;
@@ -709,10 +688,8 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Retrieves the StopCharTester that determines the end of text with escaping.
-     * The tester is fetched from a thread-local storage and then reset.
-     *
-     * @return The StopCharTester for determining the end of text with escaping.
+     * Returns a thread-local {@link StopCharTester} configured for parsing text
+     * until the end of a scalar value, respecting YAML escapes.
      */
     @NotNull
     protected StopCharTester getEscapingEndOfText() {
@@ -723,10 +700,7 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Retrieves the StopCharsTester that determines the end of text with strict escaping.
-     * The tester is fetched from thread-local storage and is then reset.
-     *
-     * @return The StopCharsTester for determining the end of text with strict escaping.
+     * Returns a thread-local {@link StopCharsTester} for strict end-of-text detection.
      */
     @NotNull
     protected StopCharsTester getStrictEscapingEndOfText() {
@@ -736,20 +710,18 @@ public class TextWire extends YamlWireOut<TextWire> {
         return escaping;
     }
 
+    /**
+     * Returns a thread-local {@link StopCharsTester} for parsing an event name.
+     */
     @NotNull
     protected StopCharsTester getEscapingEndEventName() {
         StopCharsTester escaping = ThreadLocalHelper.getTL(STRICT_ESCAPED_END_OF_TEXT, END_EVENT_NAME_ESCAPING);
-
-        // Reset the stop characters tester to stop at space characters.
         escaping.isStopChar(' ', ' ');
         return escaping;
     }
 
     /**
-     * Retrieves the StopCharTester that determines the end of a quoted text section with escaping.
-     * The tester is fetched from thread-local storage and is then reset.
-     *
-     * @return The StopCharTester for determining the end of a quoted text section with escaping.
+     * Returns a thread-local {@link StopCharTester} for parsing a quoted section.
      */
     @Nullable
     protected StopCharTester getEscapingQuotes() {
@@ -772,11 +744,10 @@ public class TextWire extends YamlWireOut<TextWire> {
 
     // TODO Move to valueIn
     /**
-     * Consumes padding characters from the current reading position.
-     * Padding characters include spaces, tabs, new lines, commas, and comments. This method also
-     * handles skipping over any comments encountered during this process.
-     *
-     * @param commas The number of comma characters to consume. Once this count is reached, the method will return.
+     * Consumes whitespace and comment lines. The {@code commas} parameter
+     * indicates how many comma separators are expected to be consumed as part of
+     * this padding; if more commas are found than expected and they are followed
+     * by structural characters, padding stops.
      */
     public void consumePadding(int commas) {
         for (; ; ) {
@@ -832,9 +803,8 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Consumes the start of a document in the byte stream. The start is determined by
-     * the presence of three consecutive '-' characters followed by certain words
-     * (e.g., "!!data", "!!meta-data").
+     * Consumes the YAML document start marker ({@code ---}) and any associated
+     * directives or leading whitespace/comments.
      */
     protected void consumeDocumentStart() {
         // Check if there are at least 4 bytes remaining to read.
@@ -864,18 +834,14 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Peeks the next unsigned byte from the current read position without advancing the pointer.
-     *
-     * @return The next unsigned byte as an integer.
+     * Internal method to peek the next character code without advancing.
      */
     int peekCode() {
         return bytes.peekUnsignedByte();
     }
 
     /**
-     * Peeks the unsigned byte after the current read position without advancing the pointer.
-     *
-     * @return The unsigned byte after the current read position as an integer.
+     * Internal method to peek one character ahead without advancing.
      */
     int peekCodeNext() {
         return bytes.peekUnsignedByte(bytes.readPosition() + 1);
@@ -909,9 +875,7 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Reads the next byte as an unsigned integer.
-     *
-     * @return The next byte if available or -1 if end-of-file.
+     * Internal method to read the next character code from the buffer.
      */
     protected int readCode() {
         if (bytes.readRemaining() < 1)

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -199,17 +199,17 @@ public class TextWire extends YamlWireOut<TextWire> {
      * For instance, "\\n" is converted to a newline character, "\\t" to a tab, etc.
      * This method modifies the given sequence directly and adjusts its length if needed.
      *
-     * @param targetBuffer A {@link CharSequence} that is also an {@link Appendable}, containing potentially escaped sequences.
-     *                     This sequence will be modified directly.
+     * @param sb A {@link CharSequence} that is also an {@link Appendable}, containing potentially escaped sequences.
+     *           This sequence will be modified directly.
      */
-    public static <ACS extends Appendable & CharSequence> void unescape(@NotNull ACS targetBuffer) {
+    public static <ACS extends Appendable & CharSequence> void unescape(@NotNull ACS sb) {
         int end = 0;
-        int length = targetBuffer.length();
+        int length = sb.length();
         for (int i = 0; i < length; i++) {
-            char ch = targetBuffer.charAt(i);
+            char ch = sb.charAt(i);
             // Check if the character is an escape character and if there's a character after it
             if (ch == '\\' && i < length - 1) {
-                char ch3 = targetBuffer.charAt(++i);
+                char ch3 = sb.charAt(++i);
                 // Handle different escaped characters
                 switch (ch3) {
                     case '0':
@@ -253,27 +253,27 @@ public class TextWire extends YamlWireOut<TextWire> {
                         break;
                     case 'x':
                         ch = (char)
-                                (Character.getNumericValue(targetBuffer.charAt(++i)) * 16 +
-                                        Character.getNumericValue(targetBuffer.charAt(++i)));
+                                (Character.getNumericValue(sb.charAt(++i)) * 16 +
+                                        Character.getNumericValue(sb.charAt(++i)));
                         break;
                     case 'u':
                         ch = (char)
-                                (Character.getNumericValue(targetBuffer.charAt(++i)) * 4096 +
-                                        Character.getNumericValue(targetBuffer.charAt(++i)) * 256 +
-                                        Character.getNumericValue(targetBuffer.charAt(++i)) * 16 +
-                                        Character.getNumericValue(targetBuffer.charAt(++i)));
+                                (Character.getNumericValue(sb.charAt(++i)) * 4096 +
+                                        Character.getNumericValue(sb.charAt(++i)) * 256 +
+                                        Character.getNumericValue(sb.charAt(++i)) * 16 +
+                                        Character.getNumericValue(sb.charAt(++i)));
                         break;
                     default:
                         ch = ch3;
                 }
             }
             // Set the unescaped character into the sequence
-            AppendableUtil.setCharAt(targetBuffer, end++, ch);
+            AppendableUtil.setCharAt(sb, end++, ch);
         }
         // Validate the length consistency after unescaping
-        if (length != targetBuffer.length())
-            throw new IllegalStateException("Length changed from " + length + " to " + targetBuffer.length() + " for " + targetBuffer);
-        AppendableUtil.setLength(targetBuffer, end);
+        if (length != sb.length())
+            throw new IllegalStateException("Length changed from " + length + " to " + sb.length() + " for " + sb);
+        AppendableUtil.setLength(sb, end);
     }
 
     /**
@@ -682,12 +682,12 @@ public class TextWire extends YamlWireOut<TextWire> {
      * The content of the StringBuilder is interned before the conversion.
      *
      * @param expectedClass The class to which the StringBuilder's content should be converted.
-     * @param keyTextBuilder The StringBuilder containing the data to be converted.
+     * @param sb The StringBuilder containing the data to be converted.
      * @return An instance of the expected class, converted from the StringBuilder's content.
      */
     @Nullable
-    private <K> K toExpected(Class<K> expectedClass, StringBuilder keyTextBuilder) {
-        return ObjectUtils.convertTo(expectedClass, WireInternal.INTERNER.intern(keyTextBuilder));
+    private <K> K toExpected(Class<K> expectedClass, StringBuilder sb) {
+        return ObjectUtils.convertTo(expectedClass, WireInternal.INTERNER.intern(sb));
     }
 
     /**
@@ -866,11 +866,11 @@ public class TextWire extends YamlWireOut<TextWire> {
     /**
      * returns {@code true} if the next string is {@code str}
      *
-     * @param expectedString string
+     * @param source string
      * @return true if the strings are the same
      */
-    protected boolean peekStringIgnoreCase(@NotNull final String expectedString) {
-        if (expectedString.isEmpty())
+    protected boolean peekStringIgnoreCase(@NotNull final String source) {
+        if (source.isEmpty())
             return true;
 
         if (bytes.readRemaining() < 1)
@@ -879,8 +879,8 @@ public class TextWire extends YamlWireOut<TextWire> {
         long pos = bytes.readPosition();
 
         try {
-            for (int i = 0; i < expectedString.length(); i++) {
-                if (Character.toLowerCase(expectedString.charAt(i)) != Character.toLowerCase(bytes.readByte()))
+            for (int i = 0; i < source.length(); i++) {
+                if (Character.toLowerCase(source.charAt(i)) != Character.toLowerCase(bytes.readByte()))
                     return false;
             }
         } finally {
@@ -1073,24 +1073,24 @@ public class TextWire extends YamlWireOut<TextWire> {
      * Parses a word from the current byte position until it encounters a space or stop character.
      * The parsed word is then appended to the provided StringBuilder.
      *
-     * @param outputBuilder The StringBuilder to which the parsed word will be appended.
+     * @param sb The StringBuilder to which the parsed word will be appended.
      */
-    public void parseWord(@NotNull StringBuilder outputBuilder) {
-        parseUntil(outputBuilder, StopCharTesters.SPACE_STOP);
+    public void parseWord(@NotNull StringBuilder sb) {
+        parseUntil(sb, StopCharTesters.SPACE_STOP);
     }
 
     /**
      * Parses characters from the current byte position until one of the specified stop characters
      * in the tester is encountered. The parsed characters are then appended to the provided StringBuilder.
      *
-     * @param outputBuilder       The StringBuilder to which the parsed characters will be appended.
+     * @param sb       The StringBuilder to which the parsed characters will be appended.
      * @param stopTester  A StopCharTester which determines which characters should stop the parsing.
      */
-    public void parseUntil(@NotNull StringBuilder outputBuilder, @NotNull StopCharTester stopTester) {
+    public void parseUntil(@NotNull StringBuilder sb, @NotNull StopCharTester stopTester) {
         if (use8bit)
-            bytes.parse8bit(outputBuilder, stopTester);
+            bytes.parse8bit(sb, stopTester);
         else
-            bytes.parseUtf8(outputBuilder, stopTester);
+            bytes.parseUtf8(sb, stopTester);
     }
 
     /**
@@ -1098,15 +1098,15 @@ public class TextWire extends YamlWireOut<TextWire> {
      * until one of the specified stop characters in the tester is encountered.
      * The parsed characters are then appended to the provided StringBuilder.
      *
-     * @param outputBuilder       The StringBuilder to which the parsed characters will be appended.
+     * @param sb       The StringBuilder to which the parsed characters will be appended.
      * @param stopTester  A StopCharsTester which determines which characters should stop the parsing.
      */
-    public void parseUntil(@NotNull StringBuilder outputBuilder, @NotNull StopCharsTester stopTester) {
-        outputBuilder.setLength(0);
+    public void parseUntil(@NotNull StringBuilder sb, @NotNull StopCharsTester stopTester) {
+        sb.setLength(0);
         if (use8bit) {
-            AppendableUtil.read8bitAndAppend(bytes, outputBuilder, stopTester);
+            AppendableUtil.read8bitAndAppend(bytes, sb, stopTester);
         } else {
-            AppendableUtil.readUTFAndAppend(bytes, outputBuilder, stopTester);
+            AppendableUtil.readUTFAndAppend(bytes, sb, stopTester);
         }
     }
 
@@ -1281,12 +1281,6 @@ public class TextWire extends YamlWireOut<TextWire> {
         bytes.clear();
     }
 
-    /**
-     * Checks whether the current wire position starts with the
-     * {@code !!meta-data} tag. If present the tag is consumed.
-     *
-     * @return {@code true} when the prefix was found and skipped
-     */
     @Override
     public boolean hasMetaDataPrefix() {
         if (bytes.startsWith(META_DATA)
@@ -1305,6 +1299,9 @@ public class TextWire extends YamlWireOut<TextWire> {
     /**
      * Represents a textual input value for deserialization. It manages a stack
      * of states, allowing for nested or sequential value reading.
+     * Provides the {@link ValueIn} implementation for {@link TextWire},
+     * handling deserialisation of values in a YAML-like text format.
+     * It manages a stack of states, allowing for nested or sequential value reading.
      */
     public class TextValueIn implements ValueIn {
 
@@ -1405,6 +1402,11 @@ public class TextWire extends YamlWireOut<TextWire> {
             }
         }
 
+        /**
+         * Core logic for reading a textual value into {@code destination}. Handles quoted
+         * strings, unquoted text, YAML tags such as {@code !null} and
+         * {@code !binary}, and resolves anchors or aliases.
+         */
         @SuppressWarnings("fallthrough")
         @Nullable <ACS extends Appendable & CharSequence> CharSequence textTo0(@NotNull ACS destination) {
             consumePadding();
@@ -1510,7 +1512,7 @@ public class TextWire extends YamlWireOut<TextWire> {
         /**
          * Called when a variable substitution such as {@code ${name}} is
          * encountered but not expanded. A warning is logged and the literal
-         * characters are copied into {@code a}.
+         * characters are copied into {@code destination}.
          */
         private <ACS extends Appendable & CharSequence> void unsubstitutedString(@NotNull ACS destination) {
             String text = bytes.toString();
@@ -2921,12 +2923,12 @@ public class TextWire extends YamlWireOut<TextWire> {
          *
          * @param reusableInstance An object to potentially reuse during deserialization for efficiency.
          * @param strategy The serialization strategy to be applied during deserialization.
-         * @param defaultType The expected type of the resulting object.
+         * @param type The expected type of the resulting object.
          * @return The deserialized object.
          * @throws InvalidMarshallableException If any issues are encountered during the deserialization process.
          */
         @Nullable
-        Object objectWithInferredType0(Object reusableInstance, @NotNull SerializationStrategy strategy, Class<?> defaultType) throws InvalidMarshallableException {
+        Object objectWithInferredType0(Object reusableInstance, @NotNull SerializationStrategy strategy, Class<?> type) throws InvalidMarshallableException {
             int code = peekCode();
             switch (code) {
                 // Different cases for different object types or data representations.
@@ -2934,7 +2936,7 @@ public class TextWire extends YamlWireOut<TextWire> {
                 case '?':
                     return map(Object.class, Object.class, (Map) reusableInstance);
                 case '!':
-                    return object(reusableInstance, defaultType);
+                    return object(reusableInstance, type);
                 case '-':
                     if (peekCodeNext() == ' ')
                         return readList(indentation(), null);
@@ -3058,13 +3060,13 @@ public class TextWire extends YamlWireOut<TextWire> {
          * If the class type isn't one of the recognized specialized types, an
          * {@link UnsupportedOperationException} will be thrown.
          *
-         * @param targetSequenceType The expected type of the sequence to be read.
+         * @param clazz The expected type of the sequence to be read.
          * @return An array or collection representing the read sequence.
          * @throws UnsupportedOperationException if the provided class type isn't supported.
          */
         @NotNull
-        private Object readSequence(@NotNull Class<?> targetSequenceType) {
-            if (targetSequenceType == Object[].class || targetSequenceType == Object.class) {
+        private Object readSequence(@NotNull Class<?> clazz) {
+            if (clazz == Object[].class || clazz == Object.class) {
                 // TODO: Consider using reflection to handle all array types.
                 @NotNull List<Object> list = new ArrayList<>();
                 sequence(list, (l, v) -> {
@@ -3072,10 +3074,10 @@ public class TextWire extends YamlWireOut<TextWire> {
                         l.add(v.object(Object.class));
                     }
                 });
-                return targetSequenceType == Object[].class ? list.toArray() : list;
+                return clazz == Object[].class ? list.toArray() : list;
 
             // Handle sequences expected to be of type String[].
-            } else if (targetSequenceType == String[].class) {
+            } else if (clazz == String[].class) {
                 @NotNull List<String> list = new ArrayList<>();
                 sequence(list, (l, v) -> {
                     while (v.hasNextSequenceItem()) {
@@ -3085,7 +3087,7 @@ public class TextWire extends YamlWireOut<TextWire> {
                 return list.toArray(new String[0]);
 
             // Handle sequences expected to be of type List.
-            } else if (targetSequenceType == List.class) {
+            } else if (clazz == List.class) {
                 @NotNull List<String> list = new ArrayList<>();
                 sequence(list, (l, v) -> {
                     while (v.hasNextSequenceItem()) {
@@ -3095,7 +3097,7 @@ public class TextWire extends YamlWireOut<TextWire> {
                 return list;
 
             // Handle sequences expected to be of type Set.
-            } else if (targetSequenceType == Set.class) {
+            } else if (clazz == Set.class) {
                 @NotNull Set<String> list = new HashSet<>();
                 sequence(list, (l, v) -> {
                     while (v.hasNextSequenceItem()) {
@@ -3107,7 +3109,7 @@ public class TextWire extends YamlWireOut<TextWire> {
             // Throw an exception if the class type is unsupported.
             } else {
                 throw new UnsupportedOperationException("Arrays of type "
-                        + targetSequenceType + " not supported.");
+                        + clazz + " not supported.");
             }
         }
 

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -1292,24 +1292,26 @@ public class TextWire extends YamlWireOut<TextWire> {
     enum NoObject {NO_OBJECT}
 
     /**
-     * Represents a textual input value for deserialization. It manages a stack
-     * of states, allowing for nested or sequential value reading.
+     * Provides the {@link ValueIn} implementation for {@link TextWire},
+     * handling deserialisation of values in a YAML-like text format.
      */
     public class TextValueIn implements ValueIn {
 
         /**
-         * Stack maintaining the states of value readings,
-         * allowing for nested structure reading.
+         * Maintains nested parsing state so complex structures can be read
+         * incrementally.
          */
         final ValueInStack stack = new ValueInStack();
 
         /**
-         * Limit for sequence reading.
+         * Tracks how many sequence items remain to be read in the current
+         * context.
          */
         int sequenceLimit = 0;
 
         /**
-         * Flag to denote if any kind of reading should be consumed.
+         * Set while {@link #readLengthMarshallable()} consumes the underlying
+         * text to measure its length.
          */
         private boolean consumeAny;
 
@@ -1394,6 +1396,12 @@ public class TextWire extends YamlWireOut<TextWire> {
             }
         }
 
+        /**
+         * Core logic for reading a textual value into {@code a}. Handles quoted
+         * strings, unquoted text, YAML tags such as {@code !null} and
+         * {@code !binary}, and resolves anchors or aliases. The raw text from
+         * the tokeniser is unescaped before returning.
+         */
         @SuppressWarnings("fallthrough")
         @Nullable <ACS extends Appendable & CharSequence> CharSequence textTo0(@NotNull ACS a) {
             consumePadding();
@@ -1496,6 +1504,11 @@ public class TextWire extends YamlWireOut<TextWire> {
             return ret;
         }
 
+        /**
+         * Called when a variable substitution such as {@code ${name}} is
+         * encountered but not expanded. A warning is logged and the literal
+         * characters are copied into {@code a}.
+         */
         private <ACS extends Appendable & CharSequence> void unsubstitutedString(@NotNull ACS a) {
             String text = bytes.toString();
             // Limit the log output to 32 characters for brevity
@@ -1517,20 +1530,27 @@ public class TextWire extends YamlWireOut<TextWire> {
             } while (!bytes.isEmpty() && c != '}');
         }
 
+        /**
+         * Helper used by {@link #textTo0(Appendable)} to read text delimited by
+         * {@code quotes}. The surrounding quote is skipped, the body parsed and
+         * unescaped, then any trailing padding is consumed.
+         */
         private <ACS extends Appendable & CharSequence> void readText(@NotNull ACS a, @NotNull StopCharTester quotes) {
-            // Skip the initial quote (either ' or ")
-            bytes.readSkip(1);
-            // Read the content based on the character encoding being used
+            bytes.readSkip(1); // consume opening quote
             if (use8bit)
-                bytes.parse8bit(a, quotes);  // Parse using 8-bit encoding
+                bytes.parse8bit(a, quotes);
             else
-                bytes.parseUtf8(a, quotes);  // Parse using UTF-8 encoding
-            // Unescape any escape sequences found in the content
+                bytes.parseUtf8(a, quotes);
             unescape(a);
-            // Consume any padding characters (e.g. whitespace)
             consumePadding(1);
         }
 
+        /**
+         * Peeks at the last significant character that was written or parsed,
+         * rewinding over spaces. If a newline is encountered the line start
+         * position is adjusted. The value is used when deciding whether to
+         * terminate values or handle optional commas.
+         */
         protected int peekBack() {
             while (bytes.readPosition() > bytes.start()) {
                 int prev = bytes.readUnsignedByte(bytes.readPosition() - 1);
@@ -1670,16 +1690,18 @@ public class TextWire extends YamlWireOut<TextWire> {
             return TextWire.this;
         }
 
+        /**
+         * Calculates the length of the current textual value by temporarily
+         * consuming it. The read position is restored once the measurement is
+         * complete.
+         */
         protected long readLengthMarshallable() {
             long start = bytes.readPosition();
             this.consumeAny = true;
             try {
-                // Consume all data until a meaningful stopping point
                 consumeAny();
-                // Calculate and return the length of the consumed data
                 return bytes.readPosition() - start;
             } finally {
-                // Reset the consumption flag and reading position
                 this.consumeAny = false;
                 bytes.readPosition(start);
                 // @TODO - use ScopedResource<StringBuilder> for consistency throughout YamlWireOut - https://github.com/OpenHFT/Chronicle-Wire/issues/879
@@ -1687,6 +1709,11 @@ public class TextWire extends YamlWireOut<TextWire> {
             }
         }
 
+        /**
+         * Recursively consumes the current YAML value without constructing an
+         * object. Maps, sequences, scalars and typed values are skipped so that
+         * the caller can move to the next field or token.
+         */
         protected void consumeAny() {
             consumePadding();
             int code = peekCode();
@@ -1763,7 +1790,8 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Consumes the type annotation (e.g., `!type`) in the text format.
+         * Consumes a {@code !type} tag and any trailing characters. The
+         * following value is then consumed by {@link #consumeAny()}.
          */
         private void consumeType2() {
             // Skip the '!' character which indicates the start of a type annotation
@@ -1788,7 +1816,8 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Consumes a sequence or list (e.g., `[item1, item2]`) in the text format.
+         * Consumes a YAML sequence without creating objects. Used by
+         * {@link #consumeAny()} when skipping over values.
          */
         private void consumeSeq() {
             int code;
@@ -1827,7 +1856,8 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Consumes a map structure (e.g., `{key1: value1, key2: value2}`) in the text format.
+         * Consumes a YAML map without materialising its contents. Invoked from
+         * {@link #consumeAny()} when skipping values or reading out of order.
          */
         private void consumeMap() {
             int code;
@@ -1866,7 +1896,8 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Consumes a value, which can be a primitive, type-annotated value, or another structure.
+         * Consumes a scalar or typed value. This method defers to
+         * {@link #consumeAny()} for nested structures.
          */
         private void consumeValue() {
             consumePadding();
@@ -1888,7 +1919,8 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Consumes a type, which is expected to end with a comma, space or another stop character.
+         * Consumes characters making up a type name, stopping at a comma or
+         * space. Used by {@link #consumeValue()}.
          */
         private void consumeType() {
             parseUntil(acquireStringBuilder(), StopCharTesters.COMMA_SPACE_STOP);
@@ -1950,10 +1982,9 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Retrieves a long value from the current position in the stream.
-         * It can handle quotes, booleans, or actual numbers.
-         *
-         * @return the long value from the stream or a default/fallback value in case of unconventional formats.
+         * Parses the current text token as a {@code long}. Quotes and boolean
+         * literals are handled and the method expects the token to contain plain
+         * text.
          */
         long getALong() {
             final int code = peekCode();
@@ -1986,7 +2017,9 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Handles the scenario where a number is expected, but an unsubstituted expression is found instead.
+         * Logs a warning when an unsubstituted variable such as {@code ${id}}
+         * is encountered where a number was expected and then skips the literal
+         * characters.
          */
         private void unsubstitutedNumber() {
             // Parse up to the closing character of the unsubstituted expression
@@ -2752,7 +2785,9 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Checks if the previous character is an end character, and if so, moves the read position back by one byte.
+         * After parsing a number this verifies whether the following byte is a
+         * delimiter such as '}', ']' or ','. If it is, the read position is
+         * rewound by one byte so the delimiter can be processed by the caller.
          */
         public void checkRewind() {
             // Peek at the previous character without changing the read position.
@@ -2765,8 +2800,8 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Checks for rewind condition. Currently, this just calls the checkRewind() method.
-         * This might be a placeholder for additional functionality or for overriding in subclasses.
+         * Variant used after reading a double. Currently delegates to
+         * {@link #checkRewind()}.
          */
         public void checkRewindDouble() {
             checkRewind();
@@ -2809,8 +2844,8 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * If the next character indicates the start of a type (i.e., it's a '!'),
-         * this method reads and discards the type string.
+         * If the current token begins with {@code !} this method consumes the
+         * tag name so that subsequent parsing sees only the value.
          */
         void skipType() {
             // Peek at the next byte without changing the read position.
@@ -2835,8 +2870,9 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * @return true if !!null "", if {@code true} reads the !!null "" up to the next STOP, if
-         * {@code false} no  data is read  ( data is only peaked if {@code false} )
+         * Checks whether the next token is {@code !!null ""}. If so the token
+         * is consumed and {@code true} returned; otherwise the stream is left
+         * untouched and {@code false} is returned.
          */
         @Override
         public boolean isNull() {
@@ -2893,16 +2929,14 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Reads an object from the byte stream based on inferred data type.
-         * This method dynamically determines the object's type based on specific
-         * indicators or sequences in the stream and then invokes the appropriate
-         * deserialization logic for that type.
+         * Core logic for deserialising an object when its type may be deduced
+         * from tags, anchors or surrounding structure.
          *
-         * @param using An object to potentially reuse during deserialization for efficiency.
-         * @param strategy The serialization strategy to be applied during deserialization.
-         * @param type The expected type of the resulting object.
-         * @return The deserialized object.
-         * @throws InvalidMarshallableException If any issues are encountered during the deserialization process.
+         * @param using     optional instance to reuse
+         * @param strategy  strategy describing how the value is bracketed
+         * @param type      the default type to instantiate
+         * @return the resulting object
+         * @throws InvalidMarshallableException if an error occurs while reading
          */
         @Nullable
         Object objectWithInferredType0(Object using, @NotNull SerializationStrategy strategy, Class<?> type) throws InvalidMarshallableException {
@@ -2962,16 +2996,11 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Attempts to read a number from the current stream context, dynamically determining
-         * its potential type and format. If it's not a recognizable number, the method may
-         * also consider the string as a date or time format.
-         * <p>
-         * The method supports various formats including long, double, {@link LocalTime},
-         * {@link LocalDate}, and {@link ZonedDateTime}. If the string representation is not
-         * recognizable as any of these formats, the original string is returned.
+         * Attempts to parse the current text token as a number or common
+         * date/time format. Falls back to returning the text itself if no known
+         * representation matches.
          *
-         * @return The decoded number, date, time, or original string. Returns null if the
-         *         string is either null or exceeds 40 characters in length.
+         * @return the decoded value or the original string
          */
         @Nullable
         protected Object readNumber() {
@@ -3029,17 +3058,9 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Reads a sequence from the current stream context and attempts to interpret
-         * it based on the provided class type. This method has specialized handling
-         * for arrays and collections including {@link Object[]}, {@link String[]},
-         * {@link List}, and {@link Set}.
-         * <p>
-         * If the class type isn't one of the recognized specialized types, an
-         * {@link UnsupportedOperationException} will be thrown.
-         *
-         * @param clazz The expected type of the sequence to be read.
-         * @return An array or collection representing the read sequence.
-         * @throws UnsupportedOperationException if the provided class type isn't supported.
+         * Deserialises a YAML sequence into either an array or a {@link Collection}
+         * of the requested type. Only a small set of collection types are
+         * supported.
          */
         @NotNull
         private Object readSequence(@NotNull Class<?> clazz) {

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -1434,11 +1434,11 @@ public class TextWire extends YamlWireOut<TextWire> {
 
                 }
                 case '"':
-                    readText(a, getEscapingQuotes());
+                    readText(destination, getEscapingQuotes());
                     break;
 
                 case '\'':
-                    readText(a, getEscapingSingleQuotes());
+                    readText(destination, getEscapingSingleQuotes());
                     break;
 
                 case '!': {
@@ -3069,9 +3069,17 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Deserialises a YAML sequence into either an array or a {@link Collection}
-         * of the requested type. Only a small set of collection types are
-         * supported.
+         * Reads a sequence from the current stream context and attempts to interpret
+         * it based on the provided class type. This method has specialized handling
+         * for arrays and collections including {@link Object[]}, {@link String[]},
+         * {@link List}, and {@link Set}.
+         * <p>
+         * If the class type isn't one of the recognized specialized types, an
+         * {@link UnsupportedOperationException} will be thrown.
+         *
+         * @param targetSequenceType The expected type of the sequence to be read.
+         * @return An array or collection representing the read sequence.
+         * @throws UnsupportedOperationException if the provided class type isn't supported.
          */
         @NotNull
         private Object readSequence(@NotNull Class<?> targetSequenceType) {
@@ -3086,7 +3094,7 @@ public class TextWire extends YamlWireOut<TextWire> {
                 return targetSequenceType == Object[].class ? list.toArray() : list;
 
             // Handle sequences expected to be of type String[].
-            } else if (clazz == String[].class) {
+            } else if (targetSequenceType == String[].class) {
                 @NotNull List<String> list = new ArrayList<>();
                 sequence(list, (l, v) -> {
                     while (v.hasNextSequenceItem()) {
@@ -3096,7 +3104,7 @@ public class TextWire extends YamlWireOut<TextWire> {
                 return list.toArray(new String[0]);
 
             // Handle sequences expected to be of type List.
-            } else if (clazz == List.class) {
+            } else if (targetSequenceType == List.class) {
                 @NotNull List<String> list = new ArrayList<>();
                 sequence(list, (l, v) -> {
                     while (v.hasNextSequenceItem()) {
@@ -3106,7 +3114,7 @@ public class TextWire extends YamlWireOut<TextWire> {
                 return list;
 
             // Handle sequences expected to be of type Set.
-            } else if (clazz == Set.class) {
+            } else if (targetSequenceType == Set.class) {
                 @NotNull Set<String> list = new HashSet<>();
                 sequence(list, (l, v) -> {
                     while (v.hasNextSequenceItem()) {
@@ -3118,7 +3126,7 @@ public class TextWire extends YamlWireOut<TextWire> {
             // Throw an exception if the class type is unsupported.
             } else {
                 throw new UnsupportedOperationException("Arrays of type "
-                        + clazz + " not supported.");
+                        + targetSequenceType + " not supported.");
             }
         }
 

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -1270,6 +1270,12 @@ public class TextWire extends YamlWireOut<TextWire> {
         bytes.clear();
     }
 
+    /**
+     * Checks whether the current wire position starts with the
+     * {@code !!meta-data} tag. If present the tag is consumed.
+     *
+     * @return {@code true} when the prefix was found and skipped
+     */
     @Override
     /**
      * Checks whether the current wire position starts with the

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -174,13 +174,13 @@ public class TextWire extends YamlWireOut<TextWire> {
      * Returns a new {@code TextWire} initialised with the contents of the named
      * file.
      *
-     * @param name file path
-     * @return wire over the file contents
-     * @throws IOException if the file cannot be read
+     * @param filePath Name of the file.
+     * @return A new instance of `TextWire`.
+     * @throws IOException if any I/O error occurs.
      */
     @NotNull
-    public static TextWire fromFile(String name) throws IOException {
-        return new TextWire(BytesUtil.readFile(name), true);
+    public static TextWire fromFile(String filePath) throws IOException {
+        return new TextWire(BytesUtil.readFile(filePath), true);
     }
 
     /**
@@ -221,16 +221,17 @@ public class TextWire extends YamlWireOut<TextWire> {
      * Unescapes YAML escape sequences in-place. See the YAML&nbsp;1.2.2 spec
      * section&nbsp;5.7 for details.
      *
-     * @param sb text to modify in-place
+     * @param targetBuffer A {@link CharSequence} that is also an {@link Appendable}, containing potentially escaped sequences.
+     *                     This sequence will be modified directly.
      */
-    public static <ACS extends Appendable & CharSequence> void unescape(@NotNull ACS sb) {
+    public static <ACS extends Appendable & CharSequence> void unescape(@NotNull ACS targetBuffer) {
         int end = 0;
-        int length = sb.length();
+        int length = targetBuffer.length();
         for (int i = 0; i < length; i++) {
-            char ch = sb.charAt(i);
+            char ch = targetBuffer.charAt(i);
             // Check if the character is an escape character and if there's a character after it
             if (ch == '\\' && i < length - 1) {
-                char ch3 = sb.charAt(++i);
+                char ch3 = targetBuffer.charAt(++i);
                 // Handle different escaped characters
                 switch (ch3) {
                     case '0':
@@ -274,27 +275,27 @@ public class TextWire extends YamlWireOut<TextWire> {
                         break;
                     case 'x':
                         ch = (char)
-                                (Character.getNumericValue(sb.charAt(++i)) * 16 +
-                                        Character.getNumericValue(sb.charAt(++i)));
+                                (Character.getNumericValue(targetBuffer.charAt(++i)) * 16 +
+                                        Character.getNumericValue(targetBuffer.charAt(++i)));
                         break;
                     case 'u':
                         ch = (char)
-                                (Character.getNumericValue(sb.charAt(++i)) * 4096 +
-                                        Character.getNumericValue(sb.charAt(++i)) * 256 +
-                                        Character.getNumericValue(sb.charAt(++i)) * 16 +
-                                        Character.getNumericValue(sb.charAt(++i)));
+                                (Character.getNumericValue(targetBuffer.charAt(++i)) * 4096 +
+                                        Character.getNumericValue(targetBuffer.charAt(++i)) * 256 +
+                                        Character.getNumericValue(targetBuffer.charAt(++i)) * 16 +
+                                        Character.getNumericValue(targetBuffer.charAt(++i)));
                         break;
                     default:
                         ch = ch3;
                 }
             }
             // Set the unescaped character into the sequence
-            AppendableUtil.setCharAt(sb, end++, ch);
+            AppendableUtil.setCharAt(targetBuffer, end++, ch);
         }
         // Validate the length consistency after unescaping
-        if (length != sb.length())
-            throw new IllegalStateException("Length changed from " + length + " to " + sb.length() + " for " + sb);
-        AppendableUtil.setLength(sb, end);
+        if (length != targetBuffer.length())
+            throw new IllegalStateException("Length changed from " + length + " to " + targetBuffer.length() + " for " + targetBuffer);
+        AppendableUtil.setLength(targetBuffer, end);
     }
 
     /**
@@ -679,12 +680,12 @@ public class TextWire extends YamlWireOut<TextWire> {
      * The content of the StringBuilder is interned before the conversion.
      *
      * @param expectedClass The class to which the StringBuilder's content should be converted.
-     * @param sb The StringBuilder containing the data to be converted.
+     * @param keyTextBuilder The StringBuilder containing the data to be converted.
      * @return An instance of the expected class, converted from the StringBuilder's content.
      */
     @Nullable
-    private <K> K toExpected(Class<K> expectedClass, StringBuilder sb) {
-        return ObjectUtils.convertTo(expectedClass, WireInternal.INTERNER.intern(sb));
+    private <K> K toExpected(Class<K> expectedClass, StringBuilder keyTextBuilder) {
+        return ObjectUtils.convertTo(expectedClass, WireInternal.INTERNER.intern(keyTextBuilder));
     }
 
     /**
@@ -850,11 +851,11 @@ public class TextWire extends YamlWireOut<TextWire> {
     /**
      * returns {@code true} if the next string is {@code str}
      *
-     * @param source string
+     * @param expectedString string
      * @return true if the strings are the same
      */
-    protected boolean peekStringIgnoreCase(@NotNull final String source) {
-        if (source.isEmpty())
+    protected boolean peekStringIgnoreCase(@NotNull final String expectedString) {
+        if (expectedString.isEmpty())
             return true;
 
         if (bytes.readRemaining() < 1)
@@ -863,8 +864,8 @@ public class TextWire extends YamlWireOut<TextWire> {
         long pos = bytes.readPosition();
 
         try {
-            for (int i = 0; i < source.length(); i++) {
-                if (Character.toLowerCase(source.charAt(i)) != Character.toLowerCase(bytes.readByte()))
+            for (int i = 0; i < expectedString.length(); i++) {
+                if (Character.toLowerCase(expectedString.charAt(i)) != Character.toLowerCase(bytes.readByte()))
                     return false;
             }
         } finally {
@@ -954,27 +955,27 @@ public class TextWire extends YamlWireOut<TextWire> {
      * search key a {@link DefaultValueIn} containing {@code defaultValue} is
      * returned.
      *
-     * @param keyName      field name being searched for
-     * @param keyCode      identifier used when marshalling numbers
-     * @param defaultValue default value to supply when the field is absent
-     * @param curr         state tracking previously read fields
-     * @param sb           scratch buffer used for name comparison
-     * @param name         same as {@code keyName}; retained for compatibility
-     * @return a {@link ValueIn} positioned on the matched value or a default one
+     * @param keyName       The name of the key for which the value needs to be read.
+     * @param keyCode       The code for the key.
+     * @param defaultValue  The default value to return if the key isn't found.
+     * @param currentState  The current state of the ValueIn.
+     * @param tempNameBuilder            The StringBuilder used to capture the field name.
+     * @param name          The name of the key (same as keyName, possibly added for clarity in some cases).
+     * @return              The value associated with the key or the default value if the key is not found.
      */
-    protected ValueIn read2(CharSequence keyName, int keyCode, Object defaultValue, @NotNull ValueInState curr, @NotNull StringBuilder sb, @NotNull CharSequence name) {
+    protected ValueIn read2(CharSequence keyName, int keyCode, Object defaultValue, @NotNull ValueInState currentState, @NotNull StringBuilder tempNameBuilder, @NotNull CharSequence name) {
         final long position2 = bytes.readPosition();
 
         // if not a match go back and look at old fields.
-        for (int i = 0; i < curr.unexpectedSize(); i++) {
-            bytes.readPosition(curr.unexpected(i));
+        for (int i = 0; i < currentState.unexpectedSize(); i++) {
+            bytes.readPosition(currentState.unexpected(i));
             valueIn.consumeAny = true;
-            readField(sb);
+            readField(tempNameBuilder);
             valueIn.consumeAny = false;
-            if (sb.length() == 0 || StringUtils.equalsCaseIgnore(sb, name)) {
+            if (tempNameBuilder.length() == 0 || StringUtils.equalsCaseIgnore(tempNameBuilder, name)) {
                 // if an old field matches, remove it, save the current position
-                curr.removeUnexpected(i);
-                curr.savedPosition(position2 + 1);
+                currentState.removeUnexpected(i);
+                currentState.savedPosition(position2 + 1);
                 return valueIn;
             }
         }
@@ -1066,38 +1067,38 @@ public class TextWire extends YamlWireOut<TextWire> {
      * Parses a single word from the wire and appends it to {@code sb}. A word is
      * delimited by whitespace.
      *
-     * @param sb destination for the parsed characters
+     * @param outputBuilder The StringBuilder to which the parsed word will be appended.
      */
-    public void parseWord(@NotNull StringBuilder sb) {
-        parseUntil(sb, StopCharTesters.SPACE_STOP);
+    public void parseWord(@NotNull StringBuilder outputBuilder) {
+        parseUntil(outputBuilder, StopCharTesters.SPACE_STOP);
     }
 
     /**
      * Parses text from the wire into {@code sb} until {@code testers} signals a
      * stop.
      *
-     * @param sb      destination for the parsed characters
-     * @param testers stop condition
+     * @param outputBuilder       The StringBuilder to which the parsed characters will be appended.
+     * @param stopTester  A StopCharTester which determines which characters should stop the parsing.
      */
-    public void parseUntil(@NotNull StringBuilder sb, @NotNull StopCharTester testers) {
+    public void parseUntil(@NotNull StringBuilder outputBuilder, @NotNull StopCharTester stopTester) {
         if (use8bit)
-            bytes.parse8bit(sb, testers);
+            bytes.parse8bit(outputBuilder, stopTester);
         else
-            bytes.parseUtf8(sb, testers);
+            bytes.parseUtf8(outputBuilder, stopTester);
     }
 
     /**
      * Clears {@code sb} and parses text until {@code testers} requests a stop.
      *
-     * @param sb      destination builder that will be cleared before use
-     * @param testers stop condition operating on multiple characters
+     * @param outputBuilder       The StringBuilder to which the parsed characters will be appended.
+     * @param stopTester  A StopCharsTester which determines which characters should stop the parsing.
      */
-    public void parseUntil(@NotNull StringBuilder sb, @NotNull StopCharsTester testers) {
-        sb.setLength(0);
+    public void parseUntil(@NotNull StringBuilder outputBuilder, @NotNull StopCharsTester stopTester) {
+        outputBuilder.setLength(0);
         if (use8bit) {
-            AppendableUtil.read8bitAndAppend(bytes, sb, testers);
+            AppendableUtil.read8bitAndAppend(bytes, outputBuilder, stopTester);
         } else {
-            AppendableUtil.readUTFAndAppend(bytes, sb, testers);
+            AppendableUtil.readUTFAndAppend(bytes, outputBuilder, stopTester);
         }
     }
 
@@ -1409,17 +1410,17 @@ public class TextWire extends YamlWireOut<TextWire> {
          * the tokeniser is unescaped before returning.
          */
         @SuppressWarnings("fallthrough")
-        @Nullable <ACS extends Appendable & CharSequence> CharSequence textTo0(@NotNull ACS a) {
+        @Nullable <ACS extends Appendable & CharSequence> CharSequence textTo0(@NotNull ACS destination) {
             consumePadding();
             int ch = peekCode();
-            @Nullable CharSequence ret = a;
+            @Nullable CharSequence ret = destination;
 
             switch (ch) {
                 case '{': {
                     // For map-like structures: read the length of the content and append to the target appendable
                     final long len = readLength();
                     try {
-                        a.append(Bytes.toString(bytes, bytes.readPosition(), len));
+                        destination.append(Bytes.toString(bytes, bytes.readPosition(), len));
                     } catch (IOException e) {
                         throw new AssertionError(e);
                     }
@@ -1429,7 +1430,7 @@ public class TextWire extends YamlWireOut<TextWire> {
                     // Move to the next comma or the end of the map
                     bytes.skipTo(StopCharTesters.COMMA_STOP);
 
-                    return a;
+                    return destination;
 
                 }
                 case '"':
@@ -1451,8 +1452,8 @@ public class TextWire extends YamlWireOut<TextWire> {
                         ret = null;
                     } else {
                         // ignore the type.
-                        if (a instanceof StringBuilder) {
-                            textTo((StringBuilder) a);
+                        if (destination instanceof StringBuilder) {
+                            textTo((StringBuilder) destination);
                         } else {
                             textTo(stringBuilder);
                             ret = stringBuilder;
@@ -1468,8 +1469,8 @@ public class TextWire extends YamlWireOut<TextWire> {
                 case '$':
                     // For variable substitution syntax (e.g. "${variable}")
                     if (peekCodeNext() == '{') {
-                        unsubstitutedString(a);
-                        return a;
+                        unsubstitutedString(destination);
+                        return destination;
                     }
                     // fall through
 
@@ -1478,24 +1479,24 @@ public class TextWire extends YamlWireOut<TextWire> {
 
                     final long rem = bytes.readRemaining();
                     if (rem > 0) {
-                        if (a instanceof Bytes) {
-                            bytes.parse8bit((Bytes) a, getStrictEscapingEndOfText());
+                        if (destination instanceof Bytes) {
+                            bytes.parse8bit((Bytes) destination, getStrictEscapingEndOfText());
                         } else if (use8bit) {
-                            bytes.parse8bit((StringBuilder) a, getStrictEscapingEndOfText());
+                            bytes.parse8bit((StringBuilder) destination, getStrictEscapingEndOfText());
                         } else {
-                            bytes.parseUtf8(a, getStrictEscapingEndOfText());
+                            bytes.parseUtf8(destination, getStrictEscapingEndOfText());
                         }
                         // If nothing was read, throw an exception
                         if (rem == bytes.readRemaining())
                             throw new IORuntimeException("Nothing to read at " + bytes.toDebugString(32));
                     } else {
                         // Clear the target appendable if no remaining content
-                        AppendableUtil.setLength(a, 0);
+                        AppendableUtil.setLength(destination, 0);
                     }
                     // trim trailing spaces.
-                    while (a.length() > 0) {
-                        if (Character.isWhitespace(a.charAt(a.length() - 1)))
-                            AppendableUtil.setLength(a, a.length() - 1);
+                    while (destination.length() > 0) {
+                        if (Character.isWhitespace(destination.charAt(destination.length() - 1)))
+                            AppendableUtil.setLength(destination, destination.length() - 1);
                         else
                             break;
                     }
@@ -1515,7 +1516,7 @@ public class TextWire extends YamlWireOut<TextWire> {
          * encountered but not expanded. A warning is logged and the literal
          * characters are copied into {@code a}.
          */
-        private <ACS extends Appendable & CharSequence> void unsubstitutedString(@NotNull ACS a) {
+        private <ACS extends Appendable & CharSequence> void unsubstitutedString(@NotNull ACS destination) {
             String text = bytes.toString();
             // Limit the log output to 32 characters for brevity
             if (text.length() > 32)
@@ -1528,7 +1529,7 @@ public class TextWire extends YamlWireOut<TextWire> {
                 c = bytes.readChar();
                 try {
                     // Append the read character to the provided appendable
-                    a.append(c);
+                    destination.append(c);
                 } catch (IOException e) {
                     throw new AssertionError(e);
                 }
@@ -1541,13 +1542,17 @@ public class TextWire extends YamlWireOut<TextWire> {
          * {@code quotes}. The surrounding quote is skipped, the body parsed and
          * unescaped, then any trailing padding is consumed.
          */
-        private <ACS extends Appendable & CharSequence> void readText(@NotNull ACS a, @NotNull StopCharTester quotes) {
-            bytes.readSkip(1); // consume opening quote
+        private <ACS extends Appendable & CharSequence> void readText(@NotNull ACS destination, @NotNull StopCharTester quotes) {
+            // Skip the initial quote (either ' or ")
+            bytes.readSkip(1);
+            // Read the content based on the character encoding being used
             if (use8bit)
-                bytes.parse8bit(a, quotes);
+                bytes.parse8bit(destination, quotes);  // Parse using 8-bit encoding
             else
-                bytes.parseUtf8(a, quotes);
-            unescape(a);
+                bytes.parseUtf8(destination, quotes);  // Parse using UTF-8 encoding
+            // Unescape any escape sequences found in the content
+            unescape(destination);
+            // Consume any padding characters (e.g. whitespace)
             consumePadding(1);
         }
 
@@ -2938,22 +2943,22 @@ public class TextWire extends YamlWireOut<TextWire> {
          * Core logic for deserialising an object when its type may be deduced
          * from tags, anchors or surrounding structure.
          *
-         * @param using     optional instance to reuse
-         * @param strategy  strategy describing how the value is bracketed
-         * @param type      the default type to instantiate
-         * @return the resulting object
-         * @throws InvalidMarshallableException if an error occurs while reading
+         * @param reusableInstance An object to potentially reuse during deserialization for efficiency.
+         * @param strategy The serialization strategy to be applied during deserialization.
+         * @param defaultType The expected type of the resulting object.
+         * @return The deserialized object.
+         * @throws InvalidMarshallableException If any issues are encountered during the deserialization process.
          */
         @Nullable
-        Object objectWithInferredType0(Object using, @NotNull SerializationStrategy strategy, Class<?> type) throws InvalidMarshallableException {
+        Object objectWithInferredType0(Object reusableInstance, @NotNull SerializationStrategy strategy, Class<?> defaultType) throws InvalidMarshallableException {
             int code = peekCode();
             switch (code) {
                 // Different cases for different object types or data representations.
                 // Each case handles the deserialization logic for that specific representation.
                 case '?':
-                    return map(Object.class, Object.class, (Map) using);
+                    return map(Object.class, Object.class, (Map) reusableInstance);
                 case '!':
-                    return object(using, type);
+                    return object(reusableInstance, defaultType);
                 case '-':
                     if (peekCodeNext() == ' ')
                         return readList(indentation(), null);
@@ -2981,11 +2986,11 @@ public class TextWire extends YamlWireOut<TextWire> {
             }
 
             // Convert the content to a Bytes or StringBuilder if the using object is of that type.
-            if (using instanceof Bytes)
-                return valueIn.textTo((Bytes) using);
+            if (reusableInstance instanceof Bytes)
+                return valueIn.textTo((Bytes) reusableInstance);
 
-            if (using instanceof StringBuilder)
-                return valueIn.textTo((StringBuilder) using);
+            if (reusableInstance instanceof StringBuilder)
+                return valueIn.textTo((StringBuilder) reusableInstance);
 
             @Nullable String text = valueIn.text();
             if (text == null || Enum.class.isAssignableFrom(strategy.type()))
@@ -3069,8 +3074,8 @@ public class TextWire extends YamlWireOut<TextWire> {
          * supported.
          */
         @NotNull
-        private Object readSequence(@NotNull Class<?> clazz) {
-            if (clazz == Object[].class || clazz == Object.class) {
+        private Object readSequence(@NotNull Class<?> targetSequenceType) {
+            if (targetSequenceType == Object[].class || targetSequenceType == Object.class) {
                 // TODO: Consider using reflection to handle all array types.
                 @NotNull List<Object> list = new ArrayList<>();
                 sequence(list, (l, v) -> {
@@ -3078,7 +3083,7 @@ public class TextWire extends YamlWireOut<TextWire> {
                         l.add(v.object(Object.class));
                     }
                 });
-                return clazz == Object[].class ? list.toArray() : list;
+                return targetSequenceType == Object[].class ? list.toArray() : list;
 
             // Handle sequences expected to be of type String[].
             } else if (clazz == String[].class) {

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -174,13 +174,13 @@ public class TextWire extends YamlWireOut<TextWire> {
      * Returns a new {@code TextWire} initialised with the contents of the named
      * file.
      *
-     * @param filePath Name of the file.
-     * @return A new instance of `TextWire`.
-     * @throws IOException if any I/O error occurs.
+     * @param name file path
+     * @return wire over the file contents
+     * @throws IOException if the file cannot be read
      */
     @NotNull
-    public static TextWire fromFile(String filePath) throws IOException {
-        return new TextWire(BytesUtil.readFile(filePath), true);
+    public static TextWire fromFile(String name) throws IOException {
+        return new TextWire(BytesUtil.readFile(name), true);
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -49,62 +49,43 @@ import static net.openhft.chronicle.wire.TextStopCharTesters.END_OF_TYPE;
 import static net.openhft.chronicle.wire.Wires.*;
 
 /**
- * A YAML-based wire format optimised for human readability. It supports reading
- * and writing objects in a YAML-like form and encapsulates the
- * peculiarities of that text format.
+ * A representation of the YAML-based wire format. `TextWire` provides functionalities
+ * for reading and writing objects in a YAML-based format, and encapsulates various characteristics
+ * of the YAML text format.
  *
- * <p>It is often used for configuration, debugging and interoperability with
- * systems that expect YAML. While compatibility is a goal, the
- * implementation is tuned for performance within the Chronicle ecosystem.</p>
+ * <p>This class utilizes bit sets, thread locals, and regular expressions to efficiently handle
+ * the YAML formatting nuances.
+ *
+ * <p><b>Important:</b> Some configurations and methods in this class are marked as deprecated
+ * and are slated for removal in future versions, suggesting that its behavior might evolve in future releases.
  */
 @SuppressWarnings({"rawtypes", "unchecked", "this-escape"})
 public class TextWire extends YamlWireOut<TextWire> {
 
-    /** Prefix used when emitting binary data. */
+    // Constants representing specific textual constructs in YAML.
     public static final BytesStore<?, ?> BINARY = BytesStore.from("!!binary");
-
-    /** Marker for explicit type information within the text wire. */
     public static final @NotNull Bytes<byte[]> TYPE_STR = Bytes.from("type ");
-
-    /** Keyword for representing a sequence as a map. */
     static final String SEQ_MAP = "!seqmap";
 
-    /** Characters that terminate events or values when reading. */
+    // A set of characters considered as "end characters" in this wire format.
     static final BitSet END_CHARS = new BitSet();
 
-    /**
-     * Provides thread-local testers for escaping rules so allocations are
-     * avoided during parsing.
-     */
-    static final ThreadLocal<WeakReference<StopCharTester>> ESCAPED_QUOTES = new ThreadLocal<>();
-
-    /** Thread-local tester for text inside single quotes. */
-    static final ThreadLocal<WeakReference<StopCharTester>> ESCAPED_SINGLE_QUOTES = new ThreadLocal<>();
-
-    /** Thread-local tester for content that ends at the first terminator. */
-    static final ThreadLocal<WeakReference<StopCharTester>> ESCAPED_END_OF_TEXT = new ThreadLocal<>();
-
-    /** Thread-local tester enforcing strict end-of-text rules. */
-    static final ThreadLocal<WeakReference<StopCharsTester>> STRICT_ESCAPED_END_OF_TEXT = new ThreadLocal<>();
-    /** Pattern used when processing regular expression escapes. */
+    // Thread locals for stop char testers that might need escaping in specific contexts.
+    // They are weakly referenced to avoid potential memory leaks in multithreaded environments.
+    static final ThreadLocal<WeakReference<StopCharTester>> ESCAPED_QUOTES = new ThreadLocal<>();//ThreadLocal.withInitial(StopCharTesters.QUOTES::escaping);
+    static final ThreadLocal<WeakReference<StopCharTester>> ESCAPED_SINGLE_QUOTES = new ThreadLocal<>();//ThreadLocal.withInitial(() -> StopCharTesters.SINGLE_QUOTES.escaping());
+    static final ThreadLocal<WeakReference<StopCharTester>> ESCAPED_END_OF_TEXT = new ThreadLocal<>();// ThreadLocal.withInitial(() -> TextStopCharsTesters.END_OF_TEXT.escaping());
+    static final ThreadLocal<WeakReference<StopCharsTester>> STRICT_ESCAPED_END_OF_TEXT = new ThreadLocal<>();// ThreadLocal.withInitial(() -> TextStopCharsTesters.END_OF_TEXT.escaping());
     static final Pattern REGX_PATTERN = Pattern.compile("\\.|\\$");
 
-    /** Suppliers returning new stop char testers when thread locals are empty. */
+    // Suppliers for various stop char testers.
     static final Supplier<StopCharTester> QUOTES_ESCAPING = StopCharTesters.QUOTES::escaping;
-
-    /** Supplier for a tester that escapes single quoted text. */
     static final Supplier<StopCharTester> SINGLE_QUOTES_ESCAPING = StopCharTesters.SINGLE_QUOTES::escaping;
-
-    /** Supplier for an end-of-text tester. */
     static final Supplier<StopCharTester> END_OF_TEXT_ESCAPING = TextStopCharTesters.END_OF_TEXT::escaping;
-
-    /** Supplier for a strict end-of-text tester. */
     static final Supplier<StopCharsTester> STRICT_END_OF_TEXT_ESCAPING = TextStopCharsTesters.STRICT_END_OF_TEXT::escaping;
-
-    /** Supplier for escaping event name delimiters. */
     static final Supplier<StopCharsTester> END_EVENT_NAME_ESCAPING = TextStopCharsTesters.END_EVENT_NAME::escaping;
 
-    /** Marker used to denote meta-data documents. */
+    // Metadata representation in bytes.
     static final Bytes<?> META_DATA = Bytes.from("!!meta-data");
 
     static {
@@ -118,65 +99,62 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Primary {@link TextValueIn} instance used when deserialising values from
-     * this wire.
+     * Input value parser specifically for text-based wire format.
      */
     protected final TextValueIn valueIn = createValueIn();
 
     /**
-     * Byte position of the start of the current line used when calculating
-     * indentation.
+     * Represents the start of the current line being processed in the wire format.
      */
     protected long lineStart = 0;
 
     /**
-     * Supplies a fallback {@link ValueIn} when a field is absent.
+     * Default value input utility.
      */
     private DefaultValueIn defaultValueIn;
 
     /**
-     * The active {@link WriteDocumentContext} managing document boundaries.
+     * Context for writing documents in the wire format.
      */
     protected WriteDocumentContext writeContext;
 
     /**
-     * The active {@link ReadDocumentContext} managing document boundaries.
+     * Context for reading documents from the wire format.
      */
     protected ReadDocumentContext readContext;
 
     /**
-     * If true, parsing adheres to strict YAML rules and is less forgiving of
-     * deviations.
+     * Flag to determine if strict parsing rules are applied.
      */
     private boolean strict = false;
 
     /**
-     * Creates a wire backed by the provided bytes.
+     * Constructor to initialize the `TextWire` with a specific bytes representation
+     * and a flag to determine if 8-bit encoding is to be used.
      *
-     * @param bytes   underlying data store
-     * @param use8bit if true strings are read and written using ISO-8859-1
-     *                rather than UTF-8
+     * @param bytes   Bytes representation.
+     * @param use8bit Flag to determine if 8-bit encoding is to be used.
      */
     public TextWire(@NotNull Bytes<?> bytes, boolean use8bit) {
         super(bytes, use8bit);
     }
 
     /**
-     * Creates a UTF-8 based wire backed by the provided bytes.
+     * Constructor that initializes the `TextWire` with bytes representation
+     * with default 8-bit encoding turned off.
      *
-     * @param bytes underlying data store
+     * @param bytes Bytes representation.
      */
     public TextWire(@NotNull Bytes<?> bytes) {
         this(bytes, false);
     }
 
     /**
-     * Returns a new {@code TextWire} initialised with the contents of the named
-     * file.
+     * Factory method to create a `TextWire` from a file.
      *
-     * @param name file path
-     * @return wire over the file contents
-     * @throws IOException if the file cannot be read
+     * @param name Name of the file.
+     * @return A new instance of `TextWire`.
+     * @throws IOException if any I/O error occurs.
      */
     @NotNull
     public static TextWire fromFile(String name) throws IOException {
@@ -184,10 +162,10 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Returns a new wire over the supplied text.
+     * Factory method to create a `TextWire` from a string representation.
      *
-     * @param text YAML-like string
-     * @return wire instance containing that text
+     * @param text String representation of the wire format.
+     * @return A new instance of `TextWire`.
      */
     @NotNull
     public static TextWire from(@NotNull String text) {
@@ -195,11 +173,10 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Converts any given wire into its textual representation. Handy for
-     * debugging or logging.
+     * Converts any wire format into a text representation.
      *
-     * @param wire source wire
-     * @return YAML-style text
+     * @param wire The wire format to be converted.
+     * @return The text representation of the wire format.
      */
     public static String asText(@NotNull Wire wire) {
         NativeBytes<Void> bytes = nativeBytes();
@@ -218,8 +195,9 @@ public class TextWire extends YamlWireOut<TextWire> {
 
     // https://yaml.org/spec/1.2.2/#escaped-characters
     /**
-     * Unescapes YAML escape sequences in-place. See the YAML&nbsp;1.2.2 spec
-     * section&nbsp;5.7 for details.
+     * Processes and unescapes the provided {@link CharSequence} containing escaped sequences.
+     * For instance, "\\n" is converted to a newline character, "\\t" to a tab, etc.
+     * This method modifies the given sequence directly and adjusts its length if needed.
      *
      * @param targetBuffer A {@link CharSequence} that is also an {@link Appendable}, containing potentially escaped sequences.
      *                     This sequence will be modified directly.
@@ -299,8 +277,11 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Returns a thread-local {@link StopCharTester} for text inside single
-     * quotes.
+     * Acquires a {@link StopCharTester} instance related to escaping single quotes.
+     * This method utilizes thread-local storage to ensure that the returned instance is thread-safe.
+     *
+     * @return A {@link StopCharTester} instance specifically designed for escaping single quotes,
+     *         or null if such an instance could not be acquired.
      */
     @Nullable
     static StopCharTester getEscapingSingleQuotes() {
@@ -312,12 +293,12 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Static utility to load and deserialise an object from a YAML-formatted file.
+     * Loads an Object from a file
      *
-     * @param filename file-path containing the YAML representation
-     * @param <T>      the expected object type
-     * @return deserialised instance created from the file contents
-     * @throws IOException if the file can not be read
+     * @param filename the file-path containing the object
+     * @param <T>      the type of the object to load
+     * @return an instance of the object created from the data in the file
+     * @throws IOException if the file can not be found or read
      */
     public static <T> T load(String filename) throws IOException, InvalidMarshallableException {
         return (T) TextWire.fromFile(filename).readObject();
@@ -329,25 +310,26 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Returns whether strict parsing is enabled.
+     * Retrieves the current strict mode setting for this TextWire instance.
+     *
+     * @return A boolean indicating whether strict mode is enabled (true) or disabled (false).
      */
     public boolean strict() {
         return strict;
     }
 
     /**
-     * Enables or disables strict parsing mode.
+     * Sets the strict mode for this TextWire instance.
+     * When strict mode is enabled, the instance may enforce stricter parsing or serialization rules.
+     *
+     * @param strict A boolean value to set the strict mode. True to enable, false to disable.
+     * @return The current TextWire instance, allowing for method chaining.
      */
     public TextWire strict(boolean strict) {
         this.strict = strict;
         return this;
     }
 
-    /**
-     * Creates a method writer proxy for the given interface(s). Method calls on
-     * the proxy will be serialised to this {@code TextWire} instance using
-     * {@link WireType#TEXT}.
-     */
     @Override
     @NotNull
     public <T> T methodWriter(@NotNull Class<T> tClass, Class<?>... additional) {
@@ -362,8 +344,12 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Internal factory for creating the invocation handler used by text based
-     * method writers.
+     * Creates a new textual method writer invocation handler based on provided interface(s).
+     * If any of the provided interfaces have a {@link Comment} annotation,
+     * the associated comment is written to the wire.
+     *
+     * @param interfaces One or more interfaces that the created handler should be aware of.
+     * @return A newly instantiated {@link TextMethodWriterInvocationHandler} for the provided interface(s).
      */
     @NotNull
     TextMethodWriterInvocationHandler newTextMethodWriterInvocationHandler(Class<?>... interfaces) {
@@ -375,10 +361,6 @@ public class TextWire extends YamlWireOut<TextWire> {
         return new TextMethodWriterInvocationHandler(interfaces[0], this);
     }
 
-    /**
-     * Creates a builder for a text-based method writer. The resulting writer
-     * will serialise method calls to this {@code TextWire} instance.
-     */
     @Override
     @NotNull
     public <T> MethodWriterBuilder<T> methodWriterBuilder(@NotNull Class<T> tClass) {
@@ -438,8 +420,10 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Switches to binary document mode where document boundaries are length
-     * prefixed and metadata is kept separate from data.
+     * Configures this TextWire instance to use binary document contexts for reading and writing.
+     * This will replace the current read and write contexts with binary contexts.
+     *
+     * @return The current TextWire instance, allowing for method chaining.
      */
     @NotNull
     public TextWire useBinaryDocuments() {
@@ -449,8 +433,10 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Switches to text document mode where documents are separated by the
-     * {@code ---} and {@code ...} markers.
+     * Configures this TextWire instance to use textual document contexts for reading and writing.
+     * This will replace the current read and write contexts with textual contexts.
+     *
+     * @return The current TextWire instance, allowing for method chaining.
      */
     @NotNull
     public TextWire useTextDocuments() {
@@ -472,7 +458,10 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Protected factory method to create the {@link TextValueIn} used by this wire.
+     * Creates and returns a new instance of TextValueIn.
+     * This method is primarily intended for internal use to provide consistent access to TextValueIn instances.
+     *
+     * @return A new instance of TextValueIn.
      */
     @NotNull
     protected TextValueIn createValueIn() {
@@ -480,8 +469,10 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Returns the remaining readable content of the wire's buffer.
-     * If more than 1&nbsp;MiB remains only the first MiB is returned followed by "..".
+     * Converts the underlying bytes of this TextWire to its string representation.
+     * For large byte sequences, only the initial part of the data is returned followed by "..".
+     *
+     * @return A string representation of the TextWire's underlying bytes.
      */
     public String toString() {
         if (bytes.readRemaining() > (1024 * 1024)) {
@@ -497,14 +488,18 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Returns the remaining readable content as an ISO-8859-1 string.
+     * Converts the underlying bytes of this TextWire to its ISO-8859-1 string representation.
+     *
+     * @return A string representation of the TextWire's underlying bytes in ISO-8859-1 encoding.
      */
     public String to8bitString() {
         return bytes.to8bitString();
     }
 
     /**
-     * Returns the remaining readable content as a UTF-8 string.
+     * Converts the underlying bytes of this TextWire to its UTF-8 string representation.
+     *
+     * @return A string representation of the TextWire's underlying bytes in UTF-8 encoding.
      */
     public String toUtf8String() {
         return bytes.toUtf8String();
@@ -542,7 +537,11 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Reads the next field name and appends it to the provided {@code StringBuilder}.
+     * Reads the field from the current position of the wire and appends it to the given StringBuilder.
+     * The method handles different encodings and escape sequences, and ensures correct parsing of field data.
+     *
+     * @param sb The StringBuilder to which the field value should be appended.
+     * @return The updated StringBuilder containing the field value.
      */
     @NotNull
     protected StringBuilder readField(@NotNull StringBuilder sb) {
@@ -600,16 +599,16 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Internal utility to remove trailing whitespace from a {@code StringBuilder}.
+     * Trims trailing whitespace from the end of the given StringBuilder.
+     * This utility method ensures that field values are read without trailing spaces.
+     *
+     * @param sb The StringBuilder to be trimmed.
      */
     private void trimTheEnd(@NotNull StringBuilder sb) {
         while (sb.length() > 0 && Character.isWhitespace(sb.charAt(sb.length() - 1)))
             sb.setLength(sb.length() - 1);
     }
 
-    /**
-     * Reads the next event key and attempts to convert it to {@code expectedClass}.
-     */
     @Nullable
     @Override
     public <K> K readEvent(@NotNull Class<K> expectedClass) throws InvalidMarshallableException {
@@ -669,7 +668,10 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Specifies the default class to assume for map keys if not otherwise specified.
+     * Returns the default class to be used as a key.
+     * By default, this method returns the Object class.
+     *
+     * @return The default key class, which is {@link Object}.
      */
     protected Class<?> defaultKeyClass() {
         return Object.class;
@@ -689,8 +691,10 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Returns a thread-local {@link StopCharTester} configured for parsing text
-     * until the end of a scalar value, respecting YAML escapes.
+     * Retrieves the StopCharTester that determines the end of text with escaping.
+     * The tester is fetched from a thread-local storage and then reset.
+     *
+     * @return The StopCharTester for determining the end of text with escaping.
      */
     @NotNull
     protected StopCharTester getEscapingEndOfText() {
@@ -701,7 +705,10 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Returns a thread-local {@link StopCharsTester} for strict end-of-text detection.
+     * Retrieves the StopCharsTester that determines the end of text with strict escaping.
+     * The tester is fetched from thread-local storage and is then reset.
+     *
+     * @return The StopCharsTester for determining the end of text with strict escaping.
      */
     @NotNull
     protected StopCharsTester getStrictEscapingEndOfText() {
@@ -711,18 +718,20 @@ public class TextWire extends YamlWireOut<TextWire> {
         return escaping;
     }
 
-    /**
-     * Returns a thread-local {@link StopCharsTester} for parsing an event name.
-     */
     @NotNull
     protected StopCharsTester getEscapingEndEventName() {
         StopCharsTester escaping = ThreadLocalHelper.getTL(STRICT_ESCAPED_END_OF_TEXT, END_EVENT_NAME_ESCAPING);
+
+        // Reset the stop characters tester to stop at space characters.
         escaping.isStopChar(' ', ' ');
         return escaping;
     }
 
     /**
-     * Returns a thread-local {@link StopCharTester} for parsing a quoted section.
+     * Retrieves the StopCharTester that determines the end of a quoted text section with escaping.
+     * The tester is fetched from thread-local storage and is then reset.
+     *
+     * @return The StopCharTester for determining the end of a quoted text section with escaping.
      */
     @Nullable
     protected StopCharTester getEscapingQuotes() {
@@ -745,10 +754,11 @@ public class TextWire extends YamlWireOut<TextWire> {
 
     // TODO Move to valueIn
     /**
-     * Consumes whitespace and comment lines. The {@code commas} parameter
-     * indicates how many comma separators are expected to be consumed as part of
-     * this padding; if more commas are found than expected and they are followed
-     * by structural characters, padding stops.
+     * Consumes padding characters from the current reading position.
+     * Padding characters include spaces, tabs, new lines, commas, and comments. This method also
+     * handles skipping over any comments encountered during this process.
+     *
+     * @param commas The number of comma characters to consume. Once this count is reached, the method will return.
      */
     public void consumePadding(int commas) {
         for (; ; ) {
@@ -804,8 +814,9 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Consumes the YAML document start marker ({@code ---}) and any associated
-     * directives or leading whitespace/comments.
+     * Consumes the start of a document in the byte stream. The start is determined by
+     * the presence of three consecutive '-' characters followed by certain words
+     * (e.g., "!!data", "!!meta-data").
      */
     protected void consumeDocumentStart() {
         // Check if there are at least 4 bytes remaining to read.
@@ -835,14 +846,18 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Internal method to peek the next character code without advancing.
+     * Peeks the next unsigned byte from the current read position without advancing the pointer.
+     *
+     * @return The next unsigned byte as an integer.
      */
     int peekCode() {
         return bytes.peekUnsignedByte();
     }
 
     /**
-     * Internal method to peek one character ahead without advancing.
+     * Peeks the unsigned byte after the current read position without advancing the pointer.
+     *
+     * @return The unsigned byte after the current read position as an integer.
      */
     int peekCodeNext() {
         return bytes.peekUnsignedByte(bytes.readPosition() + 1);
@@ -876,7 +891,9 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Internal method to read the next character code from the buffer.
+     * Reads the next byte as an unsigned integer.
+     *
+     * @return The next byte if available or -1 if end-of-file.
      */
     protected int readCode() {
         if (bytes.readRemaining() < 1)
@@ -891,19 +908,12 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Core implementation used by the various {@code read} overloads. The
-     * method first checks any previously parsed fields stored in the current
-     * {@link ValueInState}. New fields are then read from the wire until a match
-     * for {@code keyName} is found. If the name matches (case-insensitive) the
-     * associated value becomes available via the returned {@link ValueIn}.
-     * Fields that do not match are remembered in the state so that a later read
-     * with a different key may pick them up. If no match is found a
-     * {@link DefaultValueIn} initialised with {@code defaultValue} is returned.
+     * Reads the value associated with a given key name, code, and provides a default value.
      *
-     * @param keyName      the name of the field to search for
-     * @param keyCode      identifier used when marshalling numbers
-     * @param defaultValue default value to supply when the field is absent
-     * @return a {@link ValueIn} positioned on the matched value or a default one
+     * @param keyName The name of the key.
+     * @param keyCode The code for the key.
+     * @param defaultValue The default value to return if the key isn't found.
+     * @return The value associated with the given key or the default value if not found.
      */
     private ValueIn read(@NotNull CharSequence keyName, int keyCode, Object defaultValue) {
         consumePadding();
@@ -948,12 +958,8 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Continuation of the named-field lookup used by {@link #read(WireKey)}. It
-     * scans any positions remembered as out-of-order by {@code curr}. When a
-     * remembered field matches {@code keyName} its value is returned and the
-     * remembered position removed. If none of the stored positions match the
-     * search key a {@link DefaultValueIn} containing {@code defaultValue} is
-     * returned.
+     * Attempts to read the value of a given key, continuing the read operation from the primary `read` method.
+     * If the current and old fields do not match the specified key, the default value is returned.
      *
      * @param keyName       The name of the key for which the value needs to be read.
      * @param keyCode       The code for the key.
@@ -1064,8 +1070,8 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Parses a single word from the wire and appends it to {@code sb}. A word is
-     * delimited by whitespace.
+     * Parses a word from the current byte position until it encounters a space or stop character.
+     * The parsed word is then appended to the provided StringBuilder.
      *
      * @param outputBuilder The StringBuilder to which the parsed word will be appended.
      */
@@ -1074,8 +1080,8 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Parses text from the wire into {@code sb} until {@code testers} signals a
-     * stop.
+     * Parses characters from the current byte position until one of the specified stop characters
+     * in the tester is encountered. The parsed characters are then appended to the provided StringBuilder.
      *
      * @param outputBuilder       The StringBuilder to which the parsed characters will be appended.
      * @param stopTester  A StopCharTester which determines which characters should stop the parsing.
@@ -1088,7 +1094,9 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Clears {@code sb} and parses text until {@code testers} requests a stop.
+     * Clears the StringBuilder and then parses characters from the current byte position
+     * until one of the specified stop characters in the tester is encountered.
+     * The parsed characters are then appended to the provided StringBuilder.
      *
      * @param outputBuilder       The StringBuilder to which the parsed characters will be appended.
      * @param stopTester  A StopCharsTester which determines which characters should stop the parsing.
@@ -1103,12 +1111,11 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Attempts to parse the next YAML structure from the wire. Document start
-     * markers and indentation are consumed before delegating to
-     * {@link #getValueIn()}.
+     * Reads and returns an object from the current position in the bytes stream.
+     * Any padding and document start metadata are consumed before attempting to read the object.
      *
-     * @return the parsed object or {@code null} if at end of data
-     * @throws InvalidMarshallableException if the structure cannot be read
+     * @return An instance of the read object, or null if the end of the stream is reached.
+     * @throws InvalidMarshallableException If the object could not be properly unmarshalled.
      */
     @Nullable
     public Object readObject() throws InvalidMarshallableException {
@@ -1118,14 +1125,14 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Variant of {@link #readObject()} that expects nested structures indented
-     * at the supplied level. The method inspects the next character to decide
-     * whether a list, map, typed object or scalar should be parsed.
+     * Attempts to read an object from the current position in the bytes stream based on its
+     * detected type (e.g., list, map, typed object). The type of the object is inferred from
+     * the current and next code. The method also considers the given indentation for nested structures.
      *
-     * @param indentation indentation level of the current block
-     * @return the parsed object, {@link NoObject#NO_OBJECT} when a closing token
-     *         is encountered, or {@code null} at end of data
-     * @throws InvalidMarshallableException if the structure cannot be read
+     * @param indentation The current indentation level to handle nested objects.
+     * @return An instance of the read object, `NoObject.NO_OBJECT` if the object denotes
+     *         an end of block or structure, or null if the end of the stream is reached.
+     * @throws InvalidMarshallableException If the object could not be properly unmarshalled.
      */
     @Nullable
     Object readObject(int indentation) throws InvalidMarshallableException {
@@ -1168,11 +1175,11 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Helper for {@link #readObject(int)} that processes a {@code !type} entry.
-     * The next value is read with the explicit type from the text.
+     * Reads a typed object from the current position in the bytes stream. The type
+     * of the object is determined by the bytes' content.
      *
-     * @return the typed object
-     * @throws InvalidMarshallableException if marshalling fails
+     * @return An instance of the read object.
+     * @throws InvalidMarshallableException If the object could not be properly unmarshalled.
      */
     @Nullable
     private Object readTypedObject() throws InvalidMarshallableException {
@@ -1180,11 +1187,12 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Parses a bracketed list such as {@code [a, b]}. The text wire does not yet
-     * support this syntax so the method always throws.
+     * Attempts to read a list from the current position in the bytes stream. This method
+     * currently throws an UnsupportedOperationException, indicating that reading lists
+     * directly is not supported in this context.
      *
-     * @return never returns
-     * @throws UnsupportedOperationException always
+     * @return This method does not currently return a value due to the exception.
+     * @throws UnsupportedOperationException Always thrown since this method is not supported.
      */
     @NotNull
     private List readList() {
@@ -1192,13 +1200,15 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Reads a YAML sequence where each item is denoted by {@code -}. Parsing
-     * continues until the indentation drops below {@code indentation}.
+     * Reads a list of objects from the current position in the bytes stream.
+     * The method consumes lines starting with '-' as list elements, and utilizes
+     * the provided indentation to understand nested structures.
      *
-     * @param indentation indentation level marking list items
-     * @param elementType expected element class or {@code null}
-     * @return list of parsed elements
-     * @throws InvalidMarshallableException if an element cannot be parsed
+     * @param indentation The current indentation level to handle nested list items.
+     * @param elementType The expected type of elements within the list. Used when inferring
+     *                    the type of the read object.
+     * @return A list containing objects read from the bytes stream.
+     * @throws InvalidMarshallableException If any object within the list could not be properly unmarshalled.
      */
     @NotNull
     List readList(int indentation, Class<?> elementType) throws InvalidMarshallableException {
@@ -1225,15 +1235,15 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Reads a YAML mapping at the supplied indentation. Keys are parsed as
-     * strings followed by values obtained via {@link ValueIn#object(Class)}.
-     * Parsing stops when the indentation decreases or the special key
-     * {@code ...} is encountered.
+     * Reads a map of key-value pairs from the current position in the bytes stream.
+     * This method utilizes the provided indentation to understand nested structures.
+     * Each key is followed by its value. If a key named "..." is encountered, the parsing breaks.
      *
-     * @param indentation indentation level marking map entries
-     * @param valueType   expected value class or {@code null}
-     * @return the populated map
-     * @throws InvalidMarshallableException if a value cannot be parsed
+     * @param indentation The current indentation level to handle nested key-value pairs.
+     * @param valueType The expected type of values within the map. Used when inferring
+     *                  the type of the read object.
+     * @return A map containing key-value pairs read from the bytes stream.
+     * @throws InvalidMarshallableException If any key-value pair within the map could not be properly unmarshalled.
      */
     @NotNull
     private Map readMap(int indentation, Class<?> valueType) throws InvalidMarshallableException {
@@ -1278,12 +1288,6 @@ public class TextWire extends YamlWireOut<TextWire> {
      * @return {@code true} when the prefix was found and skipped
      */
     @Override
-    /**
-     * Checks whether the current wire position starts with the
-     * {@code !!meta-data} tag. If present the tag is consumed.
-     *
-     * @return {@code true} when the prefix was found and skipped
-     */
     public boolean hasMetaDataPrefix() {
         if (bytes.startsWith(META_DATA)
                 && bytes.peekUnsignedByte(bytes.readPosition() + 11) <= ' ') {
@@ -1299,26 +1303,24 @@ public class TextWire extends YamlWireOut<TextWire> {
     enum NoObject {NO_OBJECT}
 
     /**
-     * Provides the {@link ValueIn} implementation for {@link TextWire},
-     * handling deserialisation of values in a YAML-like text format.
+     * Represents a textual input value for deserialization. It manages a stack
+     * of states, allowing for nested or sequential value reading.
      */
     public class TextValueIn implements ValueIn {
 
         /**
-         * Maintains nested parsing state so complex structures can be read
-         * incrementally.
+         * Stack maintaining the states of value readings,
+         * allowing for nested structure reading.
          */
         final ValueInStack stack = new ValueInStack();
 
         /**
-         * Tracks how many sequence items remain to be read in the current
-         * context.
+         * Limit for sequence reading.
          */
         int sequenceLimit = 0;
 
         /**
-         * Set while {@link #readLengthMarshallable()} consumes the underlying
-         * text to measure its length.
+         * Flag to denote if any kind of reading should be consumed.
          */
         private boolean consumeAny;
 
@@ -1403,12 +1405,6 @@ public class TextWire extends YamlWireOut<TextWire> {
             }
         }
 
-        /**
-         * Core logic for reading a textual value into {@code a}. Handles quoted
-         * strings, unquoted text, YAML tags such as {@code !null} and
-         * {@code !binary}, and resolves anchors or aliases. The raw text from
-         * the tokeniser is unescaped before returning.
-         */
         @SuppressWarnings("fallthrough")
         @Nullable <ACS extends Appendable & CharSequence> CharSequence textTo0(@NotNull ACS destination) {
             consumePadding();
@@ -1556,12 +1552,6 @@ public class TextWire extends YamlWireOut<TextWire> {
             consumePadding(1);
         }
 
-        /**
-         * Peeks at the last significant character that was written or parsed,
-         * rewinding over spaces. If a newline is encountered the line start
-         * position is adjusted. The value is used when deciding whether to
-         * terminate values or handle optional commas.
-         */
         protected int peekBack() {
             while (bytes.readPosition() > bytes.start()) {
                 int prev = bytes.readUnsignedByte(bytes.readPosition() - 1);
@@ -1701,18 +1691,16 @@ public class TextWire extends YamlWireOut<TextWire> {
             return TextWire.this;
         }
 
-        /**
-         * Calculates the length of the current textual value by temporarily
-         * consuming it. The read position is restored once the measurement is
-         * complete.
-         */
         protected long readLengthMarshallable() {
             long start = bytes.readPosition();
             this.consumeAny = true;
             try {
+                // Consume all data until a meaningful stopping point
                 consumeAny();
+                // Calculate and return the length of the consumed data
                 return bytes.readPosition() - start;
             } finally {
+                // Reset the consumption flag and reading position
                 this.consumeAny = false;
                 bytes.readPosition(start);
                 // @TODO - use ScopedResource<StringBuilder> for consistency throughout YamlWireOut - https://github.com/OpenHFT/Chronicle-Wire/issues/879
@@ -1720,11 +1708,6 @@ public class TextWire extends YamlWireOut<TextWire> {
             }
         }
 
-        /**
-         * Recursively consumes the current YAML value without constructing an
-         * object. Maps, sequences, scalars and typed values are skipped so that
-         * the caller can move to the next field or token.
-         */
         protected void consumeAny() {
             consumePadding();
             int code = peekCode();
@@ -1801,8 +1784,7 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Consumes a {@code !type} tag and any trailing characters. The
-         * following value is then consumed by {@link #consumeAny()}.
+         * Consumes the type annotation (e.g., `!type`) in the text format.
          */
         private void consumeType2() {
             // Skip the '!' character which indicates the start of a type annotation
@@ -1827,8 +1809,7 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Consumes a YAML sequence without creating objects. Used by
-         * {@link #consumeAny()} when skipping over values.
+         * Consumes a sequence or list (e.g., `[item1, item2]`) in the text format.
          */
         private void consumeSeq() {
             int code;
@@ -1867,8 +1848,7 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Consumes a YAML map without materialising its contents. Invoked from
-         * {@link #consumeAny()} when skipping values or reading out of order.
+         * Consumes a map structure (e.g., `{key1: value1, key2: value2}`) in the text format.
          */
         private void consumeMap() {
             int code;
@@ -1907,8 +1887,7 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Consumes a scalar or typed value. This method defers to
-         * {@link #consumeAny()} for nested structures.
+         * Consumes a value, which can be a primitive, type-annotated value, or another structure.
          */
         private void consumeValue() {
             consumePadding();
@@ -1930,8 +1909,7 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Consumes characters making up a type name, stopping at a comma or
-         * space. Used by {@link #consumeValue()}.
+         * Consumes a type, which is expected to end with a comma, space or another stop character.
          */
         private void consumeType() {
             parseUntil(acquireStringBuilder(), StopCharTesters.COMMA_SPACE_STOP);
@@ -1993,9 +1971,10 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Parses the current text token as a {@code long}. Quotes and boolean
-         * literals are handled and the method expects the token to contain plain
-         * text.
+         * Retrieves a long value from the current position in the stream.
+         * It can handle quotes, booleans, or actual numbers.
+         *
+         * @return the long value from the stream or a default/fallback value in case of unconventional formats.
          */
         long getALong() {
             final int code = peekCode();
@@ -2028,9 +2007,7 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Logs a warning when an unsubstituted variable such as {@code ${id}}
-         * is encountered where a number was expected and then skips the literal
-         * characters.
+         * Handles the scenario where a number is expected, but an unsubstituted expression is found instead.
          */
         private void unsubstitutedNumber() {
             // Parse up to the closing character of the unsubstituted expression
@@ -2796,9 +2773,7 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * After parsing a number this verifies whether the following byte is a
-         * delimiter such as '}', ']' or ','. If it is, the read position is
-         * rewound by one byte so the delimiter can be processed by the caller.
+         * Checks if the previous character is an end character, and if so, moves the read position back by one byte.
          */
         public void checkRewind() {
             // Peek at the previous character without changing the read position.
@@ -2811,8 +2786,8 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Variant used after reading a double. Currently delegates to
-         * {@link #checkRewind()}.
+         * Checks for rewind condition. Currently, this just calls the checkRewind() method.
+         * This might be a placeholder for additional functionality or for overriding in subclasses.
          */
         public void checkRewindDouble() {
             checkRewind();
@@ -2855,8 +2830,8 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * If the current token begins with {@code !} this method consumes the
-         * tag name so that subsequent parsing sees only the value.
+         * If the next character indicates the start of a type (i.e., it's a '!'),
+         * this method reads and discards the type string.
          */
         void skipType() {
             // Peek at the next byte without changing the read position.
@@ -2881,9 +2856,8 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Checks whether the next token is {@code !!null ""}. If so the token
-         * is consumed and {@code true} returned; otherwise the stream is left
-         * untouched and {@code false} is returned.
+         * @return true if !!null "", if {@code true} reads the !!null "" up to the next STOP, if
+         * {@code false} no  data is read  ( data is only peaked if {@code false} )
          */
         @Override
         public boolean isNull() {
@@ -2940,8 +2914,10 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Core logic for deserialising an object when its type may be deduced
-         * from tags, anchors or surrounding structure.
+         * Reads an object from the byte stream based on inferred data type.
+         * This method dynamically determines the object's type based on specific
+         * indicators or sequences in the stream and then invokes the appropriate
+         * deserialization logic for that type.
          *
          * @param reusableInstance An object to potentially reuse during deserialization for efficiency.
          * @param strategy The serialization strategy to be applied during deserialization.
@@ -3007,11 +2983,16 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Attempts to parse the current text token as a number or common
-         * date/time format. Falls back to returning the text itself if no known
-         * representation matches.
+         * Attempts to read a number from the current stream context, dynamically determining
+         * its potential type and format. If it's not a recognizable number, the method may
+         * also consider the string as a date or time format.
+         * <p>
+         * The method supports various formats including long, double, {@link LocalTime},
+         * {@link LocalDate}, and {@link ZonedDateTime}. If the string representation is not
+         * recognizable as any of these formats, the original string is returned.
          *
-         * @return the decoded value or the original string
+         * @return The decoded number, date, time, or original string. Returns null if the
+         *         string is either null or exceeds 40 characters in length.
          */
         @Nullable
         protected Object readNumber() {

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -890,12 +890,19 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Reads the value associated with a given key name, code, and provides a default value.
+     * Core implementation used by the various {@code read} overloads. The
+     * method first checks any previously parsed fields stored in the current
+     * {@link ValueInState}. New fields are then read from the wire until a match
+     * for {@code keyName} is found. If the name matches (case-insensitive) the
+     * associated value becomes available via the returned {@link ValueIn}.
+     * Fields that do not match are remembered in the state so that a later read
+     * with a different key may pick them up. If no match is found a
+     * {@link DefaultValueIn} initialised with {@code defaultValue} is returned.
      *
-     * @param keyName The name of the key.
-     * @param keyCode The code for the key.
-     * @param defaultValue The default value to return if the key isn't found.
-     * @return The value associated with the given key or the default value if not found.
+     * @param keyName      the name of the field to search for
+     * @param keyCode      identifier used when marshalling numbers
+     * @param defaultValue default value to supply when the field is absent
+     * @return a {@link ValueIn} positioned on the matched value or a default one
      */
     private ValueIn read(@NotNull CharSequence keyName, int keyCode, Object defaultValue) {
         consumePadding();
@@ -940,16 +947,20 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Attempts to read the value of a given key, continuing the read operation from the primary `read` method.
-     * If the current and old fields do not match the specified key, the default value is returned.
+     * Continuation of the named-field lookup used by {@link #read(WireKey)}. It
+     * scans any positions remembered as out-of-order by {@code curr}. When a
+     * remembered field matches {@code keyName} its value is returned and the
+     * remembered position removed. If none of the stored positions match the
+     * search key a {@link DefaultValueIn} containing {@code defaultValue} is
+     * returned.
      *
-     * @param keyName       The name of the key for which the value needs to be read.
-     * @param keyCode       The code for the key.
-     * @param defaultValue  The default value to return if the key isn't found.
-     * @param curr          The current state of the ValueIn.
-     * @param sb            The StringBuilder used to capture the field name.
-     * @param name          The name of the key (same as keyName, possibly added for clarity in some cases).
-     * @return              The value associated with the key or the default value if the key is not found.
+     * @param keyName      field name being searched for
+     * @param keyCode      identifier used when marshalling numbers
+     * @param defaultValue default value to supply when the field is absent
+     * @param curr         state tracking previously read fields
+     * @param sb           scratch buffer used for name comparison
+     * @param name         same as {@code keyName}; retained for compatibility
+     * @return a {@link ValueIn} positioned on the matched value or a default one
      */
     protected ValueIn read2(CharSequence keyName, int keyCode, Object defaultValue, @NotNull ValueInState curr, @NotNull StringBuilder sb, @NotNull CharSequence name) {
         final long position2 = bytes.readPosition();
@@ -1052,21 +1063,21 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Parses a word from the current byte position until it encounters a space or stop character.
-     * The parsed word is then appended to the provided StringBuilder.
+     * Parses a single word from the wire and appends it to {@code sb}. A word is
+     * delimited by whitespace.
      *
-     * @param sb The StringBuilder to which the parsed word will be appended.
+     * @param sb destination for the parsed characters
      */
     public void parseWord(@NotNull StringBuilder sb) {
         parseUntil(sb, StopCharTesters.SPACE_STOP);
     }
 
     /**
-     * Parses characters from the current byte position until one of the specified stop characters
-     * in the tester is encountered. The parsed characters are then appended to the provided StringBuilder.
+     * Parses text from the wire into {@code sb} until {@code testers} signals a
+     * stop.
      *
-     * @param sb       The StringBuilder to which the parsed characters will be appended.
-     * @param testers  A StopCharTester which determines which characters should stop the parsing.
+     * @param sb      destination for the parsed characters
+     * @param testers stop condition
      */
     public void parseUntil(@NotNull StringBuilder sb, @NotNull StopCharTester testers) {
         if (use8bit)
@@ -1076,12 +1087,10 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Clears the StringBuilder and then parses characters from the current byte position
-     * until one of the specified stop characters in the tester is encountered.
-     * The parsed characters are then appended to the provided StringBuilder.
+     * Clears {@code sb} and parses text until {@code testers} requests a stop.
      *
-     * @param sb       The StringBuilder to which the parsed characters will be appended.
-     * @param testers  A StopCharsTester which determines which characters should stop the parsing.
+     * @param sb      destination builder that will be cleared before use
+     * @param testers stop condition operating on multiple characters
      */
     public void parseUntil(@NotNull StringBuilder sb, @NotNull StopCharsTester testers) {
         sb.setLength(0);
@@ -1093,11 +1102,12 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Reads and returns an object from the current position in the bytes stream.
-     * Any padding and document start metadata are consumed before attempting to read the object.
+     * Attempts to parse the next YAML structure from the wire. Document start
+     * markers and indentation are consumed before delegating to
+     * {@link #getValueIn()}.
      *
-     * @return An instance of the read object, or null if the end of the stream is reached.
-     * @throws InvalidMarshallableException If the object could not be properly unmarshalled.
+     * @return the parsed object or {@code null} if at end of data
+     * @throws InvalidMarshallableException if the structure cannot be read
      */
     @Nullable
     public Object readObject() throws InvalidMarshallableException {
@@ -1107,14 +1117,14 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Attempts to read an object from the current position in the bytes stream based on its
-     * detected type (e.g., list, map, typed object). The type of the object is inferred from
-     * the current and next code. The method also considers the given indentation for nested structures.
+     * Variant of {@link #readObject()} that expects nested structures indented
+     * at the supplied level. The method inspects the next character to decide
+     * whether a list, map, typed object or scalar should be parsed.
      *
-     * @param indentation The current indentation level to handle nested objects.
-     * @return An instance of the read object, `NoObject.NO_OBJECT` if the object denotes
-     *         an end of block or structure, or null if the end of the stream is reached.
-     * @throws InvalidMarshallableException If the object could not be properly unmarshalled.
+     * @param indentation indentation level of the current block
+     * @return the parsed object, {@link NoObject#NO_OBJECT} when a closing token
+     *         is encountered, or {@code null} at end of data
+     * @throws InvalidMarshallableException if the structure cannot be read
      */
     @Nullable
     Object readObject(int indentation) throws InvalidMarshallableException {
@@ -1157,11 +1167,11 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Reads a typed object from the current position in the bytes stream. The type
-     * of the object is determined by the bytes' content.
+     * Helper for {@link #readObject(int)} that processes a {@code !type} entry.
+     * The next value is read with the explicit type from the text.
      *
-     * @return An instance of the read object.
-     * @throws InvalidMarshallableException If the object could not be properly unmarshalled.
+     * @return the typed object
+     * @throws InvalidMarshallableException if marshalling fails
      */
     @Nullable
     private Object readTypedObject() throws InvalidMarshallableException {
@@ -1169,12 +1179,11 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Attempts to read a list from the current position in the bytes stream. This method
-     * currently throws an UnsupportedOperationException, indicating that reading lists
-     * directly is not supported in this context.
+     * Parses a bracketed list such as {@code [a, b]}. The text wire does not yet
+     * support this syntax so the method always throws.
      *
-     * @return This method does not currently return a value due to the exception.
-     * @throws UnsupportedOperationException Always thrown since this method is not supported.
+     * @return never returns
+     * @throws UnsupportedOperationException always
      */
     @NotNull
     private List readList() {
@@ -1182,15 +1191,13 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Reads a list of objects from the current position in the bytes stream.
-     * The method consumes lines starting with '-' as list elements, and utilizes
-     * the provided indentation to understand nested structures.
+     * Reads a YAML sequence where each item is denoted by {@code -}. Parsing
+     * continues until the indentation drops below {@code indentation}.
      *
-     * @param indentation The current indentation level to handle nested list items.
-     * @param elementType The expected type of elements within the list. Used when inferring
-     *                    the type of the read object.
-     * @return A list containing objects read from the bytes stream.
-     * @throws InvalidMarshallableException If any object within the list could not be properly unmarshalled.
+     * @param indentation indentation level marking list items
+     * @param elementType expected element class or {@code null}
+     * @return list of parsed elements
+     * @throws InvalidMarshallableException if an element cannot be parsed
      */
     @NotNull
     List readList(int indentation, Class<?> elementType) throws InvalidMarshallableException {
@@ -1217,15 +1224,15 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     /**
-     * Reads a map of key-value pairs from the current position in the bytes stream.
-     * This method utilizes the provided indentation to understand nested structures.
-     * Each key is followed by its value. If a key named "..." is encountered, the parsing breaks.
+     * Reads a YAML mapping at the supplied indentation. Keys are parsed as
+     * strings followed by values obtained via {@link ValueIn#object(Class)}.
+     * Parsing stops when the indentation decreases or the special key
+     * {@code ...} is encountered.
      *
-     * @param indentation The current indentation level to handle nested key-value pairs.
-     * @param valueType The expected type of values within the map. Used when inferring
-     *                  the type of the read object.
-     * @return A map containing key-value pairs read from the bytes stream.
-     * @throws InvalidMarshallableException If any key-value pair within the map could not be properly unmarshalled.
+     * @param indentation indentation level marking map entries
+     * @param valueType   expected value class or {@code null}
+     * @return the populated map
+     * @throws InvalidMarshallableException if a value cannot be parsed
      */
     @NotNull
     private Map readMap(int indentation, Class<?> valueType) throws InvalidMarshallableException {
@@ -1264,6 +1271,12 @@ public class TextWire extends YamlWireOut<TextWire> {
     }
 
     @Override
+    /**
+     * Checks whether the current wire position starts with the
+     * {@code !!meta-data} tag. If present the tag is consumed.
+     *
+     * @return {@code true} when the prefix was found and skipped
+     */
     public boolean hasMetaDataPrefix() {
         if (bytes.startsWith(META_DATA)
                 && bytes.peekUnsignedByte(bytes.readPosition() + 11) <= ' ') {

--- a/src/main/java/net/openhft/chronicle/wire/VanillaWireParser.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaWireParser.java
@@ -30,60 +30,42 @@ import java.util.Map;
 import java.util.TreeMap;
 
 /**
- * Provides an implementation of {@link WireParser} that maps field names or ids to
- * {@link WireParselet}s. Named parselets are looked up via {@link #namedConsumer} and
- * numbered fields via {@link #numberedConsumer}. A {@link #defaultConsumer} handles
- * fields that are not explicitly registered and {@link #fieldNumberParselet} deals with
- * unmapped numeric identifiers.
+ * Provides an implementation of the WireParser interface, parsing wire inputs using both named and numbered
+ * parselets to associate specific actions with events or field names.
+ * <p>
+ * This parser uses a default consumer to handle unmatched entries and a field number parselet for numbered fields.
  */
 public class VanillaWireParser implements WireParser {
 
-    /**
-     * {@link TreeMap} of field names to parselets. {@link CharSequenceComparator#INSTANCE}
-     * provides stable ordering and lookup semantics.
-     */
+    // Map of field names to their associated parselets, sorted by CharSequence order.
     private final Map<CharSequence, WireParselet> namedConsumer = new TreeMap<>(CharSequenceComparator.INSTANCE);
 
-    /**
-     * {@link HashMap} of numeric field ids to the original name and parselet.
-     */
+    // Map of field numbers to their associated parselets.
     private final Map<Integer, Map.Entry<String, WireParselet>> numberedConsumer = new HashMap<>();
 
-    /**
-     * Invoked when a field name is not present in {@link #namedConsumer}.
-     */
+    // The default consumer to handle unmatched entries.
     private final WireParselet defaultConsumer;
 
-    /**
-     * Reusable buffer for reading textual field names.
-     */
+    // Used for building strings for parsing.
     private final StringBuilder sb = new StringBuilder(128);
 
-    /**
-     * Caches the most recently parsed field name.
-     */
+    // Holds the name of the last event that was parsed.
     private final StringBuilder lastEventName = new StringBuilder(128);
 
-    /**
-     * Called when a numeric field id is not mapped in {@link #numberedConsumer}.
-     */
+    // Handles numbered fields.
     private FieldNumberParselet fieldNumberParselet;
 
-    /**
-     * Cache of the parselet associated with {@link #lastEventName}.
-     */
+    // Holds the last parslet that was used.
     private WireParselet lastParslet = null;
 
-    /**
-     * Start position of the last parsed event for debugging purposes.
-     */
+    // Indicates the position in the wire input of the last parsed event.
     private long lastStart = 0;
 
     /**
      * Constructs a new VanillaWireParser with the specified default consumer and field number parselet.
      *
-     * @param defaultConsumer      consumer for unregistered named fields. Must not be {@code null}.
-     * @param fieldNumberParselet  handler for unregistered numeric ids. Must not be {@code null}.
+     * @param defaultConsumer The default consumer to handle unmatched entries.
+     * @param fieldNumberParselet The field number parselet for handling numbered fields.
      */
     public VanillaWireParser(@NotNull WireParselet defaultConsumer,
                              @NotNull FieldNumberParselet fieldNumberParselet) {
@@ -95,8 +77,10 @@ public class VanillaWireParser implements WireParser {
     }
 
     /**
-     * Returns the next byte in {@code wireIn} without altering its read position.
-     * The value is returned as an unsigned int.
+     * Peeks at the next code or byte in the wire input without moving the read position.
+     *
+     * @param wireIn The wire input to peek into.
+     * @return The next unsigned byte as an integer.
      */
     private int peekCode(@NotNull WireIn wireIn) {
         return wireIn.bytes().peekUnsignedByte();
@@ -108,16 +92,12 @@ public class VanillaWireParser implements WireParser {
     }
 
     /**
-     * Reads one field from {@code wireIn}. Binary fields (identified by
-     * {@link BinaryWireCode#FIELD_NUMBER}) are handled by
-     * {@link #parseOneBinary(WireIn)}. Otherwise the field name is read into
-     * {@link #sb} and the matching parselet located via {@link #namedConsumer}.
-     * If no match is found, {@link #getDefaultConsumer()} is used. The chosen
-     * parselet and name are cached for the next call.
+     * Parses a single input from the wire. Determines if the input should be parsed as binary or not.
+     * Throws specific exceptions in the case of invocation issues or invalid marshallable data.
      *
-     * @param wireIn the source of the field
-     * @throws InvocationTargetRuntimeException if a parselet throws a checked exception
-     * @throws InvalidMarshallableException     if the wire data is malformed
+     * @param wireIn The wire input to parse.
+     * @throws InvocationTargetRuntimeException if an invocation error occurs during parsing.
+     * @throws InvalidMarshallableException if invalid marshallable data is encountered during parsing.
      */
     public void parseOne(@NotNull WireIn wireIn) throws InvocationTargetRuntimeException, InvalidMarshallableException {
         long start = wireIn.bytes().readPosition();
@@ -157,11 +137,11 @@ public class VanillaWireParser implements WireParser {
     }
 
     /**
-     * Called when {@link ValueIn#text()} returns an empty name. Emits a warning
-     * with the surrounding bytes to aid debugging.
+     * Handles the scenario where an attempt to read a method name results in an empty value.
+     * Logs a warning about the situation and the contents leading up to this.
      *
-     * @param wireIn source of the bytes
-     * @param start  position at which the field began
+     * @param wireIn The wire input being parsed.
+     * @param start  The position in the wire input at which the method started.
      */
     private void parseOneEmpty(@NotNull WireIn wireIn, long start) {
         // Log a warning message indicating a potential misplaced method.
@@ -174,12 +154,11 @@ public class VanillaWireParser implements WireParser {
     }
 
     /**
-     * Handles binary wires that encode the field by numeric id. The id is read
-     * as a stop-bit long. If a parselet is registered for that id it is invoked;
-     * otherwise {@link #fieldNumberParselet} is called.
+     * Parses binary data from the wire based on a method ID. If the ID is not mapped, the
+     * field number parselet is used to continue the parsing process.
      *
-     * @param wireIn binary wire to read from
-     * @throws InvalidMarshallableException if the wire contains malformed data
+     * @param wireIn The wire input containing binary data.
+     * @throws InvalidMarshallableException if invalid marshallable data is encountered.
      */
     private void parseOneBinary(@NotNull WireIn wireIn) throws InvalidMarshallableException {
         long methodId = wireIn.readEventNumber();
@@ -197,10 +176,6 @@ public class VanillaWireParser implements WireParser {
         fieldNumberParselet.readOne(methodId, wireIn);
     }
 
-    /**
-     * Registers {@code valueInConsumer} for both the text and numeric forms of
-     * {@code key}.
-     */
     @NotNull
     @Override
     public VanillaWireParser register(@NotNull WireKey key, WireParselet valueInConsumer) {
@@ -208,12 +183,12 @@ public class VanillaWireParser implements WireParser {
     }
 
     /**
-     * Registers {@code valueInConsumer} to handle the field named {@code keyName}.
-     * Also associates it with {@code keyName.hashCode()} for binary ids.
+     * Registers a WireParselet with a keyName. This method calculates the hashcode
+     * of the keyName and delegates to the private register method.
      *
-     * @param keyName         textual field name
-     * @param valueInConsumer parselet invoked for this field
-     * @return this parser instance
+     * @param keyName         The name of the key to register.
+     * @param valueInConsumer The WireParselet associated with the keyName.
+     * @return Returns the current instance of VanillaWireParser for method chaining.
      */
     @NotNull
     public VanillaWireParser register(String keyName, WireParselet valueInConsumer) {
@@ -226,10 +201,10 @@ public class VanillaWireParser implements WireParser {
      * The keyName is stored in the namedConsumer map and the code
      * with its corresponding keyName in the numberedConsumer map.
      *
-     * @param keyName         textual name of the field
-     * @param code            numeric id of the field
-     * @param valueInConsumer parselet invoked for this field
-     * @return this parser instance
+     * @param keyName         The name of the key to register.
+     * @param code            The code associated with the keyName.
+     * @param valueInConsumer The WireParselet associated with the keyName.
+     * @return Returns the current instance of VanillaWireParser for method chaining.
      */
     private VanillaWireParser register(String keyName, int code, WireParselet valueInConsumer) {
         // Store the WireParselet in the namedConsumer map using the keyName.
@@ -240,9 +215,6 @@ public class VanillaWireParser implements WireParser {
         return this;
     }
 
-    /**
-     * Returns the parselet registered for {@code name} or {@code null} if none.
-     */
     @Override
     public WireParselet lookup(CharSequence name) {
         return namedConsumer.get(name);

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -137,11 +137,12 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Creates a marshaller for the given type.
-     * Synthetic fields introduced by later Java versions are filtered out.
+     * Factory method to create an instance of the WireMarshaller for a specific class type.
+     * Determines the appropriate marshaller type (basic or one that handles unexpected fields)
+     * based on the characteristics of the provided class.
      *
-     * @param tClass the type to marshall
-     * @return marshaller instance for {@code tClass}
+     * @param tClass The class type for which the marshaller is to be created.
+     * @return A new instance of WireMarshaller for the provided class type.
      */
     @NotNull
     public static <T> WireMarshaller<T> of(@NotNull Class<T> tClass) {
@@ -171,11 +172,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Determines if the field type can be treated as a leaf during serialisation.
-     * Collections and non-dynamic-enum {@link WriteMarshallable} types are not leaves.
+     * Checks if the provided field accessor corresponds to a "leaf" entity.
+     * An entity is considered a leaf if it doesn't need to be further broken down in the serialization process.
      *
-     * @param c accessor for the field
-     * @return true if the field can be treated as a leaf
+     * @param c The field accessor to be checked.
+     * @return {@code true} if the field accessor is leafable, {@code false} otherwise.
      */
     protected static boolean leafable(FieldAccess c) {
         Class<?> type = c.field.getType();
@@ -203,11 +204,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Factory for {@link Throwable} subclasses.
-     * Includes fields needed to serialise exception state.
+     * Factory method to create an instance of the WireMarshaller for a Throwable class type.
+     * The method identifies fields that should be marshalled and prepares the marshaller accordingly.
      *
-     * @param tClass exception type
-     * @return marshaller for the throwable
+     * @param tClass The Throwable class type for which the marshaller is to be created.
+     * @return A new instance of WireMarshaller for the provided Throwable class type.
      */
     @NotNull
     private static <T> WireMarshaller<T> ofThrowable(@NotNull Class<T> tClass) {
@@ -222,11 +223,10 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Utility to check whether the class represents an array, a
-     * {@link Collection} or a {@link Map}.
+     * Determines if the provided class is a collection type, including arrays, standard Collections, or Maps.
      *
-     * @param c class to test
-     * @return true if it is a collection type
+     * @param c The class to be checked.
+     * @return {@code true} if the class is a collection type, {@code false} otherwise.
      */
     private static boolean isCollection(@NotNull Class<?> c) {
         return c.isArray() ||
@@ -235,14 +235,12 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Recursively collects all non-static and non-transient fields from
-     * {@code clazz} and its parents until {@link Object} or
-     * {@link AbstractCommonMarshallable}. The map is keyed by field name.
-     * Skips values such as {@code ordinal} on enums and inner-class synthetic
-     * links.
+     * Recursively fetches all non-static, non-transient fields from the provided class and its superclasses,
+     * up to but not including Object or AbstractCommonMarshallable, and adds them to the provided map.
+     * Fields that are flagged for exclusion (e.g., the "ordinal" field for Enum types) are skipped.
      *
-     * @param clazz class to inspect
-     * @param map   destination for discovered fields
+     * @param clazz The class type from which fields are to be extracted.
+     * @param map   The map to populate with field names and their corresponding Field objects.
      */
     public static void getAllField(@NotNull Class<?> clazz, @NotNull Map<String, Field> map) {
         if (clazz != Object.class && clazz != AbstractCommonMarshallable.class)
@@ -295,7 +293,15 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Lexicographical comparison used by {@link #fieldMap}.
+     * Compares two CharSequences lexicographically. This is a character-by-character comparison
+     * that returns the difference of the first unmatched characters or the difference in their lengths
+     * if one sequence is a prefix of the other.
+     *
+     * @param cs0 The first CharSequence to be compared.
+     * @param cs1 The second CharSequence to be compared.
+     * @return A positive integer if {@code cs0} comes after {@code cs1},
+     *         a negative integer if {@code cs0} comes before {@code cs1},
+     *         or zero if the sequences are equal.
      */
     private static int compare(CharSequence cs0, CharSequence cs1) {
         for (int i = 0, len = Math.min(cs0.length(), cs1.length()); i < len; i++) {
@@ -307,8 +313,12 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Helper used by reflection code to resolve the actual generic arguments for
-     * {@code field} relative to {@code iface}.
+     * Computes the actual type arguments for a given field of an interface. This method determines
+     * the generic type arguments that the field uses based on the interface's type parameters.
+     *
+     * @param iface The interface containing the field.
+     * @param field The field whose type arguments need to be determined.
+     * @return An array of actual type arguments or the interface's type parameters if no actual arguments can be deduced.
      */
     private static Type[] computeActualTypeArguments(Class<?> iface, Field field) {
         Type[] actual = consumeActualTypeArguments(new HashMap<>(), iface, field.getGenericType());
@@ -320,8 +330,19 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Recursive helper for {@link #computeActualTypeArguments(Class, Field)}.
-     * Walks the type hierarchy to map parameter names to concrete classes.
+     * Determines the actual type arguments used by a class or interface for a given interface type.
+     * This method recursively inspects the type hierarchy to match type arguments against the
+     * interface's type parameters. It uses a previously built map of type parameter names to their
+     * actual types to deduce the correct arguments for the given interface.
+     *
+     * @param prevTypeParameters A map containing previously discovered type parameter names
+     *                           mapped to their actual types.
+     * @param iface              The interface for which we want to determine the type arguments.
+     * @param type               The type to inspect. This could be an actual class, interface, or
+     *                           a parameterized type that uses generic arguments.
+     *
+     * @return An array of actual type arguments used by the provided type for the specified interface,
+     *         or null if the type doesn't directly or indirectly implement or extend the given interface.
      */
     private static Type[] consumeActualTypeArguments(Map<String, Type> prevTypeParameters, Class<?> iface, Type type) {
         Class<?> cls = null;
@@ -393,8 +414,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Returns a marshaller that omits the named fields.
-     * Useful when only a subset of a DTO should be serialised.
+     * Excludes specified fields from the current marshaller and returns a new instance of the marshaller
+     * with the remaining fields.
+     *
+     * @param fieldNames Names of the fields to be excluded.
+     * @return A new instance of the {@link WireMarshaller} with the specified fields excluded.
      */
     public WireMarshaller<T> excludeFields(String... fieldNames) {
         Set<String> fieldSet = new HashSet<>(Arrays.asList(fieldNames));
@@ -405,8 +429,13 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Serialises {@code t} to {@code out} in field order. Hex dump indentation
-     * is adjusted for readability.
+     * Writes the marshallable representation of the given object to the provided {@link WireOut} destination.
+     * This will traverse the fields and use their respective {@link FieldAccess} to write each field.
+     * The method also adjusts the hex dump indentation for better readability in the output.
+     *
+     * @param t   The object to write.
+     * @param out The destination {@link WireOut} where the object representation will be written.
+     * @throws InvalidMarshallableException If the object fails validation checks before serialization.
      */
     public void writeMarshallable(T t, @NotNull WireOut out) throws InvalidMarshallableException {
         ValidatableUtil.validate(t);
@@ -422,8 +451,12 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Serialises {@code t} directly to the given byte store using raw field
-     * access.
+     * Writes the marshallable representation of the given object to the provided {@link Bytes} destination.
+     * Unlike the previous method, this doesn't adjust the hex dump indentation. It's a more direct
+     * serialization of the fields to bytes.
+     *
+     * @param t     The object to write.
+     * @param bytes The destination {@link Bytes} where the object representation will be written.
      */
     public void writeMarshallable(T t, Bytes<?> bytes) {
         for (@NotNull FieldAccess field : fields) {
@@ -436,8 +469,14 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Serialises {@code t} to {@code out}, optionally copying written values
-     * into the stored default instance.
+     * Writes the values of the fields from the provided object (DTO) to the output. Before writing,
+     * the object is validated. The method also supports optional copying of the values
+     * from the source object to a previous instance.
+     *
+     * @param t    Object whose field values are to be written.
+     * @param out  Output destination where the field values are written to.
+     * @param copy Flag indicating whether to copy values from the source object to the previous object.
+     * @throws InvalidMarshallableException If there's an error during marshalling.
      */
     public void writeMarshallable(T t, @NotNull WireOut out, boolean copy) throws InvalidMarshallableException {
         // Validate the object before writing
@@ -453,8 +492,13 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Deserialises from {@code in} into {@code t}. When {@code overwrite} is
-     * true missing fields are reset from {@link #defaultValue}.
+     * Reads and populates the DTO based on the provided input. The input order can be hinted.
+     * After reading, the object is validated.
+     *
+     * @param t         Object to populate with read values.
+     * @param in        Input source from which values are read.
+     * @param overwrite Flag indicating whether to overwrite the existing value in the target object.
+     * @throws InvalidMarshallableException If there is an error during marshalling.
      */
     public void readMarshallable(T t, @NotNull WireIn in, boolean overwrite) throws InvalidMarshallableException {
         // Choose the reading method based on the hint
@@ -468,8 +512,12 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Deserialises fields in declared order from {@code in}.
-     * Fields not present are optionally taken from {@link #defaultValue}.
+     * Reads and populates the DTO based on the provided order.
+     *
+     * @param t         Target object to populate with read values.
+     * @param in        Input source from which values are read.
+     * @param overwrite Flag indicating whether to overwrite the existing value in the target object.
+     * @throws InvalidMarshallableException If there is an error during marshalling.
      */
     public void readMarshallableDTOOrder(T t, @NotNull WireIn in, boolean overwrite) throws InvalidMarshallableException {
         try {
@@ -484,9 +532,12 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Reads fields in the order they appear on the wire. Any DTO fields not
-     * encountered are optionally restored from {@link #defaultValue} once all
-     * input has been processed.
+     * Reads and populates the DTO based on the input's order.
+     *
+     * @param t         Target object to populate with read values.
+     * @param in        Input source from which values are read.
+     * @param overwrite Flag indicating whether to overwrite the existing value in the target object.
+     * @throws InvalidMarshallableException If there is an error during marshalling.
      */
     public void readMarshallableInputOrder(T t, @NotNull WireIn in, boolean overwrite) throws InvalidMarshallableException {
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
@@ -531,14 +582,23 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Case-insensitive field name check. An empty builder matches any field.
+     * Checks if the given field name (represented by a StringBuilder) matches the field name of the provided {@link FieldAccess}.
+     * If the StringBuilder has a length of 0, it's assumed to match any field name.
+     *
+     * @param sb    The StringBuilder containing the field name to be checked.
+     * @param field The {@link FieldAccess} whose field name needs to be matched against.
+     * @return True if the field name matches or if the StringBuilder is empty; False otherwise.
      */
     public boolean matchesFieldName(StringBuilder sb, FieldAccess field) {
         return sb.length() == 0 || StringUtils.equalsCaseIgnore(field.field.getName(), sb);
     }
 
     /**
-     * Writes the first field of {@code t} as a key to {@code bytes}.
+     * Writes the key representation of the given object to the provided {@link Bytes} destination.
+     * As per the assumption, only the first field (key) of the object is written.
+     *
+     * @param t     The object whose key needs to be written.
+     * @param bytes The destination {@link Bytes} where the object's key representation will be written.
      */
     public void writeKey(T t, Bytes<?> bytes) {
         // assume one key for now.
@@ -577,7 +637,13 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Returns the named field value as a long, applying conversions when needed.
+     * Retrieves the value of a specified field from the provided object and converts it to a long.
+     * If the field's type is not inherently long or int, it attempts a conversion using the ObjectUtils class.
+     *
+     * @param o    The object from which the field value is to be retrieved.
+     * @param name The name of the field whose value needs to be fetched.
+     * @return The long value of the specified field.
+     * @throws NoSuchFieldException If no field with the specified name is found in the object.
      */
     public long getLongField(@NotNull Object o, String name) throws NoSuchFieldException {
         try {
@@ -598,7 +664,13 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Writes {@code value} into the named field, performing type conversion when required.
+     * Sets the value of a specified field in the provided object.
+     * If the type of the value does not directly match the field's type, it attempts a conversion using the ObjectUtils class.
+     *
+     * @param o     The object in which the field's value needs to be set.
+     * @param name  The name of the field whose value needs to be set.
+     * @param value The value to set to the field.
+     * @throws NoSuchFieldException If no field with the specified name is found in the object.
      */
     public void setField(Object o, String name, Object value) throws NoSuchFieldException {
         try {
@@ -614,7 +686,13 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Convenience for writing a long value via {@link FieldAccess}.
+     * Sets a long value to a specified field in the provided object.
+     * If the field's type is not inherently long or int, it attempts a conversion using the ObjectUtils class.
+     *
+     * @param o     The object in which the field's value needs to be set.
+     * @param name  The name of the field whose value needs to be set.
+     * @param value The long value to set to the field.
+     * @throws NoSuchFieldException If no field with the specified name is found in the object.
      */
     public void setLongField(Object o, String name, long value) throws NoSuchFieldException {
         try {
@@ -644,7 +722,9 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Copies values from {@link #defaultValue} into {@code o}.
+     * Resets the fields of the given object 'o' to the default value.
+     *
+     * @param o The object whose fields are to be reset to the default value.
      */
     public void reset(T o) {
         try {
@@ -664,8 +744,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for values annotated with {@link LongConversion}.
-     * Converts between the numeric value stored in the object and its text representation.
+     * Provides a field accessor that's specialized for handling fields which require
+     * conversion between integer values and string representations using a LongConverter.
      */
     static class LongConverterFieldAccess extends FieldAccess {
 
@@ -703,11 +783,11 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Writes the long value using {@link LongConverter} when text is required.
+         * Reads the long value from an object and writes it using the provided ValueOut writer.
          *
-         * @param o        source object
-         * @param write    destination
-         * @param previous ignored previous value
+         * @param o        The source object.
+         * @param write    The writer for output.
+         * @param previous The previous value (currently not used).
          */
         @Override
         protected void getValue(Object o, @NotNull ValueOut write, @Nullable Object previous) {
@@ -834,8 +914,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Base class that performs low level field access for marshalling.
-     * Implementations specialise the handling for the field's type.
+     * Abstract class to manage access to fields of objects.
+     * This class provides utility methods to read and write fields from/to objects.
      */
     abstract static class FieldAccess {
         @NotNull
@@ -848,19 +928,19 @@ public class WireMarshaller<T> {
         Boolean isLeaf;
 
         /**
-         * Creates an accessor for {@code field}.
+         * Constructor initializing field with given value.
          *
-         * @param field the field being accessed
+         * @param field Field to be accessed.
          */
         FieldAccess(@NotNull Field field) {
             this(field, null);
         }
 
         /**
-         * Creates an accessor for {@code field}.
+         * Constructor initializing field and isLeaf with given values.
          *
-         * @param field  the field being accessed
-         * @param isLeaf whether this field should be treated as a leaf. {@code null} for auto-detect
+         * @param field  Field to be accessed.
+         * @param isLeaf Flag to indicate whether the field is a leaf node.
          */
         FieldAccess(@NotNull Field field, Boolean isLeaf) {
             this.field = field;
@@ -878,13 +958,10 @@ public class WireMarshaller<T> {
         // ... (code continues)
 
         /**
-         * Builds a {@link FieldAccess} suited to {@code field}'s type.
-         * Handles primitives, strings, collections, maps, enum sets and fields
-         * annotated with {@link LongConversion}.
+         * Create a specific FieldAccess object based on the field type.
          *
-         * @param field         field to create an accessor for
-         * @param defaultObject optional default instance used for Resettable fields
-         * @return an accessor for the given field
+         * @param field Field for which FieldAccess object is created.
+         * @return FieldAccess object specific to the field type.
          */
         @Nullable
         public static Object create(@NotNull Field field, @Nullable Object defaultObject) {
@@ -983,11 +1060,13 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Helper to obtain a {@link LongConverter} for {@code field} when annotated
-         * with {@link LongConversion}.
-         *
-         * @param field field being inspected
-         * @return converter instance or {@code null} if not annotated
+         * Acquires a LongConverter instance associated with a given field, if available.
+         * <p>
+         * This method checks if the provided field has a LongConversion annotation. If present,
+         * it retrieves the corresponding LongConverter using the LongConverterFieldAccess helper class.
+                 *
+         * @param field The field for which the LongConverter needs to be obtained
+         * @return The associated LongConverter instance, or null if not present
          */
         @Nullable
         private static LongConverter acquireLongConverter(@NotNull Field field) {
@@ -999,11 +1078,13 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Returns the raw {@link Class} for the supplied {@link Type}.
-         * Handles {@link ParameterizedType} by returning its raw type.
-         *
-         * @param type0 input type
-         * @return resolved class or {@link Object} if unknown
+         * Extracts the raw Class type from a given Type object.
+         * <p>
+         * This method aims to handle various Type representations, like Class or ParameterizedType,
+         * and return the underlying Class representation.
+                 *
+         * @param type0 The type from which the class should be extracted
+         * @return The extracted Class representation
          */
         @NotNull
         static Class<?> extractClass(Type type0) {
@@ -1025,13 +1106,16 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Writes this field from {@code o} to {@code out}.
-         * If a {@link Comment} annotation is present the comment is emitted after the value.
-         *
-         * @param o   source object
-         * @param out target wire
-         * @throws IllegalAccessException        if field access fails
-         * @throws InvalidMarshallableException  if a value cannot be marshalled
+         * Writes the value of a given object's field to a provided WireOut instance.
+         * <p>
+         * This method serializes the value of the specified object's field and writes it to
+         * the WireOut. If the field has a Comment annotation, a special processing is done
+         * using the CommentAnnotationNotifier.
+                 *
+         * @param o    The object containing the field to be written
+         * @param out  The WireOut instance to write the field value to
+         * @throws IllegalAccessException If the field cannot be accessed
+         * @throws InvalidMarshallableException If the object cannot be marshalled
          */
         void write(Object o, @NotNull WireOut out) throws IllegalAccessException, InvalidMarshallableException {
 
@@ -1047,13 +1131,17 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Writes the field value followed by its {@link Comment} text.
-         *
-         * @param o        source object
-         * @param out      target wire
-         * @param valueOut {@code out} wrapper for the value
-         * @throws IllegalAccessException       if reflection fails
-         * @throws InvalidMarshallableException if marshalling fails
+         * Retrieves the value of the provided object's field and writes it to the provided WireOut instance,
+         * appending a comment based on the associated Comment annotation.
+         * <p>
+         * If the field has a Comment annotation, its value is formatted using the field's value and appended as a comment.
+         * The CommentAnnotationNotifier is used to indicate that the written value is preceded by a comment.
+                 *
+         * @param o         The object containing the field whose value needs to be retrieved
+         * @param out       The WireOut instance to which the value and the comment are written
+         * @param valueOut  The ValueOut instance representing the field's value
+         * @throws IllegalAccessException If the field cannot be accessed
+         * @throws InvalidMarshallableException If the object cannot be marshalled
          */
         private void getValueCommentAnnotated(Object o, @NotNull WireOut out, ValueOut valueOut) throws IllegalAccessException, InvalidMarshallableException {
             CommentAnnotationNotifier notifier = (CommentAnnotationNotifier) valueOut;
@@ -1092,12 +1180,12 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Tests whether this field holds equal values in {@code o} and {@code o2}.
+         * Check if the values of a field in two objects are the same.
          *
-         * @param o  first object
-         * @param o2 second object
-         * @return {@code true} if the values are equal
-         * @throws IllegalAccessException if reflection fails
+         * @param o  First object.
+         * @param o2 Second object.
+         * @return true if values are the same, false otherwise.
+         * @throws IllegalAccessException If unable to access the field.
          */
         protected boolean sameValue(Object o, Object o2) throws IllegalAccessException {
             final Object v1 = field.get(o);
@@ -1108,11 +1196,11 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Copies this field from {@code from} to {@code to}.
+         * Copies the value of a field from one object to another.
          *
-         * @param from source object
-         * @param to   destination object
-         * @throws IllegalAccessException if reflection fails
+         * @param from Source object.
+         * @param to   Destination object.
+         * @throws IllegalAccessException If unable to access the field.
          */
         protected void copy(Object from, Object to) throws IllegalAccessException {
             ObjectUtils.requireNonNull(from);
@@ -1122,14 +1210,13 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Writes this field from {@code o} to {@code write}.
-         * Implementations may use {@code previous} for delta encoding.
+         * Abstract method to get the value of a field from an object.
          *
-         * @param o        source object
-         * @param write    destination
-         * @param previous previous state or {@code null}
-         * @throws IllegalAccessException       if reflection fails
-         * @throws InvalidMarshallableException on marshalling error
+         * @param o        Object from which to get the value.
+         * @param write    Output destination.
+         * @param previous Previous object for comparison.
+         * @throws IllegalAccessException       If unable to access the field.
+         * @throws InvalidMarshallableException If marshalling fails.
          */
         protected abstract void getValue(Object o, ValueOut write, Object previous) throws IllegalAccessException, InvalidMarshallableException;
 
@@ -1167,32 +1254,33 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Reads this field from {@code read} and updates {@code o}.
+         * Abstract method to set the value of a field in an object.
          *
-         * @param o         target object
-         * @param read      wire input
-         * @param overwrite if false a missing value leaves the field unchanged
-         * @throws IllegalAccessException if reflection fails
+         * @param o         Object to set the value in.
+         * @param read      Input source.
+         * @param overwrite Whether to overwrite existing value.
+         * @throws IllegalAccessException If unable to access the field.
          */
         protected abstract void setValue(Object o, ValueIn read, boolean overwrite) throws IllegalAccessException;
 
         /**
-         * Resets this field on {@code o} using the value from {@code defaultObject}.
-         * Existing objects are reused where possible to avoid allocation.
+         * Abstract method to reset the value of a field in an object to default value.
+         * The default value is the one present in objects of that class after no-argument constructor.
+         * Where possible, existing data structures should be preserved without reallocation to avoid garbage.
          *
-         * @param defaultObject reference instance containing default values
-         * @param o             target object
+         * @param defaultObject A reference unmodified instance of this class.
+         * @param o             Object to reset the value in.
          */
         protected void setDefaultValue(Object defaultObject, Object o) throws IllegalAccessException {
             copy(defaultObject, o);
         }
 
         /**
-         * Writes the value of this field to {@code bytes} in binary form.
+         * Abstract method to convert the value of a field in an object to bytes.
          *
-         * @param o     source object
-         * @param bytes destination buffer
-         * @throws IllegalAccessException if reflection fails
+         * @param o     Object containing the field.
+         * @param bytes Destination to write the bytes to.
+         * @throws IllegalAccessException If unable to access the field.
          */
         public abstract void getAsBytes(Object o, Bytes<?> bytes) throws IllegalAccessException;
 
@@ -1213,7 +1301,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@link IntValue} references.
+     * This is a specialized FieldAccess implementation for fields of type IntValue.
+     * It provides implementations for reading and writing the IntValue from and to various sources.
      */
     static class IntValueAccess extends FieldAccess {
 
@@ -1250,7 +1339,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@link LongValue} references.
+     * This is a specialized FieldAccess implementation for fields of type LongValue.
+     * It provides implementations for reading and writing the LongValue from and to various sources.
      */
     static class LongValueAccess extends FieldAccess {
 
@@ -1287,7 +1377,9 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for arbitrary object references. Supports {@link AsMarshallable}.
+     * This is a specialized FieldAccess implementation for generic object fields.
+     * It provides methods for reading and writing object fields from and to various sources,
+     * taking into account special cases where the field may be marshaled differently based on annotations.
      */
     static class ObjectFieldAccess extends FieldAccess {
         private final Class<?> type; // Type of the object field
@@ -1573,7 +1665,12 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for array fields.
+     * The ArrayFieldAccess class extends FieldAccess to provide specialized access
+     * and manipulation methods for fields that are arrays.
+     * <p>
+     * It calculates the component type of the array and retrieves its equivalent object type
+     * for ease of use. The class is designed to handle arrays in a generic manner and
+     * use the provided methods of the superclass for actual field manipulation.
      */
     static class ArrayFieldAccess extends FieldAccess {
         private final Class<?> componentType;
@@ -1651,7 +1748,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@code byte[]} fields.
+     * The ByteArrayFieldAccess class extends FieldAccess to provide specialized access
+     * and manipulation methods for fields that are byte arrays.
+     * <p>
+     * The class is optimized for reading and writing byte arrays to and from a wire format
+     * while preserving encapsulation and supporting null values.
      */
     static class ByteArrayFieldAccess extends FieldAccess {
 
@@ -1708,7 +1809,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@link EnumSet} fields.
+     * The EnumSetFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
+     * for fields that are of type {@link EnumSet}.
+     * <p>
+     * This class allows efficient reading and writing of EnumSet fields to and from a wire format while
+     * preserving encapsulation and supporting null values.
      */
     static class EnumSetFieldAccess extends FieldAccess {
 
@@ -1855,7 +1960,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@link Collection} types.
+     * The CollectionFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
+     * for fields that are of type {@link Collection}.
+     * <p>
+     * It is optimized to handle both random-access and non-random-access collections efficiently. Additionally,
+     * the class provides flexibility by allowing users to supply custom collection creation logic if needed.
      */
     static class CollectionFieldAccess extends FieldAccess {
 
@@ -2028,7 +2137,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for collections of {@link String} values.
+     * The StringCollectionFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
+     * for fields that are of type {@link Collection} where the elements of the collection are {@link String} instances.
+     * <p>
+     * This extension particularly manages the parsing of strings from the given input and offers utility functions
+     * for instantiation of the correct {@link Collection} type.
      */
     static class StringCollectionFieldAccess extends FieldAccess {
 
@@ -2145,7 +2258,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@link Map} types.
+     * The MapFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
+     * for fields that are of type {@link Map}.
+     * <p>
+     * This extension is designed to manage the parsing and instantiation of the correct {@link Map} type
+     * and provides functionality to work with the key-value pairs within the map.
      */
     static class MapFieldAccess extends FieldAccess {
 
@@ -2250,7 +2367,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@code boolean} fields.
+     * The BooleanFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
+     * for fields that are of type boolean or {@link Boolean}.
+     * <p>
+     * This extension uses unsafe operations to get and set the boolean value efficiently without invoking reflection
+     * on each operation.
      */
     static class BooleanFieldAccess extends FieldAccess {
         BooleanFieldAccess(@NotNull Field field) {
@@ -2284,7 +2405,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@code byte} fields.
+     * The ByteFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
+     * for fields that are of type byte or {@link Byte}.
+     * <p>
+     * This extension leverages unsafe operations to get and set the byte value directly without the need for
+     * reflective access each time, ensuring better performance.
      */
     static class ByteFieldAccess extends FieldAccess {
         ByteFieldAccess(@NotNull Field field) {
@@ -2318,7 +2443,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@code short} fields.
+     * The ShortFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
+     * for fields that are of type short or {@link Short}.
+     * <p>
+     * This extension leverages unsafe operations to get and set the short value directly without the need for
+     * reflective access each time, ensuring optimal performance.
      */
     static class ShortFieldAccess extends FieldAccess {
         ShortFieldAccess(@NotNull Field field) {
@@ -2352,7 +2481,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@code char} fields.
+     * The CharFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
+     * for fields that are of type char or {@link Character}.
+     * <p>
+     * This extension leverages unsafe operations to get and set the character value directly without the need for
+     * reflective access each time, ensuring optimal performance.
      */
     static class CharFieldAccess extends FieldAccess {
 
@@ -2408,7 +2541,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@code int} fields.
+     * The IntegerFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
+     * for fields that are of type int or {@link Integer}.
+     * <p>
+     * This extension leverages unsafe operations to get and set the integer value directly without the need for
+     * reflective access each time, ensuring optimal performance.
      */
     static class IntegerFieldAccess extends FieldAccess {
         IntegerFieldAccess(@NotNull Field field) {
@@ -2777,7 +2914,9 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@code float} fields.
+     * The FloatFieldAccess class extends the FieldAccess class, providing specialized access
+     * to float fields of an object. This class supports reading and writing float values,
+     * considering a potential "previous" value for optimized serialization or other comparative tasks.
      */
     static class FloatFieldAccess extends FieldAccess {
         FloatFieldAccess(@NotNull Field field) {
@@ -2815,7 +2954,10 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@code long} fields.
+     * The LongFieldAccess class extends FieldAccess to provide specialized access
+     * to long fields of an object. It supports reading and writing long values,
+     * considering a potential "previous" value for optimized serialization or other
+     * comparative tasks.
      */
     static class LongFieldAccess extends FieldAccess {
         LongFieldAccess(@NotNull Field field) {
@@ -2853,7 +2995,10 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Field access for {@code double} fields.
+     * The DoubleFieldAccess class extends FieldAccess to provide specialized access
+     * to double fields of an object. It supports reading and writing double values,
+     * considering a potential "previous" value for optimized serialization or other
+     * comparative tasks.
      */
     static class DoubleFieldAccess extends FieldAccess {
         DoubleFieldAccess(@NotNull Field field) {

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -44,27 +44,49 @@ import java.util.stream.Stream;
 import static net.openhft.chronicle.core.UnsafeMemory.*;
 
 /**
- * The WireMarshaller class is responsible for marshalling and unmarshalling of objects of type T.
- * This class provides an efficient mechanism for serialization/deserialization using wire protocols.
- * It utilizes field accessors to read and write values directly to and from the fields of the object.
+ * Engine for marshalling and unmarshalling objects based on their field
+ * definitions. Each {@code WireMarshaller} is typically cached per class via
+ * {@link #WIRE_MARSHALLER_CL}. Reflection is used once to discover the fields
+ * and then optimised {@link FieldAccess} instances perform subsequent read and
+ * write operations.
  *
- * @param <T> The type of the object to be marshalled/unmarshalled.
+ * @param <T> the type handled by this marshaller
  */
 @SuppressWarnings({"rawtypes", "unchecked", "deprecation"})
 public class WireMarshaller<T> {
     private static final Class[] UNEXPECTED_FIELDS_PARAMETER_TYPES = {Object.class, ValueIn.class};
+    /**
+     * An empty array of {@link FieldAccess}, used for classes that have no
+     * marshallable fields such as interfaces or some enum types.
+     */
     private static final FieldAccess[] NO_FIELDS = {};
+    /**
+     * Reflection accessor for {@link Class#isRecord()} available on Java 14+.
+     */
     private static Method isRecord;
+    /**
+     * One entry per marshallable field of {@code T}. The ordering is preserved
+     * so that field writers can honour input order hints if provided.
+     */
     @NotNull
     final FieldAccess[] fields;
 
-    // Map for quick field look-up based on their names.
+    /**
+     * Map for quick field look-up based on the name. Implemented as a
+     * {@link TreeMap} to allow ordered iteration and case-insensitive searches.
+     */
     final TreeMap<CharSequence, FieldAccess> fieldMap = new TreeMap<>(WireMarshaller::compare);
 
-    // Flag to determine if this marshaller is for a leaf class.
+    /**
+     * Indicates if {@code T} is considered a leaf in the object graph. Leaf
+     * types may be treated more compactly by some wire formats.
+     */
     private final boolean isLeaf;
 
-    // Default value for the type T.
+    /**
+     * Pre-instantiated default instance used to identify unchanged fields and
+     * to populate missing values during read operations.
+     */
     @Nullable
     private final T defaultValue;
 
@@ -90,8 +112,11 @@ public class WireMarshaller<T> {
         this(fields, isLeaf, defaultValueForType(tClass));
     }
 
-    // A class-local storage for caching WireMarshallers for different types.
-    // Depending on the type of class, it either creates a marshaller for exceptions or a generic one.
+    /**
+     * A class-local cache of {@code WireMarshaller} instances. {@link Throwable}
+     * types receive a specialised marshaller that handles their field discovery
+     * slightly differently, while all other classes use the generic variant.
+     */
     public static final ClassLocal<WireMarshaller> WIRE_MARSHALLER_CL = ClassLocal.withInitial
             (tClass ->
                     Throwable.class.isAssignableFrom(tClass)

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -78,11 +78,13 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Constructs a new instance of the WireMarshaller with the specified parameters.
+     * Protected constructor used by factory methods.
+     * Prefer {@link #of(Class)} or {@link #WIRE_MARSHALLER_CL} to obtain
+     * instances.
      *
-     * @param tClass  The class of the object to be marshalled.
-     * @param fields  An array of field accessors that provide access to the fields of the object.
-     * @param isLeaf  Indicates if the marshaller is for a leaf class.
+     * @param tClass the type being marshalled
+     * @param fields fields to marshall
+     * @param isLeaf whether the type is considered a leaf
      */
     protected WireMarshaller(@NotNull Class<T> tClass, @NotNull FieldAccess[] fields, boolean isLeaf) {
         this(fields, isLeaf, defaultValueForType(tClass));
@@ -97,6 +99,9 @@ public class WireMarshaller<T> {
                             : WireMarshaller.of(tClass)
             );
 
+    /**
+     * Internal constructor used by the factory methods.
+     */
     WireMarshaller(@NotNull FieldAccess[] fields, boolean isLeaf, @Nullable T defaultValue) {
         this.fields = fields;
         this.isLeaf = isLeaf;
@@ -107,12 +112,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Factory method to create an instance of the WireMarshaller for a specific class type.
-     * Determines the appropriate marshaller type (basic or one that handles unexpected fields)
-     * based on the characteristics of the provided class.
+     * Creates a marshaller for the given type.
+     * Synthetic fields introduced by later Java versions are filtered out.
      *
-     * @param tClass The class type for which the marshaller is to be created.
-     * @return A new instance of WireMarshaller for the provided class type.
+     * @param tClass the type to marshall
+     * @return marshaller instance for {@code tClass}
      */
     @NotNull
     public static <T> WireMarshaller<T> of(@NotNull Class<T> tClass) {
@@ -142,11 +146,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Checks if the provided field accessor corresponds to a "leaf" entity.
-     * An entity is considered a leaf if it doesn't need to be further broken down in the serialization process.
+     * Determines if the field type can be treated as a leaf during serialisation.
+     * Collections and non-dynamic-enum {@link WriteMarshallable} types are not leaves.
      *
-     * @param c The field accessor to be checked.
-     * @return {@code true} if the field accessor is leafable, {@code false} otherwise.
+     * @param c accessor for the field
+     * @return true if the field can be treated as a leaf
      */
     protected static boolean leafable(FieldAccess c) {
         Class<?> type = c.field.getType();
@@ -158,10 +162,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Determines if the provided class overrides the "unexpectedField" method from the ReadMarshallable interface.
+     * Checks whether {@code tClass} supplies its own
+     * {@link ReadMarshallable#unexpectedField(Object, ValueIn)} implementation.
      *
-     * @param tClass The class type to be checked.
-     * @return {@code true} if the class overrides the "unexpectedField" method, {@code false} otherwise.
+     * @param tClass the type to check
+     * @return true if {@code tClass} overrides the method
      */
     private static <T> boolean overridesUnexpectedFields(Class<T> tClass) {
         try {
@@ -173,11 +178,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Factory method to create an instance of the WireMarshaller for a Throwable class type.
-     * The method identifies fields that should be marshalled and prepares the marshaller accordingly.
+     * Factory for {@link Throwable} subclasses.
+     * Includes fields needed to serialise exception state.
      *
-     * @param tClass The Throwable class type for which the marshaller is to be created.
-     * @return A new instance of WireMarshaller for the provided Throwable class type.
+     * @param tClass exception type
+     * @return marshaller for the throwable
      */
     @NotNull
     private static <T> WireMarshaller<T> ofThrowable(@NotNull Class<T> tClass) {
@@ -192,10 +197,11 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Determines if the provided class is a collection type, including arrays, standard Collections, or Maps.
+     * Utility to check whether the class represents an array, a
+     * {@link Collection} or a {@link Map}.
      *
-     * @param c The class to be checked.
-     * @return {@code true} if the class is a collection type, {@code false} otherwise.
+     * @param c class to test
+     * @return true if it is a collection type
      */
     private static boolean isCollection(@NotNull Class<?> c) {
         return c.isArray() ||
@@ -204,12 +210,14 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Recursively fetches all non-static, non-transient fields from the provided class and its superclasses,
-     * up to but not including Object or AbstractCommonMarshallable, and adds them to the provided map.
-     * Fields that are flagged for exclusion (e.g., the "ordinal" field for Enum types) are skipped.
+     * Recursively collects all non-static and non-transient fields from
+     * {@code clazz} and its parents until {@link Object} or
+     * {@link AbstractCommonMarshallable}. The map is keyed by field name.
+     * Skips values such as {@code ordinal} on enums and inner-class synthetic
+     * links.
      *
-     * @param clazz The class type from which fields are to be extracted.
-     * @param map   The map to populate with field names and their corresponding Field objects.
+     * @param clazz class to inspect
+     * @param map   destination for discovered fields
      */
     public static void getAllField(@NotNull Class<?> clazz, @NotNull Map<String, Field> map) {
         if (clazz != Object.class && clazz != AbstractCommonMarshallable.class)
@@ -231,6 +239,12 @@ public class WireMarshaller<T> {
         }
     }
 
+    /**
+     * Creates a default instance for {@code tClass} when possible.
+     * Concrete, non-Java-core classes get an empty instance. For
+     * {@link DynamicEnum} types a special '[unset]' constant is produced.
+     * Returns {@code null} for primitives, arrays and interfaces.
+     */
     static <T> T defaultValueForType(@NotNull Class<T> tClass) {
 //        tClass = ObjectUtils.implementationToUse(tClass);
         if (ObjectUtils.isConcreteClass(tClass)
@@ -256,15 +270,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Compares two CharSequences lexicographically. This is a character-by-character comparison
-     * that returns the difference of the first unmatched characters or the difference in their lengths
-     * if one sequence is a prefix of the other.
-     *
-     * @param cs0 The first CharSequence to be compared.
-     * @param cs1 The second CharSequence to be compared.
-     * @return A positive integer if {@code cs0} comes after {@code cs1},
-     *         a negative integer if {@code cs0} comes before {@code cs1},
-     *         or zero if the sequences are equal.
+     * Lexicographical comparison used by {@link #fieldMap}.
      */
     private static int compare(CharSequence cs0, CharSequence cs1) {
         for (int i = 0, len = Math.min(cs0.length(), cs1.length()); i < len; i++) {
@@ -276,12 +282,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Computes the actual type arguments for a given field of an interface. This method determines
-     * the generic type arguments that the field uses based on the interface's type parameters.
-     *
-     * @param iface The interface containing the field.
-     * @param field The field whose type arguments need to be determined.
-     * @return An array of actual type arguments or the interface's type parameters if no actual arguments can be deduced.
+     * Helper used by reflection code to resolve the actual generic arguments for
+     * {@code field} relative to {@code iface}.
      */
     private static Type[] computeActualTypeArguments(Class<?> iface, Field field) {
         Type[] actual = consumeActualTypeArguments(new HashMap<>(), iface, field.getGenericType());
@@ -293,19 +295,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Determines the actual type arguments used by a class or interface for a given interface type.
-     * This method recursively inspects the type hierarchy to match type arguments against the
-     * interface's type parameters. It uses a previously built map of type parameter names to their
-     * actual types to deduce the correct arguments for the given interface.
-     *
-     * @param prevTypeParameters A map containing previously discovered type parameter names
-     *                           mapped to their actual types.
-     * @param iface              The interface for which we want to determine the type arguments.
-     * @param type               The type to inspect. This could be an actual class, interface, or
-     *                           a parameterized type that uses generic arguments.
-     *
-     * @return An array of actual type arguments used by the provided type for the specified interface,
-     *         or null if the type doesn't directly or indirectly implement or extend the given interface.
+     * Recursive helper for {@link #computeActualTypeArguments(Class, Field)}.
+     * Walks the type hierarchy to map parameter names to concrete classes.
      */
     private static Type[] consumeActualTypeArguments(Map<String, Type> prevTypeParameters, Class<?> iface, Type type) {
         Class<?> cls = null;
@@ -377,11 +368,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Excludes specified fields from the current marshaller and returns a new instance of the marshaller
-     * with the remaining fields.
-     *
-     * @param fieldNames Names of the fields to be excluded.
-     * @return A new instance of the {@link WireMarshaller} with the specified fields excluded.
+     * Returns a marshaller that omits the named fields.
+     * Useful when only a subset of a DTO should be serialised.
      */
     public WireMarshaller<T> excludeFields(String... fieldNames) {
         Set<String> fieldSet = new HashSet<>(Arrays.asList(fieldNames));
@@ -392,13 +380,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Writes the marshallable representation of the given object to the provided {@link WireOut} destination.
-     * This will traverse the fields and use their respective {@link FieldAccess} to write each field.
-     * The method also adjusts the hex dump indentation for better readability in the output.
-     *
-     * @param t   The object to write.
-     * @param out The destination {@link WireOut} where the object representation will be written.
-     * @throws InvalidMarshallableException If the object fails validation checks before serialization.
+     * Serialises {@code t} to {@code out} in field order. Hex dump indentation
+     * is adjusted for readability.
      */
     public void writeMarshallable(T t, @NotNull WireOut out) throws InvalidMarshallableException {
         ValidatableUtil.validate(t);
@@ -414,12 +397,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Writes the marshallable representation of the given object to the provided {@link Bytes} destination.
-     * Unlike the previous method, this doesn't adjust the hex dump indentation. It's a more direct
-     * serialization of the fields to bytes.
-     *
-     * @param t     The object to write.
-     * @param bytes The destination {@link Bytes} where the object representation will be written.
+     * Serialises {@code t} directly to the given byte store using raw field
+     * access.
      */
     public void writeMarshallable(T t, Bytes<?> bytes) {
         for (@NotNull FieldAccess field : fields) {
@@ -432,14 +411,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Writes the values of the fields from the provided object (DTO) to the output. Before writing,
-     * the object is validated. The method also supports optional copying of the values
-     * from the source object to a previous instance.
-     *
-     * @param t    Object whose field values are to be written.
-     * @param out  Output destination where the field values are written to.
-     * @param copy Flag indicating whether to copy values from the source object to the previous object.
-     * @throws InvalidMarshallableException If there's an error during marshalling.
+     * Serialises {@code t} to {@code out}, optionally copying written values
+     * into the stored default instance.
      */
     public void writeMarshallable(T t, @NotNull WireOut out, boolean copy) throws InvalidMarshallableException {
         // Validate the object before writing
@@ -455,13 +428,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Reads and populates the DTO based on the provided input. The input order can be hinted.
-     * After reading, the object is validated.
-     *
-     * @param t         Object to populate with read values.
-     * @param in        Input source from which values are read.
-     * @param overwrite Flag indicating whether to overwrite the existing value in the target object.
-     * @throws InvalidMarshallableException If there is an error during marshalling.
+     * Deserialises from {@code in} into {@code t}. When {@code overwrite} is
+     * true missing fields are reset from {@link #defaultValue}.
      */
     public void readMarshallable(T t, @NotNull WireIn in, boolean overwrite) throws InvalidMarshallableException {
         // Choose the reading method based on the hint
@@ -475,12 +443,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Reads and populates the DTO based on the provided order.
-     *
-     * @param t         Target object to populate with read values.
-     * @param in        Input source from which values are read.
-     * @param overwrite Flag indicating whether to overwrite the existing value in the target object.
-     * @throws InvalidMarshallableException If there is an error during marshalling.
+     * Deserialises fields in declared order from {@code in}.
+     * Fields not present are optionally taken from {@link #defaultValue}.
      */
     public void readMarshallableDTOOrder(T t, @NotNull WireIn in, boolean overwrite) throws InvalidMarshallableException {
         try {
@@ -495,12 +459,9 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Reads and populates the DTO based on the input's order.
-     *
-     * @param t         Target object to populate with read values.
-     * @param in        Input source from which values are read.
-     * @param overwrite Flag indicating whether to overwrite the existing value in the target object.
-     * @throws InvalidMarshallableException If there is an error during marshalling.
+     * Reads fields in the order they appear on the wire. Any DTO fields not
+     * encountered are optionally restored from {@link #defaultValue} once all
+     * input has been processed.
      */
     public void readMarshallableInputOrder(T t, @NotNull WireIn in, boolean overwrite) throws InvalidMarshallableException {
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
@@ -545,23 +506,14 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Checks if the given field name (represented by a StringBuilder) matches the field name of the provided {@link FieldAccess}.
-     * If the StringBuilder has a length of 0, it's assumed to match any field name.
-     *
-     * @param sb    The StringBuilder containing the field name to be checked.
-     * @param field The {@link FieldAccess} whose field name needs to be matched against.
-     * @return True if the field name matches or if the StringBuilder is empty; False otherwise.
+     * Case-insensitive field name check. An empty builder matches any field.
      */
     public boolean matchesFieldName(StringBuilder sb, FieldAccess field) {
         return sb.length() == 0 || StringUtils.equalsCaseIgnore(field.field.getName(), sb);
     }
 
     /**
-     * Writes the key representation of the given object to the provided {@link Bytes} destination.
-     * As per the assumption, only the first field (key) of the object is written.
-     *
-     * @param t     The object whose key needs to be written.
-     * @param bytes The destination {@link Bytes} where the object's key representation will be written.
+     * Writes the first field of {@code t} as a key to {@code bytes}.
      */
     public void writeKey(T t, Bytes<?> bytes) {
         // assume one key for now.
@@ -573,12 +525,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Compares two objects field by field to determine their equality.
-     * Uses each field's {@link FieldAccess} to perform the equality check.
-     *
-     * @param o1 The first object to compare.
-     * @param o2 The second object to compare.
-     * @return True if all fields of both objects are equal; False if at least one field differs.
+     * Compares two objects field by field.
      */
     public boolean isEqual(Object o1, Object o2) {
         for (@NotNull FieldAccess field : fields) {
@@ -589,12 +536,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Fetches the value of the specified field from the provided object.
-     *
-     * @param o    The object from which the field value needs to be fetched.
-     * @param name The name of the field whose value is to be fetched.
-     * @return The value of the specified field from the object.
-     * @throws NoSuchFieldException If no field with the specified name is found in the object.
+     * Returns the named field value using {@link FieldAccess}.
      */
     public Object getField(Object o, String name) throws NoSuchFieldException {
         try {
@@ -610,13 +552,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Retrieves the value of a specified field from the provided object and converts it to a long.
-     * If the field's type is not inherently long or int, it attempts a conversion using the ObjectUtils class.
-     *
-     * @param o    The object from which the field value is to be retrieved.
-     * @param name The name of the field whose value needs to be fetched.
-     * @return The long value of the specified field.
-     * @throws NoSuchFieldException If no field with the specified name is found in the object.
+     * Returns the named field value as a long, applying conversions when needed.
      */
     public long getLongField(@NotNull Object o, String name) throws NoSuchFieldException {
         try {
@@ -637,13 +573,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Sets the value of a specified field in the provided object.
-     * If the type of the value does not directly match the field's type, it attempts a conversion using the ObjectUtils class.
-     *
-     * @param o     The object in which the field's value needs to be set.
-     * @param name  The name of the field whose value needs to be set.
-     * @param value The value to set to the field.
-     * @throws NoSuchFieldException If no field with the specified name is found in the object.
+     * Writes {@code value} into the named field, performing type conversion when required.
      */
     public void setField(Object o, String name, Object value) throws NoSuchFieldException {
         try {
@@ -659,13 +589,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Sets a long value to a specified field in the provided object.
-     * If the field's type is not inherently long or int, it attempts a conversion using the ObjectUtils class.
-     *
-     * @param o     The object in which the field's value needs to be set.
-     * @param name  The name of the field whose value needs to be set.
-     * @param value The long value to set to the field.
-     * @throws NoSuchFieldException If no field with the specified name is found in the object.
+     * Convenience for writing a long value via {@link FieldAccess}.
      */
     public void setLongField(Object o, String name, long value) throws NoSuchFieldException {
         try {
@@ -695,9 +619,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Resets the fields of the given object 'o' to the default value.
-     *
-     * @param o The object whose fields are to be reset to the default value.
+     * Copies values from {@link #defaultValue} into {@code o}.
      */
     public void reset(T o) {
         try {
@@ -710,9 +632,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Checks if the current WireMarshaller is a leaf.
-     *
-     * @return true if the WireMarshaller is a leaf, false otherwise.
+     * @return true if this marshaller is for a leaf type
      */
     public boolean isLeaf() {
         return isLeaf;

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -639,8 +639,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Provides a field accessor that's specialized for handling fields which require
-     * conversion between integer values and string representations using a LongConverter.
+     * Field access for values annotated with {@link LongConversion}.
+     * Converts between the numeric value stored in the object and its text representation.
      */
     static class LongConverterFieldAccess extends FieldAccess {
 
@@ -678,11 +678,11 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Reads the long value from an object and writes it using the provided ValueOut writer.
+         * Writes the long value using {@link LongConverter} when text is required.
          *
-         * @param o        The source object.
-         * @param write    The writer for output.
-         * @param previous The previous value (currently not used).
+         * @param o        source object
+         * @param write    destination
+         * @param previous ignored previous value
          */
         @Override
         protected void getValue(Object o, @NotNull ValueOut write, @Nullable Object previous) {
@@ -809,8 +809,8 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * Abstract class to manage access to fields of objects.
-     * This class provides utility methods to read and write fields from/to objects.
+     * Base class that performs low level field access for marshalling.
+     * Implementations specialise the handling for the field's type.
      */
     abstract static class FieldAccess {
         @NotNull
@@ -823,19 +823,19 @@ public class WireMarshaller<T> {
         Boolean isLeaf;
 
         /**
-         * Constructor initializing field with given value.
+         * Creates an accessor for {@code field}.
          *
-         * @param field Field to be accessed.
+         * @param field the field being accessed
          */
         FieldAccess(@NotNull Field field) {
             this(field, null);
         }
 
         /**
-         * Constructor initializing field and isLeaf with given values.
+         * Creates an accessor for {@code field}.
          *
-         * @param field  Field to be accessed.
-         * @param isLeaf Flag to indicate whether the field is a leaf node.
+         * @param field  the field being accessed
+         * @param isLeaf whether this field should be treated as a leaf. {@code null} for auto-detect
          */
         FieldAccess(@NotNull Field field, Boolean isLeaf) {
             this.field = field;
@@ -853,10 +853,13 @@ public class WireMarshaller<T> {
         // ... (code continues)
 
         /**
-         * Create a specific FieldAccess object based on the field type.
+         * Builds a {@link FieldAccess} suited to {@code field}'s type.
+         * Handles primitives, strings, collections, maps, enum sets and fields
+         * annotated with {@link LongConversion}.
          *
-         * @param field Field for which FieldAccess object is created.
-         * @return FieldAccess object specific to the field type.
+         * @param field         field to create an accessor for
+         * @param defaultObject optional default instance used for Resettable fields
+         * @return an accessor for the given field
          */
         @Nullable
         public static Object create(@NotNull Field field, @Nullable Object defaultObject) {
@@ -955,13 +958,11 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Acquires a LongConverter instance associated with a given field, if available.
-         * <p>
-         * This method checks if the provided field has a LongConversion annotation. If present,
-         * it retrieves the corresponding LongConverter using the LongConverterFieldAccess helper class.
-                 *
-         * @param field The field for which the LongConverter needs to be obtained
-         * @return The associated LongConverter instance, or null if not present
+         * Helper to obtain a {@link LongConverter} for {@code field} when annotated
+         * with {@link LongConversion}.
+         *
+         * @param field field being inspected
+         * @return converter instance or {@code null} if not annotated
          */
         @Nullable
         private static LongConverter acquireLongConverter(@NotNull Field field) {
@@ -973,13 +974,11 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Extracts the raw Class type from a given Type object.
-         * <p>
-         * This method aims to handle various Type representations, like Class or ParameterizedType,
-         * and return the underlying Class representation.
-                 *
-         * @param type0 The type from which the class should be extracted
-         * @return The extracted Class representation
+         * Returns the raw {@link Class} for the supplied {@link Type}.
+         * Handles {@link ParameterizedType} by returning its raw type.
+         *
+         * @param type0 input type
+         * @return resolved class or {@link Object} if unknown
          */
         @NotNull
         static Class<?> extractClass(Type type0) {
@@ -1001,16 +1000,13 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Writes the value of a given object's field to a provided WireOut instance.
-         * <p>
-         * This method serializes the value of the specified object's field and writes it to
-         * the WireOut. If the field has a Comment annotation, a special processing is done
-         * using the CommentAnnotationNotifier.
-                 *
-         * @param o    The object containing the field to be written
-         * @param out  The WireOut instance to write the field value to
-         * @throws IllegalAccessException If the field cannot be accessed
-         * @throws InvalidMarshallableException If the object cannot be marshalled
+         * Writes this field from {@code o} to {@code out}.
+         * If a {@link Comment} annotation is present the comment is emitted after the value.
+         *
+         * @param o   source object
+         * @param out target wire
+         * @throws IllegalAccessException        if field access fails
+         * @throws InvalidMarshallableException  if a value cannot be marshalled
          */
         void write(Object o, @NotNull WireOut out) throws IllegalAccessException, InvalidMarshallableException {
 
@@ -1026,17 +1022,13 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Retrieves the value of the provided object's field and writes it to the provided WireOut instance,
-         * appending a comment based on the associated Comment annotation.
-         * <p>
-         * If the field has a Comment annotation, its value is formatted using the field's value and appended as a comment.
-         * The CommentAnnotationNotifier is used to indicate that the written value is preceded by a comment.
-                 *
-         * @param o         The object containing the field whose value needs to be retrieved
-         * @param out       The WireOut instance to which the value and the comment are written
-         * @param valueOut  The ValueOut instance representing the field's value
-         * @throws IllegalAccessException If the field cannot be accessed
-         * @throws InvalidMarshallableException If the object cannot be marshalled
+         * Writes the field value followed by its {@link Comment} text.
+         *
+         * @param o        source object
+         * @param out      target wire
+         * @param valueOut {@code out} wrapper for the value
+         * @throws IllegalAccessException       if reflection fails
+         * @throws InvalidMarshallableException if marshalling fails
          */
         private void getValueCommentAnnotated(Object o, @NotNull WireOut out, ValueOut valueOut) throws IllegalAccessException, InvalidMarshallableException {
             CommentAnnotationNotifier notifier = (CommentAnnotationNotifier) valueOut;
@@ -1050,16 +1042,15 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Writes the value of the field from the provided object to the output. If the value is the same
-         * as the previous value, it skips the writing. If the copy flag is set, it also copies the value
-         * from the source object to the previous object.
+         * Writes this field to {@code out} if it differs from {@code previous}.
+         * When {@code copy} is true the written value is also copied into {@code previous}.
          *
-         * @param o        Object from which the field value is fetched.
-         * @param out      Output destination where the value is written to.
-         * @param previous Previous object to compare for sameness and optionally copy to.
-         * @param copy     Flag indicating whether to copy the value from source to the previous object.
-         * @throws IllegalAccessException       If there's an access violation when fetching the field value.
-         * @throws InvalidMarshallableException If there's an error during marshalling.
+         * @param o        source object
+         * @param out      target wire
+         * @param previous object containing the last written value
+         * @param copy     copy the new value into {@code previous} after writing
+         * @throws IllegalAccessException       if reflection fails
+         * @throws InvalidMarshallableException on marshalling error
          */
         void write(Object o, @NotNull WireOut out, Object previous, boolean copy) throws IllegalAccessException, InvalidMarshallableException {
             // Check if the current and previous values are the same
@@ -1076,12 +1067,12 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Check if the values of a field in two objects are the same.
+         * Tests whether this field holds equal values in {@code o} and {@code o2}.
          *
-         * @param o  First object.
-         * @param o2 Second object.
-         * @return true if values are the same, false otherwise.
-         * @throws IllegalAccessException If unable to access the field.
+         * @param o  first object
+         * @param o2 second object
+         * @return {@code true} if the values are equal
+         * @throws IllegalAccessException if reflection fails
          */
         protected boolean sameValue(Object o, Object o2) throws IllegalAccessException {
             final Object v1 = field.get(o);
@@ -1092,11 +1083,11 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Copies the value of a field from one object to another.
+         * Copies this field from {@code from} to {@code to}.
          *
-         * @param from Source object.
-         * @param to   Destination object.
-         * @throws IllegalAccessException If unable to access the field.
+         * @param from source object
+         * @param to   destination object
+         * @throws IllegalAccessException if reflection fails
          */
         protected void copy(Object from, Object to) throws IllegalAccessException {
             ObjectUtils.requireNonNull(from);
@@ -1106,25 +1097,27 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Abstract method to get the value of a field from an object.
+         * Writes this field from {@code o} to {@code write}.
+         * Implementations may use {@code previous} for delta encoding.
          *
-         * @param o        Object from which to get the value.
-         * @param write    Output destination.
-         * @param previous Previous object for comparison.
-         * @throws IllegalAccessException       If unable to access the field.
-         * @throws InvalidMarshallableException If marshalling fails.
+         * @param o        source object
+         * @param write    destination
+         * @param previous previous state or {@code null}
+         * @throws IllegalAccessException       if reflection fails
+         * @throws InvalidMarshallableException on marshalling error
          */
         protected abstract void getValue(Object o, ValueOut write, Object previous) throws IllegalAccessException, InvalidMarshallableException;
 
         /**
-         * Reads the value of a field from an input and sets it in an object.
+         * Reads the field value from {@code read} and applies it to {@code o}.
+         * If the value is absent and {@code overwrite} is true the value from {@code defaults} is used.
          *
-         * @param o         Object to set the value in.
-         * @param defaults  Default values.
-         * @param read      Input source.
-         * @param overwrite Whether to overwrite existing value.
-         * @throws IllegalAccessException       If unable to access the field.
-         * @throws InvalidMarshallableException If marshalling fails.
+         * @param o         target object
+         * @param defaults  object providing default values
+         * @param read      source of data
+         * @param overwrite whether an absent value should reset to default
+         * @throws IllegalAccessException       if reflection fails
+         * @throws InvalidMarshallableException on parsing error
          */
         protected void readValue(Object o, Object defaults, ValueIn read, boolean overwrite) throws IllegalAccessException, InvalidMarshallableException {
             if (!read.isPresent()) {
@@ -1149,42 +1142,41 @@ public class WireMarshaller<T> {
         }
 
         /**
-         * Abstract method to set the value of a field in an object.
+         * Reads this field from {@code read} and updates {@code o}.
          *
-         * @param o         Object to set the value in.
-         * @param read      Input source.
-         * @param overwrite Whether to overwrite existing value.
-         * @throws IllegalAccessException If unable to access the field.
+         * @param o         target object
+         * @param read      wire input
+         * @param overwrite if false a missing value leaves the field unchanged
+         * @throws IllegalAccessException if reflection fails
          */
         protected abstract void setValue(Object o, ValueIn read, boolean overwrite) throws IllegalAccessException;
 
         /**
-         * Abstract method to reset the value of a field in an object to default value.
-         * The default value is the one present in objects of that class after no-argument constructor.
-         * Where possible, existing data structures should be preserved without reallocation to avoid garbage.
+         * Resets this field on {@code o} using the value from {@code defaultObject}.
+         * Existing objects are reused where possible to avoid allocation.
          *
-         * @param defaultObject A reference unmodified instance of this class.
-         * @param o             Object to reset the value in.
+         * @param defaultObject reference instance containing default values
+         * @param o             target object
          */
         protected void setDefaultValue(Object defaultObject, Object o) throws IllegalAccessException {
             copy(defaultObject, o);
         }
 
         /**
-         * Abstract method to convert the value of a field in an object to bytes.
+         * Writes the value of this field to {@code bytes} in binary form.
          *
-         * @param o     Object containing the field.
-         * @param bytes Destination to write the bytes to.
-         * @throws IllegalAccessException If unable to access the field.
+         * @param o     source object
+         * @param bytes destination buffer
+         * @throws IllegalAccessException if reflection fails
          */
         public abstract void getAsBytes(Object o, Bytes<?> bytes) throws IllegalAccessException;
 
         /**
-         * Checks whether the values of a field in two objects are equal.
+         * Compares this field in {@code o1} and {@code o2} for equality.
          *
-         * @param o1 First object.
-         * @param o2 Second object.
-         * @return true if the values are equal, false otherwise.
+         * @param o1 first object
+         * @param o2 second object
+         * @return {@code true} if the values match
          */
         public boolean isEqual(Object o1, Object o2) {
             try {
@@ -1196,8 +1188,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * This is a specialized FieldAccess implementation for fields of type IntValue.
-     * It provides implementations for reading and writing the IntValue from and to various sources.
+     * Field access for {@link IntValue} references.
      */
     static class IntValueAccess extends FieldAccess {
 
@@ -1234,8 +1225,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * This is a specialized FieldAccess implementation for fields of type LongValue.
-     * It provides implementations for reading and writing the LongValue from and to various sources.
+     * Field access for {@link LongValue} references.
      */
     static class LongValueAccess extends FieldAccess {
 
@@ -1272,9 +1262,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * This is a specialized FieldAccess implementation for generic object fields.
-     * It provides methods for reading and writing object fields from and to various sources,
-     * taking into account special cases where the field may be marshaled differently based on annotations.
+     * Field access for arbitrary object references. Supports {@link AsMarshallable}.
      */
     static class ObjectFieldAccess extends FieldAccess {
         private final Class<?> type; // Type of the object field
@@ -1560,12 +1548,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The ArrayFieldAccess class extends FieldAccess to provide specialized access
-     * and manipulation methods for fields that are arrays.
-     * <p>
-     * It calculates the component type of the array and retrieves its equivalent object type
-     * for ease of use. The class is designed to handle arrays in a generic manner and
-     * use the provided methods of the superclass for actual field manipulation.
+     * Field access for array fields.
      */
     static class ArrayFieldAccess extends FieldAccess {
         private final Class<?> componentType;
@@ -1643,11 +1626,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The ByteArrayFieldAccess class extends FieldAccess to provide specialized access
-     * and manipulation methods for fields that are byte arrays.
-     * <p>
-     * The class is optimized for reading and writing byte arrays to and from a wire format
-     * while preserving encapsulation and supporting null values.
+     * Field access for {@code byte[]} fields.
      */
     static class ByteArrayFieldAccess extends FieldAccess {
 
@@ -1704,11 +1683,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The EnumSetFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
-     * for fields that are of type {@link EnumSet}.
-     * <p>
-     * This class allows efficient reading and writing of EnumSet fields to and from a wire format while
-     * preserving encapsulation and supporting null values.
+     * Field access for {@link EnumSet} fields.
      */
     static class EnumSetFieldAccess extends FieldAccess {
 
@@ -1855,11 +1830,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The CollectionFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
-     * for fields that are of type {@link Collection}.
-     * <p>
-     * It is optimized to handle both random-access and non-random-access collections efficiently. Additionally,
-     * the class provides flexibility by allowing users to supply custom collection creation logic if needed.
+     * Field access for {@link Collection} types.
      */
     static class CollectionFieldAccess extends FieldAccess {
 
@@ -2032,11 +2003,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The StringCollectionFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
-     * for fields that are of type {@link Collection} where the elements of the collection are {@link String} instances.
-     * <p>
-     * This extension particularly manages the parsing of strings from the given input and offers utility functions
-     * for instantiation of the correct {@link Collection} type.
+     * Field access for collections of {@link String} values.
      */
     static class StringCollectionFieldAccess extends FieldAccess {
 
@@ -2153,11 +2120,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The MapFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
-     * for fields that are of type {@link Map}.
-     * <p>
-     * This extension is designed to manage the parsing and instantiation of the correct {@link Map} type
-     * and provides functionality to work with the key-value pairs within the map.
+     * Field access for {@link Map} types.
      */
     static class MapFieldAccess extends FieldAccess {
 
@@ -2262,11 +2225,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The BooleanFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
-     * for fields that are of type boolean or {@link Boolean}.
-     * <p>
-     * This extension uses unsafe operations to get and set the boolean value efficiently without invoking reflection
-     * on each operation.
+     * Field access for {@code boolean} fields.
      */
     static class BooleanFieldAccess extends FieldAccess {
         BooleanFieldAccess(@NotNull Field field) {
@@ -2300,11 +2259,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The ByteFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
-     * for fields that are of type byte or {@link Byte}.
-     * <p>
-     * This extension leverages unsafe operations to get and set the byte value directly without the need for
-     * reflective access each time, ensuring better performance.
+     * Field access for {@code byte} fields.
      */
     static class ByteFieldAccess extends FieldAccess {
         ByteFieldAccess(@NotNull Field field) {
@@ -2338,11 +2293,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The ShortFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
-     * for fields that are of type short or {@link Short}.
-     * <p>
-     * This extension leverages unsafe operations to get and set the short value directly without the need for
-     * reflective access each time, ensuring optimal performance.
+     * Field access for {@code short} fields.
      */
     static class ShortFieldAccess extends FieldAccess {
         ShortFieldAccess(@NotNull Field field) {
@@ -2376,11 +2327,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The CharFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
-     * for fields that are of type char or {@link Character}.
-     * <p>
-     * This extension leverages unsafe operations to get and set the character value directly without the need for
-     * reflective access each time, ensuring optimal performance.
+     * Field access for {@code char} fields.
      */
     static class CharFieldAccess extends FieldAccess {
 
@@ -2436,11 +2383,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The IntegerFieldAccess class extends FieldAccess to provide specialized access and manipulation methods
-     * for fields that are of type int or {@link Integer}.
-     * <p>
-     * This extension leverages unsafe operations to get and set the integer value directly without the need for
-     * reflective access each time, ensuring optimal performance.
+     * Field access for {@code int} fields.
      */
     static class IntegerFieldAccess extends FieldAccess {
         IntegerFieldAccess(@NotNull Field field) {
@@ -2809,9 +2752,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The FloatFieldAccess class extends the FieldAccess class, providing specialized access
-     * to float fields of an object. This class supports reading and writing float values,
-     * considering a potential "previous" value for optimized serialization or other comparative tasks.
+     * Field access for {@code float} fields.
      */
     static class FloatFieldAccess extends FieldAccess {
         FloatFieldAccess(@NotNull Field field) {
@@ -2849,10 +2790,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The LongFieldAccess class extends FieldAccess to provide specialized access
-     * to long fields of an object. It supports reading and writing long values,
-     * considering a potential "previous" value for optimized serialization or other
-     * comparative tasks.
+     * Field access for {@code long} fields.
      */
     static class LongFieldAccess extends FieldAccess {
         LongFieldAccess(@NotNull Field field) {
@@ -2890,10 +2828,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * The DoubleFieldAccess class extends FieldAccess to provide specialized access
-     * to double fields of an object. It supports reading and writing double values,
-     * considering a potential "previous" value for optimized serialization or other
-     * comparative tasks.
+     * Field access for {@code double} fields.
      */
     static class DoubleFieldAccess extends FieldAccess {
         DoubleFieldAccess(@NotNull Field field) {

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshallerForUnexpectedFields.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshallerForUnexpectedFields.java
@@ -23,15 +23,24 @@ import net.openhft.chronicle.core.scoped.ScopedResource;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * This class extends the WireMarshaller and provides the ability to handle unexpected fields.
- * It maps fields by their name (both in their original form and lower-cased) for easy access.
- * It overrides the method to read marshallable objects and provides specialized logic to
- * handle unexpected fields that might be present in the data source.
+ * Extends {@link WireMarshaller} to provide custom handling for unexpected fields during
+ * deserialisation. Used when the target class overrides
+ * {@link ReadMarshallable#unexpectedField(CharSequence, ValueIn)} to gain control of unknown
+ * data.
  */
 public class WireMarshallerForUnexpectedFields<T> extends WireMarshaller<T> {
-    // Map for storing fields based on their names.
+    /**
+     * A {@link CharSequenceObjectMap} for efficient lookup of {@link FieldAccess} objects by
+     * field name, supporting both original and lower-cased names for flexibility in matching
+     * fields from the input wire.
+     */
     final CharSequenceObjectMap<FieldAccess> fieldMap;
 
+    /**
+     * Constructs a marshaller that can delegate to
+     * {@link ReadMarshallable#unexpectedField(CharSequence, ValueIn)} if unknown fields are
+     * encountered. Initialises the internal field map for quick lookups.
+     */
     public WireMarshallerForUnexpectedFields(@NotNull FieldAccess[] fields, boolean isLeaf, T defaultValue) {
         super(fields, isLeaf, defaultValue);
         fieldMap = new CharSequenceObjectMap<>(fields.length * 3);
@@ -41,6 +50,15 @@ public class WireMarshallerForUnexpectedFields<T> extends WireMarshaller<T> {
         }
     }
 
+    /**
+     * Overrides the default deserialisation logic to handle unexpected fields. When a field name
+     * read from {@code WireIn} is not found in the known {@link #fields} (even after
+     * case-insensitive matching), it calls
+     * {@link ReadMarshallable#unexpectedField(CharSequence, ValueIn)} on object {@code t} if
+     * possible. Known fields are processed as usual. The check
+     * {@code sb.length() == 0 && vin.isPresent()} optimises for DTO-order field reading by using
+     * the next field directly. Ensures progress is made during parsing to avoid infinite loops.
+     */
     @Override
     public void readMarshallable(T t, @NotNull WireIn in, boolean overwrite) throws InvalidMarshallableException {
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshallerForUnexpectedFields.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshallerForUnexpectedFields.java
@@ -23,10 +23,10 @@ import net.openhft.chronicle.core.scoped.ScopedResource;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Extends {@link WireMarshaller} to provide custom handling for unexpected fields during
- * deserialisation. Used when the target class overrides
- * {@link ReadMarshallable#unexpectedField(CharSequence, ValueIn)} to gain control of unknown
- * data.
+ * This class extends the WireMarshaller and provides the ability to handle unexpected fields.
+ * It maps fields by their name (both in their original form and lower-cased) for easy access.
+ * It overrides the method to read marshallable objects and provides specialized logic to
+ * handle unexpected fields that might be present in the data source.
  */
 public class WireMarshallerForUnexpectedFields<T> extends WireMarshaller<T> {
     /**
@@ -36,11 +36,6 @@ public class WireMarshallerForUnexpectedFields<T> extends WireMarshaller<T> {
      */
     final CharSequenceObjectMap<FieldAccess> fieldMap;
 
-    /**
-     * Constructs a marshaller that can delegate to
-     * {@link ReadMarshallable#unexpectedField(CharSequence, ValueIn)} if unknown fields are
-     * encountered. Initialises the internal field map for quick lookups.
-     */
     public WireMarshallerForUnexpectedFields(@NotNull FieldAccess[] fields, boolean isLeaf, T defaultValue) {
         super(fields, isLeaf, defaultValue);
         fieldMap = new CharSequenceObjectMap<>(fields.length * 3);
@@ -54,7 +49,7 @@ public class WireMarshallerForUnexpectedFields<T> extends WireMarshaller<T> {
      * Overrides the default deserialisation logic to handle unexpected fields. When a field name
      * read from {@code WireIn} is not found in the known {@link #fields} (even after
      * case-insensitive matching), it calls
-     * {@link ReadMarshallable#unexpectedField(CharSequence, ValueIn)} on object {@code t} if
+     * {@link ReadMarshallable#unexpectedField(Object, ValueIn)} on object {@code t} if
      * possible. Known fields are processed as usual. The check
      * {@code sb.length() == 0 && vin.isPresent()} optimises for DTO-order field reading by using
      * the next field directly. Ensures progress is made during parsing to avoid infinite loops.

--- a/src/main/java/net/openhft/chronicle/wire/WireParselet.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireParselet.java
@@ -20,20 +20,20 @@ package net.openhft.chronicle.wire;
 import net.openhft.chronicle.core.io.InvalidMarshallableException;
 
 /**
- * Functional interface invoked when a field name is parsed.
- * It is typically registered with a {@link WireParser} to define how to
- * deserialise the value associated with a specific field name.
+ * Represents a functional interface that can process wire input based on a given
+ * character sequence key and a value input. The `WireParselet` can be seen as a
+ * specific action or handler for a particular key found in the wire input.
  */
 @FunctionalInterface
 public interface WireParselet {
 
     /**
-     * Invoked with the field name and corresponding value.
+     * Consumes and processes a wire input based on a given character sequence
+     * and a value input.
      *
-     * @param s   the field name that matched this parselet
-     * @param in  the {@link ValueIn} positioned at the value for {@code s}. Use it to
-     *            deserialise the value
-     * @throws InvalidMarshallableException if the value cannot be processed
+     * @param s The character sequence (usually representing a key) from the wire input.
+     * @param in The value associated with the key in the wire input.
+     * @throws InvalidMarshallableException If there's an issue with processing the data.
      */
     void accept(CharSequence s, ValueIn in) throws InvalidMarshallableException;
 }

--- a/src/main/java/net/openhft/chronicle/wire/WireParser.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireParser.java
@@ -26,34 +26,20 @@ import org.jetbrains.annotations.NotNull;
 import java.util.function.Consumer;
 
 /**
- * Defines a contract for parsing field-value data from a {@link WireIn} stream.
- * A {@code WireParser} typically maintains a set of {@link WireParselet} or
- * {@link FieldNumberParselet} instances, each responsible for a particular
- * field name or number encountered in the input. It orchestrates reading the
- * field identifiers and dispatches to the relevant parselet to deserialise the
- * value. As a {@link java.util.function.Consumer}{@code <WireIn>} it can
- * process a whole document or a sequence of events within a wire.
+ * Defines the interface for parsing arbitrary field-value data from wire input.
  */
 public interface WireParser extends Consumer<WireIn> {
 
     /**
-     * A predefined {@link FieldNumberParselet} that, when invoked, consumes and
-     * discards all remaining readable bytes in the current value or document
-     * context of the {@link WireIn}. This is often used as a default handler for
-     * unknown or uninteresting field numbers.
+     * A predefined parselet that skips all readable bytes in the wire.
      */
     FieldNumberParselet SKIP_READABLE_BYTES = WireParser::skipReadable;
 
     /**
-     * Creates a new {@code WireParser} with a default consumer.
+     * Creates a new WireParser with a default consumer.
      *
-     * @param defaultConsumer the {@link WireParselet} to invoke when a field name
-     *                        read from the wire does not match any registered
-     *                        named parselets. This typically handles unknown
-     *                        fields or logs warnings.
-     * @return a new {@link VanillaWireParser} configured with the given default
-     *         consumer and {@link #SKIP_READABLE_BYTES} for unknown field
-     *         numbers.
+     * @param defaultConsumer The default consumer that handles the wire data when no specific handler is provided.
+     * @return A new WireParser instance.
      */
     @NotNull
     static WireParser wireParser(WireParselet defaultConsumer) {
@@ -61,15 +47,11 @@ public interface WireParser extends Consumer<WireIn> {
     }
 
     /**
-     * Creates a new {@code WireParser} with a default consumer and a custom
-     * field number parselet.
+     * Creates a new WireParser with a default consumer and a custom field number parselet.
      *
-     * @param defaultConsumer     the {@link WireParselet} for unhandled named
-     *                             fields.
-     * @param fieldNumberParselet the {@link FieldNumberParselet} to invoke when
-     *                             a field number read from a binary wire does not
-     *                             match any registered numbered parselets.
-     * @return a new {@link VanillaWireParser} instance.
+     * @param defaultConsumer     The default consumer to handle the wire data when no specific handler is provided.
+     * @param fieldNumberParselet Custom field number parselet to handle field numbers in the wire data.
+     * @return A new WireParser instance.
      */
     @NotNull
     static WireParser wireParser(@NotNull WireParselet defaultConsumer,
@@ -78,14 +60,10 @@ public interface WireParser extends Consumer<WireIn> {
     }
 
     /**
-     * Skips all readable bytes in the provided wire.
+     * Skips all readable bytes in the wire.
      *
-     * @param ignoreMethodId the method id or field number that triggered this
-     *                       skip action. It is often unused by the skip logic
-     *                       itself but provided for context.
-     * @param wire           the {@link WireIn} whose current value's readable
-     *                       bytes should be skipped. This advances the read
-     *                       position to the end of the current value or context.
+     * @param ignoreMethodId The method ID to ignore. (Currently unused in the method's logic)
+     * @param wire           The wire input source.
      */
     static void skipReadable(long ignoreMethodId, WireIn wire) {
         Bytes<?> bytes = wire.bytes();
@@ -93,20 +71,14 @@ public interface WireParser extends Consumer<WireIn> {
     }
 
     /**
-     * Retrieves the {@link WireParselet} used when a field name encountered in
-     * the input does not match any explicitly registered parselet.
+     * Retrieves the default consumer of this parser.
      *
-     * @return the default consumer for unmatched field names.
+     * @return The default consumer.
      */
     WireParselet getDefaultConsumer();
 
     /**
-     * Parses a single field-value pair from the given {@link WireIn}. The method
-     * reads the field identifier (name or number) and dispatches to the
-     * appropriate registered {@link WireParselet} or
-     * {@link FieldNumberParselet} to deserialise the value. If no matching
-     * parselet is found the {@link #getDefaultConsumer()} or its numbered
-     * counterpart is used.
+     * Parses a single field-value data from the provided wire input.
      *
      * @param wireIn The wire input source.
      * @throws InvocationTargetRuntimeException When there's a failure invoking the target action for a field.
@@ -115,13 +87,11 @@ public interface WireParser extends Consumer<WireIn> {
     void parseOne(@NotNull WireIn wireIn) throws InvocationTargetRuntimeException, InvalidMarshallableException;
 
     /**
-     * Processes an entire document or event from {@code wireIn}. The default
-     * implementation repeatedly calls {@link #parseOne(WireIn)} until all fields
-     * within the current event or document have been consumed. Event boundaries
-     * are handled using {@link WireIn#startEvent()} and
-     * {@link WireIn#endEvent()}.
+     * Default implementation for the Consumer's accept method. This method
+     * reads and processes data from the wire input, invoking the appropriate
+     * parselets for handling the data.
      *
-     * @param wireIn the wire input source
+     * @param wireIn The wire input source.
      */
     @Override
     default void accept(@NotNull WireIn wireIn) {
@@ -154,11 +124,9 @@ public interface WireParser extends Consumer<WireIn> {
      * is already registered with the same key, a warning is emitted and the new
      * registration is ignored.
      *
-     * @param key            the {@link WireKey} (providing both name and code)
-     *                       to associate with the parselet
-     * @param valueInConsumer the {@link WireParselet} to register for the key
-     * @return this {@code WireParser} instance, cast to {@link VanillaWireParser},
-     *         for fluent configuration
+     * @param key            The key to associate the parselet with.
+     * @param valueInConsumer The parselet to register.
+     * @return This instance for method chaining.
      */
     @NotNull
     default VanillaWireParser registerOnce(WireKey key, WireParselet valueInConsumer) {
@@ -172,15 +140,11 @@ public interface WireParser extends Consumer<WireIn> {
     }
 
     /**
-     * Registers a {@link WireParselet} to handle fields matching the supplied
-     * {@link WireKey}. This typically registers the parselet for both the key's
-     * name and its code. If a parselet is already registered for the name this
-     * may overwrite it or log a warning, depending on the implementation (see
-     * {@link #registerOnce}).
+     * Registers a new {@link WireParselet} for a given key.
      *
-     * @param key            the key to associate with the parselet
-     * @param valueInConsumer the parselet to register
-     * @return this instance for method chaining
+     * @param key            The key to associate the parselet with.
+     * @param valueInConsumer The parselet to register.
+     * @return This instance for method chaining.
      */
     @NotNull
     default VanillaWireParser register(WireKey key, WireParselet valueInConsumer) {
@@ -188,13 +152,11 @@ public interface WireParser extends Consumer<WireIn> {
     }
 
     /**
-     * Registers a {@link WireParselet} to handle fields matching the provided
-     * {@code keyName}. This typically also registers the parselet for a code
-     * derived from {@code keyName.hashCode()}.
+     * Registers a new {@link WireParselet} for a given key name.
      *
-     * @param keyName        the name of the key to associate with the parselet
-     * @param valueInConsumer the parselet to register
-     * @return this instance for method chaining
+     * @param keyName        The name of the key to associate the parselet with.
+     * @param valueInConsumer The parselet to register.
+     * @return This instance for method chaining.
      */
     @NotNull
     VanillaWireParser register(String keyName, WireParselet valueInConsumer);

--- a/src/main/java/net/openhft/chronicle/wire/YamlKeys.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlKeys.java
@@ -33,7 +33,7 @@ public class YamlKeys {
     // The current number of offsets stored
     int count = 0;
 
-    // The dynamic array of offsets
+    /** The dynamic array of offsets. */
     long[] offsets = NO_OFFSETS;
 
     /**
@@ -50,9 +50,7 @@ public class YamlKeys {
     }
 
     /**
-     * Returns the current number of offsets stored in the collection.
-     *
-     * @return The count of offsets.
+     * Returns the number of stored offsets in the collection.
      */
     public int count() {
         return count;
@@ -76,11 +74,7 @@ public class YamlKeys {
     }
 
     /**
-     * Removes the offset at the specified index.
-     *
-     * <p>Subsequent offsets are shifted to the left (their indices decrease by one).
-     *
-     * @param i The index of the offset to be removed.
+     * Removes the offset at {@code i}, shifting remaining values left by one.
      */
     public void removeIndex(int i) {
         count--;

--- a/src/main/java/net/openhft/chronicle/wire/YamlKeys.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlKeys.java
@@ -20,26 +20,23 @@ package net.openhft.chronicle.wire;
 import java.util.Arrays;
 
 /**
- * Represents a collection of offsets used in a YAML structure.
- * The class provides mechanisms to add, retrieve, and manipulate the offsets,
- * which can be useful for various YAML parsing and generation tasks.
- *
- * <p>Internally, this class employs a dynamic array resizing strategy to accommodate
- * varying numbers of offsets without a significant overhead in space.
+ * Internal helper class for {@link YamlTokeniser} to manage a list of byte offsets.
+ * <p>
+ * These offsets mark the starting positions of YAML keys skipped during an initial
+ * parse pass. They can then be revisited without rescanning the stream.
  */
 public class YamlKeys {
+    /** A shared, empty array instance. */
     private static final long[] NO_OFFSETS = {};
 
-    // The current number of offsets stored
+    /** The number of valid offsets in {@link #offsets}. */
     int count = 0;
 
-    // The dynamic array of offsets
+    /** Array storing the offset values; resized as required. */
     long[] offsets = NO_OFFSETS;
 
     /**
-     * Adds a new offset to the collection.
-     *
-     * @param offset The offset value to be added.
+     * Adds {@code offset} to the end of the list, resizing if needed.
      */
     public void push(long offset) {
         if (count == offsets.length) {
@@ -50,37 +47,29 @@ public class YamlKeys {
     }
 
     /**
-     * Returns the current number of offsets stored in the collection.
-     *
-     * @return The count of offsets.
+     * Returns the number of stored offsets.
      */
     public int count() {
         return count;
     }
 
     /**
-     * Retrieves all the stored offsets.
-     *
-     * @return An array of stored offsets.
+     * Returns the internal array of offsets. Only the first {@link #count} values
+     * are valid.
      */
     public long[] offsets() {
         return offsets;
     }
 
     /**
-     * Resets the count of offsets to zero.
-     * This method does not clear the offset data but allows for reuse of the storage.
+     * Clears the list while retaining the underlying array for reuse.
      */
     public void reset() {
         count = 0;
     }
 
     /**
-     * Removes the offset at the specified index.
-     *
-     * <p>Subsequent offsets are shifted to the left (their indices decrease by one).
-     *
-     * @param i The index of the offset to be removed.
+     * Removes the offset at {@code i}, shifting remaining values left.
      */
     public void removeIndex(int i) {
         count--;

--- a/src/main/java/net/openhft/chronicle/wire/YamlKeys.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlKeys.java
@@ -20,23 +20,26 @@ package net.openhft.chronicle.wire;
 import java.util.Arrays;
 
 /**
- * Internal helper class for {@link YamlTokeniser} to manage a list of byte offsets.
- * <p>
- * These offsets mark the starting positions of YAML keys skipped during an initial
- * parse pass. They can then be revisited without rescanning the stream.
+ * Represents a collection of offsets used in a YAML structure.
+ * The class provides mechanisms to add, retrieve, and manipulate the offsets,
+ * which can be useful for various YAML parsing and generation tasks.
+ *
+ * <p>Internally, this class employs a dynamic array resizing strategy to accommodate
+ * varying numbers of offsets without a significant overhead in space.
  */
 public class YamlKeys {
-    /** A shared, empty array instance. */
     private static final long[] NO_OFFSETS = {};
 
-    /** The number of valid offsets in {@link #offsets}. */
+    // The current number of offsets stored
     int count = 0;
 
-    /** Array storing the offset values; resized as required. */
+    // The dynamic array of offsets
     long[] offsets = NO_OFFSETS;
 
     /**
-     * Adds {@code offset} to the end of the list, resizing if needed.
+     * Adds a new offset to the collection.
+     *
+     * @param offset The offset value to be added.
      */
     public void push(long offset) {
         if (count == offsets.length) {
@@ -47,29 +50,37 @@ public class YamlKeys {
     }
 
     /**
-     * Returns the number of stored offsets.
+     * Returns the current number of offsets stored in the collection.
+     *
+     * @return The count of offsets.
      */
     public int count() {
         return count;
     }
 
     /**
-     * Returns the internal array of offsets. Only the first {@link #count} values
-     * are valid.
+     * Retrieves all the stored offsets.
+     *
+     * @return An array of stored offsets.
      */
     public long[] offsets() {
         return offsets;
     }
 
     /**
-     * Clears the list while retaining the underlying array for reuse.
+     * Resets the count of offsets to zero.
+     * This method does not clear the offset data but allows for reuse of the storage.
      */
     public void reset() {
         count = 0;
     }
 
     /**
-     * Removes the offset at {@code i}, shifting remaining values left.
+     * Removes the offset at the specified index.
+     *
+     * <p>Subsequent offsets are shifted to the left (their indices decrease by one).
+     *
+     * @param i The index of the offset to be removed.
      */
     public void removeIndex(int i) {
         count--;

--- a/src/main/java/net/openhft/chronicle/wire/YamlLogging.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlLogging.java
@@ -76,10 +76,10 @@ public enum YamlLogging {
     /**
      * Enable or disable logging for all message types.
      *
-     * @param flag {@code true} to enable, {@code false} to disable.
+     * @param enable The boolean value to set for all logging flags.
      */
-    public static void setAll(boolean flag) {
-        showServerReads = showServerWrites = clientWrites = clientReads = flag;
+    public static void setAll(boolean enable) {
+        showServerReads = showServerWrites = clientWrites = clientReads = enable;
     }
 
     /**
@@ -97,17 +97,21 @@ public enum YamlLogging {
     }
 
     /**
-     * Associate a message with subsequent write operations.
+     * Updates the message associated with a write operation.
+     *
+     * @param message The new message to be set.
      */
-    public static void writeMessage(@NotNull String s) {
-        writeMessage = s;
+    public static void writeMessage(@NotNull String message) {
+        writeMessage = message;
     }
 
     /**
-     * Enable or disable logging of server writes.
+     * Sets the flag to determine whether server writes should be logged.
+     *
+     * @param enable {@code true} to enable logging for server writes; {@code false} to disable.
      */
-    public static void showServerWrites(boolean logging) {
-        showServerWrites = logging;
+    public static void showServerWrites(boolean enable) {
+        showServerWrites = enable;
     }
 
     /**
@@ -140,24 +144,30 @@ public enum YamlLogging {
     }
 
     /**
-     * Enable or disable logging of heartbeats.
+     * Sets the flag to determine whether heartbeats should be logged.
+     *
+     * @param enable {@code true} to enable heartbeat logging; {@code false} to disable.
      */
-    public static void showHeartBeats(boolean log) {
-        showHeartBeats = log;
+    public static void showHeartBeats(boolean enable) {
+        showHeartBeats = enable;
     }
 
     /**
-     * Enable or disable logging of client writes.
+     * Sets the flag to determine whether client writes should be logged.
+     *
+     * @param enable {@code true} to enable logging for client writes; {@code false} to disable.
      */
-    public static void showClientWrites(boolean logging) {
-        clientWrites = logging;
+    public static void showClientWrites(boolean enable) {
+        clientWrites = enable;
     }
 
     /**
-     * Enable or disable logging of client reads.
+     * Sets the flag to determine whether client reads should be logged.
+     *
+     * @param enable {@code true} to enable logging for client reads; {@code false} to disable.
      */
-    public static void showClientReads(boolean logging) {
-        clientReads = logging;
+    public static void showClientReads(boolean enable) {
+        clientReads = enable;
     }
 
     /**
@@ -168,10 +178,12 @@ public enum YamlLogging {
     }
 
     /**
-     * Enable or disable logging of server reads.
+     * Sets the flag to determine whether server reads should be logged.
+     *
+     * @param enable {@code true} to enable logging for server reads; {@code false} to disable.
      */
-    public static void showServerReads(boolean logging) {
-        showServerReads = logging;
+    public static void showServerReads(boolean enable) {
+        showServerReads = enable;
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/YamlLogging.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlLogging.java
@@ -21,60 +21,40 @@ import net.openhft.chronicle.core.Jvm;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Utility to control YAML message logging.
- * <p>
- * The behaviour can be toggled via system properties or at runtime through this
- * class's static methods, which aids debugging and documentation generation.
+ * Provides utility functions to control the logging of Yaml messages, which can be
+ * useful for debugging or generating documentation. The logging settings can be toggled
+ * using system properties or programmatically through this class's static methods.
  */
 // Used in Chronicle Services
 public enum YamlLogging {
     ; // No enum instances are intended for this utility enum.
 
-    /**
-     * Global title prepended to YAML messages. May be changed at runtime.
-     */
+    // The title for logging (can be changed during runtime).
     @NotNull
     public static volatile String title = "";
 
-    /**
-     * Whether server write operations are logged as YAML. Initialised from the
-     * {@code yaml.logging} system property. Modifiable at runtime.
-     * TODO Doesn't show all writes. Use clientReads instead.
-     */
+    // Flag indicating whether server writes should be shown.
+    // TODO Doesn't show all writes. Use clientReads instead.
     private static volatile boolean showServerWrites = Jvm.getBoolean("yaml.logging");
 
-    /**
-     * Whether client write operations are logged as YAML. Initialised from the
-     * {@code yaml.logging} system property. Modifiable at runtime.
-     */
+    // Flag indicating whether client writes should be shown.
     private static volatile boolean clientWrites = Jvm.getBoolean("yaml.logging");
 
-    /**
-     * Message associated with write operations that may appear in logs.
-     */
+    // A message associated with a write operation.
     @NotNull
     private static volatile String writeMessage = "";
 
-    /**
-     * Whether client read operations are logged as YAML. Initialised from the
-     * {@code yaml.logging} system property. Modifiable at runtime.
-     */
+    // Flag indicating whether client reads should be shown.
     private static volatile boolean clientReads = Jvm.getBoolean("yaml.logging");
 
-    /**
-     * Whether server read operations are logged as YAML. Initialised from the
-     * {@code yaml.logging} system property. Modifiable at runtime.
-     */
+    // Flag indicating whether server reads should be shown.
     private static volatile boolean showServerReads = Jvm.getBoolean("yaml.logging");
 
-    /**
-     * Whether heartbeat messages are logged as YAML. Defaults to {@code false}.
-     * Modifiable at runtime.
-     */
+    // Flag indicating whether heartbeat messages should be shown.
     private static volatile boolean showHeartBeats = false;
 
     /**
-     * Enable or disable logging for all message types.
+     * Sets the logging flags for all message types (reads/writes for both client and server).
      *
      * @param enable The boolean value to set for all logging flags.
      */
@@ -83,14 +63,18 @@ public enum YamlLogging {
     }
 
     /**
-     * Set logging flags for all message types according to the level.
+     * Sets the logging flags for all message types based on the provided {@link YamlLoggingLevel}.
+     *
+     * @param level The {@link YamlLoggingLevel} determining whether to set or unset the logging flags.
      */
     public static void setAll(@NotNull YamlLoggingLevel level) {
         showServerReads = showServerWrites = clientWrites = clientReads = level.isSet();
     }
 
     /**
-     * Returns {@code true} if client read logging is enabled.
+     * Checks whether logging for client reads is enabled.
+     *
+     * @return {@code true} if logging for client reads is enabled; {@code false} otherwise.
      */
     public static boolean showClientReads() {
         return clientReads;
@@ -115,14 +99,18 @@ public enum YamlLogging {
     }
 
     /**
-     * Returns {@code true} if client write logging is enabled.
+     * Checks whether logging for client writes is enabled.
+     *
+     * @return {@code true} if logging for client writes is enabled; {@code false} otherwise.
      */
     public static boolean showClientWrites() {
         return clientWrites;
     }
 
     /**
-     * Returns the message associated with write operations.
+     * Retrieves the current message associated with a write operation.
+     *
+     * @return The message currently associated with a write operation.
      */
     @NotNull
     public static String writeMessage() {
@@ -130,14 +118,18 @@ public enum YamlLogging {
     }
 
     /**
-     * Returns {@code true} if heartbeat logging is enabled.
+     * Checks whether heartbeat logging is enabled.
+     *
+     * @return {@code true} if heartbeat logging is enabled; {@code false} otherwise.
      */
     public static boolean showHeartBeats() {
         return showHeartBeats;
     }
 
     /**
-     * Returns {@code true} if server read logging is enabled.
+     * Checks whether logging for server reads is enabled.
+     *
+     * @return {@code true} if logging for server reads is enabled; {@code false} otherwise.
      */
     public static boolean showServerReads() {
         return showServerReads;
@@ -171,7 +163,9 @@ public enum YamlLogging {
     }
 
     /**
-     * Returns {@code true} if server write logging is enabled.
+     * Checks whether logging for server writes is enabled.
+     *
+     * @return {@code true} if logging for server writes is enabled; {@code false} otherwise.
      */
     public static boolean showServerWrites() {
         return showServerWrites;
@@ -187,24 +181,22 @@ public enum YamlLogging {
     }
 
     /**
-     * Levels controlling when YAML logging is active.
+     * Enum representing the various logging levels for Yaml.
+     * The levels include OFF (no logging), DEBUG_ONLY (logs only when in debug mode), and ON (always logs).
      */
     public enum YamlLoggingLevel {
-        /** Logging is disabled. */
         OFF {
             @Override
             public boolean isSet() {
                 return false;
             }
         },
-        /** Logging enabled only when {@link Jvm#isDebug()} is {@code true}. */
         DEBUG_ONLY {
             @Override
             public boolean isSet() {
                 return Jvm.isDebug();
             }
         },
-        /** Logging is always enabled. */
         ON {
             @Override
             public boolean isSet() {
@@ -213,7 +205,9 @@ public enum YamlLogging {
         };
 
         /**
-         * Returns {@code true} if this level currently enables logging.
+         * Checks if the current logging level is set (enabled).
+         *
+         * @return {@code true} if the current logging level is enabled; {@code false} otherwise.
          */
         public abstract boolean isSet();
     }

--- a/src/main/java/net/openhft/chronicle/wire/YamlLogging.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlLogging.java
@@ -56,10 +56,10 @@ public enum YamlLogging {
     /**
      * Sets the logging flags for all message types (reads/writes for both client and server).
      *
-     * @param enable The boolean value to set for all logging flags.
+     * @param flag The boolean value to set for all logging flags.
      */
-    public static void setAll(boolean enable) {
-        showServerReads = showServerWrites = clientWrites = clientReads = enable;
+    public static void setAll(boolean flag) {
+        showServerReads = showServerWrites = clientWrites = clientReads = flag;
     }
 
     /**
@@ -92,10 +92,10 @@ public enum YamlLogging {
     /**
      * Sets the flag to determine whether server writes should be logged.
      *
-     * @param enable {@code true} to enable logging for server writes; {@code false} to disable.
+     * @param flag {@code true} to enable logging for server writes; {@code false} to disable.
      */
-    public static void showServerWrites(boolean enable) {
-        showServerWrites = enable;
+    public static void showServerWrites(boolean flag) {
+        showServerWrites = flag;
     }
 
     /**
@@ -138,28 +138,28 @@ public enum YamlLogging {
     /**
      * Sets the flag to determine whether heartbeats should be logged.
      *
-     * @param enable {@code true} to enable heartbeat logging; {@code false} to disable.
+     * @param flag {@code true} to enable heartbeat logging; {@code false} to disable.
      */
-    public static void showHeartBeats(boolean enable) {
-        showHeartBeats = enable;
+    public static void showHeartBeats(boolean flag) {
+        showHeartBeats = flag;
     }
 
     /**
      * Sets the flag to determine whether client writes should be logged.
      *
-     * @param enable {@code true} to enable logging for client writes; {@code false} to disable.
+     * @param flag {@code true} to enable logging for client writes; {@code false} to disable.
      */
-    public static void showClientWrites(boolean enable) {
-        clientWrites = enable;
+    public static void showClientWrites(boolean flag) {
+        clientWrites = flag;
     }
 
     /**
      * Sets the flag to determine whether client reads should be logged.
      *
-     * @param enable {@code true} to enable logging for client reads; {@code false} to disable.
+     * @param flag {@code true} to enable logging for client reads; {@code false} to disable.
      */
-    public static void showClientReads(boolean enable) {
-        clientReads = enable;
+    public static void showClientReads(boolean flag) {
+        clientReads = flag;
     }
 
     /**
@@ -174,10 +174,10 @@ public enum YamlLogging {
     /**
      * Sets the flag to determine whether server reads should be logged.
      *
-     * @param enable {@code true} to enable logging for server reads; {@code false} to disable.
+     * @param flag {@code true} to enable logging for server reads; {@code false} to disable.
      */
-    public static void showServerReads(boolean enable) {
-        showServerReads = enable;
+    public static void showServerReads(boolean flag) {
+        showServerReads = flag;
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/YamlLogging.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlLogging.java
@@ -21,96 +21,104 @@ import net.openhft.chronicle.core.Jvm;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Provides utility functions to control the logging of Yaml messages, which can be
- * useful for debugging or generating documentation. The logging settings can be toggled
- * using system properties or programmatically through this class's static methods.
+ * Utility to control YAML message logging.
+ * <p>
+ * The behaviour can be toggled via system properties or at runtime through this
+ * class's static methods, which aids debugging and documentation generation.
  */
 // Used in Chronicle Services
 public enum YamlLogging {
     ; // No enum instances are intended for this utility enum.
 
-    // The title for logging (can be changed during runtime).
+    /**
+     * Global title prepended to YAML messages. May be changed at runtime.
+     */
     @NotNull
     public static volatile String title = "";
 
-    // Flag indicating whether server writes should be shown.
-    // TODO Doesn't show all writes. Use clientReads instead.
+    /**
+     * Whether server write operations are logged as YAML. Initialised from the
+     * {@code yaml.logging} system property. Modifiable at runtime.
+     * TODO Doesn't show all writes. Use clientReads instead.
+     */
     private static volatile boolean showServerWrites = Jvm.getBoolean("yaml.logging");
 
-    // Flag indicating whether client writes should be shown.
+    /**
+     * Whether client write operations are logged as YAML. Initialised from the
+     * {@code yaml.logging} system property. Modifiable at runtime.
+     */
     private static volatile boolean clientWrites = Jvm.getBoolean("yaml.logging");
 
-    // A message associated with a write operation.
+    /**
+     * Message associated with write operations that may appear in logs.
+     */
     @NotNull
     private static volatile String writeMessage = "";
 
-    // Flag indicating whether client reads should be shown.
+    /**
+     * Whether client read operations are logged as YAML. Initialised from the
+     * {@code yaml.logging} system property. Modifiable at runtime.
+     */
     private static volatile boolean clientReads = Jvm.getBoolean("yaml.logging");
 
-    // Flag indicating whether server reads should be shown.
+    /**
+     * Whether server read operations are logged as YAML. Initialised from the
+     * {@code yaml.logging} system property. Modifiable at runtime.
+     */
     private static volatile boolean showServerReads = Jvm.getBoolean("yaml.logging");
 
-    // Flag indicating whether heartbeat messages should be shown.
+    /**
+     * Whether heartbeat messages are logged as YAML. Defaults to {@code false}.
+     * Modifiable at runtime.
+     */
     private static volatile boolean showHeartBeats = false;
 
     /**
-     * Sets the logging flags for all message types (reads/writes for both client and server).
+     * Enable or disable logging for all message types.
      *
-     * @param flag The boolean value to set for all logging flags.
+     * @param flag {@code true} to enable, {@code false} to disable.
      */
     public static void setAll(boolean flag) {
         showServerReads = showServerWrites = clientWrites = clientReads = flag;
     }
 
     /**
-     * Sets the logging flags for all message types based on the provided {@link YamlLoggingLevel}.
-     *
-     * @param level The {@link YamlLoggingLevel} determining whether to set or unset the logging flags.
+     * Set logging flags for all message types according to the level.
      */
     public static void setAll(@NotNull YamlLoggingLevel level) {
         showServerReads = showServerWrites = clientWrites = clientReads = level.isSet();
     }
 
     /**
-     * Checks whether logging for client reads is enabled.
-     *
-     * @return {@code true} if logging for client reads is enabled; {@code false} otherwise.
+     * Returns {@code true} if client read logging is enabled.
      */
     public static boolean showClientReads() {
         return clientReads;
     }
 
     /**
-     * Updates the message associated with a write operation.
-     *
-     * @param s The new message to be set.
+     * Associate a message with subsequent write operations.
      */
     public static void writeMessage(@NotNull String s) {
         writeMessage = s;
     }
 
     /**
-     * Sets the flag to determine whether server writes should be logged.
-     *
-     * @param logging {@code true} to enable logging for server writes; {@code false} to disable.
+     * Enable or disable logging of server writes.
      */
     public static void showServerWrites(boolean logging) {
         showServerWrites = logging;
     }
 
     /**
-     * Checks whether logging for client writes is enabled.
-     *
-     * @return {@code true} if logging for client writes is enabled; {@code false} otherwise.
+     * Returns {@code true} if client write logging is enabled.
      */
     public static boolean showClientWrites() {
         return clientWrites;
     }
 
     /**
-     * Retrieves the current message associated with a write operation.
-     *
-     * @return The message currently associated with a write operation.
+     * Returns the message associated with write operations.
      */
     @NotNull
     public static String writeMessage() {
@@ -118,85 +126,73 @@ public enum YamlLogging {
     }
 
     /**
-     * Checks whether heartbeat logging is enabled.
-     *
-     * @return {@code true} if heartbeat logging is enabled; {@code false} otherwise.
+     * Returns {@code true} if heartbeat logging is enabled.
      */
     public static boolean showHeartBeats() {
         return showHeartBeats;
     }
 
     /**
-     * Checks whether logging for server reads is enabled.
-     *
-     * @return {@code true} if logging for server reads is enabled; {@code false} otherwise.
+     * Returns {@code true} if server read logging is enabled.
      */
     public static boolean showServerReads() {
         return showServerReads;
     }
 
     /**
-     * Sets the flag to determine whether heartbeats should be logged.
-     *
-     * @param log {@code true} to enable heartbeat logging; {@code false} to disable.
+     * Enable or disable logging of heartbeats.
      */
     public static void showHeartBeats(boolean log) {
         showHeartBeats = log;
     }
 
     /**
-     * Sets the flag to determine whether client writes should be logged.
-     *
-     * @param logging {@code true} to enable logging for client writes; {@code false} to disable.
+     * Enable or disable logging of client writes.
      */
     public static void showClientWrites(boolean logging) {
         clientWrites = logging;
     }
 
     /**
-     * Sets the flag to determine whether client reads should be logged.
-     *
-     * @param logging {@code true} to enable logging for client reads; {@code false} to disable.
+     * Enable or disable logging of client reads.
      */
     public static void showClientReads(boolean logging) {
         clientReads = logging;
     }
 
     /**
-     * Checks whether logging for server writes is enabled.
-     *
-     * @return {@code true} if logging for server writes is enabled; {@code false} otherwise.
+     * Returns {@code true} if server write logging is enabled.
      */
     public static boolean showServerWrites() {
         return showServerWrites;
     }
 
     /**
-     * Sets the flag to determine whether server reads should be logged.
-     *
-     * @param logging {@code true} to enable logging for server reads; {@code false} to disable.
+     * Enable or disable logging of server reads.
      */
     public static void showServerReads(boolean logging) {
         showServerReads = logging;
     }
 
     /**
-     * Enum representing the various logging levels for Yaml.
-     * The levels include OFF (no logging), DEBUG_ONLY (logs only when in debug mode), and ON (always logs).
+     * Levels controlling when YAML logging is active.
      */
     public enum YamlLoggingLevel {
+        /** Logging is disabled. */
         OFF {
             @Override
             public boolean isSet() {
                 return false;
             }
         },
+        /** Logging enabled only when {@link Jvm#isDebug()} is {@code true}. */
         DEBUG_ONLY {
             @Override
             public boolean isSet() {
                 return Jvm.isDebug();
             }
         },
+        /** Logging is always enabled. */
         ON {
             @Override
             public boolean isSet() {
@@ -205,9 +201,7 @@ public enum YamlLogging {
         };
 
         /**
-         * Checks if the current logging level is set (enabled).
-         *
-         * @return {@code true} if the current logging level is enabled; {@code false} otherwise.
+         * Returns {@code true} if this level currently enables logging.
          */
         public abstract boolean isSet();
     }

--- a/src/main/java/net/openhft/chronicle/wire/YamlToken.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlToken.java
@@ -20,34 +20,76 @@ package net.openhft.chronicle.wire;
 /**
  * Enumerates the different types of tokens that can be found in a YAML document.
  * Each token represents a distinct construct or symbol in YAML, which can be used
- * for tasks such as parsing or tokenization of YAML documents.
+ * for tasks such as parsing or tokenisation of YAML documents.
  */
 public enum YamlToken {
+    /**
+     * Represents no specific token, often used as a sentinel or when parsing
+     * reaches an ambiguous state.
+     */
     NONE,
+
+    /** A YAML comment line (starts with '#'). */
     COMMENT,
+
+    /** A YAML tag such as {@code !str} or {@code !!map}. */
     TAG,
+
+    /** A YAML directive like {@code %YAML 1.2}. */
     DIRECTIVE,
+
+    /** The end of a YAML document marker ({@code ...}). */
     DOCUMENT_END(),
-    /** Represents the end of the directives in a YAML document. */
+
+    /** The end of the directives section marker ({@code ---}). */
     DIRECTIVES_END(DOCUMENT_END),
+
+    /** Indicates that the following token is a key in a YAML mapping. */
     MAPPING_KEY(NONE),
+
+    /** The end of a YAML mapping (<code>}</code>). */
     MAPPING_END(),
-    /** Represents the start of a key-value mapping in a YAML document. */
+
+    /** The start of a YAML mapping (<code>{</code>). */
     MAPPING_START(MAPPING_END),
+
+    /** The end of a YAML sequence ({@code ]}). */
     SEQUENCE_END(),
+
+    /** Indicates a new entry in a YAML sequence. */
     SEQUENCE_ENTRY,
-    /** Represents the start of a sequence in a YAML document. */
+
+    /** The start of a YAML sequence (<code>[</code> or indicated by <code>-</code>). */
     SEQUENCE_START(SEQUENCE_END),
+
+    /** A scalar textual value (string, number or boolean). */
     TEXT,
+
+    /** A literal block scalar introduced by {@code |} or {@code >}. */
     LITERAL,
+
+    /** A YAML anchor such as {@code &anchor_name}. */
     ANCHOR,
+
+    /** A YAML alias such as {@code *anchor_name}. */
     ALIAS,
+
+    /** A reserved YAML indicator, for example {@code @} or {@code `}. */
     RESERVED,
+
+    /** The end of a YAML stream. */
     STREAM_END,
-    /** Represents the start of a YAML document stream. */
+
+    /** The start of a YAML stream, implicit before any content. */
     STREAM_START(STREAM_END);
 
-    /** The corresponding end token for certain start tokens. */
+    /**
+     * For tokens that represent the start of a block structure (for example
+     * {@link #MAPPING_START}, {@link #SEQUENCE_START} or {@link #STREAM_START}),
+     * this field holds the token that marks the end of that block, such as
+     * {@link #MAPPING_END}. It is {@code null} when the token does not start a
+     * block.
+     */
     public final YamlToken toEnd;
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/YamlToken.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlToken.java
@@ -20,76 +20,34 @@ package net.openhft.chronicle.wire;
 /**
  * Enumerates the different types of tokens that can be found in a YAML document.
  * Each token represents a distinct construct or symbol in YAML, which can be used
- * for tasks such as parsing or tokenisation of YAML documents.
+ * for tasks such as parsing or tokenization of YAML documents.
  */
 public enum YamlToken {
-    /**
-     * Represents no specific token, often used as a sentinel or when parsing
-     * reaches an ambiguous state.
-     */
     NONE,
-
-    /** A YAML comment line (starts with '#'). */
     COMMENT,
-
-    /** A YAML tag such as {@code !str} or {@code !!map}. */
     TAG,
-
-    /** A YAML directive like {@code %YAML 1.2}. */
     DIRECTIVE,
-
-    /** The end of a YAML document marker ({@code ...}). */
     DOCUMENT_END(),
-
-    /** The end of the directives section marker ({@code ---}). */
+    /** Represents the end of the directives in a YAML document. */
     DIRECTIVES_END(DOCUMENT_END),
-
-    /** Indicates that the following token is a key in a YAML mapping. */
     MAPPING_KEY(NONE),
-
-    /** The end of a YAML mapping (<code>}</code>). */
     MAPPING_END(),
-
-    /** The start of a YAML mapping (<code>{</code>). */
+    /** Represents the start of a key-value mapping in a YAML document. */
     MAPPING_START(MAPPING_END),
-
-    /** The end of a YAML sequence ({@code ]}). */
     SEQUENCE_END(),
-
-    /** Indicates a new entry in a YAML sequence. */
     SEQUENCE_ENTRY,
-
-    /** The start of a YAML sequence (<code>[</code> or indicated by <code>-</code>). */
+    /** Represents the start of a sequence in a YAML document. */
     SEQUENCE_START(SEQUENCE_END),
-
-    /** A scalar textual value (string, number or boolean). */
     TEXT,
-
-    /** A literal block scalar introduced by {@code |} or {@code >}. */
     LITERAL,
-
-    /** A YAML anchor such as {@code &anchor_name}. */
     ANCHOR,
-
-    /** A YAML alias such as {@code *anchor_name}. */
     ALIAS,
-
-    /** A reserved YAML indicator, for example {@code @} or {@code `}. */
     RESERVED,
-
-    /** The end of a YAML stream. */
     STREAM_END,
-
-    /** The start of a YAML stream, implicit before any content. */
+    /** Represents the start of a YAML document stream. */
     STREAM_START(STREAM_END);
 
-    /**
-     * For tokens that represent the start of a block structure (for example
-     * {@link #MAPPING_START}, {@link #SEQUENCE_START} or {@link #STREAM_START}),
-     * this field holds the token that marks the end of that block, such as
-     * {@link #MAPPING_END}. It is {@code null} when the token does not start a
-     * block.
-     */
+    /** The corresponding end token for certain start tokens. */
     public final YamlToken toEnd;
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
@@ -135,11 +135,11 @@ public class YamlTokeniser {
     /**
      * Constructs a new YAML tokenizer with the specified input.
      *
-     * @param in The input source containing raw YAML content.
+     * @param inputStream The input source containing raw YAML content.
      */
-    public YamlTokeniser(BytesIn<?> in) {
+    public YamlTokeniser(BytesIn<?> inputStream) {
         reset();
-        this.in = in;
+        this.in = inputStream;
     }
 
     /**
@@ -449,14 +449,19 @@ public class YamlTokeniser {
     }
 
     /**
-     * Pops contexts until the given start token is reached when closing a flow
-     * collection.
+     * Pop from the context stack until a specified start token is encountered.
+     * This method is useful for flow constructs where we need to determine the
+     * boundaries (like a list or map).
+     *
+     * @param flowStartToken The token to identify the start of the flow construct.
+     * @param flowEndChar The character representing the end of the flow construct.
+     * @return The appropriate {@link YamlToken} after popping the context.
      */
-    private YamlToken flowPop(YamlToken start, char end) {
+    private YamlToken flowPop(YamlToken flowStartToken, char flowEndChar) {
         int pos = pushed.size();
-        while (context() != start) {
+        while (context() != flowStartToken) {
             if (contextSize() <= 1)
-                throw new IllegalArgumentException("Unexpected '" + end + '\'');
+                throw new IllegalArgumentException("Unexpected '" + flowEndChar + '\'');
             contextPop();
         }
         contextPop();
@@ -615,48 +620,53 @@ public class YamlTokeniser {
     }
 
     /**
-     * Manages indentation changes. De-indentation may pop existing contexts and
-     * emit their end tokens, whilst increasing indentation pushes a new context
-     * and its start token onto {@link #pushed}.
+     * Handles and determines the indentation level and relevant token type based on context.
+     *
+     * @param currentIndentedContextToken The token for the start of indentation context.
+     * @param keyDefinitionToken The key token type.
+     * @param nextTokenToParse The token type to be pushed to the stack.
+     * @param currentIndentLevel The current indentation level.
+     * @return The next token after processing the current input.
      */
     private YamlToken indent(
-            YamlToken indented,
-            @NotNull YamlToken key,
-            @NotNull YamlToken push,
-            int indent) {
-        if (push != YamlToken.STREAM_START)
-            this.pushed.add(push);
+            YamlToken currentIndentedContextToken,
+            @NotNull YamlToken keyDefinitionToken,
+            @NotNull YamlToken nextTokenToParse,
+            int currentIndentLevel) {
+        if (nextTokenToParse != YamlToken.STREAM_START)
+            this.pushed.add(nextTokenToParse);
         if (isInFlow()) {
-            return key; // If we are inside a flow structure, return the key token.
+            return keyDefinitionToken; // If we are inside a flow structure, return the key token.
         }
         int pos = this.pushed.size();
 
         // Pop contexts until the current indent matches the existing context.
-        while (indent < contextIndent()) {
+        while (currentIndentLevel < contextIndent()) {
             contextPop();
         }
         int contextIndent = contextIndent();
 
         // Push the indented token if we are starting a new indentation level.
-        if (indented != null && indent != contextIndent)
-            this.pushed.add(indented);
-        this.pushed.add(key);
+        if (currentIndentedContextToken != null && currentIndentLevel != contextIndent)
+            this.pushed.add(currentIndentedContextToken);
+        this.pushed.add(keyDefinitionToken);
 
         // Reverse the order of the tokens in the pushed stack.
         reversePushed(pos);
 
         // Push a new context if we are starting a new indentation level.
-        if (indented != null && indent > contextIndent())
-            contextPush(indented, indent);
+        if (currentIndentedContextToken != null && currentIndentLevel > contextIndent())
+            contextPush(currentIndentedContextToken, currentIndentLevel);
         return popPushed();
     }
 
     /**
-     * Reads a plain scalar (unquoted text). Uses {@link #readWords()} to update
-     * {@link #blockStart} and {@link #blockEnd}. If the scalar is followed by a
-     * colon it is treated as a {@link YamlToken#MAPPING_KEY}.
+     * Reads plain scalar text from the YAML input, handling mappings and sequences.
+     *
+     * @param currentIndentLevel The current indentation level.
+     * @return The token after processing the text.
      */
-    private YamlToken readText(int indent2) {
+    private YamlToken readText(int currentIndentLevel) {
         long pos = in.readPosition(); // Store the current position of input.
 
         blockQuote = 0;
@@ -666,7 +676,7 @@ public class YamlTokeniser {
         if (isFieldEnd()) {
             lastKeyPosition = pos;
             if (topContext().token != YamlToken.MAPPING_KEY)
-                return indent(YamlToken.MAPPING_START, YamlToken.MAPPING_KEY, YamlToken.TEXT, indent2);
+                return indent(YamlToken.MAPPING_START, YamlToken.MAPPING_KEY, YamlToken.TEXT, currentIndentLevel);
         }
 
         // By default, treat the scalar as plain text.
@@ -1062,16 +1072,17 @@ public class YamlTokeniser {
     }
 
     /**
-     * Variant of {@link #text()} that appends the value to the supplied
-     * {@link StringBuilder}.
+     * Extracts the text of the current block into the provided StringBuilder.
+     *
+     * @param outputBuilder StringBuilder to which the block's text will be appended.
      */
-    public void text(StringBuilder sb) {
+    public void text(StringBuilder outputBuilder) {
         // If blockEnd is not set and a temporary value exists, use that.
         if (blockEnd < 0 && temp != null) {
-            sb.append(temp);
+            outputBuilder.append(temp);
             return;
         }
-        sb.setLength(0);  // Clear the StringBuilder.
+        outputBuilder.setLength(0);  // Clear the StringBuilder.
 
         // Return if there is no text to parse or if last token doesn't allow text extraction.
         if (blockStart == blockEnd || NO_TEXT.contains(last))
@@ -1079,7 +1090,7 @@ public class YamlTokeniser {
         long pos = in.readPosition();
         try {
             in.readPosition(blockStart);
-            in.parseUtf8(sb, Math.toIntExact(blockEnd - blockStart));
+            in.parseUtf8(outputBuilder, Math.toIntExact(blockEnd - blockStart));
         } finally {
             // Reset the reading position.
             in.readPosition(pos);

--- a/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
@@ -32,18 +32,22 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * A tokenizer for YAML documents. The YamlTokeniser class is responsible for
- * converting a raw YAML input into individual tokens, each representing
- * a distinct construct or symbol in YAML. This class is integral to
- * processes such as parsing or tokenization of YAML documents.
+ * Tokeniser for YAML documents.
+ * Converts a raw YAML stream into a sequence of {@link YamlToken tokens},
+ * each representing a distinct construct or symbol.
+ * It is used internally by {@link YamlWire} to drive the parsing process.
  */
 @SuppressWarnings({"this-escape","deprecation"})
 public class YamlTokeniser {
 
-    /** Represents an undefined or invalid indentation. */
+    /**
+     * Represents an undefined or invalid indentation.
+     */
     static final int NO_INDENT = -1;
 
-    /** Set of YAML tokens that don't contain any associated text content. */
+    /**
+     * Set of YAML tokens that contain no textual content.
+     */
     static final Set<YamlToken> NO_TEXT = EnumSet.of(
             YamlToken.SEQUENCE_START,
             YamlToken.SEQUENCE_ENTRY,
@@ -53,46 +57,79 @@ public class YamlTokeniser {
             YamlToken.MAPPING_END,
             YamlToken.DIRECTIVES_END);
 
-    /** A pool of StringBuilders to improve efficiency and reduce memory overhead. */
+    /**
+     * A thread-local pool of {@link StringBuilder} instances for efficient
+     * string manipulation during tokenisation.
+     */
     static final ScopedResourcePool<StringBuilder> SBP = StringBuilderPool.createThreadLocal(1);
 
-    /** Stack to manage contextual information during tokenization. */
+    /**
+     * A stack of {@link YTContext} objects describing the current nesting of
+     * YAML structures.
+     */
     protected final List<YTContext> contexts = new ArrayList<>();
 
-    /** The input source containing the raw YAML content. */
+    /**
+     * The {@link BytesIn} providing the raw YAML input stream.
+     */
     private final BytesIn<?> in;
 
-    /** A pool of reusable context objects to manage YAML structures. */
+    /**
+     * Pool of reusable {@link YTContext} instances to reduce allocations.
+     */
     private final List<YTContext> freeContexts = new ArrayList<>();
 
-    /** List of tokens that have been identified but not yet processed. */
+    /**
+     * Tokens that have been pushed back and will be returned before further
+     * parsing the input.
+     */
     private final List<YamlToken> pushed = new ArrayList<>();
 
-    /** Temporary bytes buffer. */
+    /**
+     * Temporary buffer, often used for accumulating literal block content.
+     */
     Bytes<?> temp = null;
 
-    /** Position marker for the start of a line. */
+    /**
+     * Byte offset marking the start of the current line in {@link #in}.
+     */
     long lineStart;
 
-    /** Position marker for the start of a block. */
+    /**
+     * Byte offset for the start of the textual content of the current scalar.
+     */
     long blockStart;
 
-    /** Position marker for the end of a block. */
+    /**
+     * Byte offset for the end of the textual content of the current scalar.
+     */
     long blockEnd;
 
-    /** Current depth of flow structures, like lists or maps. */
+    /**
+     * Tracks the nesting depth of flow style collections ({@code {...}} or
+     * {@code [...]}).
+     */
     int flowDepth = Integer.MAX_VALUE;
 
-    /** Character used to denote quoting in a block. */
+    /**
+     * Quote character if the current scalar was quoted; {@code 0} otherwise.
+     */
     char blockQuote = 0;
 
-    /** Flag to indicate if a sequence entry has been encountered. */
+    /**
+     * Flag used to manage implicit {@link YamlToken#SEQUENCE_ENTRY} tokens
+     * within flow sequences.
+     */
     boolean hasSequenceEntry;
 
-    /** Position marker for the last key in a key-value pair. */
+    /**
+     * Byte offset of the start of the most recently parsed mapping key.
+     */
     long lastKeyPosition = -1;
 
-    /** The last token that was processed. */
+    /**
+     * The most recently returned token.
+     */
     private YamlToken last = YamlToken.STREAM_START;
 
     /**
@@ -115,8 +152,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Resets the state of the tokenizer. This method prepares the tokenizer
-     * for processing a new input or to restart the tokenization of the current input.
+     * Resets the tokeniser to its initial state, clearing all contexts,
+     * buffers and flags. Prepares it to tokenise a new stream or restart
+     * from the beginning of the current input.
      */
     void reset() {
         contexts.clear();
@@ -135,40 +173,31 @@ public class YamlTokeniser {
     }
 
     /**
-     * Returns the context of the YAML tokenization process.
-     * This method provides the top-level token context based on the tokenization history.
-     *
-     * @return The top context token if contexts are present, otherwise returns STREAM_START.
+     * Returns the token at the top of the context stack or
+     * {@link YamlToken#STREAM_START} if none.
      */
     public YamlToken context() {
         return contexts.isEmpty() ? YamlToken.STREAM_START : topContext().token;
     }
 
     /**
-     * Retrieves the top context from the context stack.
-     * This method provides the most recent tokenization context.
-     *
-     * @return The top YTContext object from the context stack.
+     * Most recent entry on the context stack.
      */
     public YTContext topContext() {
         return contexts.get(contextSize() - 1);
     }
 
     /**
-     * Retrieves the second to top context from the context stack.
-     * This method provides the tokenization context that's just below the topmost one.
-     *
-     * @return The second top YTContext object from the context stack.
+     * Context entry one below the top of the stack.
      */
     public YTContext secondTopContext() {
         return contexts.get(contextSize() - 2);
     }
 
     /**
-     * Gets the current token in the tokenization process.
-     * If the last token was the start of the stream, this method fetches the next token.
-     *
-     * @return The current YamlToken object representing the tokenization status.
+     * Returns the last token produced by {@link #next(int)}. If the parser
+     * is at the start of the stream, calling this method will parse and return
+     * the first real token.
      */
     public YamlToken current() {
         if (last == YamlToken.STREAM_START)
@@ -177,21 +206,19 @@ public class YamlTokeniser {
     }
 
     /**
-     * Fetches the next token based on the current context's indentation.
-     *
-     * @return The next YamlToken object in line based on the current indentation context.
+     * Convenience wrapper for {@link #next(int)} using the current context
+     * indentation.
      */
     public YamlToken next() {
         return next(contextIndent());
     }
 
     /**
-     * Retrieves the next YAML token considering the minimum indentation provided.
-     * This method drives the core tokenization process, fetching tokens based on
-     * the minimum indentation and updating the last token processed.
-     *
-     * @param minIndent The minimum indentation to consider while tokenizing.
-     * @return The next YamlToken object based on the specified indentation.
+     * Core tokenisation method. It first checks the {@link #pushed} stack and,
+     * if empty, parses the next token from the input stream via
+     * {@link #next0(int)}. The {@code minIndent} parameter is used to detect
+     * de-indentation and close block contexts. Updates {@link #last} with the
+     * produced token.
      */
     @NotNull
     public YamlToken next(int minIndent) {
@@ -204,13 +231,12 @@ public class YamlTokeniser {
     }
 
     /**
-     * Core method to tokenize the YAML content based on the given minimum indentation.
-     * The method processes the current position in the input stream and returns the
-     * next tokenized YAML construct. It utilizes the current context and the indentation
-     * level to identify and process different YAML constructs.
-     *
-     * @param minIndent The minimum indentation level to consider while tokenizing.
-     * @return The next {@link YamlToken} in the tokenization sequence.
+     * Internal tokenisation logic. Consumes leading whitespace and then
+     * examines the next character to determine the {@link YamlToken}. Handles
+     * comments, quoted strings, directives, tags, anchors, aliases, literal
+     * blocks, flow collections and plain scalars. The {@code minIndent}
+     * parameter controls when block contexts are closed due to
+     * de-indentation.
      */
     YamlToken next0(int minIndent) {
         // Consuming any whitespace present at the start of a line
@@ -404,11 +430,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Determine if the current context would change given the indentation levels.
-     *
-     * @param minIndent The minimum indentation to consider.
-     * @param indent The current indentation level.
-     * @return True if context would change, false otherwise.
+     * Checks whether parsing at the supplied {@code indent} would require the
+     * context stack to pop given the caller's {@code minIndent}.
      */
     private boolean wouldChangeContext(int minIndent, int indent) {
         if (isInFlow())
@@ -417,10 +440,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Helper method to handle scenarios where the character shouldn't be tokenized.
-     * This method ensures the last read character is reverted back and a NONE token is returned.
-     *
-     * @return The {@link YamlToken#NONE} token.
+     * Helper used when a peeked character should not be consumed.
+     * Unreads the character and returns {@link YamlToken#NONE}.
      */
     private YamlToken dontRead() {
         unreadLast();
@@ -428,13 +449,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Pop from the context stack until a specified start token is encountered.
-     * This method is useful for flow constructs where we need to determine the
-     * boundaries (like a list or map).
-     *
-     * @param start The token to identify the start of the flow construct.
-     * @param end The character representing the end of the flow construct.
-     * @return The appropriate {@link YamlToken} after popping the context.
+     * Pops contexts until the given start token is reached when closing a flow
+     * collection.
      */
     private YamlToken flowPop(YamlToken start, char end) {
         int pos = pushed.size();
@@ -449,11 +465,7 @@ public class YamlTokeniser {
     }
 
     /**
-     * Handles YAML flow constructs such as sequences and maps.
-     * This method manages the context and the stack of tokens accordingly.
-     *
-     * @param token The {@link YamlToken} to be processed.
-     * @return The next token in the sequence.
+     * Handles opening of flow collections and manages the context stack.
      */
     private YamlToken flow(YamlToken token) {
         pushed.add(token);
@@ -516,13 +528,11 @@ public class YamlTokeniser {
     }
 
     /**
-     * Reads and processes a literal scalar block from the YAML input.
-     * In YAML, literal scalars are indicated by the pipe character '|'.
-     * This method will capture content preserving formatting and any newlines
-     * present, depending on the withNewLines flag.
-     *
-     * @param withNewLines A flag indicating if newlines should be preserved (true)
-     * or converted to spaces (false) during the read process.
+     * Parses a YAML literal block scalar. When {@code withNewLines} is
+     * {@code true} (for the {@code |} style) newlines are kept; when
+     * {@code false} (for {@code >}) they are folded into spaces except for
+     * blank lines. Accumulates the content into {@link #temp} until a line with
+     * less indentation is encountered.
      */
     private void readLiteral(boolean withNewLines) {
         readNewline(); // read to the end of the line.
@@ -605,13 +615,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Handles and determines the indentation level and relevant token type based on context.
-     *
-     * @param indented The token for the start of indentation context.
-     * @param key The key token type.
-     * @param push The token type to be pushed to the stack.
-     * @param indent The current indentation level.
-     * @return The next token after processing the current input.
+     * Manages indentation changes. De-indentation may pop existing contexts and
+     * emit their end tokens, whilst increasing indentation pushes a new context
+     * and its start token onto {@link #pushed}.
      */
     private YamlToken indent(
             YamlToken indented,
@@ -646,10 +652,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Reads plain scalar text from the YAML input, handling mappings and sequences.
-     *
-     * @param indent2 The current indentation level.
-     * @return The token after processing the text.
+     * Reads a plain scalar (unquoted text). Uses {@link #readWords()} to update
+     * {@link #blockStart} and {@link #blockEnd}. If the scalar is followed by a
+     * colon it is treated as a {@link YamlToken#MAPPING_KEY}.
      */
     private YamlToken readText(int indent2) {
         long pos = in.readPosition(); // Store the current position of input.
@@ -670,10 +675,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Handles the sequence logic within the YAML structure.
-     *
-     * @param token The current token being processed.
-     * @return A {@link YamlToken} after processing the sequence logic.
+     * Helper to manage {@link YamlToken#SEQUENCE_ENTRY} tokens inside flow
+     * sequences.
      */
     private YamlToken seq(YamlToken token) {
         // If a sequence entry has not been processed yet and the current context is a sequence start, and it's in flow
@@ -812,7 +815,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Removes the top context from the context stack, and frees up the context.
+     * Pops the top context and adds it to {@link #freeContexts}. Emits the
+     * context's end token if present.
      */
     private void contextPop() {
         YTContext context0 = contexts.remove(contextSize() - 1); // Remove the top context.
@@ -830,9 +834,7 @@ public class YamlTokeniser {
     }
 
     /**
-     * Reverts to a specified context level.
-     *
-     * @param contextSize The desired context level.
+     * Drops contexts until the stack reaches the supplied {@code contextSize}.
      */
     void revertToContext(int contextSize) {
         pushed.clear(); // Clear the pushed tokens.
@@ -846,10 +848,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Pushes a new context to the context stack.
-     *
-     * @param context The YAML token representing the context.
-     * @param indent  The indentation level for this context.
+     * Pushes a new parsing context. Inserts an implicit
+     * {@link YamlToken#DIRECTIVES_END} if starting from
+     * {@link YamlToken#STREAM_START}.
      */
     private void contextPush(YamlToken context, int indent) {
         // If we're at the start of a stream and the context isn't the end of directives,
@@ -864,8 +865,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Reads a value enclosed in double quotes from the input stream.
-     * Supports escape sequences.
+     * Parses text between double quotes. Sets {@link #blockStart},
+     * {@link #blockEnd} and {@link #blockQuote} but leaves unescaping to
+     * {@link #text()}.
      */
     private void readDoublyQuoted() {
         blockQuote = '"';
@@ -887,8 +889,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Reads a value enclosed in single quotes from the input stream.
-     * Supports consecutive single quotes as escape for a single quote.
+     * Parses text between single quotes. Consecutive quotes represent an
+     * escaped quote. Unescaping is performed in {@link #text()}.
      */
     private void readSinglyQuoted() {
         blockQuote = '\'';
@@ -914,9 +916,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Checks if the current position in the stream marks the end of a field (denoted by a colon).
-     *
-     * @return true if the current position is a field end, false otherwise.
+     * Tests whether the characters after the current plain scalar form a
+     * key-value separator ({@code :}).
      */
     private boolean isFieldEnd() {
         consumeSpaces(); // Consume any spaces or tabs.
@@ -1018,10 +1019,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Pushes a new context onto the stack, or reuses one from the freeContexts list.
-     *
-     * @param token  The YAML token for the context.
-     * @param indent The indentation level for the context.
+     * Obtains a context from {@link #freeContexts} or creates one and pushes it
+     * onto the stack.
      */
     private void pushContext0(YamlToken token, int indent) {
         YTContext context = freeContexts.isEmpty() ? new YTContext() : freeContexts.remove(freeContexts.size() - 1);
@@ -1048,9 +1047,11 @@ public class YamlTokeniser {
     }
 
     /**
-     * Used primarily for testing purposes to extract the current block's text.
-     *
-     * @return the text of the current block or an empty string if no text.
+     * Returns the textual content of the last scalar token. If the token came
+     * from a literal block the data is taken from {@link #temp}; otherwise the
+     * region within {@link #in} between {@link #blockStart} and
+     * {@link #blockEnd} is used. Unescaping based on {@link #blockQuote} is
+     * applied.
      */
     public String text() {
         try (ScopedResource<StringBuilder> sbTl = SBP.get()) {
@@ -1061,9 +1062,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Extracts the text of the current block into the provided StringBuilder.
-     *
-     * @param sb StringBuilder to which the block's text will be appended.
+     * Variant of {@link #text()} that appends the value to the supplied
+     * {@link StringBuilder}.
      */
     public void text(StringBuilder sb) {
         // If blockEnd is not set and a temporary value exists, use that.
@@ -1087,9 +1087,7 @@ public class YamlTokeniser {
     }
 
     /**
-     * Parses the current block's content as a double.
-     *
-     * @return the parsed double value.
+     * Parses the text of the last scalar token as a double.
      */
     public double parseDouble() {
         if (blockEnd < 0 && temp != null) {
@@ -1109,9 +1107,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Parses the current block's content as a long. Handles octal numbers as well.
-     *
-     * @return the parsed long value.
+     * Parses the text of the last scalar token as a long. YAML octal notation
+     * ({@code 0o...}) is supported.
      */
     public long parseLong() {
         if (blockEnd < 0 && temp != null) {
@@ -1190,8 +1187,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Inner static class that represents the context during YAML parsing.
-     * This can include the current token, the indent level, and associated keys.
+     * Represents a level in the parsing context stack, storing the structure
+     * type, its indentation and any skipped keys.
      */
     static class YTContext extends SelfDescribingMarshallable {
         YamlToken token;     // The current token in this context.

--- a/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
@@ -32,22 +32,18 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Tokeniser for YAML documents.
- * Converts a raw YAML stream into a sequence of {@link YamlToken tokens},
- * each representing a distinct construct or symbol.
- * It is used internally by {@link YamlWire} to drive the parsing process.
+ * A tokenizer for YAML documents. The YamlTokeniser class is responsible for
+ * converting a raw YAML input into individual tokens, each representing
+ * a distinct construct or symbol in YAML. This class is integral to
+ * processes such as parsing or tokenization of YAML documents.
  */
 @SuppressWarnings({"this-escape","deprecation"})
 public class YamlTokeniser {
 
-    /**
-     * Represents an undefined or invalid indentation.
-     */
+    /** Represents an undefined or invalid indentation. */
     static final int NO_INDENT = -1;
 
-    /**
-     * Set of YAML tokens that contain no textual content.
-     */
+    /** Set of YAML tokens that don't contain any associated text content. */
     static final Set<YamlToken> NO_TEXT = EnumSet.of(
             YamlToken.SEQUENCE_START,
             YamlToken.SEQUENCE_ENTRY,
@@ -57,79 +53,46 @@ public class YamlTokeniser {
             YamlToken.MAPPING_END,
             YamlToken.DIRECTIVES_END);
 
-    /**
-     * A thread-local pool of {@link StringBuilder} instances for efficient
-     * string manipulation during tokenisation.
-     */
+    /** A pool of StringBuilders to improve efficiency and reduce memory overhead. */
     static final ScopedResourcePool<StringBuilder> SBP = StringBuilderPool.createThreadLocal(1);
 
-    /**
-     * A stack of {@link YTContext} objects describing the current nesting of
-     * YAML structures.
-     */
+    /** Stack to manage contextual information during tokenization. */
     protected final List<YTContext> contexts = new ArrayList<>();
 
-    /**
-     * The {@link BytesIn} providing the raw YAML input stream.
-     */
+    /** The input source containing the raw YAML content. */
     private final BytesIn<?> in;
 
-    /**
-     * Pool of reusable {@link YTContext} instances to reduce allocations.
-     */
+    /** Pool of reusable {@link YTContext} instances to reduce allocations. */
     private final List<YTContext> freeContexts = new ArrayList<>();
 
-    /**
-     * Tokens that have been pushed back and will be returned before further
-     * parsing the input.
-     */
+    /** List of tokens that have been identified but not yet processed. */
     private final List<YamlToken> pushed = new ArrayList<>();
 
-    /**
-     * Temporary buffer, often used for accumulating literal block content.
-     */
+    /** Temporary bytes buffer. */
     Bytes<?> temp = null;
 
-    /**
-     * Byte offset marking the start of the current line in {@link #in}.
-     */
+    /** Position marker for the start of a line. */
     long lineStart;
 
-    /**
-     * Byte offset for the start of the textual content of the current scalar.
-     */
+    /** Position marker for the start of a block. */
     long blockStart;
 
-    /**
-     * Byte offset for the end of the textual content of the current scalar.
-     */
+    /** Position marker for the end of a block. */
     long blockEnd;
 
-    /**
-     * Tracks the nesting depth of flow style collections ({@code {...}} or
-     * {@code [...]}).
-     */
+    /** Current depth of flow structures, like lists or maps. */
     int flowDepth = Integer.MAX_VALUE;
 
-    /**
-     * Quote character if the current scalar was quoted; {@code 0} otherwise.
-     */
+    /** Character used to denote quoting in a block. */
     char blockQuote = 0;
 
-    /**
-     * Flag used to manage implicit {@link YamlToken#SEQUENCE_ENTRY} tokens
-     * within flow sequences.
-     */
+    /** Flag to indicate if a sequence entry has been encountered. */
     boolean hasSequenceEntry;
 
-    /**
-     * Byte offset of the start of the most recently parsed mapping key.
-     */
+    /** Position marker for the last key in a key-value pair. */
     long lastKeyPosition = -1;
 
-    /**
-     * The most recently returned token.
-     */
+    /** The last token that was processed. */
     private YamlToken last = YamlToken.STREAM_START;
 
     /**
@@ -152,8 +115,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Resets the tokeniser to its initial state, clearing all contexts,
-     * buffers and flags. Prepares it to tokenise a new stream or restart
+     * Resets the tokenizer to its initial state, clearing all contexts,
+     * buffers and flags. Prepares it to tokenize a new stream or restart
      * from the beginning of the current input.
      */
     void reset() {
@@ -173,8 +136,10 @@ public class YamlTokeniser {
     }
 
     /**
-     * Returns the token at the top of the context stack or
-     * {@link YamlToken#STREAM_START} if none.
+     * Returns the context of the YAML tokenization process.
+     * This method provides the top-level token context based on the tokenization history.
+     *
+     * @return The top context token if contexts are present, otherwise returns STREAM_START.
      */
     public YamlToken context() {
         return contexts.isEmpty() ? YamlToken.STREAM_START : topContext().token;
@@ -195,9 +160,10 @@ public class YamlTokeniser {
     }
 
     /**
-     * Returns the last token produced by {@link #next(int)}. If the parser
-     * is at the start of the stream, calling this method will parse and return
-     * the first real token.
+     * Gets the current token in the tokenization process.
+     * If the last token was the start of the stream, this method fetches the next token.
+     *
+     * @return The current YamlToken object representing the tokenization status.
      */
     public YamlToken current() {
         if (last == YamlToken.STREAM_START)
@@ -206,19 +172,21 @@ public class YamlTokeniser {
     }
 
     /**
-     * Convenience wrapper for {@link #next(int)} using the current context
-     * indentation.
+     * Fetches the next token based on the current context's indentation.
+     *
+     * @return The next YamlToken object in line based on the current indentation context.
      */
     public YamlToken next() {
         return next(contextIndent());
     }
 
     /**
-     * Core tokenisation method. It first checks the {@link #pushed} stack and,
-     * if empty, parses the next token from the input stream via
-     * {@link #next0(int)}. The {@code minIndent} parameter is used to detect
-     * de-indentation and close block contexts. Updates {@link #last} with the
-     * produced token.
+     * Retrieves the next YAML token considering the minimum indentation provided.
+     * This method drives the core tokenization process, fetching tokens based on
+     * the minimum indentation and updating the last token processed.
+     *
+     * @param minIndent The minimum indentation to consider while tokenizing.
+     * @return The next YamlToken object based on the specified indentation.
      */
     @NotNull
     public YamlToken next(int minIndent) {
@@ -231,12 +199,13 @@ public class YamlTokeniser {
     }
 
     /**
-     * Internal tokenisation logic. Consumes leading whitespace and then
-     * examines the next character to determine the {@link YamlToken}. Handles
-     * comments, quoted strings, directives, tags, anchors, aliases, literal
-     * blocks, flow collections and plain scalars. The {@code minIndent}
-     * parameter controls when block contexts are closed due to
-     * de-indentation.
+     * Core method to tokenize the YAML content based on the given minimum indentation.
+     * The method processes the current position in the input stream and returns the
+     * next tokenized YAML construct. It utilizes the current context and the indentation
+     * level to identify and process different YAML constructs.
+     *
+     * @param minIndent The minimum indentation level to consider while tokenizing.
+     * @return The next {@link YamlToken} in the tokenization sequence.
      */
     YamlToken next0(int minIndent) {
         // Consuming any whitespace present at the start of a line
@@ -430,8 +399,11 @@ public class YamlTokeniser {
     }
 
     /**
-     * Checks whether parsing at the supplied {@code indent} would require the
-     * context stack to pop given the caller's {@code minIndent}.
+     * Determine if the current context would change given the indentation levels.
+     *
+     * @param minIndent The minimum indentation to consider.
+     * @param indent The current indentation level.
+     * @return True if context would change, false otherwise.
      */
     private boolean wouldChangeContext(int minIndent, int indent) {
         if (isInFlow())
@@ -470,7 +442,11 @@ public class YamlTokeniser {
     }
 
     /**
-     * Handles opening of flow collections and manages the context stack.
+     * Handles YAML flow constructs such as sequences and maps.
+     * This method manages the context and the stack of tokens accordingly.
+     *
+     * @param token The {@link YamlToken} to be processed.
+     * @return The next token in the sequence.
      */
     private YamlToken flow(YamlToken token) {
         pushed.add(token);
@@ -533,11 +509,13 @@ public class YamlTokeniser {
     }
 
     /**
-     * Parses a YAML literal block scalar. When {@code withNewLines} is
-     * {@code true} (for the {@code |} style) newlines are kept; when
-     * {@code false} (for {@code >}) they are folded into spaces except for
-     * blank lines. Accumulates the content into {@link #temp} until a line with
-     * less indentation is encountered.
+     * Reads and processes a literal scalar block from the YAML input.
+     * In YAML, literal scalars are indicated by the pipe character '|'.
+     * This method will capture content preserving formatting and any newlines
+     * present, depending on the withNewLines flag.
+     *
+     * @param withNewLines A flag indicating if newlines should be preserved (true)
+     * or converted to spaces (false) during the read process.
      */
     private void readLiteral(boolean withNewLines) {
         readNewline(); // read to the end of the line.
@@ -858,9 +836,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Pushes a new parsing context. Inserts an implicit
-     * {@link YamlToken#DIRECTIVES_END} if starting from
-     * {@link YamlToken#STREAM_START}.
+     * Pushes a new parsing context.
+     * Inserts an implicit {@link YamlToken#DIRECTIVES_END}
+     * if starting from{@link YamlToken#STREAM_START}.
      */
     private void contextPush(YamlToken context, int indent) {
         // If we're at the start of a stream and the context isn't the end of directives,
@@ -875,9 +853,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Parses text between double quotes. Sets {@link #blockStart},
-     * {@link #blockEnd} and {@link #blockQuote} but leaves unescaping to
-     * {@link #text()}.
+     * Reads a value enclosed in double quotes from the input stream.
+     * Supports escape sequences.
      */
     private void readDoublyQuoted() {
         blockQuote = '"';
@@ -899,8 +876,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Parses text between single quotes. Consecutive quotes represent an
-     * escaped quote. Unescaping is performed in {@link #text()}.
+     * Reads a value enclosed in single quotes from the input stream.
+     * Supports consecutive single quotes as escape for a single quote.
      */
     private void readSinglyQuoted() {
         blockQuote = '\'';
@@ -926,8 +903,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Tests whether the characters after the current plain scalar form a
-     * key-value separator ({@code :}).
+     * Checks if the current position in the stream marks the end of a field (denoted by a colon).
+     *
+     * @return true if the current position is a field end, false otherwise.
      */
     private boolean isFieldEnd() {
         consumeSpaces(); // Consume any spaces or tabs.
@@ -1029,8 +1007,10 @@ public class YamlTokeniser {
     }
 
     /**
-     * Obtains a context from {@link #freeContexts} or creates one and pushes it
-     * onto the stack.
+     * Pushes a new context onto the stack, or reuses one from the freeContexts list.
+     *
+     * @param token  The YAML token for the context.
+     * @param indent The indentation level for the context.
      */
     private void pushContext0(YamlToken token, int indent) {
         YTContext context = freeContexts.isEmpty() ? new YTContext() : freeContexts.remove(freeContexts.size() - 1);
@@ -1057,11 +1037,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Returns the textual content of the last scalar token. If the token came
-     * from a literal block the data is taken from {@link #temp}; otherwise the
-     * region within {@link #in} between {@link #blockStart} and
-     * {@link #blockEnd} is used. Unescaping based on {@link #blockQuote} is
-     * applied.
+     * Used primarily for testing purposes to extract the current block's text.
+     *
+     * @return the text of the current block or an empty string if no text.
      */
     public String text() {
         try (ScopedResource<StringBuilder> sbTl = SBP.get()) {
@@ -1098,7 +1076,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Parses the text of the last scalar token as a double.
+     * Parses the current block's content as a double.
+     *
+     * @return the parsed double value.
      */
     public double parseDouble() {
         if (blockEnd < 0 && temp != null) {
@@ -1118,8 +1098,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Parses the text of the last scalar token as a long. YAML octal notation
-     * ({@code 0o...}) is supported.
+     * Parses the current block's content as a long. Handles octal numbers as well.
+     *
+     * @return the parsed long value.
      */
     public long parseLong() {
         if (blockEnd < 0 && temp != null) {
@@ -1198,8 +1179,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Represents a level in the parsing context stack, storing the structure
-     * type, its indentation and any skipped keys.
+     * Inner static class that represents the context during YAML parsing.
+     * This can include the current token, the indent level, and associated keys.
      */
     static class YTContext extends SelfDescribingMarshallable {
         YamlToken token;     // The current token in this context.

--- a/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
@@ -32,22 +32,18 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Tokeniser for YAML documents.
- * Converts a raw YAML stream into a sequence of {@link YamlToken tokens},
- * each representing a distinct construct or symbol.
- * It is used internally by {@link YamlWire} to drive the parsing process.
+ * A tokenizer for YAML documents. The YamlTokeniser class is responsible for
+ * converting a raw YAML input into individual tokens, each representing
+ * a distinct construct or symbol in YAML. This class is integral to
+ * processes such as parsing or tokenization of YAML documents.
  */
 @SuppressWarnings({"this-escape","deprecation"})
 public class YamlTokeniser {
 
-    /**
-     * Represents an undefined or invalid indentation.
-     */
+    /** Represents an undefined or invalid indentation. */
     static final int NO_INDENT = -1;
 
-    /**
-     * Set of YAML tokens that contain no textual content.
-     */
+    /** Set of YAML tokens that don't contain any associated text content. */
     static final Set<YamlToken> NO_TEXT = EnumSet.of(
             YamlToken.SEQUENCE_START,
             YamlToken.SEQUENCE_ENTRY,
@@ -57,79 +53,46 @@ public class YamlTokeniser {
             YamlToken.MAPPING_END,
             YamlToken.DIRECTIVES_END);
 
-    /**
-     * A thread-local pool of {@link StringBuilder} instances for efficient
-     * string manipulation during tokenisation.
-     */
+    /** A pool of StringBuilders to improve efficiency and reduce memory overhead. */
     static final ScopedResourcePool<StringBuilder> SBP = StringBuilderPool.createThreadLocal(1);
 
-    /**
-     * A stack of {@link YTContext} objects describing the current nesting of
-     * YAML structures.
-     */
+    /** Stack to manage contextual information during tokenization. */
     protected final List<YTContext> contexts = new ArrayList<>();
 
-    /**
-     * The {@link BytesIn} providing the raw YAML input stream.
-     */
+    /** The input source containing the raw YAML content. */
     private final BytesIn<?> in;
 
-    /**
-     * Pool of reusable {@link YTContext} instances to reduce allocations.
-     */
+    /** A pool of reusable context objects to manage YAML structures. */
     private final List<YTContext> freeContexts = new ArrayList<>();
 
-    /**
-     * Tokens that have been pushed back and will be returned before further
-     * parsing the input.
-     */
+    /** List of tokens that have been identified but not yet processed. */
     private final List<YamlToken> pushed = new ArrayList<>();
 
-    /**
-     * Temporary buffer, often used for accumulating literal block content.
-     */
+    /** Temporary bytes buffer. */
     Bytes<?> temp = null;
 
-    /**
-     * Byte offset marking the start of the current line in {@link #in}.
-     */
+    /** Position marker for the start of a line. */
     long lineStart;
 
-    /**
-     * Byte offset for the start of the textual content of the current scalar.
-     */
+    /** Position marker for the start of a block. */
     long blockStart;
 
-    /**
-     * Byte offset for the end of the textual content of the current scalar.
-     */
+    /** Position marker for the end of a block. */
     long blockEnd;
 
-    /**
-     * Tracks the nesting depth of flow style collections ({@code {...}} or
-     * {@code [...]}).
-     */
+    /** Current depth of flow structures, like lists or maps. */
     int flowDepth = Integer.MAX_VALUE;
 
-    /**
-     * Quote character if the current scalar was quoted; {@code 0} otherwise.
-     */
+    /** Character used to denote quoting in a block. */
     char blockQuote = 0;
 
-    /**
-     * Flag used to manage implicit {@link YamlToken#SEQUENCE_ENTRY} tokens
-     * within flow sequences.
-     */
+    /** Flag to indicate if a sequence entry has been encountered. */
     boolean hasSequenceEntry;
 
-    /**
-     * Byte offset of the start of the most recently parsed mapping key.
-     */
+    /** Position marker for the last key in a key-value pair. */
     long lastKeyPosition = -1;
 
-    /**
-     * The most recently returned token.
-     */
+    /** The last token that was processed. */
     private YamlToken last = YamlToken.STREAM_START;
 
     /**
@@ -152,9 +115,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Resets the tokeniser to its initial state, clearing all contexts,
-     * buffers and flags. Prepares it to tokenise a new stream or restart
-     * from the beginning of the current input.
+     * Resets the state of the tokenizer. This method prepares the tokenizer
+     * for processing a new input or to restart the tokenization of the current input.
      */
     void reset() {
         contexts.clear();
@@ -173,31 +135,40 @@ public class YamlTokeniser {
     }
 
     /**
-     * Returns the token at the top of the context stack or
-     * {@link YamlToken#STREAM_START} if none.
+     * Returns the context of the YAML tokenization process.
+     * This method provides the top-level token context based on the tokenization history.
+     *
+     * @return The top context token if contexts are present, otherwise returns STREAM_START.
      */
     public YamlToken context() {
         return contexts.isEmpty() ? YamlToken.STREAM_START : topContext().token;
     }
 
     /**
-     * Most recent entry on the context stack.
+     * Retrieves the top context from the context stack.
+     * This method provides the most recent tokenization context.
+     *
+     * @return The top YTContext object from the context stack.
      */
     public YTContext topContext() {
         return contexts.get(contextSize() - 1);
     }
 
     /**
-     * Context entry one below the top of the stack.
+     * Retrieves the second to top context from the context stack.
+     * This method provides the tokenization context that's just below the topmost one.
+     *
+     * @return The second top YTContext object from the context stack.
      */
     public YTContext secondTopContext() {
         return contexts.get(contextSize() - 2);
     }
 
     /**
-     * Returns the last token produced by {@link #next(int)}. If the parser
-     * is at the start of the stream, calling this method will parse and return
-     * the first real token.
+     * Gets the current token in the tokenization process.
+     * If the last token was the start of the stream, this method fetches the next token.
+     *
+     * @return The current YamlToken object representing the tokenization status.
      */
     public YamlToken current() {
         if (last == YamlToken.STREAM_START)
@@ -206,19 +177,21 @@ public class YamlTokeniser {
     }
 
     /**
-     * Convenience wrapper for {@link #next(int)} using the current context
-     * indentation.
+     * Fetches the next token based on the current context's indentation.
+     *
+     * @return The next YamlToken object in line based on the current indentation context.
      */
     public YamlToken next() {
         return next(contextIndent());
     }
 
     /**
-     * Core tokenisation method. It first checks the {@link #pushed} stack and,
-     * if empty, parses the next token from the input stream via
-     * {@link #next0(int)}. The {@code minIndent} parameter is used to detect
-     * de-indentation and close block contexts. Updates {@link #last} with the
-     * produced token.
+     * Retrieves the next YAML token considering the minimum indentation provided.
+     * This method drives the core tokenization process, fetching tokens based on
+     * the minimum indentation and updating the last token processed.
+     *
+     * @param minIndent The minimum indentation to consider while tokenizing.
+     * @return The next YamlToken object based on the specified indentation.
      */
     @NotNull
     public YamlToken next(int minIndent) {
@@ -231,12 +204,13 @@ public class YamlTokeniser {
     }
 
     /**
-     * Internal tokenisation logic. Consumes leading whitespace and then
-     * examines the next character to determine the {@link YamlToken}. Handles
-     * comments, quoted strings, directives, tags, anchors, aliases, literal
-     * blocks, flow collections and plain scalars. The {@code minIndent}
-     * parameter controls when block contexts are closed due to
-     * de-indentation.
+     * Core method to tokenize the YAML content based on the given minimum indentation.
+     * The method processes the current position in the input stream and returns the
+     * next tokenized YAML construct. It utilizes the current context and the indentation
+     * level to identify and process different YAML constructs.
+     *
+     * @param minIndent The minimum indentation level to consider while tokenizing.
+     * @return The next {@link YamlToken} in the tokenization sequence.
      */
     YamlToken next0(int minIndent) {
         // Consuming any whitespace present at the start of a line
@@ -430,8 +404,11 @@ public class YamlTokeniser {
     }
 
     /**
-     * Checks whether parsing at the supplied {@code indent} would require the
-     * context stack to pop given the caller's {@code minIndent}.
+     * Determine if the current context would change given the indentation levels.
+     *
+     * @param minIndent The minimum indentation to consider.
+     * @param indent The current indentation level.
+     * @return True if context would change, false otherwise.
      */
     private boolean wouldChangeContext(int minIndent, int indent) {
         if (isInFlow())
@@ -440,8 +417,10 @@ public class YamlTokeniser {
     }
 
     /**
-     * Helper used when a peeked character should not be consumed.
-     * Unreads the character and returns {@link YamlToken#NONE}.
+     * Helper method to handle scenarios where the character shouldn't be tokenized.
+     * This method ensures the last read character is reverted back and a NONE token is returned.
+     *
+     * @return The {@link YamlToken#NONE} token.
      */
     private YamlToken dontRead() {
         unreadLast();
@@ -470,7 +449,11 @@ public class YamlTokeniser {
     }
 
     /**
-     * Handles opening of flow collections and manages the context stack.
+     * Handles YAML flow constructs such as sequences and maps.
+     * This method manages the context and the stack of tokens accordingly.
+     *
+     * @param token The {@link YamlToken} to be processed.
+     * @return The next token in the sequence.
      */
     private YamlToken flow(YamlToken token) {
         pushed.add(token);
@@ -533,11 +516,13 @@ public class YamlTokeniser {
     }
 
     /**
-     * Parses a YAML literal block scalar. When {@code withNewLines} is
-     * {@code true} (for the {@code |} style) newlines are kept; when
-     * {@code false} (for {@code >}) they are folded into spaces except for
-     * blank lines. Accumulates the content into {@link #temp} until a line with
-     * less indentation is encountered.
+     * Reads and processes a literal scalar block from the YAML input.
+     * In YAML, literal scalars are indicated by the pipe character '|'.
+     * This method will capture content preserving formatting and any newlines
+     * present, depending on the withNewLines flag.
+     *
+     * @param withNewLines A flag indicating if newlines should be preserved (true)
+     * or converted to spaces (false) during the read process.
      */
     private void readLiteral(boolean withNewLines) {
         readNewline(); // read to the end of the line.
@@ -685,8 +670,10 @@ public class YamlTokeniser {
     }
 
     /**
-     * Helper to manage {@link YamlToken#SEQUENCE_ENTRY} tokens inside flow
-     * sequences.
+     * Handles the sequence logic within the YAML structure.
+     *
+     * @param token The current token being processed.
+     * @return A {@link YamlToken} after processing the sequence logic.
      */
     private YamlToken seq(YamlToken token) {
         // If a sequence entry has not been processed yet and the current context is a sequence start, and it's in flow
@@ -825,8 +812,7 @@ public class YamlTokeniser {
     }
 
     /**
-     * Pops the top context and adds it to {@link #freeContexts}. Emits the
-     * context's end token if present.
+     * Removes the top context from the context stack, and frees up the context.
      */
     private void contextPop() {
         YTContext context0 = contexts.remove(contextSize() - 1); // Remove the top context.
@@ -844,7 +830,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Drops contexts until the stack reaches the supplied {@code contextSize}.
+     * Reverts to a specified context level.
+     *
+     * @param contextSize The desired context level.
      */
     void revertToContext(int contextSize) {
         pushed.clear(); // Clear the pushed tokens.
@@ -858,9 +846,10 @@ public class YamlTokeniser {
     }
 
     /**
-     * Pushes a new parsing context. Inserts an implicit
-     * {@link YamlToken#DIRECTIVES_END} if starting from
-     * {@link YamlToken#STREAM_START}.
+     * Pushes a new context to the context stack.
+     *
+     * @param context The YAML token representing the context.
+     * @param indent  The indentation level for this context.
      */
     private void contextPush(YamlToken context, int indent) {
         // If we're at the start of a stream and the context isn't the end of directives,
@@ -875,9 +864,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Parses text between double quotes. Sets {@link #blockStart},
-     * {@link #blockEnd} and {@link #blockQuote} but leaves unescaping to
-     * {@link #text()}.
+     * Reads a value enclosed in double quotes from the input stream.
+     * Supports escape sequences.
      */
     private void readDoublyQuoted() {
         blockQuote = '"';
@@ -899,8 +887,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Parses text between single quotes. Consecutive quotes represent an
-     * escaped quote. Unescaping is performed in {@link #text()}.
+     * Reads a value enclosed in single quotes from the input stream.
+     * Supports consecutive single quotes as escape for a single quote.
      */
     private void readSinglyQuoted() {
         blockQuote = '\'';
@@ -926,8 +914,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Tests whether the characters after the current plain scalar form a
-     * key-value separator ({@code :}).
+     * Checks if the current position in the stream marks the end of a field (denoted by a colon).
+     *
+     * @return true if the current position is a field end, false otherwise.
      */
     private boolean isFieldEnd() {
         consumeSpaces(); // Consume any spaces or tabs.
@@ -1029,8 +1018,10 @@ public class YamlTokeniser {
     }
 
     /**
-     * Obtains a context from {@link #freeContexts} or creates one and pushes it
-     * onto the stack.
+     * Pushes a new context onto the stack, or reuses one from the freeContexts list.
+     *
+     * @param token  The YAML token for the context.
+     * @param indent The indentation level for the context.
      */
     private void pushContext0(YamlToken token, int indent) {
         YTContext context = freeContexts.isEmpty() ? new YTContext() : freeContexts.remove(freeContexts.size() - 1);
@@ -1057,11 +1048,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Returns the textual content of the last scalar token. If the token came
-     * from a literal block the data is taken from {@link #temp}; otherwise the
-     * region within {@link #in} between {@link #blockStart} and
-     * {@link #blockEnd} is used. Unescaping based on {@link #blockQuote} is
-     * applied.
+     * Used primarily for testing purposes to extract the current block's text.
+     *
+     * @return the text of the current block or an empty string if no text.
      */
     public String text() {
         try (ScopedResource<StringBuilder> sbTl = SBP.get()) {
@@ -1098,7 +1087,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Parses the text of the last scalar token as a double.
+     * Parses the current block's content as a double.
+     *
+     * @return the parsed double value.
      */
     public double parseDouble() {
         if (blockEnd < 0 && temp != null) {
@@ -1118,8 +1109,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Parses the text of the last scalar token as a long. YAML octal notation
-     * ({@code 0o...}) is supported.
+     * Parses the current block's content as a long. Handles octal numbers as well.
+     *
+     * @return the parsed long value.
      */
     public long parseLong() {
         if (blockEnd < 0 && temp != null) {
@@ -1198,8 +1190,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Represents a level in the parsing context stack, storing the structure
-     * type, its indentation and any skipped keys.
+     * Inner static class that represents the context during YAML parsing.
+     * This can include the current token, the indent level, and associated keys.
      */
     static class YTContext extends SelfDescribingMarshallable {
         YamlToken token;     // The current token in this context.

--- a/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
@@ -612,6 +612,13 @@ public class YamlTokeniser {
      * @param nextTokenToParse The token type to be pushed to the stack.
      * @param currentIndentLevel The current indentation level.
      * @return The next token after processing the current input.
+     * Handles and determines the indentation level and relevant token type based on context.
+     *
+     * @param currentIndentedContextToken The token for the start of indentation context.
+     * @param keyDefinitionToken The key token type.
+     * @param nextTokenToParse The token type to be pushed to the stack.
+     * @param currentIndentLevel The current indentation level.
+     * @return The next token after processing the current input.
      */
     private YamlToken indent(
             YamlToken currentIndentedContextToken,
@@ -812,7 +819,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Removes the top context from the context stack, and frees up the context.
+     * Pops the top context and adds it to {@link #freeContexts}. Emits the
+     * context's end token if present.
      */
     private void contextPop() {
         YTContext context0 = contexts.remove(contextSize() - 1); // Remove the top context.

--- a/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
@@ -62,7 +62,7 @@ public class YamlTokeniser {
     /** The input source containing the raw YAML content. */
     private final BytesIn<?> in;
 
-    /** Pool of reusable {@link YTContext} instances to reduce allocations. */
+    /** A pool of reusable context objects to manage YAML structures. */
     private final List<YTContext> freeContexts = new ArrayList<>();
 
     /** List of tokens that have been identified but not yet processed. */
@@ -115,9 +115,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Resets the tokenizer to its initial state, clearing all contexts,
-     * buffers and flags. Prepares it to tokenize a new stream or restart
-     * from the beginning of the current input.
+     * Resets the state of the tokenizer. This method prepares the tokenizer
+     * for processing a new input or to restart the tokenization of the current input.
      */
     void reset() {
         contexts.clear();
@@ -146,14 +145,20 @@ public class YamlTokeniser {
     }
 
     /**
-     * Most recent entry on the context stack.
+     * Retrieves the top context from the context stack.
+     * This method provides the most recent tokenization context.
+     *
+     * @return The top YTContext object from the context stack.
      */
     public YTContext topContext() {
         return contexts.get(contextSize() - 1);
     }
 
     /**
-     * Context entry one below the top of the stack.
+     * Retrieves the second to top context from the context stack.
+     * This method provides the tokenization context that's just below the topmost one.
+     *
+     * @return The second top YTContext object from the context stack.
      */
     public YTContext secondTopContext() {
         return contexts.get(contextSize() - 2);
@@ -412,8 +417,10 @@ public class YamlTokeniser {
     }
 
     /**
-     * Helper used when a peeked character should not be consumed.
-     * Unreads the character and returns {@link YamlToken#NONE}.
+     * Helper method to handle scenarios where the character shouldn't be tokenized.
+     * This method ensures the last read character is reverted back and a NONE token is returned.
+     *
+     * @return The {@link YamlToken#NONE} token.
      */
     private YamlToken dontRead() {
         unreadLast();
@@ -663,8 +670,10 @@ public class YamlTokeniser {
     }
 
     /**
-     * Helper to manage {@link YamlToken#SEQUENCE_ENTRY} tokens inside flow
-     * sequences.
+     * Handles the sequence logic within the YAML structure.
+     *
+     * @param token The current token being processed.
+     * @return A {@link YamlToken} after processing the sequence logic.
      */
     private YamlToken seq(YamlToken token) {
         // If a sequence entry has not been processed yet and the current context is a sequence start, and it's in flow
@@ -803,8 +812,7 @@ public class YamlTokeniser {
     }
 
     /**
-     * Pops the top context and adds it to {@link #freeContexts}. Emits the
-     * context's end token if present.
+     * Removes the top context from the context stack, and frees up the context.
      */
     private void contextPop() {
         YTContext context0 = contexts.remove(contextSize() - 1); // Remove the top context.
@@ -822,7 +830,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Drops contexts until the stack reaches the supplied {@code contextSize}.
+     * Reverts to a specified context level.
+     *
+     * @param contextSize The desired context level.
      */
     void revertToContext(int contextSize) {
         pushed.clear(); // Clear the pushed tokens.
@@ -836,9 +846,10 @@ public class YamlTokeniser {
     }
 
     /**
-     * Pushes a new parsing context.
-     * Inserts an implicit {@link YamlToken#DIRECTIVES_END}
-     * if starting from{@link YamlToken#STREAM_START}.
+     * Pushes a new context to the context stack.
+     *
+     * @param context The YAML token representing the context.
+     * @param indent  The indentation level for this context.
      */
     private void contextPush(YamlToken context, int indent) {
         // If we're at the start of a stream and the context isn't the end of directives,

--- a/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
@@ -32,18 +32,22 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * A tokenizer for YAML documents. The YamlTokeniser class is responsible for
- * converting a raw YAML input into individual tokens, each representing
- * a distinct construct or symbol in YAML. This class is integral to
- * processes such as parsing or tokenization of YAML documents.
+ * Tokeniser for YAML documents.
+ * Converts a raw YAML stream into a sequence of {@link YamlToken tokens},
+ * each representing a distinct construct or symbol.
+ * It is used internally by {@link YamlWire} to drive the parsing process.
  */
 @SuppressWarnings({"this-escape","deprecation"})
 public class YamlTokeniser {
 
-    /** Represents an undefined or invalid indentation. */
+    /**
+     * Represents an undefined or invalid indentation.
+     */
     static final int NO_INDENT = -1;
 
-    /** Set of YAML tokens that don't contain any associated text content. */
+    /**
+     * Set of YAML tokens that contain no textual content.
+     */
     static final Set<YamlToken> NO_TEXT = EnumSet.of(
             YamlToken.SEQUENCE_START,
             YamlToken.SEQUENCE_ENTRY,
@@ -53,46 +57,79 @@ public class YamlTokeniser {
             YamlToken.MAPPING_END,
             YamlToken.DIRECTIVES_END);
 
-    /** A pool of StringBuilders to improve efficiency and reduce memory overhead. */
+    /**
+     * A thread-local pool of {@link StringBuilder} instances for efficient
+     * string manipulation during tokenisation.
+     */
     static final ScopedResourcePool<StringBuilder> SBP = StringBuilderPool.createThreadLocal(1);
 
-    /** Stack to manage contextual information during tokenization. */
+    /**
+     * A stack of {@link YTContext} objects describing the current nesting of
+     * YAML structures.
+     */
     protected final List<YTContext> contexts = new ArrayList<>();
 
-    /** The input source containing the raw YAML content. */
+    /**
+     * The {@link BytesIn} providing the raw YAML input stream.
+     */
     private final BytesIn<?> in;
 
-    /** A pool of reusable context objects to manage YAML structures. */
+    /**
+     * Pool of reusable {@link YTContext} instances to reduce allocations.
+     */
     private final List<YTContext> freeContexts = new ArrayList<>();
 
-    /** List of tokens that have been identified but not yet processed. */
+    /**
+     * Tokens that have been pushed back and will be returned before further
+     * parsing the input.
+     */
     private final List<YamlToken> pushed = new ArrayList<>();
 
-    /** Temporary bytes buffer. */
+    /**
+     * Temporary buffer, often used for accumulating literal block content.
+     */
     Bytes<?> temp = null;
 
-    /** Position marker for the start of a line. */
+    /**
+     * Byte offset marking the start of the current line in {@link #in}.
+     */
     long lineStart;
 
-    /** Position marker for the start of a block. */
+    /**
+     * Byte offset for the start of the textual content of the current scalar.
+     */
     long blockStart;
 
-    /** Position marker for the end of a block. */
+    /**
+     * Byte offset for the end of the textual content of the current scalar.
+     */
     long blockEnd;
 
-    /** Current depth of flow structures, like lists or maps. */
+    /**
+     * Tracks the nesting depth of flow style collections ({@code {...}} or
+     * {@code [...]}).
+     */
     int flowDepth = Integer.MAX_VALUE;
 
-    /** Character used to denote quoting in a block. */
+    /**
+     * Quote character if the current scalar was quoted; {@code 0} otherwise.
+     */
     char blockQuote = 0;
 
-    /** Flag to indicate if a sequence entry has been encountered. */
+    /**
+     * Flag used to manage implicit {@link YamlToken#SEQUENCE_ENTRY} tokens
+     * within flow sequences.
+     */
     boolean hasSequenceEntry;
 
-    /** Position marker for the last key in a key-value pair. */
+    /**
+     * Byte offset of the start of the most recently parsed mapping key.
+     */
     long lastKeyPosition = -1;
 
-    /** The last token that was processed. */
+    /**
+     * The most recently returned token.
+     */
     private YamlToken last = YamlToken.STREAM_START;
 
     /**
@@ -115,8 +152,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Resets the state of the tokenizer. This method prepares the tokenizer
-     * for processing a new input or to restart the tokenization of the current input.
+     * Resets the tokeniser to its initial state, clearing all contexts,
+     * buffers and flags. Prepares it to tokenise a new stream or restart
+     * from the beginning of the current input.
      */
     void reset() {
         contexts.clear();
@@ -135,40 +173,31 @@ public class YamlTokeniser {
     }
 
     /**
-     * Returns the context of the YAML tokenization process.
-     * This method provides the top-level token context based on the tokenization history.
-     *
-     * @return The top context token if contexts are present, otherwise returns STREAM_START.
+     * Returns the token at the top of the context stack or
+     * {@link YamlToken#STREAM_START} if none.
      */
     public YamlToken context() {
         return contexts.isEmpty() ? YamlToken.STREAM_START : topContext().token;
     }
 
     /**
-     * Retrieves the top context from the context stack.
-     * This method provides the most recent tokenization context.
-     *
-     * @return The top YTContext object from the context stack.
+     * Most recent entry on the context stack.
      */
     public YTContext topContext() {
         return contexts.get(contextSize() - 1);
     }
 
     /**
-     * Retrieves the second to top context from the context stack.
-     * This method provides the tokenization context that's just below the topmost one.
-     *
-     * @return The second top YTContext object from the context stack.
+     * Context entry one below the top of the stack.
      */
     public YTContext secondTopContext() {
         return contexts.get(contextSize() - 2);
     }
 
     /**
-     * Gets the current token in the tokenization process.
-     * If the last token was the start of the stream, this method fetches the next token.
-     *
-     * @return The current YamlToken object representing the tokenization status.
+     * Returns the last token produced by {@link #next(int)}. If the parser
+     * is at the start of the stream, calling this method will parse and return
+     * the first real token.
      */
     public YamlToken current() {
         if (last == YamlToken.STREAM_START)
@@ -177,21 +206,19 @@ public class YamlTokeniser {
     }
 
     /**
-     * Fetches the next token based on the current context's indentation.
-     *
-     * @return The next YamlToken object in line based on the current indentation context.
+     * Convenience wrapper for {@link #next(int)} using the current context
+     * indentation.
      */
     public YamlToken next() {
         return next(contextIndent());
     }
 
     /**
-     * Retrieves the next YAML token considering the minimum indentation provided.
-     * This method drives the core tokenization process, fetching tokens based on
-     * the minimum indentation and updating the last token processed.
-     *
-     * @param minIndent The minimum indentation to consider while tokenizing.
-     * @return The next YamlToken object based on the specified indentation.
+     * Core tokenisation method. It first checks the {@link #pushed} stack and,
+     * if empty, parses the next token from the input stream via
+     * {@link #next0(int)}. The {@code minIndent} parameter is used to detect
+     * de-indentation and close block contexts. Updates {@link #last} with the
+     * produced token.
      */
     @NotNull
     public YamlToken next(int minIndent) {
@@ -204,13 +231,12 @@ public class YamlTokeniser {
     }
 
     /**
-     * Core method to tokenize the YAML content based on the given minimum indentation.
-     * The method processes the current position in the input stream and returns the
-     * next tokenized YAML construct. It utilizes the current context and the indentation
-     * level to identify and process different YAML constructs.
-     *
-     * @param minIndent The minimum indentation level to consider while tokenizing.
-     * @return The next {@link YamlToken} in the tokenization sequence.
+     * Internal tokenisation logic. Consumes leading whitespace and then
+     * examines the next character to determine the {@link YamlToken}. Handles
+     * comments, quoted strings, directives, tags, anchors, aliases, literal
+     * blocks, flow collections and plain scalars. The {@code minIndent}
+     * parameter controls when block contexts are closed due to
+     * de-indentation.
      */
     YamlToken next0(int minIndent) {
         // Consuming any whitespace present at the start of a line
@@ -404,11 +430,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Determine if the current context would change given the indentation levels.
-     *
-     * @param minIndent The minimum indentation to consider.
-     * @param indent The current indentation level.
-     * @return True if context would change, false otherwise.
+     * Checks whether parsing at the supplied {@code indent} would require the
+     * context stack to pop given the caller's {@code minIndent}.
      */
     private boolean wouldChangeContext(int minIndent, int indent) {
         if (isInFlow())
@@ -417,10 +440,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Helper method to handle scenarios where the character shouldn't be tokenized.
-     * This method ensures the last read character is reverted back and a NONE token is returned.
-     *
-     * @return The {@link YamlToken#NONE} token.
+     * Helper used when a peeked character should not be consumed.
+     * Unreads the character and returns {@link YamlToken#NONE}.
      */
     private YamlToken dontRead() {
         unreadLast();
@@ -449,11 +470,7 @@ public class YamlTokeniser {
     }
 
     /**
-     * Handles YAML flow constructs such as sequences and maps.
-     * This method manages the context and the stack of tokens accordingly.
-     *
-     * @param token The {@link YamlToken} to be processed.
-     * @return The next token in the sequence.
+     * Handles opening of flow collections and manages the context stack.
      */
     private YamlToken flow(YamlToken token) {
         pushed.add(token);
@@ -516,13 +533,11 @@ public class YamlTokeniser {
     }
 
     /**
-     * Reads and processes a literal scalar block from the YAML input.
-     * In YAML, literal scalars are indicated by the pipe character '|'.
-     * This method will capture content preserving formatting and any newlines
-     * present, depending on the withNewLines flag.
-     *
-     * @param withNewLines A flag indicating if newlines should be preserved (true)
-     * or converted to spaces (false) during the read process.
+     * Parses a YAML literal block scalar. When {@code withNewLines} is
+     * {@code true} (for the {@code |} style) newlines are kept; when
+     * {@code false} (for {@code >}) they are folded into spaces except for
+     * blank lines. Accumulates the content into {@link #temp} until a line with
+     * less indentation is encountered.
      */
     private void readLiteral(boolean withNewLines) {
         readNewline(); // read to the end of the line.
@@ -670,10 +685,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Handles the sequence logic within the YAML structure.
-     *
-     * @param token The current token being processed.
-     * @return A {@link YamlToken} after processing the sequence logic.
+     * Helper to manage {@link YamlToken#SEQUENCE_ENTRY} tokens inside flow
+     * sequences.
      */
     private YamlToken seq(YamlToken token) {
         // If a sequence entry has not been processed yet and the current context is a sequence start, and it's in flow
@@ -812,7 +825,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Removes the top context from the context stack, and frees up the context.
+     * Pops the top context and adds it to {@link #freeContexts}. Emits the
+     * context's end token if present.
      */
     private void contextPop() {
         YTContext context0 = contexts.remove(contextSize() - 1); // Remove the top context.
@@ -830,9 +844,7 @@ public class YamlTokeniser {
     }
 
     /**
-     * Reverts to a specified context level.
-     *
-     * @param contextSize The desired context level.
+     * Drops contexts until the stack reaches the supplied {@code contextSize}.
      */
     void revertToContext(int contextSize) {
         pushed.clear(); // Clear the pushed tokens.
@@ -846,10 +858,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Pushes a new context to the context stack.
-     *
-     * @param context The YAML token representing the context.
-     * @param indent  The indentation level for this context.
+     * Pushes a new parsing context. Inserts an implicit
+     * {@link YamlToken#DIRECTIVES_END} if starting from
+     * {@link YamlToken#STREAM_START}.
      */
     private void contextPush(YamlToken context, int indent) {
         // If we're at the start of a stream and the context isn't the end of directives,
@@ -864,8 +875,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Reads a value enclosed in double quotes from the input stream.
-     * Supports escape sequences.
+     * Parses text between double quotes. Sets {@link #blockStart},
+     * {@link #blockEnd} and {@link #blockQuote} but leaves unescaping to
+     * {@link #text()}.
      */
     private void readDoublyQuoted() {
         blockQuote = '"';
@@ -887,8 +899,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Reads a value enclosed in single quotes from the input stream.
-     * Supports consecutive single quotes as escape for a single quote.
+     * Parses text between single quotes. Consecutive quotes represent an
+     * escaped quote. Unescaping is performed in {@link #text()}.
      */
     private void readSinglyQuoted() {
         blockQuote = '\'';
@@ -914,9 +926,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Checks if the current position in the stream marks the end of a field (denoted by a colon).
-     *
-     * @return true if the current position is a field end, false otherwise.
+     * Tests whether the characters after the current plain scalar form a
+     * key-value separator ({@code :}).
      */
     private boolean isFieldEnd() {
         consumeSpaces(); // Consume any spaces or tabs.
@@ -1018,10 +1029,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Pushes a new context onto the stack, or reuses one from the freeContexts list.
-     *
-     * @param token  The YAML token for the context.
-     * @param indent The indentation level for the context.
+     * Obtains a context from {@link #freeContexts} or creates one and pushes it
+     * onto the stack.
      */
     private void pushContext0(YamlToken token, int indent) {
         YTContext context = freeContexts.isEmpty() ? new YTContext() : freeContexts.remove(freeContexts.size() - 1);
@@ -1048,9 +1057,11 @@ public class YamlTokeniser {
     }
 
     /**
-     * Used primarily for testing purposes to extract the current block's text.
-     *
-     * @return the text of the current block or an empty string if no text.
+     * Returns the textual content of the last scalar token. If the token came
+     * from a literal block the data is taken from {@link #temp}; otherwise the
+     * region within {@link #in} between {@link #blockStart} and
+     * {@link #blockEnd} is used. Unescaping based on {@link #blockQuote} is
+     * applied.
      */
     public String text() {
         try (ScopedResource<StringBuilder> sbTl = SBP.get()) {
@@ -1087,9 +1098,7 @@ public class YamlTokeniser {
     }
 
     /**
-     * Parses the current block's content as a double.
-     *
-     * @return the parsed double value.
+     * Parses the text of the last scalar token as a double.
      */
     public double parseDouble() {
         if (blockEnd < 0 && temp != null) {
@@ -1109,9 +1118,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Parses the current block's content as a long. Handles octal numbers as well.
-     *
-     * @return the parsed long value.
+     * Parses the text of the last scalar token as a long. YAML octal notation
+     * ({@code 0o...}) is supported.
      */
     public long parseLong() {
         if (blockEnd < 0 && temp != null) {
@@ -1190,8 +1198,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Inner static class that represents the context during YAML parsing.
-     * This can include the current token, the indent level, and associated keys.
+     * Represents a level in the parsing context stack, storing the structure
+     * type, its indentation and any skipped keys.
      */
     static class YTContext extends SelfDescribingMarshallable {
         YamlToken token;     // The current token in this context.

--- a/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
@@ -62,7 +62,7 @@ public class YamlTokeniser {
     /** The input source containing the raw YAML content. */
     private final BytesIn<?> in;
 
-    /** A pool of reusable context objects to manage YAML structures. */
+    /** Pool of reusable {@link YTContext} instances to reduce allocations. */
     private final List<YTContext> freeContexts = new ArrayList<>();
 
     /** List of tokens that have been identified but not yet processed. */
@@ -115,8 +115,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Resets the state of the tokenizer. This method prepares the tokenizer
-     * for processing a new input or to restart the tokenization of the current input.
+     * Resets the tokenizer to its initial state, clearing all contexts,
+     * buffers and flags. Prepares it to tokenize a new stream or restart
+     * from the beginning of the current input.
      */
     void reset() {
         contexts.clear();
@@ -145,20 +146,14 @@ public class YamlTokeniser {
     }
 
     /**
-     * Retrieves the top context from the context stack.
-     * This method provides the most recent tokenization context.
-     *
-     * @return The top YTContext object from the context stack.
+     * Most recent entry on the context stack.
      */
     public YTContext topContext() {
         return contexts.get(contextSize() - 1);
     }
 
     /**
-     * Retrieves the second to top context from the context stack.
-     * This method provides the tokenization context that's just below the topmost one.
-     *
-     * @return The second top YTContext object from the context stack.
+     * Context entry one below the top of the stack.
      */
     public YTContext secondTopContext() {
         return contexts.get(contextSize() - 2);
@@ -417,10 +412,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Helper method to handle scenarios where the character shouldn't be tokenized.
-     * This method ensures the last read character is reverted back and a NONE token is returned.
-     *
-     * @return The {@link YamlToken#NONE} token.
+     * Helper used when a peeked character should not be consumed.
+     * Unreads the character and returns {@link YamlToken#NONE}.
      */
     private YamlToken dontRead() {
         unreadLast();
@@ -612,13 +605,6 @@ public class YamlTokeniser {
      * @param nextTokenToParse The token type to be pushed to the stack.
      * @param currentIndentLevel The current indentation level.
      * @return The next token after processing the current input.
-     * Handles and determines the indentation level and relevant token type based on context.
-     *
-     * @param currentIndentedContextToken The token for the start of indentation context.
-     * @param keyDefinitionToken The key token type.
-     * @param nextTokenToParse The token type to be pushed to the stack.
-     * @param currentIndentLevel The current indentation level.
-     * @return The next token after processing the current input.
      */
     private YamlToken indent(
             YamlToken currentIndentedContextToken,
@@ -653,10 +639,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Reads plain scalar text from the YAML input, handling mappings and sequences.
-     *
-     * @param currentIndentLevel The current indentation level.
-     * @return The token after processing the text.
+     * Reads a plain scalar (unquoted text). Uses {@link #readWords()} to update
+     * {@link #blockStart} and {@link #blockEnd}. If the scalar is followed by a
+     * colon it is treated as a {@link YamlToken#MAPPING_KEY}.
      */
     private YamlToken readText(int currentIndentLevel) {
         long pos = in.readPosition(); // Store the current position of input.
@@ -677,10 +662,8 @@ public class YamlTokeniser {
     }
 
     /**
-     * Handles the sequence logic within the YAML structure.
-     *
-     * @param token The current token being processed.
-     * @return A {@link YamlToken} after processing the sequence logic.
+     * Helper to manage {@link YamlToken#SEQUENCE_ENTRY} tokens inside flow
+     * sequences.
      */
     private YamlToken seq(YamlToken token) {
         // If a sequence entry has not been processed yet and the current context is a sequence start, and it's in flow
@@ -838,9 +821,7 @@ public class YamlTokeniser {
     }
 
     /**
-     * Reverts to a specified context level.
-     *
-     * @param contextSize The desired context level.
+     * Drops contexts until the stack reaches the supplied {@code contextSize}.
      */
     void revertToContext(int contextSize) {
         pushed.clear(); // Clear the pushed tokens.
@@ -854,10 +835,9 @@ public class YamlTokeniser {
     }
 
     /**
-     * Pushes a new context to the context stack.
-     *
-     * @param context The YAML token representing the context.
-     * @param indent  The indentation level for this context.
+     * Pushes a new parsing context.
+     * Inserts an implicit {@link YamlToken#DIRECTIVES_END}
+     * if starting from{@link YamlToken#STREAM_START}.
      */
     private void contextPush(YamlToken context, int indent) {
         // If we're at the start of a stream and the context isn't the end of directives,

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -1,5 +1,7 @@
 /*
- * Copyright 2016-2025 chronicle.software
+ * Copyright 2016-2020 chronicle.software
+ *
+ *       https://chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -47,39 +47,43 @@ import java.util.function.*;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 /**
- * Represents a YAML-based wire format designed for efficient parsing and serialization of data.
- * The YamlWire class extends YamlWireOut and utilizes a custom tokenizer to convert YAML tokens into byte sequences.
- * It provides utility methods to read from and write to both byte buffers and files.
+ * Wire format implementation that follows YAML 1.2 more closely than
+ * {@link TextWire}.  It extends {@link YamlWireOut} and parses input via
+ * {@link YamlTokeniser}.  Use this when strict YAML features, such as anchors
+ * and aliases, are required.
  */
 @SuppressWarnings({"rawtypes", "unchecked", "this-escape"})
 public class YamlWire extends YamlWireOut<YamlWire> {
 
-    // YAML-specific tag constants for representing special constructs.
+    /** YAML tag for a sequence of maps. */
     static final String SEQ_MAP = "!seqmap";
+    /** YAML tag for Base64 encoded binary data. */
     static final String BINARY_TAG = "!binary";
+    /** YAML tag for encoded data blocks. */
     static final String DATA_TAG = "!data";
+    /** YAML tag denoting an explicit null. */
     static final String NULL_TAG = "!null";
 
     //for (char ch : "?%&*@`0123456789+- ',#:{}[]|>!\\".toCharArray())
-    // Internal helper for reading text-based values.
+    /** Primary {@link TextValueIn} instance used for deserialising values. */
     private final TextValueIn valueIn = createValueIn();
 
-    // Custom tokenizer for parsing YAML tokens.
+    /** Tokeniser that breaks the input YAML into tokens. */
     private final YamlTokeniser yt;
 
-    // Map to store reusable content anchors defined in the YAML.
+    /** Map of anchors ({@code &name}) to their deserialised values. */
     private final Map<String, Object> anchorValues = new HashMap<>();
 
-    // Provides default values for reading.
+    /** Provides default ValueIn when a field is missing. */
     private DefaultValueIn defaultValueIn;
 
-    // Context for writing out YAML documents.
+    /** Context for writing YAML documents. */
     private WriteDocumentContext writeContext;
 
-    // Context for reading in YAML documents.
+    /** Context for reading YAML documents. */
     private ReadDocumentContext readContext;
 
-    // Instance for re-reading or re-parsing scenarios.
+    /** Helper wire used when revisiting previously read fields. */
     private YamlWire rereadWire;
 
     /**
@@ -128,11 +132,11 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Converts the content of a given {@link Wire} object into its string representation.
+     * Convert any {@link Wire} into its canonical YAML representation.
      *
-     * @param wire The {@link Wire} object whose content needs to be converted to string.
-     * @return The string representation of the wire's content.
-     * @throws InvalidMarshallableException If the given wire's content cannot be marshalled.
+     * @param wire the wire to serialise
+     * @return YAML string of {@code wire}
+     * @throws InvalidMarshallableException if an object could not be marshalled
      */
     public static String asText(@NotNull Wire wire) throws InvalidMarshallableException {
         long pos = wire.bytes().readPosition();
@@ -143,9 +147,8 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Unescapes special characters in the provided Appendable based on the provided block quote character.
-     * This method adheres to the YAML 1.2 specification for escaped characters
-     * (see <a href="https://yaml.org/spec/1.2.2/#escaped-characters">YAML Spec 1.2.2</a>).
+     * Unescape YAML character sequences within {@code sb} in-place.
+     * Behaviour depends on the surrounding quote character.
      *
      * @param targetBuffer The appendable containing characters to be unescaped.
      * @param blockQuoteChar The block quote character that determines the escaping scheme (' or ").
@@ -259,9 +262,8 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Attempts to interpret the content of the given StringBuilder as a number (long, double) or
-     * as a date/time, based on the YAML specification. If none of these interpretations is successful,
-     * it returns the original string content.
+     * Parse {@code s} as a numeric or temporal value.
+     * Handles YAML features such as {@code 0o} octal notation and underscores.
      *
      * @param blockQuoteChar The block quote character (either ' or ") that initiated the string in YAML.
      * @param inputTextBuilder The StringBuilder containing the string to be interpreted.
@@ -523,6 +525,11 @@ public class YamlWire extends YamlWireOut<YamlWire> {
             return bytes.toString();
     }
 
+    /**
+     * Copy remaining content to {@code wire}.  Direct byte copying is used when
+     * the target is another text based wire; otherwise elements are tokenised
+     * and written individually.
+     */
     @Override
     public void copyTo(@NotNull WireOut wire) throws InvalidMarshallableException {
         if (wire.getClass() == TextWire.class || wire.getClass() == YamlWire.class) {
@@ -540,13 +547,12 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Copies a single element from the current YamlWire instance to the provided wire.
-     * This is a recursive method that handles different YAML elements like mappings,
-     * sequences, and primitive values based on the current token from the YamlTokeniser (yt).
+     * Copy one token (and any nested structure) to the target wire.
+     * Used by {@link #copyTo(WireOut)} when the destination is not a simple byte
+     * copy.
      *
-     * @param wire   The target wire to copy to.
-     * @param nested A flag indicating whether the current element is nested within another element.
-     * @throws InvalidMarshallableException If there's a problem during the marshalling process.
+     * @param wire   target wire
+     * @param nested {@code true} if inside a map or sequence
      */
     private void copyOne(WireOut wire, boolean nested) throws InvalidMarshallableException {
         ValueOut wireValueOut = wire.getValueOut();
@@ -634,10 +640,9 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Determines if the current YAML structure has reached the end of its document.
-     * It checks based on the current token from the YamlTokeniser.
+     * Check whether the tokeniser has reached the logical end of the document.
      *
-     * @return true if the current token represents the end of a document or the stream; false otherwise.
+     * @return {@code true} if no further data is present
      */
     private boolean endOfDocument() {
         // Check if there's nothing to read
@@ -655,13 +660,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Copies a mapping key from the current YamlWire instance to the provided wire.
-     * This method advances through the tokens to handle nested keys and ensures
-     * the key is correctly written to the target wire.
-     *
-     * @param wire   The target wire to copy to.
-     * @param nested A flag indicating whether the current element is nested within another element.
-     * @throws InvalidMarshallableException If there's a problem during the marshalling process.
+     * Helper for {@link #copyOne} to copy a mapping key and its value.
      */
     private void copyMappingKey(WireOut wire, boolean nested) throws InvalidMarshallableException {
         // Move to the next token to identify the key structure
@@ -745,6 +744,9 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         return targetBuffer;
     }
 
+    /**
+     * Read the next mapping key as an event name.
+     */
     @SuppressWarnings("fallthrough")
     @Nullable
     @Override
@@ -816,6 +818,9 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         return read(key.name().toString());
     }
 
+    /**
+     * Read the value for {@code keyName}, consulting previously skipped keys if necessary.
+     */
     @NotNull
     @Override
     public ValueIn read(String keyName) {
@@ -865,7 +870,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Initializes 'rereadWire', skipping any preliminary tokens to get to the main content.
+     * Lazily create {@link #rereadWire} for looking back at earlier keys.
      */
     private void initRereadWire() {
         rereadWire = new YamlWire(bytes.bytesStore().bytesForRead());
@@ -880,9 +885,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Produces a dump of the current parsing context. Useful for debugging.
-     *
-     * @return A string representation of the current parsing context.
+     * Dump the tokeniser context for debugging purposes.
      */
     public String dumpContext() {
         ValidatableUtil.startValidateDisabled();
@@ -896,10 +899,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Checks if the next token's text matches the given key name after handling any escape sequences.
-     *
-     * @param keyName The expected key name.
-     * @return true if the next token's text matches the given key name; false otherwise.
+     * Peek the next key and return {@code true} if it matches {@code keyName}.
      */
     private boolean checkForMatch(@NotNull String keyName) {
         YamlToken next = yt.next();
@@ -1156,7 +1156,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Implementation of the ValueIn interface for reading text-based values from YamlWire.
+     * {@link ValueIn} implementation handling YAML scalars, tags, anchors and aliases.
      */
     class TextValueIn implements ValueIn {
         @Override
@@ -1264,9 +1264,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         }
 
         /**
-         * Extracts the text from the current token and appends it to a StringBuilder.
-         * Handles various YAML tokens like TEXT, LITERAL, and TAG.
-         * @return StringBuilder containing the text.
+         * Extract the text for the current token.  Handles anchors, aliases and tags.
          */
         @Nullable
         StringBuilder textTo0(@NotNull StringBuilder destinationBuilder) {
@@ -2274,10 +2272,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
             return 0;
         }
 
-        /**
-         * Skips over a YAML type declaration in the current stream.
-         * If the current token indicates a YAML type (i.e., a TAG), the reading position is adjusted to skip over it.
-         */
+        /** Skip over a YAML tag if present. */
         void skipType() {
             consumePadding();
             if (yt.current() == YamlToken.TAG) {
@@ -2410,11 +2405,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         }
 
         /**
-         * Attempts to read either a number or a textual value from the YAML stream.
-         * If the current token is a LITERAL, a StringBuilder containing the text will be returned.
-         * Otherwise, the method tries to interpret the content as a number or textual data.
-         *
-         * @return An Object which might be a StringBuilder (for text) or a numeric representation.
+         * Read a scalar as a number, date/time or plain text.
          */
         @Nullable
         protected Object readNumberOrText() {
@@ -2481,14 +2472,8 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         }
 
         /**
-         * Decodes a Base64 encoded binary string from the YAML stream.
-         * This method first reads the object from the YAML as a String,
-         * then decodes the Base64 representation, and lastly tries to
-         * convert the decoded byte array into the desired type.
-         *
-         * @param type The expected type of the resulting object after decoding.
-         * @return The decoded object, potentially wrapped or converted according to the desired type.
-         * @throws InvalidMarshallableException If there's an error during the deserialization.
+         * Handle the {@code !!binary} tag by decoding the base64 data and
+         * converting to {@code type} where possible.
          */
         private Object decodeBinary(Class<?> type) throws InvalidMarshallableException {
             Object o = objectWithInferredType(null, SerializationStrategies.ANY_SCALAR, String.class);

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -2532,3 +2532,4 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         writeContext.rollbackIfNotComplete();
     }
 }
+

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -47,43 +47,39 @@ import java.util.function.*;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 /**
- * Wire format implementation that follows YAML 1.2 more closely than
- * {@link TextWire}.  It extends {@link YamlWireOut} and parses input via
- * {@link YamlTokeniser}.  Use this when strict YAML features, such as anchors
- * and aliases, are required.
+ * Represents a YAML-based wire format designed for efficient parsing and serialization of data.
+ * The YamlWire class extends YamlWireOut and utilizes a custom tokenizer to convert YAML tokens into byte sequences.
+ * It provides utility methods to read from and write to both byte buffers and files.
  */
 @SuppressWarnings({"rawtypes", "unchecked", "this-escape"})
 public class YamlWire extends YamlWireOut<YamlWire> {
 
-    /** YAML tag for a sequence of maps. */
+    // YAML-specific tag constants for representing special constructs.
     static final String SEQ_MAP = "!seqmap";
-    /** YAML tag for Base64 encoded binary data. */
     static final String BINARY_TAG = "!binary";
-    /** YAML tag for encoded data blocks. */
     static final String DATA_TAG = "!data";
-    /** YAML tag denoting an explicit null. */
     static final String NULL_TAG = "!null";
 
     //for (char ch : "?%&*@`0123456789+- ',#:{}[]|>!\\".toCharArray())
-    /** Primary {@link TextValueIn} instance used for deserialising values. */
+    // Internal helper for reading text-based values.
     private final TextValueIn valueIn = createValueIn();
 
-    /** Tokeniser that breaks the input YAML into tokens. */
+    // Custom tokenizer for parsing YAML tokens.
     private final YamlTokeniser yt;
 
-    /** Map of anchors ({@code &name}) to their deserialised values. */
+    // Map to store reusable content anchors defined in the YAML.
     private final Map<String, Object> anchorValues = new HashMap<>();
 
-    /** Provides default ValueIn when a field is missing. */
+    // Provides default values for reading.
     private DefaultValueIn defaultValueIn;
 
-    /** Context for writing YAML documents. */
+    // Context for writing out YAML documents.
     private WriteDocumentContext writeContext;
 
-    /** Context for reading YAML documents. */
+    // Context for reading in YAML documents.
     private ReadDocumentContext readContext;
 
-    /** Helper wire used when revisiting previously read fields. */
+    // Instance for re-reading or re-parsing scenarios.
     private YamlWire rereadWire;
 
     /**
@@ -132,11 +128,11 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Convert any {@link Wire} into its canonical YAML representation.
+     * Converts the content of a given {@link Wire} object into its string representation.
      *
-     * @param wire the wire to serialise
-     * @return YAML string of {@code wire}
-     * @throws InvalidMarshallableException if an object could not be marshalled
+     * @param wire The {@link Wire} object whose content needs to be converted to string.
+     * @return The string representation of the wire's content.
+     * @throws InvalidMarshallableException If the given wire's content cannot be marshalled.
      */
     public static String asText(@NotNull Wire wire) throws InvalidMarshallableException {
         long pos = wire.bytes().readPosition();
@@ -147,8 +143,9 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Unescape YAML character sequences within {@code sb} in-place.
-     * Behaviour depends on the surrounding quote character.
+     * Unescapes special characters in the provided Appendable based on the provided block quote character.
+     * This method adheres to the YAML 1.2 specification for escaped characters
+     * (see <a href="https://yaml.org/spec/1.2.2/#escaped-characters">YAML Spec 1.2.2</a>).
      *
      * @param targetBuffer The appendable containing characters to be unescaped.
      * @param blockQuoteChar The block quote character that determines the escaping scheme (' or ").
@@ -262,8 +259,9 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Parse {@code s} as a numeric or temporal value.
-     * Handles YAML features such as {@code 0o} octal notation and underscores.
+     * Attempts to interpret the content of the given StringBuilder as a number (long, double) or
+     * as a date/time, based on the YAML specification. If none of these interpretations is successful,
+     * it returns the original string content.
      *
      * @param blockQuoteChar The block quote character (either ' or ") that initiated the string in YAML.
      * @param inputTextBuilder The StringBuilder containing the string to be interpreted.
@@ -525,11 +523,6 @@ public class YamlWire extends YamlWireOut<YamlWire> {
             return bytes.toString();
     }
 
-    /**
-     * Copy remaining content to {@code wire}.  Direct byte copying is used when
-     * the target is another text based wire; otherwise elements are tokenised
-     * and written individually.
-     */
     @Override
     public void copyTo(@NotNull WireOut wire) throws InvalidMarshallableException {
         if (wire.getClass() == TextWire.class || wire.getClass() == YamlWire.class) {
@@ -547,12 +540,13 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Copy one token (and any nested structure) to the target wire.
-     * Used by {@link #copyTo(WireOut)} when the destination is not a simple byte
-     * copy.
+     * Copies a single element from the current YamlWire instance to the provided wire.
+     * This is a recursive method that handles different YAML elements like mappings,
+     * sequences, and primitive values based on the current token from the YamlTokeniser (yt).
      *
-     * @param wire   target wire
-     * @param nested {@code true} if inside a map or sequence
+     * @param wire   The target wire to copy to.
+     * @param nested A flag indicating whether the current element is nested within another element.
+     * @throws InvalidMarshallableException If there's a problem during the marshalling process.
      */
     private void copyOne(WireOut wire, boolean nested) throws InvalidMarshallableException {
         ValueOut wireValueOut = wire.getValueOut();
@@ -640,9 +634,10 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Check whether the tokeniser has reached the logical end of the document.
+     * Determines if the current YAML structure has reached the end of its document.
+     * It checks based on the current token from the YamlTokeniser.
      *
-     * @return {@code true} if no further data is present
+     * @return true if the current token represents the end of a document or the stream; false otherwise.
      */
     private boolean endOfDocument() {
         // Check if there's nothing to read
@@ -660,7 +655,13 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Helper for {@link #copyOne} to copy a mapping key and its value.
+     * Copies a mapping key from the current YamlWire instance to the provided wire.
+     * This method advances through the tokens to handle nested keys and ensures
+     * the key is correctly written to the target wire.
+     *
+     * @param wire   The target wire to copy to.
+     * @param nested A flag indicating whether the current element is nested within another element.
+     * @throws InvalidMarshallableException If there's a problem during the marshalling process.
      */
     private void copyMappingKey(WireOut wire, boolean nested) throws InvalidMarshallableException {
         // Move to the next token to identify the key structure
@@ -744,9 +745,6 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         return targetBuffer;
     }
 
-    /**
-     * Read the next mapping key as an event name.
-     */
     @SuppressWarnings("fallthrough")
     @Nullable
     @Override
@@ -818,9 +816,6 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         return read(key.name().toString());
     }
 
-    /**
-     * Read the value for {@code keyName}, consulting previously skipped keys if necessary.
-     */
     @NotNull
     @Override
     public ValueIn read(String keyName) {
@@ -870,7 +865,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Lazily create {@link #rereadWire} for looking back at earlier keys.
+     * Initializes 'rereadWire', skipping any preliminary tokens to get to the main content.
      */
     private void initRereadWire() {
         rereadWire = new YamlWire(bytes.bytesStore().bytesForRead());
@@ -885,7 +880,9 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Dump the tokeniser context for debugging purposes.
+     * Produces a dump of the current parsing context. Useful for debugging.
+     *
+     * @return A string representation of the current parsing context.
      */
     public String dumpContext() {
         ValidatableUtil.startValidateDisabled();
@@ -899,7 +896,10 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Peek the next key and return {@code true} if it matches {@code keyName}.
+     * Checks if the next token's text matches the given key name after handling any escape sequences.
+     *
+     * @param keyName The expected key name.
+     * @return true if the next token's text matches the given key name; false otherwise.
      */
     private boolean checkForMatch(@NotNull String keyName) {
         YamlToken next = yt.next();
@@ -1156,7 +1156,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * {@link ValueIn} implementation handling YAML scalars, tags, anchors and aliases.
+     * Implementation of the ValueIn interface for reading text-based values from YamlWire.
      */
     class TextValueIn implements ValueIn {
         @Override
@@ -1264,7 +1264,9 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         }
 
         /**
-         * Extract the text for the current token.  Handles anchors, aliases and tags.
+         * Extracts the text from the current token and appends it to a StringBuilder.
+         * Handles various YAML tokens like TEXT, LITERAL, and TAG.
+         * @return StringBuilder containing the text.
          */
         @Nullable
         StringBuilder textTo0(@NotNull StringBuilder destinationBuilder) {
@@ -2272,7 +2274,10 @@ public class YamlWire extends YamlWireOut<YamlWire> {
             return 0;
         }
 
-        /** Skip over a YAML tag if present. */
+        /**
+         * Skips over a YAML type declaration in the current stream.
+         * If the current token indicates a YAML type (i.e., a TAG), the reading position is adjusted to skip over it.
+         */
         void skipType() {
             consumePadding();
             if (yt.current() == YamlToken.TAG) {
@@ -2405,7 +2410,11 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         }
 
         /**
-         * Read a scalar as a number, date/time or plain text.
+         * Attempts to read either a number or a textual value from the YAML stream.
+         * If the current token is a LITERAL, a StringBuilder containing the text will be returned.
+         * Otherwise, the method tries to interpret the content as a number or textual data.
+         *
+         * @return An Object which might be a StringBuilder (for text) or a numeric representation.
          */
         @Nullable
         protected Object readNumberOrText() {
@@ -2472,8 +2481,14 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         }
 
         /**
-         * Handle the {@code !!binary} tag by decoding the base64 data and
-         * converting to {@code type} where possible.
+         * Decodes a Base64 encoded binary string from the YAML stream.
+         * This method first reads the object from the YAML as a String,
+         * then decodes the Base64 representation, and lastly tries to
+         * convert the decoded byte array into the desired type.
+         *
+         * @param type The expected type of the resulting object after decoding.
+         * @return The decoded object, potentially wrapped or converted according to the desired type.
+         * @throws InvalidMarshallableException If there's an error during the deserialization.
          */
         private Object decodeBinary(Class<?> type) throws InvalidMarshallableException {
             Object o = objectWithInferredType(null, SerializationStrategies.ANY_SCALAR, String.class);
@@ -2518,4 +2533,3 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         writeContext.rollbackIfNotComplete();
     }
 }
-

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -2533,3 +2533,4 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         writeContext.rollbackIfNotComplete();
     }
 }
+

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,13 +109,13 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     /**
      * Utility method to create a new YamlWire instance by reading bytes from a specified file.
      *
-     * @param name Name of the file from which bytes are read
+     * @param filePath Name of the file from which bytes are read
      * @return A new YamlWire instance initialized with bytes from the specified file
      * @throws IOException If there's an error in reading the file
      */
     @NotNull
-    public static YamlWire fromFile(String name) throws IOException {
-        return new YamlWire(BytesUtil.readFile(name), true);
+    public static YamlWire fromFile(String filePath) throws IOException {
+        return new YamlWire(BytesUtil.readFile(filePath), true);
     }
 
     /**
@@ -150,13 +148,13 @@ public class YamlWire extends YamlWireOut<YamlWire> {
      * Unescape YAML character sequences within {@code sb} in-place.
      * Behaviour depends on the surrounding quote character.
      *
-     * @param sb        appendable to modify
-     * @param blockQuote either {@code '} or {@code "}
-     * @param <ACS>     appendable that is also a {@link CharSequence}
+     * @param targetBuffer The appendable containing characters to be unescaped.
+     * @param blockQuoteChar The block quote character that determines the escaping scheme (' or ").
+     * @param <ACS> An appendable that also implements CharSequence interface.
      */
-    private static <ACS extends Appendable & CharSequence> void unescape(@NotNull ACS sb, char blockQuote) {
+    private static <ACS extends Appendable & CharSequence> void unescape(@NotNull ACS targetBuffer, char blockQuoteChar) {
         int end = 0;
-        int length = sb.length();
+        int length = targetBuffer.length();
         boolean skip = false;
         for (int i = 0; i < length; i++) {
             if (skip) {
@@ -164,11 +162,11 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                 continue;
             }
 
-            char ch = sb.charAt(i);
+            char ch = targetBuffer.charAt(i);
 
             // Processing escaped characters for double quotes
-            if (blockQuote == '\"' && ch == '\\' && i < length - 1) {
-                char ch3 = sb.charAt(++i);
+            if (blockQuoteChar == '\"' && ch == '\\' && i < length - 1) {
+                char ch3 = targetBuffer.charAt(++i);
                 switch (ch3) {
                     // Various cases for character unescaping based on YAML specification
                     case '0':
@@ -212,17 +210,17 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                         break;
                     case 'x':
                         ch = (char)
-                                (Character.getNumericValue(sb.charAt(++i)) * 16 +
-                                        Character.getNumericValue(sb.charAt(++i)));
+                                (Character.getNumericValue(targetBuffer.charAt(++i)) * 16 +
+                                        Character.getNumericValue(targetBuffer.charAt(++i)));
                         break;
 
                     // For Unicode escapes
                     case 'u':
                         ch = (char)
-                                (Character.getNumericValue(sb.charAt(++i)) * 4096 +
-                                        Character.getNumericValue(sb.charAt(++i)) * 256 +
-                                        Character.getNumericValue(sb.charAt(++i)) * 16 +
-                                        Character.getNumericValue(sb.charAt(++i)));
+                                (Character.getNumericValue(targetBuffer.charAt(++i)) * 4096 +
+                                        Character.getNumericValue(targetBuffer.charAt(++i)) * 256 +
+                                        Character.getNumericValue(targetBuffer.charAt(++i)) * 16 +
+                                        Character.getNumericValue(targetBuffer.charAt(++i)));
                         break;
                     default:
                         ch = ch3;
@@ -230,18 +228,18 @@ public class YamlWire extends YamlWireOut<YamlWire> {
             }
 
             // Processing escaped characters for single quotes
-            if (blockQuote == '\'' && ch == '\'' && i < length - 1) {
-                char ch2 = sb.charAt(i + 1);
+            if (blockQuoteChar == '\'' && ch == '\'' && i < length - 1) {
+                char ch2 = targetBuffer.charAt(i + 1);
                 if (ch2 == ch) {
                     skip = true;
                 }
             }
 
-            AppendableUtil.setCharAt(sb, end++, ch);
+            AppendableUtil.setCharAt(targetBuffer, end++, ch);
         }
-        if (length != sb.length())
-            throw new IllegalStateException("Length changed from " + length + " to " + sb.length() + " for " + sb);
-        AppendableUtil.setLength(sb, end);
+        if (length != targetBuffer.length())
+            throw new IllegalStateException("Length changed from " + length + " to " + targetBuffer.length() + " for " + targetBuffer);
+        AppendableUtil.setLength(targetBuffer, end);
     }
 
     /**
@@ -265,29 +263,30 @@ public class YamlWire extends YamlWireOut<YamlWire> {
      * Parse {@code s} as a numeric or temporal value.
      * Handles YAML features such as {@code 0o} octal notation and underscores.
      *
-     * @param bq quote that opened the block
-     * @param s  builder containing the text
-     * @return number, date/time or the original text
+     * @param blockQuoteChar The block quote character (either ' or ") that initiated the string in YAML.
+     * @param inputTextBuilder The StringBuilder containing the string to be interpreted.
+     * @return An Object which might be a Long, Double, Date, Time or the original String itself
+     *         depending on successful interpretation.
      */
     @Nullable
-    static Object readNumberOrTextFrom(char bq, final @Nullable StringBuilder s) {
-        if (leaveUnparsed(bq, s))
-            return s;
+    static Object readNumberOrTextFrom(char blockQuoteChar, final @Nullable StringBuilder inputTextBuilder) {
+        if (leaveUnparsed(blockQuoteChar, inputTextBuilder))
+            return inputTextBuilder;
 
-        StringBuilder sb = s;
+        StringBuilder targetBuffer = inputTextBuilder;
         // YAML octal notation
-        if (StringUtils.startsWith(s, "0o")) {
-            sb = new StringBuilder(s);
-            sb.deleteCharAt(1);
+        if (StringUtils.startsWith(inputTextBuilder, "0o")) {
+            targetBuffer = new StringBuilder(inputTextBuilder);
+            targetBuffer.deleteCharAt(1);
         }
 
         // Remove underscores if present, as they can be used in YAML as visual separators in numbers.
         if (s.indexOf("_") >= 0) {
-            sb = new StringBuilder(s);
-            removeUnderscore(sb);
+            targetBuffer = new StringBuilder(inputTextBuilder);
+            removeUnderscore(targetBuffer);
         }
 
-        String ss = sb.toString();
+        String ss = targetBuffer.toString();
 
         // Attempt to parse as a long
         try {
@@ -305,13 +304,13 @@ public class YamlWire extends YamlWireOut<YamlWire> {
 
         // Attempt to parse as a date or time
         try {
-            return parseDateOrTime(s, ss);
+            return parseDateOrTime(inputTextBuilder, ss);
         } catch (DateTimeParseException fallback) {
             // Intentionally left blank to handle fallback
         }
 
         // If none of the interpretations was successful, return the original string content
-        return s;
+        return inputTextBuilder;
     }
 
     /**
@@ -325,16 +324,16 @@ public class YamlWire extends YamlWireOut<YamlWire> {
      *     <li>If the first character of the string is not a number, decimal point, or a sign.</li>
      * </ul>
      *
-     * @param bq The block quote character (either ' or ") that initiated the string in YAML.
-     * @param s The StringBuilder containing the string to check.
+     * @param blockQuoteChar The block quote character (either ' or ") that initiated the string in YAML.
+     * @param inputTextBuilder The StringBuilder containing the string to check.
      * @return True if the string should be left unparsed, otherwise false.
      */
-    private static boolean leaveUnparsed(char bq, @Nullable StringBuilder s) {
-        return s == null
-                || bq != 0
-                || s.length() < 1
-                || s.length() > 40
-                || "0123456789.+-".indexOf(s.charAt(0)) < 0;
+    private static boolean leaveUnparsed(char blockQuoteChar, @Nullable StringBuilder inputTextBuilder) {
+        return inputTextBuilder == null
+                || blockQuoteChar != 0
+                || inputTextBuilder.length() < 1
+                || inputTextBuilder.length() > 40
+                || "0123456789.+-".indexOf(inputTextBuilder.charAt(0)) < 0;
     }
 
     /**
@@ -714,10 +713,13 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Read the next mapping key into {@code sb}.
+     * Reads a field from the current YamlToken and appends its content to the provided StringBuilder.
+     *
+     * @param targetBuffer StringBuilder instance to which the field content will be appended.
+     * @return The same StringBuilder instance with the appended content.
      */
     @NotNull
-    protected StringBuilder readField(@NotNull StringBuilder sb) {
+    protected StringBuilder readField(@NotNull StringBuilder targetBuffer) {
         startEventIfTop();
 
         // If the current token indicates a key in a map
@@ -726,18 +728,18 @@ public class YamlWire extends YamlWireOut<YamlWire> {
 
             // Ensure the key is textual
             if (yt.current() == YamlToken.TEXT) {
-                String text = yt.text(); // Captures the key's text. Note: using sb here may modify its contents
-                sb.setLength(0);         // Reset the StringBuilder
-                sb.append(text);         // Append the key's text to the StringBuilder
-                unescape(sb, yt.blockQuote()); // Handle any escape sequences within the key
+                String text = yt.text(); // Captures the key's text. Note: using targetBuffer here may modify its contents
+                targetBuffer.setLength(0);         // Reset the StringBuilder
+                targetBuffer.append(text);         // Append the key's text to the StringBuilder
+                unescape(targetBuffer, yt.blockQuote()); // Handle any escape sequences within the key
                 yt.next();
             } else {
                 throw new IllegalStateException(yt.toString());
             }
         } else {
-            sb.setLength(0); // Clear the StringBuilder if the current token isn't a MAPPING_KEY
+            targetBuffer.setLength(0); // Clear the StringBuilder if the current token isn't a MAPPING_KEY
         }
-        return sb;
+        return targetBuffer;
     }
 
     /**
@@ -1118,7 +1120,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
 
         // Clear the bytes buffer and internal StringBuilder
         bytes.clear();
-        sb.setLength(0);
+        targetBuffer.setLength(0);
 
         // Reset the YAML tokenizer and value states
         yt.reset();
@@ -1176,17 +1178,17 @@ public class YamlWire extends YamlWireOut<YamlWire> {
 
         @Nullable
         @Override
-        public StringBuilder textTo(@NotNull StringBuilder sb) {
-            sb.setLength(0);
-            @Nullable CharSequence cs = textTo0(sb);
+        public StringBuilder textTo(@NotNull StringBuilder targetBuffer) {
+            targetBuffer.setLength(0);
+            @Nullable CharSequence cs = textTo0(targetBuffer);
             yt.next();
             if (cs == null)
                 return null;
-            if (cs != sb) {
-                sb.setLength(0);
-                sb.append(cs);
+            if (cs != targetBuffer) {
+                targetBuffer.setLength(0);
+                targetBuffer.append(cs);
             }
-            return sb;
+            return targetBuffer;
         }
 
         @Nullable
@@ -1263,7 +1265,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
          * Extract the text for the current token.  Handles anchors, aliases and tags.
          */
         @Nullable
-        StringBuilder textTo0(@NotNull StringBuilder a) {
+        StringBuilder textTo0(@NotNull StringBuilder destinationBuilder) {
             consumePadding(); // consume any padding
 
             // if the current token is a sequence entry, move to the next token
@@ -1274,11 +1276,11 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                 // handle text or literal tokens
                 case TEXT:
                 case LITERAL:
-                    a.append(yt.text()); // append the text value
+                    destinationBuilder.append(yt.text()); // append the text value
 
                     // unescape the text value if needed
                     if (yt.current() == YamlToken.TEXT)
-                        unescape(a, yt.blockQuote());
+                        unescape(destinationBuilder, yt.blockQuote());
 
                     break;
 
@@ -1298,6 +1300,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                     if (o == null)
                         throw new IllegalStateException("Unknown alias " + alias + " with no corresponding anchor");
 
+                    // yt.next(); ??
                     sb.append(o);
                     break;
 
@@ -1315,14 +1318,14 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                         yt.next();
                         final byte[] arr = (byte[]) decodeBinary(byte[].class);
                         for (byte b : arr) {
-                            a.append((char) b);
+                            destinationBuilder.append((char) b);
                         }
-                        return a;
+                        return destinationBuilder;
                     }
 
                     throw new UnsupportedOperationException(yt.toString());
             }
-            return a;
+            return destinationBuilder;
         }
 
         @NotNull
@@ -1354,14 +1357,14 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         public WireIn bytes(@NotNull ReadBytesMarshallable bytesConsumer) {
             consumePadding();
             // TODO needs to be made much more efficient.
-            @NotNull StringBuilder sb = acquireStringBuilder();
+            @NotNull StringBuilder targetBuffer = acquireStringBuilder();
             if (yt.current() == YamlToken.TAG) {
                 bytes.readSkip(1);
-                yt.text(sb);
+                yt.text(targetBuffer);
                 yt.next();
                 if (yt.current() != YamlToken.TEXT)
                     throw new UnsupportedOperationException(yt.toString());
-                @Nullable byte[] uncompressed = Compression.uncompress(sb, yt, t -> {
+                @Nullable byte[] uncompressed = Compression.uncompress(targetBuffer, yt, t -> {
                     @NotNull StringBuilder sb2 = acquireStringBuilder();
                     t.text(sb2);
                     return Base64.getDecoder().decode(sb2.toString());
@@ -1374,16 +1377,16 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                         bytes.releaseLast();
                     }
 
-                } else if (StringUtils.isEqual(sb, NULL_TAG)) {
+                } else if (StringUtils.isEqual(targetBuffer, NULL_TAG)) {
                     bytesConsumer.readMarshallable(null);
                     yt.next();
 
                 } else {
-                    throw new IORuntimeException("Unsupported type=" + sb);
+                    throw new IORuntimeException("Unsupported type=" + targetBuffer);
                 }
             } else {
-                textTo(sb);
-                Bytes<byte[]> bytes = Bytes.wrapForRead(sb.toString().getBytes(ISO_8859_1));
+                textTo(targetBuffer);
+                Bytes<byte[]> bytes = Bytes.wrapForRead(targetBuffer.toString().getBytes(ISO_8859_1));
                 try {
                     bytesConsumer.readMarshallable(bytes);
                 } finally {
@@ -2086,10 +2089,10 @@ public class YamlWire extends YamlWireOut<YamlWire> {
             else
                 usingMap.clear();
 
-            @NotNull StringBuilder sb = acquireStringBuilder();
+            @NotNull StringBuilder targetBuffer = acquireStringBuilder();
             switch (yt.current()) {
                 case TAG:
-                    return typedMap(kClass, vClass, usingMap, sb);
+                    return typedMap(kClass, vClass, usingMap, targetBuffer);
                 case MAPPING_START:
                     return marshallableAsMap(kClass, vClass, usingMap);
                 case SEQUENCE_START:
@@ -2105,22 +2108,22 @@ public class YamlWire extends YamlWireOut<YamlWire> {
          * @param kClazz The class type for map keys.
          * @param vClass The class type for map values.
          * @param usingMap The map to populate based on the YAML data.
-         * @param sb A StringBuilder instance used for temporary string operations.
+         * @param targetBuffer A StringBuilder instance used for temporary string operations.
          * @return Populated map from the YAML data or null.
          * @throws InvalidMarshallableException If there's a problem with marshalling.
          * @throws IORuntimeException If an unexpected YAML structure or tag is encountered.
          */
         @Nullable
-        private <K, V> Map<K, V> typedMap(@NotNull Class<K> kClazz, @NotNull Class<V> vClass, @NotNull Map<K, V> usingMap, @NotNull StringBuilder sb) throws InvalidMarshallableException {
+        private <K, V> Map<K, V> typedMap(@NotNull Class<K> kClazz, @NotNull Class<V> vClass, @NotNull Map<K, V> usingMap, @NotNull StringBuilder targetBuffer) throws InvalidMarshallableException {
             // Read the next YAML token into the provided StringBuilder.
-            yt.text(sb);
+            yt.text(targetBuffer);
             yt.next();
-            if (NULL_TAG.contentEquals(sb)) {
+            if (NULL_TAG.contentEquals(targetBuffer)) {
                 text();
                 return null; // Return null to indicate absence of a value.
 
             // If the current token indicates a sequence map...
-            } else if (SEQ_MAP.contentEquals(sb)) {
+            } else if (SEQ_MAP.contentEquals(targetBuffer)) {
                 consumePadding();
 
                 // Verify that the next token is the start of a sequence.
@@ -2141,7 +2144,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
 
             } else {
                 // If the token isn't recognized, throw an exception.
-                throw new IORuntimeException("Unsupported type :" + sb);
+                throw new IORuntimeException("Unsupported type :" + targetBuffer);
             }
         }
 
@@ -2309,33 +2312,40 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         }
 
         /**
-         * Core logic for deserialising a YAML value.  Handles maps, sequences,
-         * scalars, anchors and aliases.
+         * Reads an object from the YAML stream, inferring its type based on provided context and current token.
+         * Depending on the encountered token, various internal methods are invoked to parse the object correctly.
+         * If a YAML ANCHOR is encountered, it's mapped to the parsed object for potential future ALIAS references.
+         *
+         * @param reusableInstance The object to potentially reuse when reading. Might be null.
+         * @param strategy The serialization strategy to employ while reading the object.
+         * @param defaultType Expected type of the object to be read. If null, the method will attempt to infer the type.
+         * @return The read object, possibly of the expected type. Might be null if the YAML token is NONE.
+         * @throws InvalidMarshallableException if any error occurs while parsing or constructing the object.
          */
         @SuppressWarnings("fallthrough")
         @Nullable
-        Object objectWithInferredType0(Object using, @NotNull SerializationStrategy strategy, Class<?> type) throws InvalidMarshallableException {
-            boolean bestEffort = type != null;
+        Object objectWithInferredType0(Object reusableInstance, @NotNull SerializationStrategy strategy, Class<?> defaultType) throws InvalidMarshallableException {
+            boolean bestEffort = defaultType != null;
 
             // Handle type declaration, if present
             if (yt.current() == YamlToken.TAG) {
                 Class<?> aClass = typePrefix();
-                if (type == null || type == Object.class || type.isInterface())
-                    type = aClass;
+                if (defaultType == null || defaultType == Object.class || defaultType.isInterface())
+                    defaultType = aClass;
             }
 
             switch (yt.current()) {
                 case MAPPING_START:
                     // Parse YAML mapping, considering the expected type
-                    if (type != null) {
+                    if (defaultType != null) {
                         // Create new TreeMap if a sorted map is expected
-                        if (type == SortedMap.class && !(using instanceof SortedMap))
-                            using = new TreeMap();
+                        if (defaultType == SortedMap.class && !(reusableInstance instanceof SortedMap))
+                            reusableInstance = new TreeMap();
                         // Handle map-specific types
-                        if (type == Object.class || Map.class.isAssignableFrom(type) || using instanceof Map)
-                            return map(Object.class, Object.class, (Map) using);
+                        if (defaultType == Object.class || Map.class.isAssignableFrom(defaultType) || reusableInstance instanceof Map)
+                            return map(Object.class, Object.class, (Map) reusableInstance);
                     }
-                    return valueIn.object(using, type, bestEffort);
+                    return valueIn.object(reusableInstance, defaultType, bestEffort);
 
                 case SEQUENCE_START:
                     // Read a YAML sequence
@@ -2356,7 +2366,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                     // Handle YAML anchors, which can be referred to later as aliases
                     String alias = yt.text();
                     yt.next();
-                    o = valueIn.object(using, type);
+                    o = valueIn.object(reusableInstance, defaultType);
                     // Store the anchor for later reference
                     anchorValues.put(alias, o);
                     return o;
@@ -2398,7 +2408,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         @Nullable
         protected Object readNumberOrText() {
             // Determine the kind of quote used for the YAML block
-            char bq = yt.blockQuote();
+            char blockQuoteChar = yt.blockQuote();
             // Extract the text content into a StringBuilder
             @Nullable StringBuilder s = textTo0(acquireStringBuilder());
             if (yt.current() == YamlToken.LITERAL)
@@ -2407,7 +2417,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                 return true;
             if (StringUtils.isEqual(s, "false"))
                 return false;
-            return readNumberOrTextFrom(bq, s);
+            return readNumberOrTextFrom(blockQuoteChar, s);
         }
 
         /**

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -281,7 +281,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         }
 
         // Remove underscores if present, as they can be used in YAML as visual separators in numbers.
-        if (s.indexOf("_") >= 0) {
+        if (inputTextBuilder.indexOf("_") >= 0) {
             targetBuffer = new StringBuilder(inputTextBuilder);
             removeUnderscore(targetBuffer);
         }
@@ -1120,7 +1120,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
 
         // Clear the bytes buffer and internal StringBuilder
         bytes.clear();
-        targetBuffer.setLength(0);
+        sb.setLength(0);
 
         // Reset the YAML tokenizer and value states
         yt.reset();
@@ -2349,7 +2349,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
 
                 case SEQUENCE_START:
                     // Read a YAML sequence
-                    return readSequence(type);
+                    return readSequence(defaultType);
 
                 case TEXT:
                 case LITERAL:
@@ -2358,9 +2358,9 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                     yt.next();
                     if (o instanceof StringBuilder)
                         o = o.toString();
-                    if (type == Class.class)
+                    if (defaultType == Class.class)
                         return classLookup.forName(o.toString());
-                    return ObjectUtils.convertTo(type, o);
+                    return ObjectUtils.convertTo(defaultType, o);
 
                 case ANCHOR:
                     // Handle YAML anchors, which can be referred to later as aliases
@@ -2393,7 +2393,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                     // Specific handling for binary data
                     if (BINARY_TAG.contentEquals(stringBuilder)) {
                         yt.next();
-                        return decodeBinary(type);
+                        return decodeBinary(defaultType);
                     }
                     // Intentional fall-through for other tags
 

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -47,39 +47,43 @@ import java.util.function.*;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 /**
- * Represents a YAML-based wire format designed for efficient parsing and serialization of data.
- * The YamlWire class extends YamlWireOut and utilizes a custom tokenizer to convert YAML tokens into byte sequences.
- * It provides utility methods to read from and write to both byte buffers and files.
+ * Wire format implementation that follows YAML 1.2 more closely than
+ * {@link TextWire}.  It extends {@link YamlWireOut} and parses input via
+ * {@link YamlTokeniser}.  Use this when strict YAML features, such as anchors
+ * and aliases, are required.
  */
 @SuppressWarnings({"rawtypes", "unchecked", "this-escape"})
 public class YamlWire extends YamlWireOut<YamlWire> {
 
-    // YAML-specific tag constants for representing special constructs.
+    /** YAML tag for a sequence of maps. */
     static final String SEQ_MAP = "!seqmap";
+    /** YAML tag for Base64 encoded binary data. */
     static final String BINARY_TAG = "!binary";
+    /** YAML tag for encoded data blocks. */
     static final String DATA_TAG = "!data";
+    /** YAML tag denoting an explicit null. */
     static final String NULL_TAG = "!null";
 
     //for (char ch : "?%&*@`0123456789+- ',#:{}[]|>!\\".toCharArray())
-    // Internal helper for reading text-based values.
+    /** Primary {@link TextValueIn} instance used for deserialising values. */
     private final TextValueIn valueIn = createValueIn();
 
-    // Custom tokenizer for parsing YAML tokens.
+    /** Tokeniser that breaks the input YAML into tokens. */
     private final YamlTokeniser yt;
 
-    // Map to store reusable content anchors defined in the YAML.
+    /** Map of anchors ({@code &name}) to their deserialised values. */
     private final Map<String, Object> anchorValues = new HashMap<>();
 
-    // Provides default values for reading.
+    /** Provides default ValueIn when a field is missing. */
     private DefaultValueIn defaultValueIn;
 
-    // Context for writing out YAML documents.
+    /** Context for writing YAML documents. */
     private WriteDocumentContext writeContext;
 
-    // Context for reading in YAML documents.
+    /** Context for reading YAML documents. */
     private ReadDocumentContext readContext;
 
-    // Instance for re-reading or re-parsing scenarios.
+    /** Helper wire used when revisiting previously read fields. */
     private YamlWire rereadWire;
 
     /**
@@ -128,11 +132,11 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Converts the content of a given {@link Wire} object into its string representation.
+     * Convert any {@link Wire} into its canonical YAML representation.
      *
-     * @param wire The {@link Wire} object whose content needs to be converted to string.
-     * @return The string representation of the wire's content.
-     * @throws InvalidMarshallableException If the given wire's content cannot be marshalled.
+     * @param wire the wire to serialise
+     * @return YAML string of {@code wire}
+     * @throws InvalidMarshallableException if an object could not be marshalled
      */
     public static String asText(@NotNull Wire wire) throws InvalidMarshallableException {
         long pos = wire.bytes().readPosition();
@@ -143,13 +147,12 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Unescapes special characters in the provided Appendable based on the provided block quote character.
-     * This method adheres to the YAML 1.2 specification for escaped characters
-     * (see <a href="https://yaml.org/spec/1.2.2/#escaped-characters">YAML Spec 1.2.2</a>).
+     * Unescape YAML character sequences within {@code sb} in-place.
+     * Behaviour depends on the surrounding quote character.
      *
-     * @param sb The appendable containing characters to be unescaped.
-     * @param blockQuote The block quote character that determines the escaping scheme (' or ").
-     * @param <ACS> An appendable that also implements CharSequence interface.
+     * @param sb        appendable to modify
+     * @param blockQuote either {@code '} or {@code "}
+     * @param <ACS>     appendable that is also a {@link CharSequence}
      */
     private static <ACS extends Appendable & CharSequence> void unescape(@NotNull ACS sb, char blockQuote) {
         int end = 0;
@@ -259,14 +262,12 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Attempts to interpret the content of the given StringBuilder as a number (long, double) or
-     * as a date/time, based on the YAML specification. If none of these interpretations is successful,
-     * it returns the original string content.
+     * Parse {@code s} as a numeric or temporal value.
+     * Handles YAML features such as {@code 0o} octal notation and underscores.
      *
-     * @param bq The block quote character (either ' or ") that initiated the string in YAML.
-     * @param s The StringBuilder containing the string to be interpreted.
-     * @return An Object which might be a Long, Double, Date, Time or the original String itself
-     *         depending on successful interpretation.
+     * @param bq quote that opened the block
+     * @param s  builder containing the text
+     * @return number, date/time or the original text
      */
     @Nullable
     static Object readNumberOrTextFrom(char bq, final @Nullable StringBuilder s) {
@@ -523,6 +524,11 @@ public class YamlWire extends YamlWireOut<YamlWire> {
             return bytes.toString();
     }
 
+    /**
+     * Copy remaining content to {@code wire}.  Direct byte copying is used when
+     * the target is another text based wire; otherwise elements are tokenised
+     * and written individually.
+     */
     @Override
     public void copyTo(@NotNull WireOut wire) throws InvalidMarshallableException {
         if (wire.getClass() == TextWire.class || wire.getClass() == YamlWire.class) {
@@ -540,13 +546,12 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Copies a single element from the current YamlWire instance to the provided wire.
-     * This is a recursive method that handles different YAML elements like mappings,
-     * sequences, and primitive values based on the current token from the YamlTokeniser (yt).
+     * Copy one token (and any nested structure) to the target wire.
+     * Used by {@link #copyTo(WireOut)} when the destination is not a simple byte
+     * copy.
      *
-     * @param wire   The target wire to copy to.
-     * @param nested A flag indicating whether the current element is nested within another element.
-     * @throws InvalidMarshallableException If there's a problem during the marshalling process.
+     * @param wire   target wire
+     * @param nested {@code true} if inside a map or sequence
      */
     private void copyOne(WireOut wire, boolean nested) throws InvalidMarshallableException {
         ValueOut wireValueOut = wire.getValueOut();
@@ -634,10 +639,9 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Determines if the current YAML structure has reached the end of its document.
-     * It checks based on the current token from the YamlTokeniser.
+     * Check whether the tokeniser has reached the logical end of the document.
      *
-     * @return true if the current token represents the end of a document or the stream; false otherwise.
+     * @return {@code true} if no further data is present
      */
     private boolean endOfDocument() {
         // Check if there's nothing to read
@@ -655,13 +659,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Copies a mapping key from the current YamlWire instance to the provided wire.
-     * This method advances through the tokens to handle nested keys and ensures
-     * the key is correctly written to the target wire.
-     *
-     * @param wire   The target wire to copy to.
-     * @param nested A flag indicating whether the current element is nested within another element.
-     * @throws InvalidMarshallableException If there's a problem during the marshalling process.
+     * Helper for {@link #copyOne} to copy a mapping key and its value.
      */
     private void copyMappingKey(WireOut wire, boolean nested) throws InvalidMarshallableException {
         // Move to the next token to identify the key structure
@@ -716,10 +714,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Reads a field from the current YamlToken and appends its content to the provided StringBuilder.
-     *
-     * @param sb StringBuilder instance to which the field content will be appended.
-     * @return The same StringBuilder instance with the appended content.
+     * Read the next mapping key into {@code sb}.
      */
     @NotNull
     protected StringBuilder readField(@NotNull StringBuilder sb) {
@@ -745,6 +740,9 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         return sb;
     }
 
+    /**
+     * Read the next mapping key as an event name.
+     */
     @SuppressWarnings("fallthrough")
     @Nullable
     @Override
@@ -816,6 +814,9 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         return read(key.name().toString());
     }
 
+    /**
+     * Read the value for {@code keyName}, consulting previously skipped keys if necessary.
+     */
     @NotNull
     @Override
     public ValueIn read(String keyName) {
@@ -865,7 +866,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Initializes 'rereadWire', skipping any preliminary tokens to get to the main content.
+     * Lazily create {@link #rereadWire} for looking back at earlier keys.
      */
     private void initRereadWire() {
         rereadWire = new YamlWire(bytes.bytesStore().bytesForRead());
@@ -880,9 +881,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Produces a dump of the current parsing context. Useful for debugging.
-     *
-     * @return A string representation of the current parsing context.
+     * Dump the tokeniser context for debugging purposes.
      */
     public String dumpContext() {
         ValidatableUtil.startValidateDisabled();
@@ -896,10 +895,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Checks if the next token's text matches the given key name after handling any escape sequences.
-     *
-     * @param keyName The expected key name.
-     * @return true if the next token's text matches the given key name; false otherwise.
+     * Peek the next key and return {@code true} if it matches {@code keyName}.
      */
     private boolean checkForMatch(@NotNull String keyName) {
         YamlToken next = yt.next();
@@ -1156,7 +1152,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Implementation of the ValueIn interface for reading text-based values from YamlWire.
+     * {@link ValueIn} implementation handling YAML scalars, tags, anchors and aliases.
      */
     class TextValueIn implements ValueIn {
         @Override
@@ -1264,9 +1260,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         }
 
         /**
-         * Extracts the text from the current token and appends it to a StringBuilder.
-         * Handles various YAML tokens like TEXT, LITERAL, and TAG.
-         * @return StringBuilder containing the text.
+         * Extract the text for the current token.  Handles anchors, aliases and tags.
          */
         @Nullable
         StringBuilder textTo0(@NotNull StringBuilder a) {
@@ -2273,10 +2267,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
             return 0;
         }
 
-        /**
-         * Skips over a YAML type declaration in the current stream.
-         * If the current token indicates a YAML type (i.e., a TAG), the reading position is adjusted to skip over it.
-         */
+        /** Skip over a YAML tag if present. */
         void skipType() {
             consumePadding();
             if (yt.current() == YamlToken.TAG) {
@@ -2318,15 +2309,8 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         }
 
         /**
-         * Reads an object from the YAML stream, inferring its type based on provided context and current token.
-         * Depending on the encountered token, various internal methods are invoked to parse the object correctly.
-         * If a YAML ANCHOR is encountered, it's mapped to the parsed object for potential future ALIAS references.
-         *
-         * @param using The object to potentially reuse when reading. Might be null.
-         * @param strategy The serialization strategy to employ while reading the object.
-         * @param type Expected type of the object to be read. If null, the method will attempt to infer the type.
-         * @return The read object, possibly of the expected type. Might be null if the YAML token is NONE.
-         * @throws InvalidMarshallableException if any error occurs while parsing or constructing the object.
+         * Core logic for deserialising a YAML value.  Handles maps, sequences,
+         * scalars, anchors and aliases.
          */
         @SuppressWarnings("fallthrough")
         @Nullable
@@ -2409,11 +2393,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         }
 
         /**
-         * Attempts to read either a number or a textual value from the YAML stream.
-         * If the current token is a LITERAL, a StringBuilder containing the text will be returned.
-         * Otherwise, the method tries to interpret the content as a number or textual data.
-         *
-         * @return An Object which might be a StringBuilder (for text) or a numeric representation.
+         * Read a scalar as a number, date/time or plain text.
          */
         @Nullable
         protected Object readNumberOrText() {
@@ -2480,14 +2460,8 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         }
 
         /**
-         * Decodes a Base64 encoded binary string from the YAML stream.
-         * This method first reads the object from the YAML as a String,
-         * then decodes the Base64 representation, and lastly tries to
-         * convert the decoded byte array into the desired type.
-         *
-         * @param type The expected type of the resulting object after decoding.
-         * @return The decoded object, potentially wrapped or converted according to the desired type.
-         * @throws InvalidMarshallableException If there's an error during the deserialization.
+         * Handle the {@code !!binary} tag by decoding the base64 data and
+         * converting to {@code type} where possible.
          */
         private Object decodeBinary(Class<?> type) throws InvalidMarshallableException {
             Object o = objectWithInferredType(null, SerializationStrategies.ANY_SCALAR, String.class);

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -802,10 +802,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         }
     }
 
-    @OverrideBuffer);
-                    // Store the anchor for later reference
-                    anchorValues.put(alias, targetBuffer.toString());
-                    break;
+    @Override
     @NotNull
     public String readingPeekYaml() {
         return "todo";

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -45,21 +45,17 @@ import java.util.function.*;
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 /**
- * Wire format implementation that follows YAML 1.2 more closely than
- * {@link TextWire}.  It extends {@link YamlWireOut} and parses input via
- * {@link YamlTokeniser}.  Use this when strict YAML features, such as anchors
- * and aliases, are required.
+ * Represents a YAML-based wire format designed for efficient parsing and serialization of data.
+ * The YamlWire class extends YamlWireOut and utilizes a custom tokenizer to convert YAML tokens into byte sequences.
+ * It provides utility methods to read from and write to both byte buffers and files.
  */
 @SuppressWarnings({"rawtypes", "unchecked", "this-escape"})
 public class YamlWire extends YamlWireOut<YamlWire> {
 
-    /** YAML tag for a sequence of maps. */
+    // YAML-specific tag constants for representing special constructs.
     static final String SEQ_MAP = "!seqmap";
-    /** YAML tag for Base64 encoded binary data. */
     static final String BINARY_TAG = "!binary";
-    /** YAML tag for encoded data blocks. */
     static final String DATA_TAG = "!data";
-    /** YAML tag denoting an explicit null. */
     static final String NULL_TAG = "!null";
 
     //for (char ch : "?%&*@`0123456789+- ',#:{}[]|>!\\".toCharArray())
@@ -109,13 +105,13 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     /**
      * Utility method to create a new YamlWire instance by reading bytes from a specified file.
      *
-     * @param filePath Name of the file from which bytes are read
+     * @param name Name of the file from which bytes are read
      * @return A new YamlWire instance initialized with bytes from the specified file
      * @throws IOException If there's an error in reading the file
      */
     @NotNull
-    public static YamlWire fromFile(String filePath) throws IOException {
-        return new YamlWire(BytesUtil.readFile(filePath), true);
+    public static YamlWire fromFile(String name) throws IOException {
+        return new YamlWire(BytesUtil.readFile(name), true);
     }
 
     /**
@@ -130,11 +126,11 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Convert any {@link Wire} into its canonical YAML representation.
+     * Converts the content of a given {@link Wire} object into its string representation.
      *
-     * @param wire the wire to serialise
-     * @return YAML string of {@code wire}
-     * @throws InvalidMarshallableException if an object could not be marshalled
+     * @param wire The {@link Wire} object whose content needs to be converted to string.
+     * @return The string representation of the wire's content.
+     * @throws InvalidMarshallableException If the given wire's content cannot be marshalled.
      */
     public static String asText(@NotNull Wire wire) throws InvalidMarshallableException {
         long pos = wire.bytes().readPosition();
@@ -145,8 +141,9 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Unescape YAML character sequences within {@code sb} in-place.
-     * Behaviour depends on the surrounding quote character.
+     * Unescapes special characters in the provided Appendable based on the provided block quote character.
+     * This method adheres to the YAML 1.2 specification for escaped characters
+     * (see <a href="https://yaml.org/spec/1.2.2/#escaped-characters">YAML Spec 1.2.2</a>).
      *
      * @param targetBuffer The appendable containing characters to be unescaped.
      * @param blockQuoteChar The block quote character that determines the escaping scheme (' or ").
@@ -260,8 +257,9 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Parse {@code s} as a numeric or temporal value.
-     * Handles YAML features such as {@code 0o} octal notation and underscores.
+     * Attempts to interpret the content of the given StringBuilder as a number (long, double) or
+     * as a date/time, based on the YAML specification. If none of these interpretations is successful,
+     * it returns the original string content.
      *
      * @param blockQuoteChar The block quote character (either ' or ") that initiated the string in YAML.
      * @param inputTextBuilder The StringBuilder containing the string to be interpreted.
@@ -523,11 +521,6 @@ public class YamlWire extends YamlWireOut<YamlWire> {
             return bytes.toString();
     }
 
-    /**
-     * Copy remaining content to {@code wire}.  Direct byte copying is used when
-     * the target is another text based wire; otherwise elements are tokenised
-     * and written individually.
-     */
     @Override
     public void copyTo(@NotNull WireOut wire) throws InvalidMarshallableException {
         if (wire.getClass() == TextWire.class || wire.getClass() == YamlWire.class) {
@@ -545,12 +538,13 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Copy one token (and any nested structure) to the target wire.
-     * Used by {@link #copyTo(WireOut)} when the destination is not a simple byte
-     * copy.
+     * Copies a single element from the current YamlWire instance to the provided wire.
+     * This is a recursive method that handles different YAML elements like mappings,
+     * sequences, and primitive values based on the current token from the YamlTokeniser (yt).
      *
-     * @param wire   target wire
-     * @param nested {@code true} if inside a map or sequence
+     * @param wire   The target wire to copy to.
+     * @param nested A flag indicating whether the current element is nested within another element.
+     * @throws InvalidMarshallableException If there's a problem during the marshalling process.
      */
     private void copyOne(WireOut wire, boolean nested) throws InvalidMarshallableException {
         ValueOut wireValueOut = wire.getValueOut();
@@ -638,9 +632,10 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Check whether the tokeniser has reached the logical end of the document.
+     * Determines if the current YAML structure has reached the end of its document.
+     * It checks based on the current token from the YamlTokeniser.
      *
-     * @return {@code true} if no further data is present
+     * @return true if the current token represents the end of a document or the stream; false otherwise.
      */
     private boolean endOfDocument() {
         // Check if there's nothing to read
@@ -658,7 +653,13 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Helper for {@link #copyOne} to copy a mapping key and its value.
+     * Copies a mapping key from the current YamlWire instance to the provided wire.
+     * This method advances through the tokens to handle nested keys and ensures
+     * the key is correctly written to the target wire.
+     *
+     * @param wire   The target wire to copy to.
+     * @param nested A flag indicating whether the current element is nested within another element.
+     * @throws InvalidMarshallableException If there's a problem during the marshalling process.
      */
     private void copyMappingKey(WireOut wire, boolean nested) throws InvalidMarshallableException {
         // Move to the next token to identify the key structure
@@ -742,9 +743,6 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         return targetBuffer;
     }
 
-    /**
-     * Read the next mapping key as an event name.
-     */
     @SuppressWarnings("fallthrough")
     @Nullable
     @Override
@@ -804,7 +802,10 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         }
     }
 
-    @Override
+    @OverrideBuffer);
+                    // Store the anchor for later reference
+                    anchorValues.put(alias, targetBuffer.toString());
+                    break;
     @NotNull
     public String readingPeekYaml() {
         return "todo";
@@ -816,9 +817,6 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         return read(key.name().toString());
     }
 
-    /**
-     * Read the value for {@code keyName}, consulting previously skipped keys if necessary.
-     */
     @NotNull
     @Override
     public ValueIn read(String keyName) {
@@ -868,7 +866,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Lazily create {@link #rereadWire} for looking back at earlier keys.
+     * Initializes 'rereadWire', skipping any preliminary tokens to get to the main content.
      */
     private void initRereadWire() {
         rereadWire = new YamlWire(bytes.bytesStore().bytesForRead());
@@ -883,7 +881,9 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Dump the tokeniser context for debugging purposes.
+     * Produces a dump of the current parsing context. Useful for debugging.
+     *
+     * @return A string representation of the current parsing context.
      */
     public String dumpContext() {
         ValidatableUtil.startValidateDisabled();
@@ -897,7 +897,10 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * Peek the next key and return {@code true} if it matches {@code keyName}.
+     * Checks if the next token's text matches the given key name after handling any escape sequences.
+     *
+     * @param keyName The expected key name.
+     * @return true if the next token's text matches the given key name; false otherwise.
      */
     private boolean checkForMatch(@NotNull String keyName) {
         YamlToken next = yt.next();
@@ -1154,7 +1157,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     }
 
     /**
-     * {@link ValueIn} implementation handling YAML scalars, tags, anchors and aliases.
+     * Implementation of the ValueIn interface for reading text-based values from YamlWire.
      */
     class TextValueIn implements ValueIn {
         @Override
@@ -1262,7 +1265,9 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         }
 
         /**
-         * Extract the text for the current token.  Handles anchors, aliases and tags.
+         * Extracts the text from the current token and appends it to a StringBuilder.
+         * Handles various YAML tokens like TEXT, LITERAL, and TAG.
+         * @return StringBuilder containing the text.
          */
         @Nullable
         StringBuilder textTo0(@NotNull StringBuilder destinationBuilder) {
@@ -2270,7 +2275,10 @@ public class YamlWire extends YamlWireOut<YamlWire> {
             return 0;
         }
 
-        /** Skip over a YAML tag if present. */
+        /**
+         * Skips over a YAML type declaration in the current stream.
+         * If the current token indicates a YAML type (i.e., a TAG), the reading position is adjusted to skip over it.
+         */
         void skipType() {
             consumePadding();
             if (yt.current() == YamlToken.TAG) {
@@ -2403,7 +2411,11 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         }
 
         /**
-         * Read a scalar as a number, date/time or plain text.
+         * Attempts to read either a number or a textual value from the YAML stream.
+         * If the current token is a LITERAL, a StringBuilder containing the text will be returned.
+         * Otherwise, the method tries to interpret the content as a number or textual data.
+         *
+         * @return An Object which might be a StringBuilder (for text) or a numeric representation.
          */
         @Nullable
         protected Object readNumberOrText() {
@@ -2470,8 +2482,14 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         }
 
         /**
-         * Handle the {@code !!binary} tag by decoding the base64 data and
-         * converting to {@code type} where possible.
+         * Decodes a Base64 encoded binary string from the YAML stream.
+         * This method first reads the object from the YAML as a String,
+         * then decodes the Base64 representation, and lastly tries to
+         * convert the decoded byte array into the desired type.
+         *
+         * @param type The expected type of the resulting object after decoding.
+         * @return The decoded object, potentially wrapped or converted according to the desired type.
+         * @throws InvalidMarshallableException If there's an error during the deserialization.
          */
         private Object decodeBinary(Class<?> type) throws InvalidMarshallableException {
             Object o = objectWithInferredType(null, SerializationStrategies.ANY_SCALAR, String.class);

--- a/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
@@ -377,8 +377,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
             return Quotes.DOUBLE;
 
         // If string starts with special characters or ends with whitespace, use double quoteStyle.
-        if (STARTS_QUOTE_CHARS.get(s.charAt(0)) ||
-                Character.isWhitespace(s.charAt(s.length() - 1)))
+        if (STARTS_QUOTE_CHARS.get(text.charAt(0)) ||
+                Character.isWhitespace(text.charAt(text.length() - 1)))
             return Quotes.DOUBLE;
         boolean hasSingleQuote = false;
         for (int i = 0; i < text.length(); i++) {
@@ -394,7 +394,7 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
 
             // If a double quote is found followed by a single quote, return double quoteStyle.
             if (ch == '"') {
-                if (i < s.length() - 1 && s.charAt(i + 1) == '\'')
+                if (i < text.length() - 1 && text.charAt(i + 1) == '\'')
                     return Quotes.DOUBLE;
                 quoteStyle = Quotes.SINGLE;
             }

--- a/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
@@ -47,41 +47,27 @@ import java.util.function.BiConsumer;
 import static net.openhft.chronicle.bytes.BytesStore.empty;
 
 /**
- * Abstract base class for {@link WireOut} implementations that serialise data
- * into a YAML-like textual format. It manages indentation, separators,
- * quoting and character escaping according to YAML conventions. Concrete
- * subclasses such as {@link TextWire} and {@link YamlWire} build upon this.
+ * Provides functionality for writing data in a YAML-based wire format.
+ * This class encapsulates methods and attributes to handle data serialization into YAML format.
  *
- * @param <T> the type that extends {@code YamlWireOut}
+ * @param <T> The type that extends YamlWireOut
  */
 @SuppressWarnings({"rawtypes", "unchecked", "this-escape", "deprecation"})
 public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire {
     @Deprecated(/* to remove in x.28 */)
     private static final boolean APPEND_0 = Jvm.getBoolean("bytes.append.0", true);
 
-    /** Marker prefix used when writing type information. */
     public static final BytesStore<?, ?> TYPE = BytesStore.from("!type ");
-    /** YAML representation for a {@code null} value. */
     static final String NULL = "!null \"\"";
-    /** Characters that require quoting when found at the start of a string. */
     static final BitSet STARTS_QUOTE_CHARS = new BitSet();
-    /** Characters that force quoting wherever they appear. */
     static final BitSet QUOTE_CHARS = new BitSet();
-    /** Separator consisting of a comma followed by a space. */
     static final BytesStore<?, ?> COMMA_SPACE = BytesStore.from(", ");
-    /** Separator consisting of a comma followed by a newline. */
     static final BytesStore<?, ?> COMMA_NEW_LINE = BytesStore.from(",\n");
-    /** A newline sequence. */
     static final BytesStore<?, ?> NEW_LINE = BytesStore.from("\n");
-    /** Placeholder for an empty value when preceded by a comment. */
-    static final BytesStore<?, ?> EMPTY_AFTER_COMMENT = BytesStore.wrap(new byte[0]);
-    /** Shared empty bytes instance. */
+    static final BytesStore<?, ?> EMPTY_AFTER_COMMENT = BytesStore.wrap(new byte[0]); // not the same as EMPTY, so we can check this value.
     static final BytesStore<?, ?> EMPTY = BytesStore.from("");
-    /** Single space bytes. */
     static final BytesStore<?, ?> SPACE = BytesStore.from(" ");
-    /** Default end-of-field marker. */
     static final BytesStore<?, ?> END_FIELD = NEW_LINE;
-    /** Hex digits used for escape sequences. */
     static final char[] HEXADECIMAL = "0123456789ABCDEF".toCharArray();
 
     // Static initializer block to configure quote characters for the YAML writer
@@ -95,17 +81,9 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         WireInternal.INTERNER.valueCount();
     }
 
-    /** The primary {@link YamlValueOut} used to serialise values. */
     protected final YamlValueOut valueOut = createValueOut();
-    /** Reusable {@link StringBuilder} for temporary conversions. */
     protected final StringBuilder sb = new StringBuilder();
-    /**
-     * If true, append a readable timestamp comment after numeric epoch values.
-     */
     private boolean addTimeStamps = false;
-    /**
-     * If true the outermost curly braces for a top level object may be omitted.
-     */
     private boolean trimFirstCurly = true;
 
     /**
@@ -120,20 +98,20 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Returns whether human readable timestamp comments are emitted.
+     * Checks if timestamps should be added during serialization.
      *
-     * @return true if timestamp comments should be added
+     * @return True if timestamps should be added, otherwise false.
      */
     public boolean addTimeStamps() {
         return addTimeStamps;
     }
 
     /**
-     * Controls whether human readable timestamp comments are added after long
-     * values that look like epoch times.
+     * Configures whether to add timestamps during serialization.
+     * This method follows the builder pattern allowing chained method calls.
      *
-     * @param addTimeStamps set to true to enable timestamp comments
-     * @return this instance for chaining
+     * @param addTimeStamps Boolean indicating whether to add timestamps.
+     * @return The current instance of YamlWireOut.
      */
     public T addTimeStamps(boolean addTimeStamps) {
         this.addTimeStamps = addTimeStamps;
@@ -141,8 +119,9 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Factory method used to obtain the main {@link YamlValueOut}. Subclasses
-     * may override if a specialised implementation is required.
+     * Creates and returns a new instance of {@link YamlValueOut}.
+     *
+     * @return A new YamlValueOut instance.
      */
     @NotNull
     protected YamlValueOut createValueOut() {
@@ -150,7 +129,10 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Returns the reusable {@link #sb} after clearing its contents.
+     * Acquires and clears the internal StringBuilder {@code sb} for use.
+     * The method ensures the StringBuilder's count is reset to 0 before returning.
+     *
+     * @return The internal StringBuilder after it has been cleared.
      */
     @NotNull
     protected StringBuilder acquireStringBuilder() {
@@ -233,8 +215,9 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Escapes {@code s} according to YAML rules. If quoting is required the
-     * chosen quote character is written around the escaped text.
+     * Escapes the given CharSequence {@code s} based on the requirements of the YAML format.
+     * If the sequence requires quotes, it will be enclosed with the appropriate quote character;
+     * otherwise, the sequence will be escaped without quotes.
      *
      * @param textToEscape The CharSequence to be escaped.
      */
@@ -251,9 +234,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
 
     // https://yaml.org/spec/1.2.2/#escaped-characters
     /**
-     * Core logic used by {@link #escape(CharSequence)} to write escape
-     * sequences for control characters and Unicode using the supplied quote
-     * style.
+     * Helper method to escape special characters in the given CharSequence {@code s} based on the requirements of the YAML format.
+     * The method handles the specific escaping requirements for various control and special characters.
      *
      * @param textToEscape The CharSequence to be escaped.
      * @param quoteStyle The quote style used to determine how certain characters are escaped.
@@ -334,8 +316,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Helper for {@link #escape0(CharSequence, Quotes)} that writes a \xHH
-     * escape.
+     * Appends a 2-character hexadecimal representation of the given character {@code ch} to the output bytes.
+     * This is used for character escaping.
      *
      * @param characterToEncode The character to be converted to hexadecimal.
      */
@@ -347,8 +329,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Helper for {@link #escape0(CharSequence, Quotes)} that writes a \uHHHH
-     * Unicode escape.
+     * Appends a 4-character hexadecimal Unicode representation of the given character {@code ch} to the output bytes.
+     * This is used for character escaping.
      *
      * @param characterToEncode The character to be converted to hexadecimal Unicode representation.
      */
@@ -407,10 +389,9 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Append {@code cs} to the underlying {@link Bytes} using 8‑bit or UTF‑8
-     * encoding depending on {@link #use8bit}.
+     * Appends the given CharSequence {@code cs} to the output bytes using either an 8-bit or UTF-8 encoding, depending on {@code use8bit}.
      *
-     * @param cs text to append
+     * @param cs CharSequence to be appended.
      */
     public void append(@NotNull CharSequence cs) {
         if (use8bit)
@@ -420,11 +401,11 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Append part of {@code cs} using either 8‑bit or UTF‑8 encoding.
+     * Appends a subsequence of the given CharSequence {@code cs} to the output bytes using either an 8-bit or UTF-8 encoding.
      *
-     * @param cs     source text
-     * @param offset starting index
-     * @param length number of characters
+     * @param cs     CharSequence from which a subsequence will be appended.
+     * @param offset Starting index of the subsequence.
+     * @param length Length of the subsequence.
      */
     public void append(@NotNull CharSequence cs, int offset, int length) {
         if (use8bit)
@@ -434,12 +415,10 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Serialises a generic object. Iterables and maps are expanded, while other
-     * types delegate to {@link ValueOut#object(Object)} or
-     * {@link ValueOut#typedMarshallable(WriteMarshallable)} as appropriate.
+     * Writes the representation of the object {@code o} to the output. Differentiates the serialization logic based on the type of the object.
      *
-     * @param o object to serialise
-     * @throws InvalidMarshallableException if marshalling fails
+     * @param o The object to be serialized.
+     * @throws InvalidMarshallableException if an error occurs during serialization.
      */
     public void writeObject(Object o) throws InvalidMarshallableException {
         if (o instanceof Iterable) {
@@ -459,11 +438,11 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Serialises {@code o} as a list item using the provided indentation.
+     * Writes the representation of the object {@code o} to the output with a specified indentation level.
      *
-     * @param o           object to serialise
-     * @param indentation indentation level in spaces
-     * @throws InvalidMarshallableException if marshalling fails
+     * @param o           The object to be serialized.
+     * @param indentation The number of spaces to use for indentation.
+     * @throws InvalidMarshallableException if an error occurs during serialization.
      */
     private void writeObject(Object o, int indentation) throws InvalidMarshallableException {
         writeTwo('-', ' ');
@@ -472,7 +451,9 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Writes {@code indentation} spaces to the output.
+     * Inserts the specified number of spaces into the output bytes for indentation.
+     *
+     * @param indentation The number of spaces to insert.
      */
     private void indentation(int indentation) {
         while (indentation-- > 0)
@@ -491,10 +472,10 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Helper to append two characters to the output buffer.
+     * Writes two characters to the 'bytes' object sequentially.
      *
-     * @param ch1 first character
-     * @param ch2 second character
+     * @param ch1 First character to write.
+     * @param ch2 Second character to write.
      */
     void writeTwo(char ch1, char ch2) {
         bytes.writeUnsignedByte(ch1);
@@ -502,18 +483,19 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Whether the outermost braces for a top level object are omitted.
+     * Returns a flag indicating if the top-level curly brackets in the serialized YAML should be dropped.
+     *
+     * @return {@code true} if the top-level curly brackets should be dropped; {@code false} otherwise.
      */
     public boolean trimFirstCurly() {
         return trimFirstCurly;
     }
 
     /**
-     * Controls whether the outermost curly braces are written for the top level
-     * object.
+     * Sets whether the top-level curly brackets in the serialized YAML should be dropped.
      *
-     * @param trimFirstCurly set to true to omit the braces
-     * @return this instance for chaining
+     * @param trimFirstCurly {@code true} to drop the top-level curly brackets; {@code false} to include them.
+     * @return The current instance of {@code YamlWireOut} (fluent API style).
      */
     public T trimFirstCurly(boolean trimFirstCurly) {
         this.trimFirstCurly = trimFirstCurly;
@@ -521,48 +503,30 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * The primary {@link ValueOut} implementation for {@link YamlWireOut}.
-     * Manages YAML-specific formatting such as indentation, separators
-     * (comma or newline based on context and {@link #leaf} state), comments and
-     * block structuring ({@code {...}}, {@code [...]}).
+     * This internal class represents an output value in the YAML format. It provides functionalities related
+     * to appending separators, handling whitespace, and maintaining indentation among others.
      */
     class YamlValueOut implements ValueOut, CommentAnnotationNotifier {
-        /** Indicates that a preceding comment annotation was encountered. */
         protected boolean hasCommentAnnotation = false;
 
-        /** Current indentation level (number of 2-space indents). */
+        // The current indentation level for the value.
         protected int indentation = 0;
 
-        /**
-         * Stack of separators used when nesting structures so the parent
-         * separator can be restored.
-         */
+        // A list of separators to be used when writing the value.
         @NotNull
         protected List<BytesStore> seps = new ArrayList<>(4);
 
-        /**
-         * The separator (",", "\n", etc.) to prepend before the next value is
-         * written.
-         */
+        // The current separator being used.
         @NotNull
         protected BytesStore<?, ?> sep = BytesStore.empty();
 
-        /**
-         * True if the value being written is a simple scalar (a 'leaf' node).
-         * Leaf nodes use comma separators whereas others use newlines.
-         */
+        // Flag indicating if the value is a leaf node (i.e., doesn't have child elements).
         protected boolean leaf = false;
 
-        /**
-         * When true, fields equal to their defaults may be omitted from the
-         * output.
-         */
+        // Flag indicating if default values should be dropped from the output.
         protected boolean dropDefault = false;
 
-        /**
-         * Stores the field name when {@link #dropDefault} is true so it can be
-         * written if the following value is non-default.
-         */
+        // The name of the event associated with this value (if any).
         @Nullable
         private String eventName;
 
@@ -587,8 +551,7 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Writes the configured {@link #sep} to the output and then clears it
-         * so the next value can supply its own separator.
+         * Appends the current separator to the output bytes, and resets the separator.
          */
         void prependSeparator() {
             appendSep();
@@ -596,9 +559,7 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Writes {@link #sep}, trims any resulting double newlines and indents
-         * if the separator ended with a newline or was
-         * {@link YamlWireOut#EMPTY_AFTER_COMMENT}.
+         * Appends the current separator to the output bytes and handles any necessary whitespace trimming.
          */
         protected void appendSep() {
             append(sep);
@@ -608,8 +569,7 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Ensures there are no double newlines in the output by removing one if
-         * a <code>\n\n</code> sequence is found.
+         * Trims excessive whitespace from the output bytes, particularly to remove double newline characters.
          */
         protected void trimWhiteSpace() {
             BytesUtil.combineDoubleNewline(bytes);
@@ -621,11 +581,6 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          * appropriate element separator.
          */
         @Override
-        /**
-         * Sets the {@link #leaf} state. If switching from leaf to non-leaf and
-         * the current separator is comma-space, the separator is changed to the
-         * appropriate element separator.
-         */
         public boolean swapLeaf(boolean isLeaf) {
             if (isLeaf == leaf)
                 return leaf;
@@ -642,8 +597,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Writes the appropriate number of spaces based on {@link #indentation}.
-         * Two spaces are emitted per level for efficiency.
+         * Indents the YAML content based on the current indentation level. It uses a trick of
+         * writing two spaces at a time to speed up the process.
          */
         protected void indent() {
             BytesUtil.combineDoubleNewline(bytes);
@@ -653,9 +608,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Sets {@link #sep} for the next element based on {@link #indentation}
-         * and {@link #leaf}. Top level or non-leaf elements use newlines; nested
-         * leaf elements use comma-space.
+         * Determines and sets the appropriate separator for the current YAML element.
+         * The separator varies based on the indentation level and whether the current value is a leaf node.
          */
         @Override
         public void elementSeparator() {
@@ -692,7 +646,10 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Returns the YAML string used for a null value: <code>!null ""</code>.
+         * Returns the string representation for null in YAML format.
+         * It utilizes the predefined NULL static configuration for constructing the output.
+         *
+         * @return String representation for null in YAML.
          */
         @NotNull
         public String nullOut() {
@@ -1107,16 +1064,16 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Writes special floating point values such as NaN or Infinity. For
-         * YAML these are emitted as unquoted strings (e.g. <code>.NaN</code>).
+         * Writes a special double value, e.g. NaN, to bytes in the context of Yaml Wire. For now this
+         * remains as an unquoted string representation.
          */
         protected void writeSpecialDoubleValueToBytes(Bytes<?> outputBytes, double value) {
             outputBytes.append(Double.toString(value));
         }
 
         /**
-         * Writes special floating point values such as NaN or Infinity. For
-         * YAML these are emitted as unquoted strings (e.g. <code>.NaN</code>).
+         * Writes a special double value, e.g. NaN, to bytes in the context of Yaml Wire. For now this
+         * remains as an unquoted string representation.
          */
         protected void writeSpecialFloatValueToBytes(Bytes<?> outputBytes, float value) {
             outputBytes.append(Float.toString(value));
@@ -1224,10 +1181,6 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          */
         @NotNull
         @Override
-        /**
-         * Writes a YAML type tag such as <code>!typeName</code> before the
-         * following value.
-         */
         public YamlValueOut typePrefix(@NotNull CharSequence typeName) {
             if (dropDefault) {
                 writeSavedEventName();
@@ -1462,15 +1415,15 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Sets {@link #sep} so that the next value starts on a new line.
+         * Sets the separator to a new line for future content additions.
          */
         protected void newLine() {
             sep = NEW_LINE;
         }
 
         /**
-         * Restores the previous separator and indentation when leaving a nested
-         * structure.
+         * Reverts the current state to the previous state by popping the last saved state.
+         * This involves reverting the separator, decreasing the indentation, and resetting certain flags.
          */
         protected void popState() {
             sep = seps.remove(seps.size() - 1);
@@ -1480,8 +1433,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Saves the current separator and increases indentation for a nested
-         * structure.
+         * Pushes the current state, preserving the current context for later restoration.
+         * This involves increasing the indentation and saving the current separator.
          */
         protected void pushState() {
             indentation++;
@@ -1495,10 +1448,6 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          */
         @NotNull
         @Override
-        /**
-         * Serialises a {@link WriteMarshallable}. Handles the outer braces and
-         * manages {@link #leaf} so leaf marshallables can be rendered inline.
-         */
         public T marshallable(@NotNull WriteMarshallable object) throws InvalidMarshallableException {
             WireMarshaller wm = WireMarshaller.WIRE_MARSHALLER_CL.get(object.getClass());
             boolean wasLeaf0 = leaf;
@@ -1561,10 +1510,6 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          */
         @NotNull
         @Override
-        /**
-         * Serialises a {@link Serializable} object using either its
-         * {@link Externalizable#writeExternal} method or default marshalling.
-         */
         public T marshallable(@NotNull Serializable object) throws InvalidMarshallableException {
             if (dropDefault) {
                 writeSavedEventName();
@@ -1635,8 +1580,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Called after a block is closed. Sets {@link #sep} to a newline and
-         * appends the current separator to the output.
+         * Performs actions after closing an element.
+         * Sets the separator to a newline and appends the current separator to the bytes.
          */
         protected void afterClose() {
             newLine();        // Set the separator to a newline
@@ -1645,8 +1590,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Called after a block is opened. The next value will follow after a
-         * space.
+         * Performs actions after opening an element.
+         * Sets the separator to a space.
          */
         protected void afterOpen() {
             sep = SPACE;      // Set the separator to a space
@@ -1663,24 +1608,24 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Sets {@link #sep} to {@link YamlWireOut#END_FIELD} (a newline) after
-         * a key–value pair.
+         * Sets the separator to denote the end of a field.
          */
         protected void endField() {
             sep = END_FIELD;
         }
 
         /**
-         * Writes the YAML key–value separator <code>:</code> followed by a
-         * space.
+         * Writes a field-value separator, which is ": ".
          */
         protected void fieldValueSeperator() {
             writeTwo(':', ' ');
         }
 
         /**
-         * Begins writing a field with no name. If {@link #dropDefault} is true
-         * the name is stored so it can be output later when a value appears.
+         * Writes an empty value to the Yaml output. If the default value is dropped,
+         * the event name is set to an empty string.
+         *
+         * @return Returns an instance of the current object, supporting chained method calls.
          */
         @NotNull
         public YamlValueOut write() {
@@ -1695,9 +1640,11 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Prepares to write a field using the supplied {@link WireKey}. When
-         * {@link #dropDefault} is true the name is saved until a non-default
-         * value is provided.
+         * Writes a given WireKey to the Yaml output. If the default value is dropped,
+         * the event name is set to the name of the key.
+         *
+         * @param key The WireKey to write.
+         * @return Returns an instance of the current object, supporting chained method calls.
          */
         @NotNull
         public YamlValueOut write(@NotNull WireKey key) {
@@ -1729,8 +1676,14 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Starts writing a field with {@code objectKey} as name. Non-string keys
-         * are unsupported when {@link #dropDefault} is active.
+         * Writes a given objectKey of an expected type to the Yaml output. If the default value is dropped,
+         * and the expected type is not a String, an exception is thrown. Otherwise, the event name is set
+         * to the string representation of the objectKey.
+         *
+         * @param expectedType The expected type of the objectKey.
+         * @param objectKey    The object key to write.
+         * @return Returns an instance of the current object, supporting chained method calls.
+         * @throws InvalidMarshallableException If the object cannot be serialized.
          */
         @NotNull
         public YamlValueOut write(Class<?> expectedType, @NotNull Object objectKey) throws InvalidMarshallableException {
@@ -1748,8 +1701,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Emits any field name saved due to {@link #dropDefault} being true and
-         * clears {@link #eventName}.
+         * Writes the saved event name to the output. This method escapes the event name
+         * and separates it from its value.
          */
         private void writeSavedEventName() {
             if (eventName == null)
@@ -1761,8 +1714,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Completes the key part written by {@link #writeStartEvent()} by adding
-         * the key–value separator and trimming trailing spaces.
+         * Ends the current event by checking and adjusting the position
+         * of the last byte written to the output, and appending a field value separator.
          */
         public void endEvent() {
             // Check if the last written byte is a whitespace character or less

--- a/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
@@ -49,27 +49,41 @@ import java.util.function.BiConsumer;
 import static net.openhft.chronicle.bytes.BytesStore.empty;
 
 /**
- * Provides functionality for writing data in a YAML-based wire format.
- * This class encapsulates methods and attributes to handle data serialization into YAML format.
+ * Abstract base class for {@link WireOut} implementations that serialise data
+ * into a YAML-like textual format. It manages indentation, separators,
+ * quoting and character escaping according to YAML conventions. Concrete
+ * subclasses such as {@link TextWire} and {@link YamlWire} build upon this.
  *
- * @param <T> The type that extends YamlWireOut
+ * @param <T> the type that extends {@code YamlWireOut}
  */
 @SuppressWarnings({"rawtypes", "unchecked", "this-escape", "deprecation"})
 public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire {
     @Deprecated(/* to remove in x.28 */)
     private static final boolean APPEND_0 = Jvm.getBoolean("bytes.append.0", true);
 
+    /** Marker prefix used when writing type information. */
     public static final BytesStore<?, ?> TYPE = BytesStore.from("!type ");
+    /** YAML representation for a {@code null} value. */
     static final String NULL = "!null \"\"";
+    /** Characters that require quoting when found at the start of a string. */
     static final BitSet STARTS_QUOTE_CHARS = new BitSet();
+    /** Characters that force quoting wherever they appear. */
     static final BitSet QUOTE_CHARS = new BitSet();
+    /** Separator consisting of a comma followed by a space. */
     static final BytesStore<?, ?> COMMA_SPACE = BytesStore.from(", ");
+    /** Separator consisting of a comma followed by a newline. */
     static final BytesStore<?, ?> COMMA_NEW_LINE = BytesStore.from(",\n");
+    /** A newline sequence. */
     static final BytesStore<?, ?> NEW_LINE = BytesStore.from("\n");
-    static final BytesStore<?, ?> EMPTY_AFTER_COMMENT = BytesStore.wrap(new byte[0]); // not the same as EMPTY, so we can check this value.
+    /** Placeholder for an empty value when preceded by a comment. */
+    static final BytesStore<?, ?> EMPTY_AFTER_COMMENT = BytesStore.wrap(new byte[0]);
+    /** Shared empty bytes instance. */
     static final BytesStore<?, ?> EMPTY = BytesStore.from("");
+    /** Single space bytes. */
     static final BytesStore<?, ?> SPACE = BytesStore.from(" ");
+    /** Default end-of-field marker. */
     static final BytesStore<?, ?> END_FIELD = NEW_LINE;
+    /** Hex digits used for escape sequences. */
     static final char[] HEXADECIMAL = "0123456789ABCDEF".toCharArray();
 
     // Static initializer block to configure quote characters for the YAML writer
@@ -83,9 +97,17 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         WireInternal.INTERNER.valueCount();
     }
 
+    /** The primary {@link YamlValueOut} used to serialise values. */
     protected final YamlValueOut valueOut = createValueOut();
+    /** Reusable {@link StringBuilder} for temporary conversions. */
     protected final StringBuilder sb = new StringBuilder();
+    /**
+     * If true, append a readable timestamp comment after numeric epoch values.
+     */
     private boolean addTimeStamps = false;
+    /**
+     * If true the outermost curly braces for a top level object may be omitted.
+     */
     private boolean trimFirstCurly = true;
 
     /**
@@ -100,20 +122,20 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Checks if timestamps should be added during serialization.
+     * Returns whether human readable timestamp comments are emitted.
      *
-     * @return True if timestamps should be added, otherwise false.
+     * @return true if timestamp comments should be added
      */
     public boolean addTimeStamps() {
         return addTimeStamps;
     }
 
     /**
-     * Configures whether to add timestamps during serialization.
-     * This method follows the builder pattern allowing chained method calls.
+     * Controls whether human readable timestamp comments are added after long
+     * values that look like epoch times.
      *
-     * @param addTimeStamps Boolean indicating whether to add timestamps.
-     * @return The current instance of YamlWireOut.
+     * @param addTimeStamps set to true to enable timestamp comments
+     * @return this instance for chaining
      */
     public T addTimeStamps(boolean addTimeStamps) {
         this.addTimeStamps = addTimeStamps;
@@ -121,7 +143,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Protected factory method to create the {@link YamlValueOut} used by this wire.
+     * Factory method used to obtain the main {@link YamlValueOut}. Subclasses
+     * may override if a specialised implementation is required.
      */
     @NotNull
     protected YamlValueOut createValueOut() {
@@ -129,10 +152,7 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Acquires and clears the internal StringBuilder {@code sb} for use.
-     * The method ensures the StringBuilder's count is reset to 0 before returning.
-     *
-     * @return The internal StringBuilder after it has been cleared.
+     * Returns the reusable {@link #sb} after clearing its contents.
      */
     @NotNull
     protected StringBuilder acquireStringBuilder() {
@@ -215,11 +235,10 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Escapes the given CharSequence {@code s} based on the requirements of the YAML format.
-     * If the sequence requires quotes, it will be enclosed with the appropriate quote character;
-     * otherwise, the sequence will be escaped without quotes.
+     * Escapes {@code s} according to YAML rules. If quoting is required the
+     * chosen quote character is written around the escaped text.
      *
-     * @param s The CharSequence to be escaped.
+     * @param s text to escape
      */
     void escape(@NotNull CharSequence s) {
         @NotNull Quotes quotes = needsQuotes(s);
@@ -234,11 +253,12 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
 
     // https://yaml.org/spec/1.2.2/#escaped-characters
     /**
-     * Helper method to escape special characters in the given CharSequence {@code s} based on the requirements of the YAML format.
-     * The method handles the specific escaping requirements for various control and special characters.
+     * Core logic used by {@link #escape(CharSequence)} to write escape
+     * sequences for control characters and Unicode using the supplied quote
+     * style.
      *
-     * @param s The CharSequence to be escaped.
-     * @param quotes The type of quotes used to determine how certain characters are escaped.
+     * @param s      text to escape
+     * @param quotes quoting strategy
      */
     protected void escape0(@NotNull CharSequence s, @NotNull Quotes quotes) {
         for (int i = 0; i < s.length(); i++) {
@@ -316,10 +336,10 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Appends a 2-character hexadecimal representation of the given character {@code ch} to the output bytes.
-     * This is used for character escaping.
+     * Helper for {@link #escape0(CharSequence, Quotes)} that writes a \xHH
+     * escape.
      *
-     * @param ch The character to be converted to hexadecimal.
+     * @param ch character to convert
      */
     private void appendX2(char ch) {
         bytes.append('\\');
@@ -329,10 +349,10 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Appends a 4-character hexadecimal Unicode representation of the given character {@code ch} to the output bytes.
-     * This is used for character escaping.
+     * Helper for {@link #escape0(CharSequence, Quotes)} that writes a \uHHHH
+     * Unicode escape.
      *
-     * @param ch The character to be converted to hexadecimal Unicode representation.
+     * @param ch character to convert
      */
     protected void appendU4(char ch) {
         bytes.append('\\');
@@ -344,11 +364,12 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Determines the type of quotes (if any) required for the given CharSequence {@code s} based on the YAML format's escaping requirements.
-     * This method decides between using no quotes, single quotes, or double quotes.
+     * Determines whether {@code s} needs quoting to be a valid YAML scalar.
+     * Considers leading characters, trailing whitespace and characters with
+     * special meaning.
      *
-     * @param s The CharSequence to be analyzed.
-     * @return The type of quotes required.
+     * @param s candidate text
+     * @return the quote style to use
      */
     @NotNull
     protected Quotes needsQuotes(@NotNull CharSequence s) {
@@ -389,9 +410,10 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Appends the given CharSequence {@code cs} to the output bytes using either an 8-bit or UTF-8 encoding, depending on {@code use8bit}.
+     * Append {@code cs} to the underlying {@link Bytes} using 8‑bit or UTF‑8
+     * encoding depending on {@link #use8bit}.
      *
-     * @param cs CharSequence to be appended.
+     * @param cs text to append
      */
     public void append(@NotNull CharSequence cs) {
         if (use8bit)
@@ -401,11 +423,11 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Appends a subsequence of the given CharSequence {@code cs} to the output bytes using either an 8-bit or UTF-8 encoding.
+     * Append part of {@code cs} using either 8‑bit or UTF‑8 encoding.
      *
-     * @param cs     CharSequence from which a subsequence will be appended.
-     * @param offset Starting index of the subsequence.
-     * @param length Length of the subsequence.
+     * @param cs     source text
+     * @param offset starting index
+     * @param length number of characters
      */
     public void append(@NotNull CharSequence cs, int offset, int length) {
         if (use8bit)
@@ -415,10 +437,12 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Writes the representation of the object {@code o} to the output. Differentiates the serialization logic based on the type of the object.
+     * Serialises a generic object. Iterables and maps are expanded, while other
+     * types delegate to {@link ValueOut#object(Object)} or
+     * {@link ValueOut#typedMarshallable(WriteMarshallable)} as appropriate.
      *
-     * @param o The object to be serialized.
-     * @throws InvalidMarshallableException if an error occurs during serialization.
+     * @param o object to serialise
+     * @throws InvalidMarshallableException if marshalling fails
      */
     public void writeObject(Object o) throws InvalidMarshallableException {
         if (o instanceof Iterable) {
@@ -438,11 +462,11 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Writes the representation of the object {@code o} to the output with a specified indentation level.
+     * Serialises {@code o} as a list item using the provided indentation.
      *
-     * @param o           The object to be serialized.
-     * @param indentation The number of spaces to use for indentation.
-     * @throws InvalidMarshallableException if an error occurs during serialization.
+     * @param o           object to serialise
+     * @param indentation indentation level in spaces
+     * @throws InvalidMarshallableException if marshalling fails
      */
     private void writeObject(Object o, int indentation) throws InvalidMarshallableException {
         writeTwo('-', ' ');
@@ -451,9 +475,7 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Inserts the specified number of spaces into the output bytes for indentation.
-     *
-     * @param indentation The number of spaces to insert.
+     * Writes {@code indentation} spaces to the output.
      */
     private void indentation(int indentation) {
         while (indentation-- > 0)
@@ -472,10 +494,10 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Writes two characters to the 'bytes' object sequentially.
+     * Helper to append two characters to the output buffer.
      *
-     * @param ch1 First character to write.
-     * @param ch2 Second character to write.
+     * @param ch1 first character
+     * @param ch2 second character
      */
     void writeTwo(char ch1, char ch2) {
         bytes.writeUnsignedByte(ch1);
@@ -483,19 +505,18 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Returns a flag indicating if the top-level curly brackets in the serialized YAML should be dropped.
-     *
-     * @return {@code true} if the top-level curly brackets should be dropped; {@code false} otherwise.
+     * Whether the outermost braces for a top level object are omitted.
      */
     public boolean trimFirstCurly() {
         return trimFirstCurly;
     }
 
     /**
-     * Sets whether the top-level curly brackets in the serialized YAML should be dropped.
+     * Controls whether the outermost curly braces are written for the top level
+     * object.
      *
-     * @param trimFirstCurly {@code true} to drop the top-level curly brackets; {@code false} to include them.
-     * @return The current instance of {@code YamlWireOut} (fluent API style).
+     * @param trimFirstCurly set to true to omit the braces
+     * @return this instance for chaining
      */
     public T trimFirstCurly(boolean trimFirstCurly) {
         this.trimFirstCurly = trimFirstCurly;

--- a/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
@@ -121,9 +121,7 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Creates and returns a new instance of {@link YamlValueOut}.
-     *
-     * @return A new YamlValueOut instance.
+     * Protected factory method to create the {@link YamlValueOut} used by this wire.
      */
     @NotNull
     protected YamlValueOut createValueOut() {

--- a/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
@@ -219,8 +219,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
 
     @NotNull
     @Override
-    public T writeComment(@NotNull CharSequence s) {
-        valueOut.writeComment(s);
+    public T writeComment(@NotNull CharSequence commentText) {
+        valueOut.writeComment(commentText);
         return (T) this;
     }
 
@@ -236,17 +236,17 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
      * Escapes {@code s} according to YAML rules. If quoting is required the
      * chosen quote character is written around the escaped text.
      *
-     * @param s text to escape
+     * @param textToEscape The CharSequence to be escaped.
      */
-    void escape(@NotNull CharSequence s) {
-        @NotNull Quotes quotes = needsQuotes(s);
-        if (quotes == Quotes.NONE) {
-            escape0(s, quotes);
+    void escape(@NotNull CharSequence textToEscape) {
+        @NotNull Quotes quoteStyle = needsQuotes(textToEscape);
+        if (quoteStyle == Quotes.NONE) {
+            escape0(textToEscape, quoteStyle);
             return;
         }
-        bytes.writeUnsignedByte(quotes.q);
-        escape0(s, quotes);
-        bytes.writeUnsignedByte(quotes.q);
+        bytes.writeUnsignedByte(quoteStyle.q);
+        escape0(textToEscape, quoteStyle);
+        bytes.writeUnsignedByte(quoteStyle.q);
     }
 
     // https://yaml.org/spec/1.2.2/#escaped-characters
@@ -255,12 +255,12 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
      * sequences for control characters and Unicode using the supplied quote
      * style.
      *
-     * @param s      text to escape
-     * @param quotes quoting strategy
+     * @param textToEscape The CharSequence to be escaped.
+     * @param quoteStyle The quote style used to determine how certain characters are escaped.
      */
-    protected void escape0(@NotNull CharSequence s, @NotNull Quotes quotes) {
-        for (int i = 0; i < s.length(); i++) {
-            char ch = s.charAt(i);
+    protected void escape0(@NotNull CharSequence textToEscape, @NotNull Quotes quoteStyle) {
+        for (int i = 0; i < textToEscape.length(); i++) {
+            char ch = textToEscape.charAt(i);
             switch (ch) {
                 case '\0':
                     bytes.append("\\0");  // Null character
@@ -290,16 +290,16 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
                     bytes.append("\\e");  // Escape
                     break;
                 case '"':
-                    // Handling double quotes
-                    if (ch == quotes.q) {
+                    // Handling double quoteStyle
+                    if (ch == quoteStyle.q) {
                         bytes.writeUnsignedByte('\\').writeUnsignedByte(ch);
                     } else {
                         bytes.writeUnsignedByte(ch);
                     }
                     break;
                 case '\'':
-                    // Handling single quotes
-                    if (ch == quotes.q) {
+                    // Handling single quoteStyle
+                    if (ch == quoteStyle.q) {
                         bytes.writeUnsignedByte('\\').writeUnsignedByte(ch);
                     } else {
                         bytes.writeUnsignedByte(ch);
@@ -337,55 +337,54 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
      * Helper for {@link #escape0(CharSequence, Quotes)} that writes a \xHH
      * escape.
      *
-     * @param ch character to convert
+     * @param characterToEncode The character to be converted to hexadecimal.
      */
-    private void appendX2(char ch) {
+    private void appendX2(char characterToEncode) {
         bytes.append('\\');
         bytes.append('x');
-        bytes.append(HEXADECIMAL[(ch >> 4) & 0xF]);
-        bytes.append(HEXADECIMAL[ch & 0xF]);
+        bytes.append(HEXADECIMAL[(characterToEncode >> 4) & 0xF]);
+        bytes.append(HEXADECIMAL[characterToEncode & 0xF]);
     }
 
     /**
      * Helper for {@link #escape0(CharSequence, Quotes)} that writes a \uHHHH
      * Unicode escape.
      *
-     * @param ch character to convert
+     * @param characterToEncode The character to be converted to hexadecimal Unicode representation.
      */
-    protected void appendU4(char ch) {
+    protected void appendU4(char characterToEncode) {
         bytes.append('\\');
         bytes.append('u');
-        bytes.append(HEXADECIMAL[ch >> 12]);
-        bytes.append(HEXADECIMAL[(ch >> 8) & 0xF]);
-        bytes.append(HEXADECIMAL[(ch >> 4) & 0xF]);
-        bytes.append(HEXADECIMAL[ch & 0xF]);
+        bytes.append(HEXADECIMAL[characterToEncode >> 12]);
+        bytes.append(HEXADECIMAL[(characterToEncode >> 8) & 0xF]);
+        bytes.append(HEXADECIMAL[(characterToEncode >> 4) & 0xF]);
+        bytes.append(HEXADECIMAL[characterToEncode & 0xF]);
     }
 
     /**
-     * Determines whether {@code s} needs quoting to be a valid YAML scalar.
-     * Considers leading characters, trailing whitespace and characters with
-     * special meaning.
+     * Determines the type of quotes (if any) required for the given CharSequence {@code text} based on the YAML format's escaping requirements.
+     * This method decides between using no quotes, single quotes, or double quotes.
      *
-     * @param s candidate text
-     * @return the quote style to use
+     * @param text The CharSequence to be analysed.
+     * @return The type of quotes required.
      */
     @NotNull
-    protected Quotes needsQuotes(@NotNull CharSequence s) {
-        @NotNull Quotes quotes = Quotes.NONE;
+    protected Quotes needsQuotes(@NotNull CharSequence text) {
+        @NotNull Quotes quoteStyle = Quotes.NONE;
 
-        // Empty strings require double quotes.
-        if (s.length() == 0)
+        // Empty strings require double quoteStyle.
+        if (text.length() == 0)
             return Quotes.DOUBLE;
 
-        // If string starts with special characters or ends with whitespace, use double quotes.
+        // If string starts with special characters or ends with whitespace, use double quoteStyle.
         if (STARTS_QUOTE_CHARS.get(s.charAt(0)) ||
                 Character.isWhitespace(s.charAt(s.length() - 1)))
             return Quotes.DOUBLE;
         boolean hasSingleQuote = false;
-        for (int i = 0; i < s.length(); i++) {
-            char ch = s.charAt(i);
+        for (int i = 0; i < text.length(); i++) {
+            char ch = text.charAt(i);
 
-            // Characters in QUOTE_CHARS or outside ASCII range need double quotes.
+            // Characters in QUOTE_CHARS or outside ASCII range need double quoteStyle.
             if (QUOTE_CHARS.get(ch) || ch < ' ' || ch > 127)
                 return Quotes.DOUBLE;
 
@@ -393,18 +392,18 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
             if (ch == '\'')
                 hasSingleQuote = true;
 
-            // If a double quote is found followed by a single quote, return double quotes.
+            // If a double quote is found followed by a single quote, return double quoteStyle.
             if (ch == '"') {
                 if (i < s.length() - 1 && s.charAt(i + 1) == '\'')
                     return Quotes.DOUBLE;
-                quotes = Quotes.SINGLE;
+                quoteStyle = Quotes.SINGLE;
             }
         }
 
-        // If only single quotes are found, no quotes are needed.
+        // If only single quoteStyle are found, no quoteStyle are needed.
         if (hasSingleQuote)
             return Quotes.NONE;
-        return quotes;
+        return quoteStyle;
     }
 
     /**
@@ -680,19 +679,14 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          */
         @NotNull
         @Override
-        /**
-         * Writes a boolean value (true, false or !null ""). When
-         * {@link #dropDefault} is true and {@code flag} is null nothing is
-         * written.
-         */
-        public T bool(@Nullable Boolean flag) {
+        public T bool(@Nullable Boolean value) {
             if (dropDefault) {
-                if (flag == null)
+                if (value == null)
                     return wireOut();
                 writeSavedEventName();
             }
             prependSeparator();
-            append(flag == null ? nullOut() : flag ? "true" : "false");
+            append(value == null ? nullOut() : value ? "true" : "false");
             elementSeparator();
             return wireOut();
         }
@@ -712,22 +706,17 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          */
         @NotNull
         @Override
-        /**
-         * Writes a text value, quoting and escaping as required. If
-         * {@link #dropDefault} is set and {@code s} is null the field is
-         * omitted.
-         */
-        public T text(@Nullable CharSequence s) {
+        public T text(@Nullable CharSequence value) {
             if (dropDefault) {
-                if (s == null)
+                if (value == null)
                     return wireOut();
                 writeSavedEventName();
             }
             prependSeparator();
-            if (s == null) {
+            if (value == null) {
                 append(nullOut());
             } else {
-                escape(s);
+                escape(value);
             }
             elementSeparator();
             return wireOut();
@@ -741,24 +730,18 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          */
         @NotNull
         @Override
-        /**
-         * Writes bytes. If the content looks textual it is emitted as quoted
-         * text; otherwise it is Base64 encoded with a <code>!binary</code> type
-         * tag. When {@link #dropDefault} is true and the argument is null the
-         * value is omitted.
-         */
-        public T bytes(@Nullable BytesStore<?, ?> fromBytes) {
+        public T bytes(@Nullable BytesStore<?, ?> value) {
             if (dropDefault) {
-                if (fromBytes == null)
+                if (value == null)
                     return wireOut();
                 writeSavedEventName();
             }
-            if (isText(fromBytes))
-                return (T) text(fromBytes);
+            if (isText(value))
+                return (T) text(value);
 
-            int length = Maths.toInt32(fromBytes.readRemaining());
+            int length = Maths.toInt32(value.readRemaining());
             @NotNull byte[] byteArray = new byte[length];
-            fromBytes.copyTo(byteArray);
+            value.copyTo(byteArray);
 
             return bytes(byteArray);
         }
@@ -991,22 +974,24 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * If {@link YamlWireOut#addTimeStamps} is true and {@code i64} resembles
-         * an epoch time in milliseconds or nanoseconds, appends a human readable
-         * date-time comment (for example <code>, # 2023-10-26T10:30:00.123</code>).
+         * Adds a timestamp to the output in a predefined format.
+         * The method appends the timestamp as a comment in YAML, depending on the range and precision
+         * of the given timestamp value. The timestamp could be in milliseconds or with nanosecond precision.
+         *
+         * @param epochNanosOrMillis The timestamp value to be appended.
          */
-        public void addTimeStamp(long i64) {
+        public void addTimeStamp(long epochNanosOrMillis) {
             // Check if the timestamp is in a millisecond precision range (e.g., between 1e12 and 4.111e12)
-            if ((long) 1e12 < i64 && i64 < (long) 4.111e12) {
+            if ((long) 1e12 < epochNanosOrMillis && epochNanosOrMillis < (long) 4.111e12) {
                 // Append the date and time in milliseconds as a comment in the output
                 bytes.append(", # ");
-                bytes.appendDateMillis(i64);
+                bytes.appendDateMillis(epochNanosOrMillis);
                 bytes.append("T");
-                bytes.appendTimeMillis(i64);
+                bytes.appendTimeMillis(epochNanosOrMillis);
                 sep = NEW_LINE;
-            } else if ((long) 1e18 < i64 && i64 < (long) 4.111e18) {
-                long millis = i64 / 1_000_000;
-                long nanos = i64 % 1_000_000;
+            } else if ((long) 1e18 < epochNanosOrMillis && epochNanosOrMillis < (long) 4.111e18) {
+                long millis = epochNanosOrMillis / 1_000_000;
+                long nanos = epochNanosOrMillis % 1_000_000;
                 bytes.append(", # ");
                 bytes.appendDateMillis(millis);
                 bytes.append("T");
@@ -1125,16 +1110,16 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          * Writes special floating point values such as NaN or Infinity. For
          * YAML these are emitted as unquoted strings (e.g. <code>.NaN</code>).
          */
-        protected void writeSpecialDoubleValueToBytes(Bytes<?> bytes, double value) {
-            bytes.append(Double.toString(value));
+        protected void writeSpecialDoubleValueToBytes(Bytes<?> outputBytes, double value) {
+            outputBytes.append(Double.toString(value));
         }
 
         /**
          * Writes special floating point values such as NaN or Infinity. For
          * YAML these are emitted as unquoted strings (e.g. <code>.NaN</code>).
          */
-        protected void writeSpecialFloatValueToBytes(Bytes<?> bytes, float value) {
-            bytes.append(Float.toString(value));
+        protected void writeSpecialFloatValueToBytes(Bytes<?> outputBytes, float value) {
+            outputBytes.append(Float.toString(value));
         }
 
         @NotNull
@@ -1170,34 +1155,37 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Converts {@code stringable} to text and writes it, applying YAML
-         * quoting rules via {@link #asTestQuoted(String, Quotes)}. When
-         * {@link #dropDefault} is true and the value is null nothing is written.
+         * Converts the provided object to its String representation and prepares it for wire output.
+         * It handles null values and applies necessary formatting based on the needsQuotes method.
+         * If the value is set to drop by default, the saved event name is written.
+         *
+         * @param valueToConvert The object to convert to a string and process.
+         * @return An instance of T, typically representing the current wire output state.
          */
         @NotNull
-        private T asText(@Nullable Object stringable) {
+        private T asText(@Nullable Object valueToConvert) {
             // Check if defaults should be dropped and handle accordingly
             if (dropDefault) {
-                if (stringable == null)
+                if (valueToConvert == null)
                     return wireOut();
                 writeSavedEventName();
             }
 
-            // Handle null stringable objects
-            if (stringable == null) {
+            // Handle null valueToConvert objects
+            if (valueToConvert == null) {
                 nu11();
             } else {
                 // Add necessary separators
                 prependSeparator();
 
                 // Convert the object to its string representation
-                final String s = stringable.toString();
+                final String s = valueToConvert.toString();
 
-                // Determine if the string needs quotes
-                final Quotes quotes = needsQuotes(s);
+                // Determine if the string needs quoteStyle
+                final Quotes quoteStyle = needsQuotes(s);
 
-                // Append the string to the wire output with necessary quotes
-                asTestQuoted(s, quotes);
+                // Append the string to the wire output with necessary quoteStyle
+                asTestQuoted(s, quoteStyle);
 
                 // Add element separator after processing the string
                 elementSeparator();
@@ -1207,16 +1195,20 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Writes {@code s} quoting it with {@code quotes.q} and escaping via
-         * {@link #escape0(CharSequence, Quotes)} when needed.
+         * Appends the provided string to the wire output, with or without quoteStyle based on the provided quote preference.
+         * If the quote preference is NONE, the string is added directly to the wire output.
+         * Otherwise, the string is escaped based on the provided quote preference.
+         *
+         * @param s      The string to append.
+         * @param quoteStyle The quote preference for the string.
          */
-        protected void asTestQuoted(String s, Quotes quotes) {
-            // Check if the string needs quotes
-            if (quotes == Quotes.NONE) {
+        protected void asTestQuoted(String s, Quotes quoteStyle) {
+            // Check if the string needs quoteStyle
+            if (quoteStyle == Quotes.NONE) {
                 append(s);
             } else {
                 // Escape the string based on the provided quote preference
-                escape0(s, quotes);
+                escape0(s, quoteStyle);
             }
         }
 
@@ -1387,11 +1379,13 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Writes the block start character (<code>{</code> or <code>[</code>)
-         * after dealing with any pending separator and pushing the current
-         * state for later restoration.
+         * Starts a block with the given character, typically an opening bracket or brace.
+         * Before writing the block starter, any necessary separators and whitespace are added.
+         * The method also pushes the current state to remember the context.
+         *
+         * @param blockStartChar The character that starts the block.
          */
-        public void startBlock(char c) {
+        public void startBlock(char blockStartChar) {
             // If defaults are to be dropped, save the event name
             if (dropDefault) {
                 writeSavedEventName();
@@ -1409,7 +1403,7 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
             pushState();
 
             // Write the starting block character
-            bytes.writeUnsignedByte(c);
+            bytes.writeUnsignedByte(blockStartChar);
         }
 
         @NotNull
@@ -1437,29 +1431,33 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Writes the closing block character and collapses any doubled newlines
-         * before it.
+         * Ends a block with the given character, typically a closing bracket or brace.
+         * Removes any double newlines to ensure a clean block closure.
+         *
+         * @param blockEndChar The character that ends the block.
          */
-        public void endBlock(char c) {
+        public void endBlock(char blockEndChar) {
             BytesUtil.combineDoubleNewline(bytes);
-            bytes.writeUnsignedByte(c);
+            bytes.writeUnsignedByte(blockEndChar);
         }
 
         /**
-         * Adds a newline only if content was written after {@code pos} within a
-         * block.
+         * Adds a newline at the specified position if applicable.
+         *
+         * @param previousWritePosition The position after which the newline should be added.
          */
-        protected void addNewLine(long pos) {
-            if (bytes.writePosition() > pos + 1)
+        protected void addNewLine(long previousWritePosition) {
+            if (bytes.writePosition() > previousWritePosition + 1)
                 bytes.writeUnsignedByte('\n');
         }
 
         /**
-         * Adds a space only if content was written after {@code pos} within a
-         * block.
+         * Adds a space at the specified position if applicable.
+         *
+         * @param previousWritePosition The position after which the space should be added.
          */
-        protected void addSpace(long pos) {
-            if (bytes.writePosition() > pos + 1)
+        protected void addSpace(long previousWritePosition) {
+            if (bytes.writePosition() > previousWritePosition + 1)
                 bytes.writeUnsignedByte(' ');
         }
 
@@ -1712,17 +1710,19 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Prepares to write a field with the provided name. If
-         * {@link #dropDefault} is true the name is stored until a value is
-         * confirmed as non-default.
+         * Writes a given CharSequence name to the Yaml output. If the default value is dropped,
+         * the event name is set to the given name.
+         *
+         * @param fieldName The CharSequence name to write.
+         * @return Returns an instance of the current object, supporting chained method calls.
          */
         @NotNull
-        public YamlValueOut write(@NotNull CharSequence name) {
+        public YamlValueOut write(@NotNull CharSequence fieldName) {
             if (dropDefault) {
-                eventName = name.toString();
+                eventName = fieldName.toString();
             } else {
                 prependSeparator();
-                escape(name);
+                escape(fieldName);
                 fieldValueSeperator();
             }
             return this;
@@ -1774,10 +1774,12 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Writes a YAML comment line. If a preceding comment annotation was
-         * detected, additional indentation is applied.
+         * Writes a comment to the Yaml output. If a comment annotation exists,
+         * specific formatting is applied. Otherwise, a standard comment format is used.
+         *
+         * @param commentText The comment text to write.
          */
-        public void writeComment(@NotNull CharSequence s) {
+        public void writeComment(@NotNull CharSequence commentText) {
 
             if (hasCommentAnnotation) {
                 // Ensure the separator ends with a newline character
@@ -1797,7 +1799,7 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
 
             writeTwo('#', ' ');
 
-            append(s);
+            append(commentText);
             bytes.writeUnsignedByte('\n');
             sep = EMPTY_AFTER_COMMENT;
         }

--- a/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
@@ -524,30 +524,48 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * This internal class represents an output value in the YAML format. It provides functionalities related
-     * to appending separators, handling whitespace, and maintaining indentation among others.
+     * The primary {@link ValueOut} implementation for {@link YamlWireOut}.
+     * Manages YAML-specific formatting such as indentation, separators
+     * (comma or newline based on context and {@link #leaf} state), comments and
+     * block structuring ({@code {...}}, {@code [...]}).
      */
     class YamlValueOut implements ValueOut, CommentAnnotationNotifier {
+        /** Indicates that a preceding comment annotation was encountered. */
         protected boolean hasCommentAnnotation = false;
 
-        // The current indentation level for the value.
+        /** Current indentation level (number of 2-space indents). */
         protected int indentation = 0;
 
-        // A list of separators to be used when writing the value.
+        /**
+         * Stack of separators used when nesting structures so the parent
+         * separator can be restored.
+         */
         @NotNull
         protected List<BytesStore> seps = new ArrayList<>(4);
 
-        // The current separator being used.
+        /**
+         * The separator (",", "\n", etc.) to prepend before the next value is
+         * written.
+         */
         @NotNull
         protected BytesStore<?, ?> sep = BytesStore.empty();
 
-        // Flag indicating if the value is a leaf node (i.e., doesn't have child elements).
+        /**
+         * True if the value being written is a simple scalar (a 'leaf' node).
+         * Leaf nodes use comma separators whereas others use newlines.
+         */
         protected boolean leaf = false;
 
-        // Flag indicating if default values should be dropped from the output.
+        /**
+         * When true, fields equal to their defaults may be omitted from the
+         * output.
+         */
         protected boolean dropDefault = false;
 
-        // The name of the event associated with this value (if any).
+        /**
+         * Stores the field name when {@link #dropDefault} is true so it can be
+         * written if the following value is non-default.
+         */
         @Nullable
         private String eventName;
 
@@ -572,7 +590,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Appends the current separator to the output bytes, and resets the separator.
+         * Writes the configured {@link #sep} to the output and then clears it
+         * so the next value can supply its own separator.
          */
         void prependSeparator() {
             appendSep();
@@ -580,7 +599,9 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Appends the current separator to the output bytes and handles any necessary whitespace trimming.
+         * Writes {@link #sep}, trims any resulting double newlines and indents
+         * if the separator ended with a newline or was
+         * {@link YamlWireOut#EMPTY_AFTER_COMMENT}.
          */
         protected void appendSep() {
             append(sep);
@@ -590,13 +611,19 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Trims excessive whitespace from the output bytes, particularly to remove double newline characters.
+         * Ensures there are no double newlines in the output by removing one if
+         * a <code>\n\n</code> sequence is found.
          */
         protected void trimWhiteSpace() {
             BytesUtil.combineDoubleNewline(bytes);
         }
 
         @Override
+        /**
+         * Sets the {@link #leaf} state. If switching from leaf to non-leaf and
+         * the current separator is comma-space, the separator is changed to the
+         * appropriate element separator.
+         */
         public boolean swapLeaf(boolean isLeaf) {
             if (isLeaf == leaf)
                 return leaf;
@@ -613,8 +640,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Indents the YAML content based on the current indentation level. It uses a trick of
-         * writing two spaces at a time to speed up the process.
+         * Writes the appropriate number of spaces based on {@link #indentation}.
+         * Two spaces are emitted per level for efficiency.
          */
         protected void indent() {
             BytesUtil.combineDoubleNewline(bytes);
@@ -624,8 +651,9 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Determines and sets the appropriate separator for the current YAML element.
-         * The separator varies based on the indentation level and whether the current value is a leaf node.
+         * Sets {@link #sep} for the next element based on {@link #indentation}
+         * and {@link #leaf}. Top level or non-leaf elements use newlines; nested
+         * leaf elements use comma-space.
          */
         @Override
         public void elementSeparator() {
@@ -644,6 +672,11 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
 
         @NotNull
         @Override
+        /**
+         * Writes a boolean value (true, false or !null ""). When
+         * {@link #dropDefault} is true and {@code flag} is null nothing is
+         * written.
+         */
         public T bool(@Nullable Boolean flag) {
             if (dropDefault) {
                 if (flag == null)
@@ -657,10 +690,7 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Returns the string representation for null in YAML format.
-         * It utilizes the predefined NULL static configuration for constructing the output.
-         *
-         * @return String representation for null in YAML.
+         * Returns the YAML string used for a null value: <code>!null ""</code>.
          */
         @NotNull
         public String nullOut() {
@@ -669,6 +699,11 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
 
         @NotNull
         @Override
+        /**
+         * Writes a text value, quoting and escaping as required. If
+         * {@link #dropDefault} is set and {@code s} is null the field is
+         * omitted.
+         */
         public T text(@Nullable CharSequence s) {
             if (dropDefault) {
                 if (s == null)
@@ -687,6 +722,12 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
 
         @NotNull
         @Override
+        /**
+         * Writes bytes. If the content looks textual it is emitted as quoted
+         * text; otherwise it is Base64 encoded with a <code>!binary</code> type
+         * tag. When {@link #dropDefault} is true and the argument is null the
+         * value is omitted.
+         */
         public T bytes(@Nullable BytesStore<?, ?> fromBytes) {
             if (dropDefault) {
                 if (fromBytes == null)
@@ -931,11 +972,9 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Adds a timestamp to the output in a predefined format.
-         * The method appends the timestamp as a comment in YAML, depending on the range and precision
-         * of the given timestamp value. The timestamp could be in milliseconds or with nanosecond precision.
-         *
-         * @param i64 The timestamp value to be appended.
+         * If {@link YamlWireOut#addTimeStamps} is true and {@code i64} resembles
+         * an epoch time in milliseconds or nanoseconds, appends a human readable
+         * date-time comment (for example <code>, # 2023-10-26T10:30:00.123</code>).
          */
         public void addTimeStamp(long i64) {
             // Check if the timestamp is in a millisecond precision range (e.g., between 1e12 and 4.111e12)
@@ -1064,16 +1103,16 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Writes a special double value, e.g. NaN, to bytes in the context of Yaml Wire. For now this
-         * remains as an unquoted string representation.
+         * Writes special floating point values such as NaN or Infinity. For
+         * YAML these are emitted as unquoted strings (e.g. <code>.NaN</code>).
          */
         protected void writeSpecialDoubleValueToBytes(Bytes<?> bytes, double value) {
             bytes.append(Double.toString(value));
         }
 
         /**
-         * Writes a special double value, e.g. NaN, to bytes in the context of Yaml Wire. For now this
-         * remains as an unquoted string representation.
+         * Writes special floating point values such as NaN or Infinity. For
+         * YAML these are emitted as unquoted strings (e.g. <code>.NaN</code>).
          */
         protected void writeSpecialFloatValueToBytes(Bytes<?> bytes, float value) {
             bytes.append(Float.toString(value));
@@ -1112,12 +1151,9 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Converts the provided object to its String representation and prepares it for wire output.
-         * It handles null values and applies necessary formatting based on the needsQuotes method.
-         * If the value is set to drop by default, the saved event name is written.
-         *
-         * @param stringable The object to convert to a string and process.
-         * @return An instance of T, typically representing the current wire output state.
+         * Converts {@code stringable} to text and writes it, applying YAML
+         * quoting rules via {@link #asTestQuoted(String, Quotes)}. When
+         * {@link #dropDefault} is true and the value is null nothing is written.
          */
         @NotNull
         private T asText(@Nullable Object stringable) {
@@ -1152,12 +1188,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Appends the provided string to the wire output, with or without quotes based on the provided quote preference.
-         * If the quote preference is NONE, the string is added directly to the wire output.
-         * Otherwise, the string is escaped based on the provided quote preference.
-         *
-         * @param s      The string to append.
-         * @param quotes The quote preference for the string.
+         * Writes {@code s} quoting it with {@code quotes.q} and escaping via
+         * {@link #escape0(CharSequence, Quotes)} when needed.
          */
         protected void asTestQuoted(String s, Quotes quotes) {
             // Check if the string needs quotes
@@ -1177,6 +1209,10 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
 
         @NotNull
         @Override
+        /**
+         * Writes a YAML type tag such as <code>!typeName</code> before the
+         * following value.
+         */
         public YamlValueOut typePrefix(@NotNull CharSequence typeName) {
             if (dropDefault) {
                 writeSavedEventName();
@@ -1328,11 +1364,9 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Starts a block with the given character, typically an opening bracket or brace.
-         * Before writing the block starter, any necessary separators and whitespace are added.
-         * The method also pushes the current state to remember the context.
-         *
-         * @param c The character that starts the block.
+         * Writes the block start character (<code>{</code> or <code>[</code>)
+         * after dealing with any pending separator and pushing the current
+         * state for later restoration.
          */
         public void startBlock(char c) {
             // If defaults are to be dropped, save the event name
@@ -1380,10 +1414,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Ends a block with the given character, typically a closing bracket or brace.
-         * Removes any double newlines to ensure a clean block closure.
-         *
-         * @param c The character that ends the block.
+         * Writes the closing block character and collapses any doubled newlines
+         * before it.
          */
         public void endBlock(char c) {
             BytesUtil.combineDoubleNewline(bytes);
@@ -1391,9 +1423,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Adds a newline at the specified position if applicable.
-         *
-         * @param pos The position after which the newline should be added.
+         * Adds a newline only if content was written after {@code pos} within a
+         * block.
          */
         protected void addNewLine(long pos) {
             if (bytes.writePosition() > pos + 1)
@@ -1401,9 +1432,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Adds a space at the specified position if applicable.
-         *
-         * @param pos The position after which the space should be added.
+         * Adds a space only if content was written after {@code pos} within a
+         * block.
          */
         protected void addSpace(long pos) {
             if (bytes.writePosition() > pos + 1)
@@ -1411,15 +1441,15 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Sets the separator to a new line for future content additions.
+         * Sets {@link #sep} so that the next value starts on a new line.
          */
         protected void newLine() {
             sep = NEW_LINE;
         }
 
         /**
-         * Reverts the current state to the previous state by popping the last saved state.
-         * This involves reverting the separator, decreasing the indentation, and resetting certain flags.
+         * Restores the previous separator and indentation when leaving a nested
+         * structure.
          */
         protected void popState() {
             sep = seps.remove(seps.size() - 1);
@@ -1429,8 +1459,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Pushes the current state, preserving the current context for later restoration.
-         * This involves increasing the indentation and saving the current separator.
+         * Saves the current separator and increases indentation for a nested
+         * structure.
          */
         protected void pushState() {
             indentation++;
@@ -1440,6 +1470,10 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
 
         @NotNull
         @Override
+        /**
+         * Serialises a {@link WriteMarshallable}. Handles the outer braces and
+         * manages {@link #leaf} so leaf marshallables can be rendered inline.
+         */
         public T marshallable(@NotNull WriteMarshallable object) throws InvalidMarshallableException {
             WireMarshaller wm = WireMarshaller.WIRE_MARSHALLER_CL.get(object.getClass());
             boolean wasLeaf0 = leaf;
@@ -1498,6 +1532,10 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
 
         @NotNull
         @Override
+        /**
+         * Serialises a {@link Serializable} object using either its
+         * {@link Externalizable#writeExternal} method or default marshalling.
+         */
         public T marshallable(@NotNull Serializable object) throws InvalidMarshallableException {
             if (dropDefault) {
                 writeSavedEventName();
@@ -1568,8 +1606,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Performs actions after closing an element.
-         * Sets the separator to a newline and appends the current separator to the bytes.
+         * Called after a block is closed. Sets {@link #sep} to a newline and
+         * appends the current separator to the output.
          */
         protected void afterClose() {
             newLine();        // Set the separator to a newline
@@ -1578,8 +1616,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Performs actions after opening an element.
-         * Sets the separator to a space.
+         * Called after a block is opened. The next value will follow after a
+         * space.
          */
         protected void afterOpen() {
             sep = SPACE;      // Set the separator to a space
@@ -1596,24 +1634,24 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Sets the separator to denote the end of a field.
+         * Sets {@link #sep} to {@link YamlWireOut#END_FIELD} (a newline) after
+         * a key–value pair.
          */
         protected void endField() {
             sep = END_FIELD;
         }
 
         /**
-         * Writes a field-value separator, which is ": ".
+         * Writes the YAML key–value separator <code>:</code> followed by a
+         * space.
          */
         protected void fieldValueSeperator() {
             writeTwo(':', ' ');
         }
 
         /**
-         * Writes an empty value to the Yaml output. If the default value is dropped,
-         * the event name is set to an empty string.
-         *
-         * @return Returns an instance of the current object, supporting chained method calls.
+         * Begins writing a field with no name. If {@link #dropDefault} is true
+         * the name is stored so it can be output later when a value appears.
          */
         @NotNull
         public YamlValueOut write() {
@@ -1628,11 +1666,9 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Writes a given WireKey to the Yaml output. If the default value is dropped,
-         * the event name is set to the name of the key.
-         *
-         * @param key The WireKey to write.
-         * @return Returns an instance of the current object, supporting chained method calls.
+         * Prepares to write a field using the supplied {@link WireKey}. When
+         * {@link #dropDefault} is true the name is saved until a non-default
+         * value is provided.
          */
         @NotNull
         public YamlValueOut write(@NotNull WireKey key) {
@@ -1645,11 +1681,9 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Writes a given CharSequence name to the Yaml output. If the default value is dropped,
-         * the event name is set to the given name.
-         *
-         * @param name The CharSequence name to write.
-         * @return Returns an instance of the current object, supporting chained method calls.
+         * Prepares to write a field with the provided name. If
+         * {@link #dropDefault} is true the name is stored until a value is
+         * confirmed as non-default.
          */
         @NotNull
         public YamlValueOut write(@NotNull CharSequence name) {
@@ -1664,14 +1698,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Writes a given objectKey of an expected type to the Yaml output. If the default value is dropped,
-         * and the expected type is not a String, an exception is thrown. Otherwise, the event name is set
-         * to the string representation of the objectKey.
-         *
-         * @param expectedType The expected type of the objectKey.
-         * @param objectKey    The object key to write.
-         * @return Returns an instance of the current object, supporting chained method calls.
-         * @throws InvalidMarshallableException If the object cannot be serialized.
+         * Starts writing a field with {@code objectKey} as name. Non-string keys
+         * are unsupported when {@link #dropDefault} is active.
          */
         @NotNull
         public YamlValueOut write(Class<?> expectedType, @NotNull Object objectKey) throws InvalidMarshallableException {
@@ -1689,8 +1717,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Writes the saved event name to the output. This method escapes the event name
-         * and separates it from its value.
+         * Emits any field name saved due to {@link #dropDefault} being true and
+         * clears {@link #eventName}.
          */
         private void writeSavedEventName() {
             if (eventName == null)
@@ -1702,8 +1730,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Ends the current event by checking and adjusting the position
-         * of the last byte written to the output, and appending a field value separator.
+         * Completes the key part written by {@link #writeStartEvent()} by adding
+         * the key–value separator and trimming trailing spaces.
          */
         public void endEvent() {
             // Check if the last written byte is a whitespace character or less
@@ -1715,10 +1743,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Writes a comment to the Yaml output. If a comment annotation exists,
-         * specific formatting is applied. Otherwise, a standard comment format is used.
-         *
-         * @param s The comment text to write.
+         * Writes a YAML comment line. If a preceding comment annotation was
+         * detected, additional indentation is applied.
          */
         public void writeComment(@NotNull CharSequence s) {
 

--- a/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
@@ -119,7 +119,7 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Creates and returns a new instance of {@link YamlValueOut}.
+     * Factory method used to obtain the main {@link YamlValueOut}.
      *
      * @return A new YamlValueOut instance.
      */
@@ -215,9 +215,9 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Escapes the given CharSequence {@code s} based on the requirements of the YAML format.
-     * If the sequence requires quotes, it will be enclosed with the appropriate quote character;
-     * otherwise, the sequence will be escaped without quotes.
+     * Escapes {@code textToEscape} according to YAML rules. If quoting is required the
+     * chosen quote character encloses the escaped text; otherwise,
+     * the sequence will be escaped without quotes.
      *
      * @param textToEscape The CharSequence to be escaped.
      */
@@ -234,7 +234,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
 
     // https://yaml.org/spec/1.2.2/#escaped-characters
     /**
-     * Helper method to escape special characters in the given CharSequence {@code s} based on the requirements of the YAML format.
+     * Helper method to escape special characters in the given CharSequence {@code textToEscape}
+     * based on the requirements of the YAML format.
      * The method handles the specific escaping requirements for various control and special characters.
      *
      * @param textToEscape The CharSequence to be escaped.
@@ -319,52 +320,52 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
      * Appends a 2-character hexadecimal representation of the given character {@code ch} to the output bytes.
      * This is used for character escaping.
      *
-     * @param characterToEncode The character to be converted to hexadecimal.
+     * @param ch The character to be converted to hexadecimal.
      */
-    private void appendX2(char characterToEncode) {
+    private void appendX2(char ch) {
         bytes.append('\\');
         bytes.append('x');
-        bytes.append(HEXADECIMAL[(characterToEncode >> 4) & 0xF]);
-        bytes.append(HEXADECIMAL[characterToEncode & 0xF]);
+        bytes.append(HEXADECIMAL[(ch >> 4) & 0xF]);
+        bytes.append(HEXADECIMAL[ch & 0xF]);
     }
 
     /**
      * Appends a 4-character hexadecimal Unicode representation of the given character {@code ch} to the output bytes.
      * This is used for character escaping.
      *
-     * @param characterToEncode The character to be converted to hexadecimal Unicode representation.
+     * @param ch The character to be converted to hexadecimal Unicode representation.
      */
-    protected void appendU4(char characterToEncode) {
+    protected void appendU4(char ch) {
         bytes.append('\\');
         bytes.append('u');
-        bytes.append(HEXADECIMAL[characterToEncode >> 12]);
-        bytes.append(HEXADECIMAL[(characterToEncode >> 8) & 0xF]);
-        bytes.append(HEXADECIMAL[(characterToEncode >> 4) & 0xF]);
-        bytes.append(HEXADECIMAL[characterToEncode & 0xF]);
+        bytes.append(HEXADECIMAL[ch >> 12]);
+        bytes.append(HEXADECIMAL[(ch >> 8) & 0xF]);
+        bytes.append(HEXADECIMAL[(ch >> 4) & 0xF]);
+        bytes.append(HEXADECIMAL[ch & 0xF]);
     }
 
     /**
-     * Determines the type of quotes (if any) required for the given CharSequence {@code text} based on the YAML format's escaping requirements.
+     * Determines the type of quotes (if any) required for the given CharSequence {@code cs} based on the YAML format's escaping requirements.
      * This method decides between using no quotes, single quotes, or double quotes.
      *
-     * @param text The CharSequence to be analysed.
+     * @param cs The CharSequence to be analyzed.
      * @return The type of quotes required.
      */
     @NotNull
-    protected Quotes needsQuotes(@NotNull CharSequence text) {
+    protected Quotes needsQuotes(@NotNull CharSequence cs) {
         @NotNull Quotes quoteStyle = Quotes.NONE;
 
         // Empty strings require double quoteStyle.
-        if (text.length() == 0)
+        if (cs.length() == 0)
             return Quotes.DOUBLE;
 
         // If string starts with special characters or ends with whitespace, use double quoteStyle.
-        if (STARTS_QUOTE_CHARS.get(text.charAt(0)) ||
-                Character.isWhitespace(text.charAt(text.length() - 1)))
+        if (STARTS_QUOTE_CHARS.get(cs.charAt(0)) ||
+                Character.isWhitespace(cs.charAt(cs.length() - 1)))
             return Quotes.DOUBLE;
         boolean hasSingleQuote = false;
-        for (int i = 0; i < text.length(); i++) {
-            char ch = text.charAt(i);
+        for (int i = 0; i < cs.length(); i++) {
+            char ch = cs.charAt(i);
 
             // Characters in QUOTE_CHARS or outside ASCII range need double quoteStyle.
             if (QUOTE_CHARS.get(ch) || ch < ' ' || ch > 127)
@@ -376,7 +377,7 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
 
             // If a double quote is found followed by a single quote, return double quoteStyle.
             if (ch == '"') {
-                if (i < text.length() - 1 && text.charAt(i + 1) == '\'')
+                if (i < cs.length() - 1 && cs.charAt(i + 1) == '\'')
                     return Quotes.DOUBLE;
                 quoteStyle = Quotes.SINGLE;
             }
@@ -415,7 +416,9 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * Writes the representation of the object {@code o} to the output. Differentiates the serialization logic based on the type of the object.
+     * Serialises a generic object. Iterables and maps are unpacked, while other
+     * types delegate to {@link ValueOut#object(Object)} or
+     * {@link ValueOut#typedMarshallable(WriteMarshallable)} as appropriate.
      *
      * @param o The object to be serialized.
      * @throws InvalidMarshallableException if an error occurs during serialization.
@@ -575,11 +578,6 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
             BytesUtil.combineDoubleNewline(bytes);
         }
 
-        /**
-         * Sets the {@link #leaf} state. If switching from leaf to non-leaf and
-         * the current separator is comma-space, the separator is changed to the
-         * appropriate element separator.
-         */
         @Override
         public boolean swapLeaf(boolean isLeaf) {
             if (isLeaf == leaf)
@@ -626,11 +624,6 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
             BytesUtil.combineDoubleNewline(bytes); // ensure no double new lines.
         }
 
-        /**
-         * Writes a boolean value (true, false or !null ""). When
-         * {@link #dropDefault} is true and {@code flag} is null nothing is
-         * written.
-         */
         @NotNull
         @Override
         public T bool(@Nullable Boolean value) {
@@ -656,11 +649,6 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
             return "!" + NULL;
         }
 
-        /**
-         * Writes a text value, quoting and escaping as required. If
-         * {@link #dropDefault} is set and {@code s} is null the field is
-         * omitted.
-         */
         @NotNull
         @Override
         public T text(@Nullable CharSequence value) {
@@ -679,12 +667,6 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
             return wireOut();
         }
 
-        /**
-         * Writes bytes. If the content looks textual it is emitted as quoted
-         * text; otherwise it is Base64 encoded with a <code>!binary</code> type
-         * tag. When {@link #dropDefault} is true and the argument is null the
-         * value is omitted.
-         */
         @NotNull
         @Override
         public T bytes(@Nullable BytesStore<?, ?> value) {
@@ -935,20 +917,20 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          * The method appends the timestamp as a comment in YAML, depending on the range and precision
          * of the given timestamp value. The timestamp could be in milliseconds or with nanosecond precision.
          *
-         * @param epochNanosOrMillis The timestamp value to be appended.
+         * @param i64 The timestamp value to be appended.
          */
-        public void addTimeStamp(long epochNanosOrMillis) {
+        public void addTimeStamp(long i64) {
             // Check if the timestamp is in a millisecond precision range (e.g., between 1e12 and 4.111e12)
-            if ((long) 1e12 < epochNanosOrMillis && epochNanosOrMillis < (long) 4.111e12) {
+            if ((long) 1e12 < i64 && i64 < (long) 4.111e12) {
                 // Append the date and time in milliseconds as a comment in the output
                 bytes.append(", # ");
-                bytes.appendDateMillis(epochNanosOrMillis);
+                bytes.appendDateMillis(i64);
                 bytes.append("T");
-                bytes.appendTimeMillis(epochNanosOrMillis);
+                bytes.appendTimeMillis(i64);
                 sep = NEW_LINE;
-            } else if ((long) 1e18 < epochNanosOrMillis && epochNanosOrMillis < (long) 4.111e18) {
-                long millis = epochNanosOrMillis / 1_000_000;
-                long nanos = epochNanosOrMillis % 1_000_000;
+            } else if ((long) 1e18 < i64 && i64 < (long) 4.111e18) {
+                long millis = i64 / 1_000_000;
+                long nanos = i64 % 1_000_000;
                 bytes.append(", # ");
                 bytes.appendDateMillis(millis);
                 bytes.append("T");
@@ -1116,27 +1098,27 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          * It handles null values and applies necessary formatting based on the needsQuotes method.
          * If the value is set to drop by default, the saved event name is written.
          *
-         * @param valueToConvert The object to convert to a string and process.
+         * @param stringable The object to convert to a string and process.
          * @return An instance of T, typically representing the current wire output state.
          */
         @NotNull
-        private T asText(@Nullable Object valueToConvert) {
+        private T asText(@Nullable Object stringable) {
             // Check if defaults should be dropped and handle accordingly
             if (dropDefault) {
-                if (valueToConvert == null)
+                if (stringable == null)
                     return wireOut();
                 writeSavedEventName();
             }
 
-            // Handle null valueToConvert objects
-            if (valueToConvert == null) {
+            // Handle null stringable objects
+            if (stringable == null) {
                 nu11();
             } else {
                 // Add necessary separators
                 prependSeparator();
 
                 // Convert the object to its string representation
-                final String s = valueToConvert.toString();
+                final String s = stringable.toString();
 
                 // Determine if the string needs quoteStyle
                 final Quotes quoteStyle = needsQuotes(s);
@@ -1175,10 +1157,6 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
             return typePrefix(aClass);
         }
 
-        /**
-         * Writes a YAML type tag such as <code>!typeName</code> before the
-         * following value.
-         */
         @NotNull
         @Override
         public YamlValueOut typePrefix(@NotNull CharSequence typeName) {
@@ -1397,20 +1375,20 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         /**
          * Adds a newline at the specified position if applicable.
          *
-         * @param previousWritePosition The position after which the newline should be added.
+         * @param pos The position after which the newline should be added.
          */
-        protected void addNewLine(long previousWritePosition) {
-            if (bytes.writePosition() > previousWritePosition + 1)
+        protected void addNewLine(long pos) {
+            if (bytes.writePosition() > pos + 1)
                 bytes.writeUnsignedByte('\n');
         }
 
         /**
          * Adds a space at the specified position if applicable.
          *
-         * @param previousWritePosition The position after which the space should be added.
+         * @param pos The position after which the space should be added.
          */
-        protected void addSpace(long previousWritePosition) {
-            if (bytes.writePosition() > previousWritePosition + 1)
+        protected void addSpace(long pos) {
+            if (bytes.writePosition() > pos + 1)
                 bytes.writeUnsignedByte(' ');
         }
 
@@ -1442,10 +1420,6 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
             sep = EMPTY;
         }
 
-        /**
-         * Serialises a {@link WriteMarshallable}. Handles the outer braces and
-         * manages {@link #leaf} so leaf marshallables can be rendered inline.
-         */
         @NotNull
         @Override
         public T marshallable(@NotNull WriteMarshallable object) throws InvalidMarshallableException {
@@ -1504,10 +1478,6 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
             return wireOut();
         }
 
-        /**
-         * Serialises a {@link Serializable} object using either its
-         * {@link Externalizable#writeExternal} method or default marshalling.
-         */
         @NotNull
         @Override
         public T marshallable(@NotNull Serializable object) throws InvalidMarshallableException {
@@ -1660,16 +1630,16 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          * Writes a given CharSequence name to the Yaml output. If the default value is dropped,
          * the event name is set to the given name.
          *
-         * @param fieldName The CharSequence name to write.
+         * @param name The CharSequence name to write.
          * @return Returns an instance of the current object, supporting chained method calls.
          */
         @NotNull
-        public YamlValueOut write(@NotNull CharSequence fieldName) {
+        public YamlValueOut write(@NotNull CharSequence name) {
             if (dropDefault) {
-                eventName = fieldName.toString();
+                eventName = name.toString();
             } else {
                 prependSeparator();
-                escape(fieldName);
+                escape(name);
                 fieldValueSeperator();
             }
             return this;

--- a/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
@@ -1,8 +1,6 @@
 /*
  * Copyright 2016-2020 chronicle.software
  *
- * https://chronicle.software
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -618,6 +616,11 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
             BytesUtil.combineDoubleNewline(bytes);
         }
 
+        /**
+         * Sets the {@link #leaf} state. If switching from leaf to non-leaf and
+         * the current separator is comma-space, the separator is changed to the
+         * appropriate element separator.
+         */
         @Override
         /**
          * Sets the {@link #leaf} state. If switching from leaf to non-leaf and
@@ -670,6 +673,11 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
             BytesUtil.combineDoubleNewline(bytes); // ensure no double new lines.
         }
 
+        /**
+         * Writes a boolean value (true, false or !null ""). When
+         * {@link #dropDefault} is true and {@code flag} is null nothing is
+         * written.
+         */
         @NotNull
         @Override
         /**
@@ -697,6 +705,11 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
             return "!" + NULL;
         }
 
+        /**
+         * Writes a text value, quoting and escaping as required. If
+         * {@link #dropDefault} is set and {@code s} is null the field is
+         * omitted.
+         */
         @NotNull
         @Override
         /**
@@ -720,6 +733,12 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
             return wireOut();
         }
 
+        /**
+         * Writes bytes. If the content looks textual it is emitted as quoted
+         * text; otherwise it is Base64 encoded with a <code>!binary</code> type
+         * tag. When {@link #dropDefault} is true and the argument is null the
+         * value is omitted.
+         */
         @NotNull
         @Override
         /**
@@ -1207,6 +1226,10 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
             return typePrefix(aClass);
         }
 
+        /**
+         * Writes a YAML type tag such as <code>!typeName</code> before the
+         * following value.
+         */
         @NotNull
         @Override
         /**
@@ -1468,6 +1491,10 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
             sep = EMPTY;
         }
 
+        /**
+         * Serialises a {@link WriteMarshallable}. Handles the outer braces and
+         * manages {@link #leaf} so leaf marshallables can be rendered inline.
+         */
         @NotNull
         @Override
         /**
@@ -1530,6 +1557,10 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
             return wireOut();
         }
 
+        /**
+         * Serialises a {@link Serializable} object using either its
+         * {@link Externalizable#writeExternal} method or default marshalling.
+         */
         @NotNull
         @Override
         /**


### PR DESCRIPTION
The net effect is that the most frequently used text/YAML classes now ship with concise, accurate JavaDocs, while all method signatures and bytecode remain **unchanged**.


## What actually lands

| Area                       | Key classes / files                                           | Outcome                                                                                                            |
| -------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
| **Core text-wire docs**    | `TextWire`, inner `TextValueIn`                               | Fresh Javadoc on parsing, strict-mode, file helpers, field reading, stop-char testers, padding & document markers. |
| **YAML wire docs**         | `YamlWire`, `YamlWireOut`, inner `YamlValueOut`               | Clarifies YAML tags, anchor/alias handling, timestamp comments, quoting/escaping logic and marshalling helpers.    |
| **Tokenisation & helpers** | `YamlTokeniser`, `YamlToken`, `TextStopCharTesters`, `Quotes` | End-to-end explanation of token flow, context stack, literal blocks, and the stop-char utilities behind them.      |
| **Utilities**              | `YamlLogging`, `YamlKeys`                                     | Describes runtime logging switches and offset-tracking used by the tokeniser.                                      |
| **Minor fixes**            | `WireDumper`, `Wires`, `hasMetaDataPrefix()` (TextWire)       | Small clarifications / missing tags.                                                                               |
