### PR TITLE
Improve JSONWire Javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/JSONWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/JSONWire.java
@@ -499,9 +499,13 @@ public class JSONWire extends TextWire {
     }
 
     /**
-     * Consumes padding and expects either a comma (indicating another entry) or a given end character.
+     * After copying an element in a JSON array or a value in a JSON object, this
+     * method consumes padding and expects either a comma (',' to separate from
+     * the next element) or the specified {@code end} character ('}' for objects,
+     * ']' for arrays).
      *
-     * @param end The expected end character (e.g., '}' for maps or ']' for sequences).
+     * @param end the terminating character that indicates the end of the current
+     *            structure
      */
     private void expectComma(char end) {
         consumePadding();
@@ -521,10 +525,8 @@ public class JSONWire extends TextWire {
     }
 
     /**
-     * Copies a sequence structure from the input to the given wire output.
-     * A sequence is assumed to be a list of values enclosed in square brackets '[]'.
-     *
-     * @param wire The wire output to copy the sequence to.
+     * Internal helper for {@link #copyOne} to copy a JSON array ({@code [...]}).
+     * Recursively calls {@link #copyOne} for each element in the array.
      */
     private void copySequence(WireOut wire) {
         wire.getValueOut().sequence(out -> {
@@ -551,21 +553,21 @@ public class JSONWire extends TextWire {
     }
 
     /**
-     * Peeks at the next byte in the buffer without advancing the read position.
+     * Internal helper to peek at the next byte at the current read position
+     * without consuming it.
      *
-     * @return The next byte from the current read position.
+     * @return the next byte from the current read position
      */
     private int peekNextByte() {
         return bytes.peekUnsignedByte(bytes.readPosition());
     }
 
     /**
-     * Copies a numeric value from the input buffer to the given wire output.
-     * The method can handle both integer and decimal numbers. For binary wire outputs,
-     * it can distinguish between the two and write the appropriate format. For textual wire outputs,
-     * the number is written as is.
-     *
-     * @param wire The wire output to which the numeric value should be copied.
+     * Internal helper for {@link #copyOne} to copy a JSON number (integer or
+     * floating-point). It reads the sequence of digits (and optional decimal
+     * point/exponent) and writes it to the target {@code wire}, attempting to
+     * preserve the numeric type (for example as {@code int64} or {@code float64}
+     * if the target wire is binary).
      */
     private void copyNumber(WireOut wire) {
         // Move back one position to re-read the first character of the number
@@ -629,6 +631,12 @@ public class JSONWire extends TextWire {
         }
     }
 
+    /**
+     * Determines if the given {@link CharSequence} {@code s} requires double
+     * quotes for JSON string representation. In JSON all strings must be quoted;
+     * this check looks for characters that must be escaped (control characters,
+     * backslash or a double quote).
+     */
     @NotNull
     @Override
     protected Quotes needsQuotes(@NotNull CharSequence s) {
@@ -640,6 +648,11 @@ public class JSONWire extends TextWire {
         return Quotes.NONE;
     }
 
+    /**
+     * Writes the given {@link CharSequence} as a JSON string, always enclosing
+     * it in double quotes and escaping internal characters as required using
+     * {@link #escape0(CharSequence, Quotes)}.
+     */
     @Override
     void escape(@NotNull CharSequence s) {
         bytes.writeUnsignedByte('"');
@@ -652,13 +665,11 @@ public class JSONWire extends TextWire {
     }
 
     /**
-     * Escapes special characters in a CharSequence as per JSON String encoding standards detailed in RFC 7159, Section 7.
-     * This ensures that the resulting string can be safely embedded within a JSON string while preserving its meaning.
-     * See <a href="https://www.rfc-editor.org/rfc/rfc7159#section-7">RFC 7159, Section 7</a> for more details.
-     *
-     * @param s The CharSequence to escape.
-     * @param quotes Specifies the type of quotes used in the CharSequence and guides escaping.
-     * @see <a href="https://www.rfc-editor.org/rfc/rfc7159#section-7">RFC 7159, Section 7</a>
+     * Escapes characters in {@code s} according to JSON string encoding rules
+     * (RFC&nbsp;7159, section&nbsp;7). Uses {@code \uXXXX} for control
+     * characters and characters outside the printable ASCII range. Always uses
+     * {@code "} as the quote character, ignoring the {@code quotes} parameter
+     * from the superclass.
      */
     protected void escape0(@NotNull CharSequence s, @NotNull Quotes quotes) {
         for (int i = 0; i < s.length(); i++) {
@@ -740,6 +751,11 @@ public class JSONWire extends TextWire {
         return escaping;
     }
 
+    /**
+     * A specialised {@link TextReadDocumentContext} for JSON. It handles the
+     * consumption of optional leading/trailing curly braces {@code {}} that
+     * might enclose a top-level JSON document.
+     */
     class JSONReadDocumentContext extends TextReadDocumentContext {
         private int first;
 
@@ -747,6 +763,12 @@ public class JSONWire extends TextWire {
             super(wire);
         }
 
+        /**
+         * Prepares for reading a JSON document. Peeks for an opening curly
+         * brace '{'. If found, it is consumed and the read limit adjusted to
+         * tentatively exclude a possible closing brace. Then delegates to the
+         * superclass implementation.
+         */
         @Override
         public void start() {
             first = bytes.peekUnsignedByte();
@@ -759,6 +781,12 @@ public class JSONWire extends TextWire {
             super.start();
         }
 
+        /**
+         * Finalises reading the JSON document. If an opening brace was consumed
+         * by {@link #start()}, this method consumes any padding and a matching
+         * closing curly brace '}' if present. Then delegates to the superclass
+         * close.
+         */
         @Override
         public void close() {
             if (first == '{') {
@@ -771,11 +799,11 @@ public class JSONWire extends TextWire {
     }
 
     /**
-     * The JSONWriteDocumentContext class extends the TextWriteDocumentContext class.
-     * It provides a specialized context for writing JSON data, adjusting writing positions
-     * and handling JSON-specific syntax such as curly braces.
-     *
-         */
+     * A specialised {@link TextWriteDocumentContext} for JSON. It ensures that
+     * top-level JSON documents are correctly enclosed in curly braces '{}' if
+     * {@link JSONWire#trimFirstCurly()} is false (the default when
+     * {@link #useTextDocuments()} is invoked).
+     */
     class JSONWriteDocumentContext extends TextWriteDocumentContext {
         // Position marker to track the start of a JSON object
         private long start;
@@ -789,11 +817,20 @@ public class JSONWire extends TextWire {
             super(wire);
         }
 
+        /**
+         * Checks if the document is empty, considering the potential initial
+         * '{'.
+         */
         @Override
         public boolean isEmpty() {
             return wire().bytes().writePosition() == position + 1;
         }
 
+        /**
+         * Prepares for writing a JSON document. If this is the outermost
+         * document context (count == 0) and a leading brace is required, it
+         * appends an opening '{' and records its position.
+         */
         @Override
         public void start(boolean metaData) {
             int count = this.count;
@@ -804,6 +841,12 @@ public class JSONWire extends TextWire {
             }
         }
 
+        /**
+         * Finalises the JSON document. If this is the outermost context and an
+         * opening brace was written by {@link #start(boolean)}, it appends a
+         * closing '}'. If the document was empty (only the opening brace was
+         * written) it backtracks to remove the empty braces.
+         */
         @Override
         public void close() {
             super.close();
@@ -1307,9 +1350,7 @@ public class JSONWire extends TextWire {
     }
 
     /**
-     * Render as a UTF-8 string.
-     *
-     * @return a UTF-8 string representation of the wire data.
+     * Returns the remaining content of this {@code JSONWire} as a UTF-8 string.
      */
     @Override
     public String toString() {


### PR DESCRIPTION
## Summary
- clarify helper behaviour in `expectComma`, `copySequence`, `peekNextByte`, and `copyNumber`
- document quoting and escaping behaviour in `needsQuotes`, `escape`, and `escape0`
- add context docs for `JSONReadDocumentContext` and `JSONWriteDocumentContext`
- document `toString`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*