### PR TITLE
Improve BinaryWire Javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -2566,6 +2566,10 @@ public class BinaryWire extends AbstractWire implements Wire {
             return BinaryWire.this;
         }
 
+        /**
+         * Writes a sequence of values preceded by a 32 bit length.
+         * The {@code writer} is invoked to emit each item within the block.
+         */
         @NotNull
         @Override
         public <T> WireOut sequence(T t, @NotNull BiConsumer<T, ValueOut> writer) {
@@ -2604,6 +2608,10 @@ public class BinaryWire extends AbstractWire implements Wire {
             bytes.writeInt(position, length);
         }
 
+        /**
+         * Writes a length prefixed block and lets the {@code writer}
+         * serialise items of type {@code K}.
+         */
         @NotNull
         @Override
         public <T, K> WireOut sequence(T t, K kls, @NotNull TriConsumer<T, K, ValueOut> writer) throws InvalidMarshallableException {
@@ -3546,8 +3554,14 @@ public class BinaryWire extends AbstractWire implements Wire {
         }
 
         @Override
+        /**
+         * Reads the length of the next value based on the current code.
+         * <p>
+         * Handles length prefixes such as {@link BinaryWireCode#BYTES_LENGTH8}
+         * and also infers the size for fixed-width primitives. Returns {@code -1}
+         * if the code is not recognised.
+         */
         public long readLength() {
-            // TODO handle non length types as well.
 
             int code = peekCode();
             if ((code & 0x80) == 0)
@@ -3647,6 +3661,13 @@ public class BinaryWire extends AbstractWire implements Wire {
             }
         }
 
+        /**
+         * Skips the value at the current read position.
+         * <p>
+         * The method reads the length of the item and moves the read pointer
+         * past that many bytes. If the length cannot be determined the value is
+         * consumed using {@link #objectBestEffort()}.
+         */
         @NotNull
         @Override
         public WireIn skipValue() {
@@ -4028,6 +4049,10 @@ public class BinaryWire extends AbstractWire implements Wire {
             return BinaryWire.this;
         }
 
+        /**
+         * Reads a length prefixed sequence and invokes the supplied
+         * {@code tReader} on each item.
+         */
         @Override
         public <T> boolean sequence(@NotNull T t, @NotNull BiConsumer<T, ValueIn> tReader) {
             if (isNull())
@@ -4048,6 +4073,10 @@ public class BinaryWire extends AbstractWire implements Wire {
             return true;
         }
 
+        /**
+         * Reads a sequence into {@code list} using a temporary buffer. The block
+         * length is read from the wire before items are processed.
+         */
         @Override
         public <T> boolean sequence(@NotNull List<T> list,
                                     @NotNull List<T> buffer,
@@ -4056,6 +4085,10 @@ public class BinaryWire extends AbstractWire implements Wire {
             return sequence(list, buffer, bufferAdd, reader0field);
         }
 
+        /**
+         * Reads a sequence using a caller supplied reader.
+         * The length prefix is honoured before delegating to {@code tReader}.
+         */
         @Override
         public <T> boolean sequence(List<T> list,
                                     @NotNull List<T> buffer,
@@ -4079,6 +4112,10 @@ public class BinaryWire extends AbstractWire implements Wire {
             return true;
         }
 
+        /**
+         * Reads a length-prefixed block and passes a {@link ValueIn} for each entry
+         * to the supplied {@code tReader}.
+         */
         @NotNull
         @Override
         public <T, K> WireIn sequence(@NotNull T t, K kls, @NotNull TriConsumer<T, K, ValueIn> tReader) throws InvalidMarshallableException {
@@ -4195,13 +4232,12 @@ public class BinaryWire extends AbstractWire implements Wire {
         }
 
         /**
-         * Tries to deserialize a typed Marshallable object from the current state of the wire.
-         * The method identifies the type of the Marshallable object by reading a UTF-8 encoded class name
-         * and then instantiates and initializes the object accordingly.
+         * Handles a {@link BinaryWireCode#TYPE_PREFIX} by reading the class name,
+         * creating an instance and unmarshalling into it.
          *
-         * @param <T> Type of the expected return object.
-         * @return The deserialized Marshallable object or null if the UTF-8 encoded class name is not found.
-         * @throws InvalidMarshallableException If the deserialization encounters any issues.
+         * @param <T> expected type
+         * @return a new instance populated from the wire or {@code null} if no class name is present
+         * @throws InvalidMarshallableException if deserialisation fails
          */
         @Nullable
         protected <T> T typedMarshallable0() throws InvalidMarshallableException {
@@ -4247,6 +4283,10 @@ public class BinaryWire extends AbstractWire implements Wire {
             return object(null, aClass);
         }
 
+        /**
+         * If the next code is {@link BinaryWireCode#TYPE_PREFIX} this reads the
+         * class name and resolves it.
+         */
         @Override
         public Class<?> typePrefix() {
             int code = peekCode();
@@ -4264,6 +4304,10 @@ public class BinaryWire extends AbstractWire implements Wire {
             }
         }
 
+        /**
+         * Variation of {@link #typePrefix()} used by generated DTOs to read the
+         * class name or return a tuple if the type is missing.
+         */
         @Override
         public Object typePrefixOrObject(Class<?> tClass) {
             int code = peekCode();
@@ -4355,14 +4399,10 @@ public class BinaryWire extends AbstractWire implements Wire {
         }
 
         /**
-         * Marshalls the given object and can optionally overwrite existing values.
-         *
-         * @param object The object to be marshalled.
-         * @param overwrite Determines if the existing values should be overwritten.
-         * @return True if the operation is successful.
-         * @throws BufferUnderflowException If there's not enough data available in the buffer.
-         * @throws IORuntimeException If there's a general IO error.
-         * @throws InvalidMarshallableException If there's an error specific to marshalling.
+         * Reads a length prefixed binary block into {@code object}.
+         * The {@code overwrite} flag controls whether existing state is replaced.
+         * The method respects {@link WireIn#useSelfDescribingMessage(CommonMarshallable)}
+         * to decide which read method to invoke.
          */
         public boolean marshallable(@NotNull ReadMarshallable object, boolean overwrite)
                 throws BufferUnderflowException, IORuntimeException, InvalidMarshallableException {
@@ -4438,12 +4478,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         }
 
         /**
-         * Deserializes an object of the given class from the wire data.
-         *
-         * @param clazz Class to be deserialized.
-         * @return An instance of the provided class.
-         * @throws BufferUnderflowException if there's not enough data in the buffer.
-         * @throws IORuntimeException for general IO issues.
+         * Instantiates and populates a new object of {@code clazz} from a
+         * length-prefixed block.
          */
         @Nullable
         public Demarshallable demarshallable(@NotNull Class<? extends Demarshallable> clazz) throws BufferUnderflowException, IORuntimeException {
@@ -4467,14 +4503,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         }
 
         /**
-         * Reads a text from the wire and attempts to convert it into a long value.
-         * If the text is not a valid representation of a long, tries to parse it as a double
-         * and then rounds to the nearest long.
-         *
-         * @param otherwise Default value to return if the conversion fails.
-         * @return Parsed long value or the provided default value.
-         * @throws IORuntimeException for general IO issues.
-         * @throws BufferUnderflowException if there's not enough data in the buffer.
+         * Parses the previously read text as a {@code long} with a numeric fallback.
+         * If parsing fails the supplied {@code otherwise} value is returned.
          */
         private long readTextAsLong(long otherwise) throws IORuntimeException, BufferUnderflowException {
             bytes.uncheckedReadSkipBackOne();  // Go back one position.
@@ -4494,11 +4524,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         }
 
         /**
-         * Reads a text from the wire and attempts to convert it into a double value.
-         *
-         * @return Parsed double value or NaN if the conversion fails.
-         * @throws IORuntimeException for general IO issues.
-         * @throws BufferUnderflowException if there's not enough data in the buffer.
+         * Parses the previously read text as a {@code double}.
+         * Returns {@code NaN} on failure.
          */
         private double readTextAsDouble() throws IORuntimeException, BufferUnderflowException {
             bytes.uncheckedReadSkipBackOne();  // Go back one position.
@@ -4659,16 +4686,18 @@ public class BinaryWire extends AbstractWire implements Wire {
         }
 
         /**
-         * Throws an exception indicating that reading the provided code is not supported.
-         *
-         * @param code The unsupported code.
-         * @return A runtime exception (never actually returned since an exception is always thrown).
+         * Convenience method used when an unexpected code is encountered.
+         * Always throws {@link UnsupportedOperationException}.
          */
         @NotNull
         private RuntimeException cantRead(int code) {
             throw new UnsupportedOperationException(stringForCode(code));
         }
 
+        /**
+         * Core logic used when the exact field type is not known in advance.
+         * The wire code is inspected to decide how the value should be read.
+         */
         @Override
         public Object objectWithInferredType(Object using, @NotNull SerializationStrategy strategy, Class<?> type) throws InvalidMarshallableException {
             int code = peekCode();
@@ -4829,10 +4858,8 @@ public class BinaryWire extends AbstractWire implements Wire {
         }
 
         /**
-         * Consumes the next set of bytes based on the provided code.
-         * The method moves the reader pointer after the current item or structure.
-         *
-         * @throws InvalidMarshallableException If there's an error while marshalling.
+         * Skips the current value by decoding its length and type without
+         * fully deserialising it.
          */
         void consumeNext() throws InvalidMarshallableException {
             // Peek at the next byte to determine the code.

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWireCode.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWireCode.java
@@ -20,31 +20,32 @@ import org.jetbrains.annotations.NotNull;
 import java.lang.reflect.Field;
 
 /**
- * Enumerates the predefined byte codes for the Binary YAML wire format.
- * Each constant in this class provides a specific purpose when working with the wire format,
- * enabling efficient serialization and deserialization processes.
+ * Defines the integer codes used by {@link BinaryWire} to denote data types and
+ * control sequences. The first byte of each value is one of these constants
+ * indicating how the following bytes are to be interpreted.
  */
 public enum BinaryWireCode {
     ; // Indicates no default enum instances
 
     // Definitions for sequence lengths:
     /**
-     * Sequence length 0 to 255 bytes.
+     * Indicates that an unsigned byte follows containing the length (0-255) of
+     * a byte sequence.
      */
     public static final int BYTES_LENGTH8 = 0x80;
 
     /**
-     * Sequence length 0 to 2^16-1 bytes.
+     * Indicates a two byte length field storing 0 to 2^16-1 bytes.
      */
     public static final int BYTES_LENGTH16 = 0x81;
 
     /**
-     * Sequence length 0 to 2^32-1 bytes.
+     * Indicates a four byte length field storing up to 2^32-1 bytes.
      */
     public static final int BYTES_LENGTH32 = 0x82;
 
     /**
-     * Indicates a HistoryMessage follows. was BYTES_MARSHALLABLE, but only used for this purpose
+     * Indicates that a {@link VanillaMessageHistory} follows in its compact form.
      */
     public static final int HISTORY_MESSAGE = 0x86;
 
@@ -88,42 +89,42 @@ public enum BinaryWireCode {
     public static final int PADDING = 0x8F;
 
     /**
-     * Represents a 32-bit floating-point number.
+     * A 32 bit IEEE-754 floating point value.
      */
     public static final int FLOAT32 = 0x90;
 
     /**
-     * Represents a 64-bit floating-point number (double precision).
+     * A 64 bit IEEE-754 floating point value.
      */
     public static final int FLOAT64 = 0x91;
 
     /**
-     * Floating-point number with 2 decimal places optimized for storage.
+     * Floating point encoded with 2 decimal places using stop bit compression.
      */
     public static final int FLOAT_STOP_2 = 0x92;
 
     /**
-     * Floating-point number with 4 decimal places optimized for storage.
+     * Floating point encoded with 4 decimal places using stop bit compression.
      */
     public static final int FLOAT_STOP_4 = 0x94;
 
     /**
-     * Floating-point number with 6 decimal places optimized for storage.
+     * Floating point encoded with 6 decimal places using stop bit compression.
      */
     public static final int FLOAT_STOP_6 = 0x96;
 
     /**
-     * Floating-point number rounded to the nearest whole number.
+     * Floating point rounded to the nearest whole number for compact storage.
      */
     public static final int FLOAT_SET_LOW_0 = 0x9A;
 
     /**
-     * Floating-point number rounded to 2 decimal places for compact storage.
+     * Floating point rounded to two decimal places.
      */
     public static final int FLOAT_SET_LOW_2 = 0x9B;
 
     /**
-     * Floating-point number rounded to 4 decimal places for compact storage.
+     * Floating point rounded to four decimal places.
      */
     public static final int FLOAT_SET_LOW_4 = 0x9C;
 
@@ -222,71 +223,74 @@ public enum BinaryWireCode {
     public static final int TYPE_PREFIX = 0xB6;
 
     /**
-     * A field name of any length.
+     * Indicates a field name of variable length encoded as an 8 bit string.
      */
     public static final int FIELD_NAME_ANY = 0xB7;
 
     /**
-     * A String of any length
+     * Indicates an arbitrary length UTF-8 string.
      */
     public static final int STRING_ANY = 0xB8;
 
     /**
-     * A field of any length, marked as an event name.
+     * Field name used to denote an event, length encoded as an 8 bit string.
      */
     public static final int EVENT_NAME = 0xB9;
 
     /**
-     * Represents a numerical field number instead of a name.
+     * Field identifier stored as an unsigned integer rather than text.
      */
     public static final int FIELD_NUMBER = 0xBA;
     /**
-     * Code representing a null value in the serialized data.
+     * Represents the {@code null} value.
      */
     public static final int NULL = 0xBB;
 
     /**
-     * Represents a type literal.
+     * Encodes a class literal as an 8 bit length followed by the UTF-8 text.
      */
     public static final int TYPE_LITERAL = 0xBC;
 
     /**
-     * Indicates an event object instead of the typical string.
+     * Signifies that an event payload follows rather than a simple string name.
      */
     public static final int EVENT_OBJECT = 0xBD;
 
     /**
-     * Marks a comment, not intended for parsing as part of the data structure.
+     * Marks a comment that should be ignored by parsers.
      */
     public static final int COMMENT = 0xBE;
 
     /**
-     * Provides a hint for serialization or deserialization processes, possibly affecting how data is interpreted.
+     * Hint used by the wire layer; consumers may ignore it.
      */
     public static final int HINT = 0xBF;
 
     /**
-     * Starting code for predefined field names of length 0, 1, 2 ... 31.
+     * Start of the compact field name range. Codes {@code FIELD_NAME0} to
+     * {@code FIELD_NAME31} represent names of length 0 to 31.
      */
     public static final int FIELD_NAME0 = 0xC0;
 
     /**
-     * Ending code for predefined field names.
+     * End of the compact field name range.
      */
     public static final int FIELD_NAME31 = 0xDF;
 
     /**
-     * Starting code for compact string representation of length 0, 1, 2 ... 31.
+     * Start of the compact string range. Values {@code STRING_0} to {@code STRING_31}
+     * encode text of length 0 to 31.
      */
     public static final int STRING_0 = 0xE0;
 
     /**
-     * Ending code for compact string representation.
+     * End of the compact string range.
      */
     public static final int STRING_31 = 0xFF;
 
     /**
-     * Array storing the string representations for each binary wire code, facilitating easier debugging and logging.
+     * Lookup table mapping a byte code to its mnemonic name. Used for debugging
+     * and diagnostic output.
      */
     public static final String[] STRING_FOR_CODE = new String[256];
 
@@ -315,10 +319,8 @@ public enum BinaryWireCode {
     }
 
     /**
-     * Determines if the provided code corresponds to a field name.
-     *
-     * @param code The binary wire code value.
-     * @return True if the code corresponds to a field, false otherwise.
+     * Returns {@code true} if the code denotes any form of field identifier
+     * (numeric or textual).
      */
     public static boolean isFieldCode(int code) {
         return code == FIELD_NAME_ANY ||
@@ -327,10 +329,8 @@ public enum BinaryWireCode {
     }
 
     /**
-     * Retrieves the string representation of a binary wire code.
-     *
-     * @param code The binary wire code value.
-     * @return The string representation for the given code.
+     * Returns a human readable name for the supplied code using
+     * {@link #STRING_FOR_CODE}. A code of {@code -1} maps to "EndOfFile".
      */
     @NotNull
     public static String stringForCode(int code) {


### PR DESCRIPTION
## Summary
- expand docs for BinaryWire methods dealing with sequences, type prefixes and marshalling
- clarify BinaryWireCode constant meanings and lookup helpers

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*