### PR TITLE
Refine parameter naming for clarity

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/GenerateJsonSchemaMain.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateJsonSchemaMain.java
@@ -101,32 +101,32 @@ public class GenerateJsonSchemaMain {
      * @return A string representation of the JSON schema.
      */
     String asJson() {
-        SourceCodeFormatter sb = new JsonSourceCodeFormatter();
+        SourceCodeFormatter builder = new JsonSourceCodeFormatter();
         String str = "{\n" +
                 "\"$schema\": \"http://json-schema.org/draft-07/schema#\",\n" +
                 "\"$id\": \"http://json-schema.org/draft-07/schema#\",\n" +
                 "\"title\": \"Core schema meta-schema\",\n" +
                 "\"definitions\": {\n";
-        sb.append(str);
+        builder.append(str);
         String sep = "";
         for (Map.Entry<Class<?>, String> entry : definitions.entrySet()) {
-            sb.append(sep);
-            sb.append("\"" + entry.getKey().getSimpleName() + "\": {\n");
-            sb.append(entry.getValue());
-            sb.append("}");
+            builder.append(sep);
+            builder.append("\"" + entry.getKey().getSimpleName() + "\": {\n");
+            builder.append(entry.getValue());
+            builder.append("}");
             sep = ",\n";
         }
-        sb.append("\n");
-        sb.append("},\n" +
+        builder.append("\n");
+        builder.append("},\n" +
                 "\"properties\": {\n");
         for (Map.Entry<String, String> entry : events.entrySet()) {
-            sb.append("\"" + entry.getKey() + "\": {\n");
-            sb.append(entry.getValue());
-            sb.append("},\n");
+            builder.append("\"" + entry.getKey() + "\": {\n");
+            builder.append(entry.getValue());
+            builder.append("},\n");
         }
-        sb.append("}\n" +
+        builder.append("}\n" +
                 "}\n");
-        return sb.toString();
+        return builder.toString();
     }
 
     /**
@@ -173,19 +173,19 @@ public class GenerateJsonSchemaMain {
      * The resulting JSON schema structure will encapsulate these properties within a 'properties' object.
      *
      * @param properties A map of property names to their JSON schema representations.
-     * @param sb         The StringBuilder to which the properties will be appended in JSON schema format.
+     * @param builder    The StringBuilder to which the properties will be appended in JSON schema format.
      */
-    private void addProperties(Map<String, String> properties, StringBuilder sb) {
-        sb.append("\"properties\": {");
+    private void addProperties(Map<String, String> properties, StringBuilder builder) {
+        builder.append("\"properties\": {");
         String sep = "\n";
         for (Map.Entry<String, String> entry : properties.entrySet()) {
-            sb.append(sep);
-            sb.append("\"" + entry.getKey() + "\": {\n");
-            sb.append(entry.getValue());
-            sb.append("}");
+            builder.append(sep);
+            builder.append("\"" + entry.getKey() + "\": {\n");
+            builder.append(entry.getValue());
+            builder.append("}");
             sep = ",\n";
         }
-        sb.append("\n" +
+        builder.append("\n" +
                 "}\n");
     }
 
@@ -206,7 +206,7 @@ public class GenerateJsonSchemaMain {
         aliases.put(type, "#/definitions/" + type.getSimpleName());
         Set<String> required = new LinkedHashSet<>();
         Map<String, String> properties = new LinkedHashMap<>();
-        StringBuilder sb = new StringBuilder();
+        StringBuilder builder = new StringBuilder();
         Map<String, Field> fieldMap = new LinkedHashMap<>();
         WireMarshaller.getAllField(type, fieldMap);
         for (Map.Entry<String, Field> entry : fieldMap.entrySet()) {
@@ -220,21 +220,21 @@ public class GenerateJsonSchemaMain {
                 required.add(name);
             properties.put(name, desc.toString());
         }
-        sb.append("\"type\": \"object\",\n");
+        builder.append("\"type\": \"object\",\n");
         if (!required.isEmpty()) {
-            sb.append("\"required\": [\n");
-            sb.append(required.stream()
+            builder.append("\"required\": [\n");
+            builder.append(required.stream()
                     .map(s -> '"' + s + '"')
                     .collect(Collectors.joining(",\n")));
-            sb.append("\n" +
+            builder.append("\n" +
                     "],\n");
         }
         Comment comment = Jvm.findAnnotation(type, Comment.class);
         if (comment != null)
-            sb.append("\"description\": \"" + comment.value() + "\",\n");
+            builder.append("\"description\": \"" + comment.value() + "\",\n");
 
-        addProperties(properties, sb);
-        definitions.put(type, sb.toString());
+        addProperties(properties, builder);
+        definitions.put(type, builder.toString());
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/GeneratedProxyClass.java
+++ b/src/main/java/net/openhft/chronicle/wire/GeneratedProxyClass.java
@@ -54,7 +54,7 @@ public enum GeneratedProxyClass {
         Set<Method> methods = new LinkedHashSet<>(16);
 
         // Builds the initial portion of the proxy class's Java code.
-        StringBuilder sb = new StringBuilder("package " + packageName + ";\n\n" +
+        StringBuilder builder = new StringBuilder("package " + packageName + ";\n\n" +
                 "import net.openhft.chronicle.core.Jvm;\n" +
                 "import net.openhft.chronicle.wire.MethodWriterInvocationHandlerSupplier;\n" +
                 "import java.lang.reflect.InvocationHandler;\n" +
@@ -63,7 +63,7 @@ public enum GeneratedProxyClass {
                 "import java.util.ArrayList;\n" +
                 "import java.util.List;\n");
 
-        sb.append("public class ")
+        builder.append("public class ")
                 .append(className)
                 .append(" implements ");
 
@@ -73,9 +73,9 @@ public enum GeneratedProxyClass {
         String sep = "";
         // create methodArray
         for (Class<?> interfaceClazz : interfaces) {
-            sb.append(sep);
+            builder.append(sep);
             String interfaceName = nameForClass(interfaceClazz);
-            sb.append(interfaceName);
+            builder.append(interfaceName);
 
             // Ensure the provided class is actually an interface
             if (!interfaceClazz.isInterface())
@@ -112,25 +112,25 @@ public enum GeneratedProxyClass {
 
             sep = ",\n              ";
         }
-        sb.append(" {\n" +
+        builder.append(" {\n" +
                 '\n');
 
         // Add fields and the constructor to the generated proxy class's code
-        addFieldsAndConstructor(maxArgs, methods, sb, className, methodArray);
+        addFieldsAndConstructor(maxArgs, methods, builder, className, methodArray);
 
         // Generate the proxy methods
-        createProxyMethods(methods, sb);
-        sb.append("}\n");
+        createProxyMethods(methods, builder);
+        builder.append("}\n");
 
         // If DUMP_CODE is true, print the generated Java code
         if (DUMP_CODE)
-            System.out.println(sb);
+            System.out.println(builder);
 
         // Attempt to load the generated proxy class
         try {
-            return Wires.loadFromJava(classLoader, packageName + '.' + className, sb.toString());
+            return Wires.loadFromJava(classLoader, packageName + '.' + className, builder.toString());
         } catch (Throwable e) {
-            throw Jvm.rethrow(new ClassNotFoundException(e.getMessage() + '\n' + sb, e));
+            throw Jvm.rethrow(new ClassNotFoundException(e.getMessage() + '\n' + builder, e));
         }
     }
 
@@ -152,13 +152,13 @@ public enum GeneratedProxyClass {
      *
      * @param maxArgs        The maximum number of arguments amongst the declared methods.
      * @param declaredMethods The set of methods to be proxied.
-     * @param sb             The StringBuilder to which the generated code is appended.
+     * @param builder             The StringBuilder to which the generated code is appended.
      * @param className      The name of the generated proxy class.
      * @param methodArray    A StringBuilder containing the array of declared methods.
      */
-    private static void addFieldsAndConstructor(final int maxArgs, final Set<Method> declaredMethods, final StringBuilder sb, final String className, final StringBuilder methodArray) {
+    private static void addFieldsAndConstructor(final int maxArgs, final Set<Method> declaredMethods, final StringBuilder builder, final String className, final StringBuilder methodArray) {
         // Define fields for the proxy class
-        sb.append("  private final MethodWriterInvocationHandlerSupplier handler;\n" +
+        builder.append("  private final MethodWriterInvocationHandlerSupplier handler;\n" +
                         "    private final Method[] methods = new Method[")
                 .append(declaredMethods.size())
                 .append("];\n")
@@ -179,9 +179,9 @@ public enum GeneratedProxyClass {
      * Generates the method signatures for proxy methods, including the logic to capture method arguments and invoke the actual method.
      *
      * @param declaredMethods The set of methods to be proxied.
-     * @param sb              The StringBuilder to which the generated code is appended.
+     * @param builder              The StringBuilder to which the generated code is appended.
      */
-    private static void createProxyMethods(final Set<Method> declaredMethods, final StringBuilder sb) {
+    private static void createProxyMethods(final Set<Method> declaredMethods, final StringBuilder builder) {
         int methodIndex = -1;
         for (final Method dm : declaredMethods) {
             // Get return type of the method
@@ -190,34 +190,34 @@ public enum GeneratedProxyClass {
             methodIndex++;
 
             // Append method signature to the StringBuilder
-            sb.append(createMethodSignature(dm, returnType));
-            sb.append("    Method _method_ = this.methods[").append(methodIndex).append("];\n");
-            sb.append("    Object[] _a_ = this.argsTL.get()[").append(dm.getParameterCount()).append("];\n");
+            builder.append(createMethodSignature(dm, returnType));
+            builder.append("    Method _method_ = this.methods[").append(methodIndex).append("];\n");
+            builder.append("    Object[] _a_ = this.argsTL.get()[").append(dm.getParameterCount()).append("];\n");
 
             // Assign method parameters to local array
-            assignParametersToArgs(sb, dm);
+            assignParametersToArgs(builder, dm);
             // Handle method invocation
-            callInvoke(sb, returnType);
+            callInvoke(builder, returnType);
         }
     }
 
     /**
      * Generates the method invocation logic. This includes invoking the method and handling any potential exceptions.
      *
-     * @param sb         The StringBuilder to which the generated code is appended.
+     * @param builder    The StringBuilder to which the generated code is appended.
      * @param returnType The return type of the method being invoked.
      */
-    private static void callInvoke(final StringBuilder sb, final Class<?> returnType) {
+    private static void callInvoke(final StringBuilder builder, final Class<?> returnType) {
         // Start method invocation
-        sb.append("    try {\n" +
+        builder.append("    try {\n" +
                 "      ");
 
         // Check if the method has a return type other than void
         if (returnType != void.class)
-            sb.append("return (").append(nameForClass(returnType)).append(')');
+            builder.append("return (").append(nameForClass(returnType)).append(')');
 
         // Invoke the method
-        sb.append(" handler.get().invoke(this,_method_,_a_);\n" +
+        builder.append(" handler.get().invoke(this,_method_,_a_);\n" +
                 "    } catch (Throwable throwable) {\n" +
                 // Handle exceptions by rethrowing them
                 "       throw Jvm.rethrow(throwable);\n" +
@@ -228,17 +228,17 @@ public enum GeneratedProxyClass {
     /**
      * Assigns the method parameters to a local array for future invocation.
      *
-     * @param sb The StringBuilder to which the generated code is appended.
+     * @param builder The StringBuilder to which the generated code is appended.
      * @param dm The method whose parameters need to be assigned.
      */
-    private static void assignParametersToArgs(final StringBuilder sb, final Method dm) {
+    private static void assignParametersToArgs(final StringBuilder builder, final Method dm) {
         // Get the number of parameters in the method
         final int len = dm.getParameters().length;
 
         // Iterate through each parameter and assign it to the array
         for (int j = 0; j < len; j++) {
             String paramName = dm.getParameters()[j].getName();
-            sb.append("    _a_[").append(j).append("] = ").append(paramName).append(";\n");
+            builder.append("    _a_[").append(j).append("] = ").append(paramName).append(";\n");
         }
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -542,7 +542,7 @@ public class TextWire extends YamlWireOut<TextWire> {
      * Reads the next field name and appends it to the provided {@code StringBuilder}.
      */
     @NotNull
-    protected StringBuilder readField(@NotNull StringBuilder sb) {
+    protected StringBuilder readField(@NotNull StringBuilder builder) {
         consumePadding();
         try {
             int ch = peekCode();
@@ -551,8 +551,8 @@ public class TextWire extends YamlWireOut<TextWire> {
                 throw new IllegalStateException("Attempting to read binary as TextWire ch=" + Integer.toHexString(ch));
             }
             if (ch < 0 || ch == '!' || ch == '[' || ch == '{') {
-                sb.setLength(0);
-                return sb;
+                builder.setLength(0);
+                return builder;
             }
             if (ch == '?') {
                 bytes.readSkip(1);
@@ -562,7 +562,7 @@ public class TextWire extends YamlWireOut<TextWire> {
             if (ch == '"') {
                 bytes.readSkip(1);
 
-                parseUntil(sb, getEscapingQuotes());
+                parseUntil(builder, getEscapingQuotes());
 
                 consumePadding();
                 ch = readCode();
@@ -572,7 +572,7 @@ public class TextWire extends YamlWireOut<TextWire> {
             } else if (ch == '\'') {
                 bytes.readSkip(1);
 
-                parseUntil(sb, getEscapingSingleQuotes());
+                parseUntil(builder, getEscapingSingleQuotes());
 
                 consumePadding();
                 ch = readCode();
@@ -580,28 +580,28 @@ public class TextWire extends YamlWireOut<TextWire> {
                     throw new UnsupportedOperationException("Expected a : at " + bytes.toDebugString() + " was " + (char) ch);
 
             } else if (ch < 0) {
-                sb.setLength(0);
-                return sb;
+                builder.setLength(0);
+                return builder;
 
             } else {
-                parseUntil(sb, getEscapingEndOfText());
-                trimTheEnd(sb);
+                parseUntil(builder, getEscapingEndOfText());
+                trimTheEnd(builder);
 
             }
-            unescape(sb);
+            unescape(builder);
 
         } catch (BufferUnderflowException e) {
             Jvm.debug().on(getClass(), e);
         }
-        return sb;
+        return builder;
     }
 
     /**
      * Internal utility to remove trailing whitespace from a {@code StringBuilder}.
      */
-    private void trimTheEnd(@NotNull StringBuilder sb) {
-        while (sb.length() > 0 && Character.isWhitespace(sb.charAt(sb.length() - 1)))
-            sb.setLength(sb.length() - 1);
+    private void trimTheEnd(@NotNull StringBuilder builder) {
+        while (builder.length() > 0 && Character.isWhitespace(builder.charAt(builder.length() - 1)))
+            builder.setLength(builder.length() - 1);
     }
 
     /**
@@ -662,7 +662,7 @@ public class TextWire extends YamlWireOut<TextWire> {
             Jvm.debug().on(getClass(), e);
         }
         //      consumePadding();
-        return toExpected(expectedClass, sb);
+        return toExpected(expectedClass, builder);
     }
 
     /**
@@ -681,8 +681,8 @@ public class TextWire extends YamlWireOut<TextWire> {
      * @return An instance of the expected class, converted from the StringBuilder's content.
      */
     @Nullable
-    private <K> K toExpected(Class<K> expectedClass, StringBuilder sb) {
-        return ObjectUtils.convertTo(expectedClass, WireInternal.INTERNER.intern(sb));
+    private <K> K toExpected(Class<K> expectedClass, StringBuilder builder) {
+        return ObjectUtils.convertTo(expectedClass, WireInternal.INTERNER.intern(builder));
     }
 
     /**
@@ -941,7 +941,7 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         // Continuation of the read operation (possibly handles edge cases or fallbacks).
-        return read2(keyName, keyCode, defaultValue, curr, stringBuilder, keyName);
+        return read2(keyName, keyCode, defaultValue, curr, stringBuilder);
     }
 
     /**
@@ -955,24 +955,25 @@ public class TextWire extends YamlWireOut<TextWire> {
      * @param keyName      field name being searched for
      * @param keyCode      identifier used when marshalling numbers
      * @param defaultValue default value to supply when the field is absent
-     * @param curr         state tracking previously read fields
-     * @param sb           scratch buffer used for name comparison
-     * @param name         same as {@code keyName}; retained for compatibility
+     * @param state        state tracking previously read fields
+     * @param scratch      scratch buffer used for name comparison
      * @return a {@link ValueIn} positioned on the matched value or a default one
      */
-    protected ValueIn read2(CharSequence keyName, int keyCode, Object defaultValue, @NotNull ValueInState curr, @NotNull StringBuilder sb, @NotNull CharSequence name) {
+    protected ValueIn read2(CharSequence keyName, int keyCode, Object defaultValue,
+                            @NotNull ValueInState state,
+                            @NotNull StringBuilder scratch) {
         final long position2 = bytes.readPosition();
 
         // if not a match go back and look at old fields.
-        for (int i = 0; i < curr.unexpectedSize(); i++) {
-            bytes.readPosition(curr.unexpected(i));
+        for (int i = 0; i < state.unexpectedSize(); i++) {
+            bytes.readPosition(state.unexpected(i));
             valueIn.consumeAny = true;
-            readField(sb);
+            readField(scratch);
             valueIn.consumeAny = false;
-            if (sb.length() == 0 || StringUtils.equalsCaseIgnore(sb, name)) {
+            if (scratch.length() == 0 || StringUtils.equalsCaseIgnore(scratch, keyName)) {
                 // if an old field matches, remove it, save the current position
-                curr.removeUnexpected(i);
-                curr.savedPosition(position2 + 1);
+                state.removeUnexpected(i);
+                state.savedPosition(position2 + 1);
                 return valueIn;
             }
         }
@@ -1074,28 +1075,28 @@ public class TextWire extends YamlWireOut<TextWire> {
      * Parses text from the wire into {@code sb} until {@code testers} signals a
      * stop.
      *
-     * @param sb      destination for the parsed characters
-     * @param testers stop condition
+     * @param target      destination for the parsed characters
+     * @param stopTester stop condition
      */
-    public void parseUntil(@NotNull StringBuilder sb, @NotNull StopCharTester testers) {
+    public void parseUntil(@NotNull StringBuilder target, @NotNull StopCharTester stopTester) {
         if (use8bit)
-            bytes.parse8bit(sb, testers);
+            bytes.parse8bit(target, stopTester);
         else
-            bytes.parseUtf8(sb, testers);
+            bytes.parseUtf8(target, stopTester);
     }
 
     /**
      * Clears {@code sb} and parses text until {@code testers} requests a stop.
      *
-     * @param sb      destination builder that will be cleared before use
-     * @param testers stop condition operating on multiple characters
+     * @param target      destination builder that will be cleared before use
+     * @param stopTester stop condition operating on multiple characters
      */
-    public void parseUntil(@NotNull StringBuilder sb, @NotNull StopCharsTester testers) {
-        sb.setLength(0);
+    public void parseUntil(@NotNull StringBuilder target, @NotNull StopCharsTester stopTester) {
+        target.setLength(0);
         if (use8bit) {
-            AppendableUtil.read8bitAndAppend(bytes, sb, testers);
+            AppendableUtil.read8bitAndAppend(bytes, target, stopTester);
         } else {
-            AppendableUtil.readUTFAndAppend(bytes, sb, testers);
+            AppendableUtil.readUTFAndAppend(bytes, target, stopTester);
         }
     }
 
@@ -1193,12 +1194,12 @@ public class TextWire extends YamlWireOut<TextWire> {
      * continues until the indentation drops below {@code indentation}.
      *
      * @param indentation indentation level marking list items
-     * @param elementType expected element class or {@code null}
+     * @param itemType    expected element class or {@code null}
      * @return list of parsed elements
      * @throws InvalidMarshallableException if an element cannot be parsed
      */
     @NotNull
-    List readList(int indentation, Class<?> elementType) throws InvalidMarshallableException {
+    List readList(int indentation, Class<?> itemType) throws InvalidMarshallableException {
         @NotNull List<Object> objects = new ArrayList<>();
         while (peekCode() == '-') {
             if (indentation() < indentation)
@@ -1209,7 +1210,7 @@ public class TextWire extends YamlWireOut<TextWire> {
             bytes.readSkip(1);
             consumePadding();
             if (lineStart == ls) {
-                objects.add(valueIn.objectWithInferredType(null, SerializationStrategies.ANY_OBJECT, elementType));
+                objects.add(valueIn.objectWithInferredType(null, SerializationStrategies.ANY_OBJECT, itemType));
             } else {
                 @Nullable Object e = readObject(indentation);
                 if (e != NoObject.NO_OBJECT)
@@ -1228,12 +1229,12 @@ public class TextWire extends YamlWireOut<TextWire> {
      * {@code ...} is encountered.
      *
      * @param indentation indentation level marking map entries
-     * @param valueType   expected value class or {@code null}
+     * @param mapValueType   expected value class or {@code null}
      * @return the populated map
      * @throws InvalidMarshallableException if a value cannot be parsed
      */
     @NotNull
-    private Map readMap(int indentation, Class<?> valueType) throws InvalidMarshallableException {
+    private Map readMap(int indentation, Class<?> mapValueType) throws InvalidMarshallableException {
         @NotNull Map map = new LinkedHashMap<>();
         consumePadding();
         while (bytes.readRemaining() > 0) {
@@ -1242,7 +1243,7 @@ public class TextWire extends YamlWireOut<TextWire> {
             @Nullable String key = readAndIntern();
             if (key.equals("..."))
                 break;
-            @Nullable Object value = valueIn.objectWithInferredType(null, SerializationStrategies.ANY_OBJECT, valueType);
+            @Nullable Object value = valueIn.objectWithInferredType(null, SerializationStrategies.ANY_OBJECT, mapValueType);
             map.put(key, value);
             consumePadding(1);
         }
@@ -1401,17 +1402,17 @@ public class TextWire extends YamlWireOut<TextWire> {
          * the tokeniser is unescaped before returning.
          */
         @SuppressWarnings("fallthrough")
-        @Nullable <ACS extends Appendable & CharSequence> CharSequence textTo0(@NotNull ACS a) {
+        @Nullable <ACS extends Appendable & CharSequence> CharSequence textTo0(@NotNull ACS dest) {
             consumePadding();
             int ch = peekCode();
-            @Nullable CharSequence ret = a;
+            @Nullable CharSequence ret = dest;
 
             switch (ch) {
                 case '{': {
                     // For map-like structures: read the length of the content and append to the target appendable
                     final long len = readLength();
                     try {
-                        a.append(Bytes.toString(bytes, bytes.readPosition(), len));
+                        dest.append(Bytes.toString(bytes, bytes.readPosition(), len));
                     } catch (IOException e) {
                         throw new AssertionError(e);
                     }
@@ -1421,15 +1422,15 @@ public class TextWire extends YamlWireOut<TextWire> {
                     // Move to the next comma or the end of the map
                     bytes.skipTo(StopCharTesters.COMMA_STOP);
 
-                    return a;
+                    return dest;
 
                 }
                 case '"':
-                    readText(a, getEscapingQuotes());
+                    readText(dest, getEscapingQuotes());
                     break;
 
                 case '\'':
-                    readText(a, getEscapingSingleQuotes());
+                    readText(dest, getEscapingSingleQuotes());
                     break;
 
                 case '!': {
@@ -1443,8 +1444,8 @@ public class TextWire extends YamlWireOut<TextWire> {
                         ret = null;
                     } else {
                         // ignore the type.
-                        if (a instanceof StringBuilder) {
-                            textTo((StringBuilder) a);
+                        if (dest instanceof StringBuilder) {
+                            textTo((StringBuilder) dest);
                         } else {
                             textTo(stringBuilder);
                             ret = stringBuilder;
@@ -1460,8 +1461,8 @@ public class TextWire extends YamlWireOut<TextWire> {
                 case '$':
                     // For variable substitution syntax (e.g. "${variable}")
                     if (peekCodeNext() == '{') {
-                        unsubstitutedString(a);
-                        return a;
+                        unsubstitutedString(dest);
+                        return dest;
                     }
                     // fall through
 
@@ -1470,24 +1471,24 @@ public class TextWire extends YamlWireOut<TextWire> {
 
                     final long rem = bytes.readRemaining();
                     if (rem > 0) {
-                        if (a instanceof Bytes) {
-                            bytes.parse8bit((Bytes) a, getStrictEscapingEndOfText());
+                        if (dest instanceof Bytes) {
+                            bytes.parse8bit((Bytes) dest, getStrictEscapingEndOfText());
                         } else if (use8bit) {
-                            bytes.parse8bit((StringBuilder) a, getStrictEscapingEndOfText());
+                            bytes.parse8bit((StringBuilder) dest, getStrictEscapingEndOfText());
                         } else {
-                            bytes.parseUtf8(a, getStrictEscapingEndOfText());
+                            bytes.parseUtf8(dest, getStrictEscapingEndOfText());
                         }
                         // If nothing was read, throw an exception
                         if (rem == bytes.readRemaining())
                             throw new IORuntimeException("Nothing to read at " + bytes.toDebugString(32));
                     } else {
                         // Clear the target appendable if no remaining content
-                        AppendableUtil.setLength(a, 0);
+                        AppendableUtil.setLength(dest, 0);
                     }
                     // trim trailing spaces.
-                    while (a.length() > 0) {
-                        if (Character.isWhitespace(a.charAt(a.length() - 1)))
-                            AppendableUtil.setLength(a, a.length() - 1);
+                    while (dest.length() > 0) {
+                        if (Character.isWhitespace(dest.charAt(dest.length() - 1)))
+                            AppendableUtil.setLength(dest, dest.length() - 1);
                         else
                             break;
                     }
@@ -1507,7 +1508,7 @@ public class TextWire extends YamlWireOut<TextWire> {
          * encountered but not expanded. A warning is logged and the literal
          * characters are copied into {@code a}.
          */
-        private <ACS extends Appendable & CharSequence> void unsubstitutedString(@NotNull ACS a) {
+        private <ACS extends Appendable & CharSequence> void unsubstitutedString(@NotNull ACS dest) {
             String text = bytes.toString();
             // Limit the log output to 32 characters for brevity
             if (text.length() > 32)
@@ -1520,7 +1521,7 @@ public class TextWire extends YamlWireOut<TextWire> {
                 c = bytes.readChar();
                 try {
                     // Append the read character to the provided appendable
-                    a.append(c);
+                    dest.append(c);
                 } catch (IOException e) {
                     throw new AssertionError(e);
                 }
@@ -1533,13 +1534,13 @@ public class TextWire extends YamlWireOut<TextWire> {
          * {@code quotes}. The surrounding quote is skipped, the body parsed and
          * unescaped, then any trailing padding is consumed.
          */
-        private <ACS extends Appendable & CharSequence> void readText(@NotNull ACS a, @NotNull StopCharTester quotes) {
+        private <ACS extends Appendable & CharSequence> void readText(@NotNull ACS dest, @NotNull StopCharTester quotes) {
             bytes.readSkip(1); // consume opening quote
             if (use8bit)
-                bytes.parse8bit(a, quotes);
+                bytes.parse8bit(dest, quotes);
             else
-                bytes.parseUtf8(a, quotes);
-            unescape(a);
+                bytes.parseUtf8(dest, quotes);
+            unescape(dest);
             consumePadding(1);
         }
 
@@ -2675,25 +2676,25 @@ public class TextWire extends YamlWireOut<TextWire> {
          * @param kClazz       The class type of the key.
          * @param vClass       The class type of the value.
          * @param usingMap     The map to populate.
-         * @param sb           A StringBuilder to use during deserialization.
+         * @param builder      A StringBuilder to use during deserialization.
          * @return The populated map or null if the input represents a null value.
          * @throws InvalidMarshallableException If there's a problem deserializing the input.
          */
         @Nullable
-        private <K, V> Map<K, V> typedMap(@NotNull Class<K> kClazz, @NotNull Class<V> vClass, @NotNull Map<K, V> usingMap, @NotNull StringBuilder sb) throws InvalidMarshallableException {
+        private <K, V> Map<K, V> typedMap(@NotNull Class<K> kClazz, @NotNull Class<V> vClass, @NotNull Map<K, V> usingMap, @NotNull StringBuilder builder) throws InvalidMarshallableException {
             // Parse the input until a space character is encountered.
-            parseUntil(sb, StopCharTesters.SPACE_STOP);
+            parseUntil(builder, StopCharTesters.SPACE_STOP);
 
             // Intern the parsed string to reduce memory usage.
-            @Nullable String str = WireInternal.INTERNER.intern(sb);
+            @Nullable String str = WireInternal.INTERNER.intern(builder);
 
             // If the string represents a null value.
-            if (("!!null").contentEquals(sb)) {
+            if (("!!null").contentEquals(builder)) {
                 text();
                 return null;
 
             // If the string indicates a sequence map type.
-            } else if (("!" + SEQ_MAP).contentEquals(sb)) {
+            } else if (("!" + SEQ_MAP).contentEquals(builder)) {
                 consumePadding();
                 int start = readCode();
                 if (start != '[')

--- a/src/main/java/net/openhft/chronicle/wire/ValueIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueIn.java
@@ -240,10 +240,10 @@ public interface ValueIn {
     /**
      * Puts the byte data into the provided ByteBuffer.
      *
-     * @param bb The ByteBuffer to put the byte data.
+     * @param buffer The ByteBuffer to put the byte data.
      */
-    default void byteBuffer(@NotNull ByteBuffer bb) {
-        bb.put(bytes());
+    default void byteBuffer(@NotNull ByteBuffer buffer) {
+        buffer.put(bytes());
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/Wires.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wires.java
@@ -1477,7 +1477,7 @@ public enum Wires {
          * @param in The ValueIn object which contains the class name.
          * @return The Class object associated with the name.
          */
-        private static Class<?> forName(Class<?> o, ValueIn in) {
+        private static Class<?> forName(Class<?> type, ValueIn in) {
             final StringBuilder sb0 = sb.get();
 
             // Reset the StringBuilder to its initial state.
@@ -1889,12 +1889,12 @@ public enum Wires {
          * @return Boolean.TRUE if the specified object is equal to the proxy, otherwise Boolean.FALSE.
          */
         @NotNull
-        private Object equals0(Object proxy, Object o) {
-            if (proxy == o)
+        private Object equals0(Object proxy, Object other) {
+            if (proxy == other)
                 return true;
-            if (!(o instanceof Marshallable))
+            if (!(other instanceof Marshallable))
                 return false;
-            Marshallable m = (Marshallable) o;
+            Marshallable m = (Marshallable) other;
             if (!m.className().equals(typeName))
                 return false;
             if (!Proxy.isProxyClass(m.getClass()))

--- a/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
@@ -618,7 +618,7 @@ public class YamlTokeniser {
      * and its start token onto {@link #pushed}.
      */
     private YamlToken indent(
-            YamlToken indented,
+            YamlToken indentToken,
             @NotNull YamlToken key,
             @NotNull YamlToken push,
             int indent) {
@@ -635,17 +635,17 @@ public class YamlTokeniser {
         }
         int contextIndent = contextIndent();
 
-        // Push the indented token if we are starting a new indentation level.
-        if (indented != null && indent != contextIndent)
-            this.pushed.add(indented);
+        // Push the indent token if we are starting a new indentation level.
+        if (indentToken != null && indent != contextIndent)
+            this.pushed.add(indentToken);
         this.pushed.add(key);
 
         // Reverse the order of the tokens in the pushed stack.
         reversePushed(pos);
 
         // Push a new context if we are starting a new indentation level.
-        if (indented != null && indent > contextIndent())
-            contextPush(indented, indent);
+        if (indentToken != null && indent > contextIndent())
+            contextPush(indentToken, indent);
         return popPushed();
     }
 
@@ -654,7 +654,7 @@ public class YamlTokeniser {
      * {@link #blockStart} and {@link #blockEnd}. If the scalar is followed by a
      * colon it is treated as a {@link YamlToken#MAPPING_KEY}.
      */
-    private YamlToken readText(int indent2) {
+    private YamlToken readText(int indent) {
         long pos = in.readPosition(); // Store the current position of input.
 
         blockQuote = 0;
@@ -664,7 +664,7 @@ public class YamlTokeniser {
         if (isFieldEnd()) {
             lastKeyPosition = pos;
             if (topContext().token != YamlToken.MAPPING_KEY)
-                return indent(YamlToken.MAPPING_START, YamlToken.MAPPING_KEY, YamlToken.TEXT, indent2);
+                return indent(YamlToken.MAPPING_START, YamlToken.MAPPING_KEY, YamlToken.TEXT, indent);
         }
 
         // By default, treat the scalar as plain text.

--- a/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
@@ -728,18 +728,18 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          * tag. When {@link #dropDefault} is true and the argument is null the
          * value is omitted.
          */
-        public T bytes(@Nullable BytesStore<?, ?> fromBytes) {
+        public T bytes(@Nullable BytesStore<?, ?> data) {
             if (dropDefault) {
-                if (fromBytes == null)
+                if (data == null)
                     return wireOut();
                 writeSavedEventName();
             }
-            if (isText(fromBytes))
-                return (T) text(fromBytes);
+            if (isText(data))
+                return (T) text(data);
 
-            int length = Maths.toInt32(fromBytes.readRemaining());
+            int length = Maths.toInt32(data.readRemaining());
             @NotNull byte[] byteArray = new byte[length];
-            fromBytes.copyTo(byteArray);
+            data.copyTo(byteArray);
 
             return bytes(byteArray);
         }
@@ -772,15 +772,15 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          * Determines if the provided BytesStore contains textual content.
          * This function checks each byte to ensure it represents a valid textual character.
          *
-         * @param fromBytes The BytesStore object to inspect.
+         * @param data The BytesStore object to inspect.
          * @return True if the content is textual, otherwise false.
          */
-        private boolean isText(@Nullable BytesStore<?, ?> fromBytes) {
+        private boolean isText(@Nullable BytesStore<?, ?> data) {
 
-            if (fromBytes == null)
+            if (data == null)
                 return true;
-            for (long i = fromBytes.readPosition(); i < fromBytes.readLimit(); i++) {
-                int ch = fromBytes.readUnsignedByte(i);
+            for (long i = data.readPosition(); i < data.readLimit(); i++) {
+                int ch = data.readUnsignedByte(i);
                 if ((ch < ' ' && ch != '\t') || ch >= 127)
                     return false;
             }
@@ -1036,9 +1036,9 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
             if (dropDefault) {
                 writeSavedEventName();
             }
-            long pos = bytes.writePosition();
+            long position = bytes.writePosition();
             TextLongArrayReference.write(bytes, capacity);
-            ((Byteable) values).bytesStore(bytes, pos, bytes.lengthWritten(pos));
+            ((Byteable) values).bytesStore(bytes, position, bytes.lengthWritten(position));
             return wireOut();
         }
 
@@ -1347,17 +1347,17 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
                 newLine();
             else
                 bytes.writeUnsignedByte(' ');
-            long pos = bytes.writePosition();
+            long position = bytes.writePosition();
             writer.accept(e, this);
             if (!leaf)
-                addNewLine(pos);
+                addNewLine(position);
 
             popState();
             this.leaf = leaf;
             if (!leaf)
                 indent();
             else
-                addSpace(pos);
+                addSpace(position);
             endBlock(']');
             elementSeparator();
             return wireOut();
@@ -1398,12 +1398,12 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
                 sep = SPACE;
             else
                 newLine();
-            long pos = bytes.readPosition();
+            long position = bytes.readPosition();
             writer.accept(e, kls, this);
             if (leaf)
-                addSpace(pos);
+                addSpace(position);
             else
-                addNewLine(pos);
+                addNewLine(position);
 
             popState();
             if (!leaf)
@@ -1426,8 +1426,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          * Adds a newline only if content was written after {@code pos} within a
          * block.
          */
-        protected void addNewLine(long pos) {
-            if (bytes.writePosition() > pos + 1)
+        protected void addNewLine(long position) {
+            if (bytes.writePosition() > position + 1)
                 bytes.writeUnsignedByte('\n');
         }
 
@@ -1435,8 +1435,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          * Adds a space only if content was written after {@code pos} within a
          * block.
          */
-        protected void addSpace(long pos) {
-            if (bytes.writePosition() > pos + 1)
+        protected void addSpace(long position) {
+            if (bytes.writePosition() > position + 1)
                 bytes.writeUnsignedByte(' ');
         }
 


### PR DESCRIPTION
## Summary
- clarify method parameters in TextWire and utility classes
- standardise buffer and builder variable names
- rename local variables in YAML tokeniser and writer classes
- update helper docs and related calls

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*