### PR TITLE
Improve Javadoc in BinaryWireHighCode

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/BinaryWireHighCode.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWireHighCode.java
@@ -16,63 +16,96 @@
 package net.openhft.chronicle.wire;
 
 /**
- * Enum to represent various high-level codes used in the binary wire protocol.
- * Each constant in this enum serves as a marker to categorize the range of values
- * used for decoding in the binary wire format. Although the enum itself does not
- * contain any instances (indicated by the empty enum body), it does define several
- * static final fields that serve as unique identifiers for each type of high-level code.
+ * Defines constants representing the high four bits of a
+ * {@link BinaryWireCode} byte. These high codes group the binary
+ * wire codes into broad types such as Control, Float, Integer,
+ * Special, Field, or String. This allows a parser to dispatch
+ * efficiently, for example by switching on {@code code >> 4}.
  */
 public enum BinaryWireHighCode {
     ; // none
 
-    /** Indicates the end of the data stream. */
+    /**
+     * Represents the end of the data stream. The value is {@code -1} and is not
+     * a high code.
+     */
     static final int END_OF_STREAM = -1;
 
-    /** Represents numerical values, no longer in use. */
+    /**
+     * Legacy high code for numerical values. Codes {@code 0x00-0x7F} normally
+     * hold single-byte positive integers.
+     */
     static final int NUM0 = 0x0;
 
-    /** Represents numerical values, no longer in use. */
+    /** See {@link #NUM0}. */
     static final int NUM1 = 0x1;
 
-    /** Represents numerical values, no longer in use. */
+    /** See {@link #NUM0}. */
     static final int NUM2 = 0x2;
 
-    /** Represents numerical values, no longer in use. */
+    /** See {@link #NUM0}. */
     static final int NUM3 = 0x3;
 
-    /** Represents numerical values, no longer in use. */
+    /** See {@link #NUM0}. */
     static final int NUM4 = 0x4;
 
-    /** Represents numerical values, no longer in use. */
+    /** See {@link #NUM0}. */
     static final int NUM5 = 0x5;
 
-    /** Represents numerical values, no longer in use. */
+    /** See {@link #NUM0}. */
     static final int NUM6 = 0x6;
 
-    /** Represents numerical values, no longer in use. */
+    /** See {@link #NUM0}. */
     static final int NUM7 = 0x7;
 
-    /** Indicates a control sequence. */
+    /**
+     * High code {@code 0x80} for control sequences such as byte length
+     * prefixes, padding and anchors.
+     */
     static final int CONTROL = 0x8;
 
-    /** Indicates a floating-point number. */
+    /**
+     * High code {@code 0x90} for floating-point numbers such as
+     * {@link BinaryWireCode#FLOAT32} or {@link BinaryWireCode#FLOAT_STOP_6}.
+     */
     static final int FLOAT = 0x9;
 
-    /** Indicates an integer value. */
+    /**
+     * High code {@code 0xA0} for integer types such as
+     * {@link BinaryWireCode#INT32}, {@link BinaryWireCode#UINT8} and
+     * {@link BinaryWireCode#UUID}.
+     */
     static final int INT = 0xA;
 
-    /** Indicates a special type. */
+    /**
+     * High code {@code 0xB0} for special values such as
+     * {@link BinaryWireCode#NULL}, {@link BinaryWireCode#TRUE},
+     * {@link BinaryWireCode#TYPE_PREFIX}, {@link BinaryWireCode#FIELD_NAME_ANY}
+     * or {@link BinaryWireCode#EVENT_NAME}.
+     */
     static final int SPECIAL = 0xB;
 
-    /** Represents fields of length 0 to 15. */
+    /**
+     * High code {@code 0xC0} for compact field name strings of length 0-15
+     * (codes {@code 0xC0-0xCF}).
+     */
     static final int FIELD0 = 0xC;
 
-    /** Represents fields of length 16 to 31. */
+    /**
+     * High code {@code 0xD0} for compact field name strings of length 16-31
+     * (codes {@code 0xD0-0xDF}).
+     */
     static final int FIELD1 = 0xD;
 
-    /** Represents strings of 0 to 15. */
+    /**
+     * High code {@code 0xE0} for general strings of UTF-8 length 0-15
+     * (codes {@code 0xE0-0xEF}).
+     */
     static final int STR0 = 0xE;
 
-    /** Represents strings of 16 to 31. */
+    /**
+     * High code {@code 0xF0} for general strings of UTF-8 length 16-31
+     * (codes {@code 0xF0-0xFF}).
+     */
     static final int STR1 = 0xF;
 }


### PR DESCRIPTION
## Summary
- clarify enum role and constants in `BinaryWireHighCode`

## Testing
- `mvn -q verify` *(fails: mvn not found)*