### PR TITLE
Improve parameter naming

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
@@ -126,7 +126,7 @@ public interface FieldInfo {
      * as an {@link Object}.
      */
     @Nullable
-    Object get(Object object);
+    Object get(Object instance);
 
     /**
      * Returns the value of the field represented by this {@code FieldInfo} object
@@ -136,7 +136,7 @@ public interface FieldInfo {
      * @return the value of the field represented by this {@code FieldInfo} object
      * as a {@code long} primitive.
      */
-    long getLong(Object object);
+    long getLong(Object instance);
 
     /**
      * Returns the value of the field represented by this {@code FieldInfo} object
@@ -146,7 +146,7 @@ public interface FieldInfo {
      * @return the value of the field represented by this {@code FieldInfo} object
      * as an {@code int} primitive.
      */
-    int getInt(Object object);
+    int getInt(Object instance);
 
     /**
      * Returns the value of the field represented by this {@code FieldInfo} object
@@ -156,7 +156,7 @@ public interface FieldInfo {
      * @return the value of the field represented by this {@code FieldInfo} object
      * as a {@code char} primitive.
      */
-    char getChar(Object object);
+    char getChar(Object instance);
 
     /**
      * Returns the value of the field represented by this {@code FieldInfo} object
@@ -166,28 +166,28 @@ public interface FieldInfo {
      * @return the value of the field represented by this {@code FieldInfo} object
      * as a {@code double} primitive.
      */
-    double getDouble(Object object);
+    double getDouble(Object instance);
 
     /**
      * Sets the value of the field represented by this {@code FieldInfo} object
      * to the provided {@code value}. The provided {@code object} is used as a
      * target to the extract eh field from.
      */
-    void set(Object object, Object value) throws IllegalArgumentException;
+    void set(Object instance, Object value) throws IllegalArgumentException;
 
     /**
      * Sets the value of the field represented by this {@code FieldInfo} object
      * to the provided {@code value}. The provided {@code object} is used as a
      * target to the extract eh field from.
      */
-    void set(Object object, char value) throws IllegalArgumentException;
+    void set(Object instance, char value) throws IllegalArgumentException;
 
     /**
      * Sets the value of the field represented by this {@code FieldInfo} object
      * to the provided {@code value}. The provided {@code object} is used as a
      * target to the extract eh field from.
      */
-    void set(Object object, int value) throws IllegalArgumentException;
+    void set(Object instance, int value) throws IllegalArgumentException;
 
     /**
      * Sets the value of the field represented by this {@code FieldInfo} object
@@ -200,7 +200,7 @@ public interface FieldInfo {
      *                                  interface declaring the underlying field, or if an unwrapping
      *                                  conversion fails.
      */
-    void set(Object object, long value) throws IllegalArgumentException;
+    void set(Object instance, long value) throws IllegalArgumentException;
 
     /**
      * Sets the value of the field represented by this {@code FieldInfo} object
@@ -213,7 +213,7 @@ public interface FieldInfo {
      *                                  interface declaring the underlying field, or if an unwrapping
      *                                  conversion fails.
      */
-    void set(Object object, double value) throws IllegalArgumentException;
+    void set(Object instance, double value) throws IllegalArgumentException;
 
     /**
      * Retrieves the {@link Class} identifying the declared generic type of the
@@ -245,5 +245,5 @@ public interface FieldInfo {
      * @param b Second object to compare the field's value.
      * @return {@code true} if the values are equal, {@code false} otherwise.
      */
-    boolean isEqual(Object a, Object b);
+    boolean isEqual(Object instanceA, Object instanceB);
 }

--- a/src/main/java/net/openhft/chronicle/wire/Quotes.java
+++ b/src/main/java/net/openhft/chronicle/wire/Quotes.java
@@ -37,9 +37,9 @@ enum Quotes {
     /**
      * Constructs a new instance of {@code Quotes} with the provided character representation.
      *
-     * @param q The character representation of the quotation mark.
+     * @param quoteCharacter The character representation of the quotation mark.
      */
-    Quotes(char q) {
-        this.q = q;
+    Quotes(char quoteCharacter) {
+        this.q = quoteCharacter;
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/TextStopCharTesters.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextStopCharTesters.java
@@ -41,14 +41,14 @@ enum TextStopCharTesters implements StopCharTester {
         private final int eowLength = eow.length();
 
         @Override
-        public boolean isStopChar(int ch) {
-            return ch >= eowLength || eow.get(ch);
+        public boolean isStopChar(int characterCode) {
+            return characterCode >= eowLength || eow.get(characterCode);
         }
     },
     END_OF_TEXT {
         @Override
-        public boolean isStopChar(int ch) throws IllegalStateException {
-            switch (ch) {
+        public boolean isStopChar(int characterCode) throws IllegalStateException {
+            switch (characterCode) {
                 // one character stop.
                 case '"':
                 case '#':

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -150,13 +150,13 @@ public class TextWire extends YamlWireOut<TextWire> {
     /**
      * Factory method to create a `TextWire` from a file.
      *
-     * @param name Name of the file.
+     * @param filePath Name of the file.
      * @return A new instance of `TextWire`.
      * @throws IOException if any I/O error occurs.
      */
     @NotNull
-    public static TextWire fromFile(String name) throws IOException {
-        return new TextWire(BytesUtil.readFile(name), true);
+    public static TextWire fromFile(String filePath) throws IOException {
+        return new TextWire(BytesUtil.readFile(filePath), true);
     }
 
     /**
@@ -197,17 +197,17 @@ public class TextWire extends YamlWireOut<TextWire> {
      * For instance, "\\n" is converted to a newline character, "\\t" to a tab, etc.
      * This method modifies the given sequence directly and adjusts its length if needed.
      *
-     * @param sb A {@link CharSequence} that is also an {@link Appendable}, containing potentially escaped sequences.
-     *           This sequence will be modified directly.
+     * @param targetBuffer A {@link CharSequence} that is also an {@link Appendable}, containing potentially escaped sequences.
+     *                     This sequence will be modified directly.
      */
-    public static <ACS extends Appendable & CharSequence> void unescape(@NotNull ACS sb) {
+    public static <ACS extends Appendable & CharSequence> void unescape(@NotNull ACS targetBuffer) {
         int end = 0;
-        int length = sb.length();
+        int length = targetBuffer.length();
         for (int i = 0; i < length; i++) {
-            char ch = sb.charAt(i);
+            char ch = targetBuffer.charAt(i);
             // Check if the character is an escape character and if there's a character after it
             if (ch == '\\' && i < length - 1) {
-                char ch3 = sb.charAt(++i);
+                char ch3 = targetBuffer.charAt(++i);
                 // Handle different escaped characters
                 switch (ch3) {
                     case '0':
@@ -251,27 +251,27 @@ public class TextWire extends YamlWireOut<TextWire> {
                         break;
                     case 'x':
                         ch = (char)
-                                (Character.getNumericValue(sb.charAt(++i)) * 16 +
-                                        Character.getNumericValue(sb.charAt(++i)));
+                                (Character.getNumericValue(targetBuffer.charAt(++i)) * 16 +
+                                        Character.getNumericValue(targetBuffer.charAt(++i)));
                         break;
                     case 'u':
                         ch = (char)
-                                (Character.getNumericValue(sb.charAt(++i)) * 4096 +
-                                        Character.getNumericValue(sb.charAt(++i)) * 256 +
-                                        Character.getNumericValue(sb.charAt(++i)) * 16 +
-                                        Character.getNumericValue(sb.charAt(++i)));
+                                (Character.getNumericValue(targetBuffer.charAt(++i)) * 4096 +
+                                        Character.getNumericValue(targetBuffer.charAt(++i)) * 256 +
+                                        Character.getNumericValue(targetBuffer.charAt(++i)) * 16 +
+                                        Character.getNumericValue(targetBuffer.charAt(++i)));
                         break;
                     default:
                         ch = ch3;
                 }
             }
             // Set the unescaped character into the sequence
-            AppendableUtil.setCharAt(sb, end++, ch);
+            AppendableUtil.setCharAt(targetBuffer, end++, ch);
         }
         // Validate the length consistency after unescaping
-        if (length != sb.length())
-            throw new IllegalStateException("Length changed from " + length + " to " + sb.length() + " for " + sb);
-        AppendableUtil.setLength(sb, end);
+        if (length != targetBuffer.length())
+            throw new IllegalStateException("Length changed from " + length + " to " + targetBuffer.length() + " for " + targetBuffer);
+        AppendableUtil.setLength(targetBuffer, end);
     }
 
     /**
@@ -680,12 +680,12 @@ public class TextWire extends YamlWireOut<TextWire> {
      * The content of the StringBuilder is interned before the conversion.
      *
      * @param expectedClass The class to which the StringBuilder's content should be converted.
-     * @param sb The StringBuilder containing the data to be converted.
+     * @param keyTextBuilder The StringBuilder containing the data to be converted.
      * @return An instance of the expected class, converted from the StringBuilder's content.
      */
     @Nullable
-    private <K> K toExpected(Class<K> expectedClass, StringBuilder sb) {
-        return ObjectUtils.convertTo(expectedClass, WireInternal.INTERNER.intern(sb));
+    private <K> K toExpected(Class<K> expectedClass, StringBuilder keyTextBuilder) {
+        return ObjectUtils.convertTo(expectedClass, WireInternal.INTERNER.intern(keyTextBuilder));
     }
 
     /**
@@ -864,11 +864,11 @@ public class TextWire extends YamlWireOut<TextWire> {
     /**
      * returns {@code true} if the next string is {@code str}
      *
-     * @param source string
+     * @param expectedString string
      * @return true if the strings are the same
      */
-    protected boolean peekStringIgnoreCase(@NotNull final String source) {
-        if (source.isEmpty())
+    protected boolean peekStringIgnoreCase(@NotNull final String expectedString) {
+        if (expectedString.isEmpty())
             return true;
 
         if (bytes.readRemaining() < 1)
@@ -877,8 +877,8 @@ public class TextWire extends YamlWireOut<TextWire> {
         long pos = bytes.readPosition();
 
         try {
-            for (int i = 0; i < source.length(); i++) {
-                if (Character.toLowerCase(source.charAt(i)) != Character.toLowerCase(bytes.readByte()))
+            for (int i = 0; i < expectedString.length(); i++) {
+                if (Character.toLowerCase(expectedString.charAt(i)) != Character.toLowerCase(bytes.readByte()))
                     return false;
             }
         } finally {
@@ -962,24 +962,24 @@ public class TextWire extends YamlWireOut<TextWire> {
      * @param keyName       The name of the key for which the value needs to be read.
      * @param keyCode       The code for the key.
      * @param defaultValue  The default value to return if the key isn't found.
-     * @param curr          The current state of the ValueIn.
-     * @param sb            The StringBuilder used to capture the field name.
+     * @param currentState  The current state of the ValueIn.
+     * @param tempNameBuilder            The StringBuilder used to capture the field name.
      * @param name          The name of the key (same as keyName, possibly added for clarity in some cases).
      * @return              The value associated with the key or the default value if the key is not found.
      */
-    protected ValueIn read2(CharSequence keyName, int keyCode, Object defaultValue, @NotNull ValueInState curr, @NotNull StringBuilder sb, @NotNull CharSequence name) {
+    protected ValueIn read2(CharSequence keyName, int keyCode, Object defaultValue, @NotNull ValueInState currentState, @NotNull StringBuilder tempNameBuilder, @NotNull CharSequence name) {
         final long position2 = bytes.readPosition();
 
         // if not a match go back and look at old fields.
-        for (int i = 0; i < curr.unexpectedSize(); i++) {
-            bytes.readPosition(curr.unexpected(i));
+        for (int i = 0; i < currentState.unexpectedSize(); i++) {
+            bytes.readPosition(currentState.unexpected(i));
             valueIn.consumeAny = true;
-            readField(sb);
+            readField(tempNameBuilder);
             valueIn.consumeAny = false;
-            if (sb.length() == 0 || StringUtils.equalsCaseIgnore(sb, name)) {
+            if (tempNameBuilder.length() == 0 || StringUtils.equalsCaseIgnore(tempNameBuilder, name)) {
                 // if an old field matches, remove it, save the current position
-                curr.removeUnexpected(i);
-                curr.savedPosition(position2 + 1);
+                currentState.removeUnexpected(i);
+                currentState.savedPosition(position2 + 1);
                 return valueIn;
             }
         }
@@ -1071,24 +1071,24 @@ public class TextWire extends YamlWireOut<TextWire> {
      * Parses a word from the current byte position until it encounters a space or stop character.
      * The parsed word is then appended to the provided StringBuilder.
      *
-     * @param sb The StringBuilder to which the parsed word will be appended.
+     * @param outputBuilder The StringBuilder to which the parsed word will be appended.
      */
-    public void parseWord(@NotNull StringBuilder sb) {
-        parseUntil(sb, StopCharTesters.SPACE_STOP);
+    public void parseWord(@NotNull StringBuilder outputBuilder) {
+        parseUntil(outputBuilder, StopCharTesters.SPACE_STOP);
     }
 
     /**
      * Parses characters from the current byte position until one of the specified stop characters
      * in the tester is encountered. The parsed characters are then appended to the provided StringBuilder.
      *
-     * @param sb       The StringBuilder to which the parsed characters will be appended.
-     * @param testers  A StopCharTester which determines which characters should stop the parsing.
+     * @param outputBuilder       The StringBuilder to which the parsed characters will be appended.
+     * @param stopTester  A StopCharTester which determines which characters should stop the parsing.
      */
-    public void parseUntil(@NotNull StringBuilder sb, @NotNull StopCharTester testers) {
+    public void parseUntil(@NotNull StringBuilder outputBuilder, @NotNull StopCharTester stopTester) {
         if (use8bit)
-            bytes.parse8bit(sb, testers);
+            bytes.parse8bit(outputBuilder, stopTester);
         else
-            bytes.parseUtf8(sb, testers);
+            bytes.parseUtf8(outputBuilder, stopTester);
     }
 
     /**
@@ -1096,15 +1096,15 @@ public class TextWire extends YamlWireOut<TextWire> {
      * until one of the specified stop characters in the tester is encountered.
      * The parsed characters are then appended to the provided StringBuilder.
      *
-     * @param sb       The StringBuilder to which the parsed characters will be appended.
-     * @param testers  A StopCharsTester which determines which characters should stop the parsing.
+     * @param outputBuilder       The StringBuilder to which the parsed characters will be appended.
+     * @param stopTester  A StopCharsTester which determines which characters should stop the parsing.
      */
-    public void parseUntil(@NotNull StringBuilder sb, @NotNull StopCharsTester testers) {
-        sb.setLength(0);
+    public void parseUntil(@NotNull StringBuilder outputBuilder, @NotNull StopCharsTester stopTester) {
+        outputBuilder.setLength(0);
         if (use8bit) {
-            AppendableUtil.read8bitAndAppend(bytes, sb, testers);
+            AppendableUtil.read8bitAndAppend(bytes, outputBuilder, stopTester);
         } else {
-            AppendableUtil.readUTFAndAppend(bytes, sb, testers);
+            AppendableUtil.readUTFAndAppend(bytes, outputBuilder, stopTester);
         }
     }
 
@@ -1404,17 +1404,17 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         @SuppressWarnings("fallthrough")
-        @Nullable <ACS extends Appendable & CharSequence> CharSequence textTo0(@NotNull ACS a) {
+        @Nullable <ACS extends Appendable & CharSequence> CharSequence textTo0(@NotNull ACS destination) {
             consumePadding();
             int ch = peekCode();
-            @Nullable CharSequence ret = a;
+            @Nullable CharSequence ret = destination;
 
             switch (ch) {
                 case '{': {
                     // For map-like structures: read the length of the content and append to the target appendable
                     final long len = readLength();
                     try {
-                        a.append(Bytes.toString(bytes, bytes.readPosition(), len));
+                        destination.append(Bytes.toString(bytes, bytes.readPosition(), len));
                     } catch (IOException e) {
                         throw new AssertionError(e);
                     }
@@ -1424,7 +1424,7 @@ public class TextWire extends YamlWireOut<TextWire> {
                     // Move to the next comma or the end of the map
                     bytes.skipTo(StopCharTesters.COMMA_STOP);
 
-                    return a;
+                    return destination;
 
                 }
                 case '"':
@@ -1446,8 +1446,8 @@ public class TextWire extends YamlWireOut<TextWire> {
                         ret = null;
                     } else {
                         // ignore the type.
-                        if (a instanceof StringBuilder) {
-                            textTo((StringBuilder) a);
+                        if (destination instanceof StringBuilder) {
+                            textTo((StringBuilder) destination);
                         } else {
                             textTo(stringBuilder);
                             ret = stringBuilder;
@@ -1463,8 +1463,8 @@ public class TextWire extends YamlWireOut<TextWire> {
                 case '$':
                     // For variable substitution syntax (e.g. "${variable}")
                     if (peekCodeNext() == '{') {
-                        unsubstitutedString(a);
-                        return a;
+                        unsubstitutedString(destination);
+                        return destination;
                     }
                     // fall through
 
@@ -1473,24 +1473,24 @@ public class TextWire extends YamlWireOut<TextWire> {
 
                     final long rem = bytes.readRemaining();
                     if (rem > 0) {
-                        if (a instanceof Bytes) {
-                            bytes.parse8bit((Bytes) a, getStrictEscapingEndOfText());
+                        if (destination instanceof Bytes) {
+                            bytes.parse8bit((Bytes) destination, getStrictEscapingEndOfText());
                         } else if (use8bit) {
-                            bytes.parse8bit((StringBuilder) a, getStrictEscapingEndOfText());
+                            bytes.parse8bit((StringBuilder) destination, getStrictEscapingEndOfText());
                         } else {
-                            bytes.parseUtf8(a, getStrictEscapingEndOfText());
+                            bytes.parseUtf8(destination, getStrictEscapingEndOfText());
                         }
                         // If nothing was read, throw an exception
                         if (rem == bytes.readRemaining())
                             throw new IORuntimeException("Nothing to read at " + bytes.toDebugString(32));
                     } else {
                         // Clear the target appendable if no remaining content
-                        AppendableUtil.setLength(a, 0);
+                        AppendableUtil.setLength(destination, 0);
                     }
                     // trim trailing spaces.
-                    while (a.length() > 0) {
-                        if (Character.isWhitespace(a.charAt(a.length() - 1)))
-                            AppendableUtil.setLength(a, a.length() - 1);
+                    while (destination.length() > 0) {
+                        if (Character.isWhitespace(destination.charAt(destination.length() - 1)))
+                            AppendableUtil.setLength(destination, destination.length() - 1);
                         else
                             break;
                     }
@@ -1505,7 +1505,7 @@ public class TextWire extends YamlWireOut<TextWire> {
             return ret;
         }
 
-        private <ACS extends Appendable & CharSequence> void unsubstitutedString(@NotNull ACS a) {
+        private <ACS extends Appendable & CharSequence> void unsubstitutedString(@NotNull ACS destination) {
             String text = bytes.toString();
             // Limit the log output to 32 characters for brevity
             if (text.length() > 32)
@@ -1518,7 +1518,7 @@ public class TextWire extends YamlWireOut<TextWire> {
                 c = bytes.readChar();
                 try {
                     // Append the read character to the provided appendable
-                    a.append(c);
+                    destination.append(c);
                 } catch (IOException e) {
                     throw new AssertionError(e);
                 }
@@ -1526,16 +1526,16 @@ public class TextWire extends YamlWireOut<TextWire> {
             } while (!bytes.isEmpty() && c != '}');
         }
 
-        private <ACS extends Appendable & CharSequence> void readText(@NotNull ACS a, @NotNull StopCharTester quotes) {
+        private <ACS extends Appendable & CharSequence> void readText(@NotNull ACS destination, @NotNull StopCharTester quotes) {
             // Skip the initial quote (either ' or ")
             bytes.readSkip(1);
             // Read the content based on the character encoding being used
             if (use8bit)
-                bytes.parse8bit(a, quotes);  // Parse using 8-bit encoding
+                bytes.parse8bit(destination, quotes);  // Parse using 8-bit encoding
             else
-                bytes.parseUtf8(a, quotes);  // Parse using UTF-8 encoding
+                bytes.parseUtf8(destination, quotes);  // Parse using UTF-8 encoding
             // Unescape any escape sequences found in the content
-            unescape(a);
+            unescape(destination);
             // Consume any padding characters (e.g. whitespace)
             consumePadding(1);
         }
@@ -2907,22 +2907,22 @@ public class TextWire extends YamlWireOut<TextWire> {
          * indicators or sequences in the stream and then invokes the appropriate
          * deserialization logic for that type.
          *
-         * @param using An object to potentially reuse during deserialization for efficiency.
+         * @param reusableInstance An object to potentially reuse during deserialization for efficiency.
          * @param strategy The serialization strategy to be applied during deserialization.
-         * @param type The expected type of the resulting object.
+         * @param defaultType The expected type of the resulting object.
          * @return The deserialized object.
          * @throws InvalidMarshallableException If any issues are encountered during the deserialization process.
          */
         @Nullable
-        Object objectWithInferredType0(Object using, @NotNull SerializationStrategy strategy, Class<?> type) throws InvalidMarshallableException {
+        Object objectWithInferredType0(Object reusableInstance, @NotNull SerializationStrategy strategy, Class<?> defaultType) throws InvalidMarshallableException {
             int code = peekCode();
             switch (code) {
                 // Different cases for different object types or data representations.
                 // Each case handles the deserialization logic for that specific representation.
                 case '?':
-                    return map(Object.class, Object.class, (Map) using);
+                    return map(Object.class, Object.class, (Map) reusableInstance);
                 case '!':
-                    return object(using, type);
+                    return object(reusableInstance, defaultType);
                 case '-':
                     if (peekCodeNext() == ' ')
                         return readList(indentation(), null);
@@ -2950,11 +2950,11 @@ public class TextWire extends YamlWireOut<TextWire> {
             }
 
             // Convert the content to a Bytes or StringBuilder if the using object is of that type.
-            if (using instanceof Bytes)
-                return valueIn.textTo((Bytes) using);
+            if (reusableInstance instanceof Bytes)
+                return valueIn.textTo((Bytes) reusableInstance);
 
-            if (using instanceof StringBuilder)
-                return valueIn.textTo((StringBuilder) using);
+            if (reusableInstance instanceof StringBuilder)
+                return valueIn.textTo((StringBuilder) reusableInstance);
 
             @Nullable String text = valueIn.text();
             if (text == null || Enum.class.isAssignableFrom(strategy.type()))
@@ -3051,8 +3051,8 @@ public class TextWire extends YamlWireOut<TextWire> {
          * @throws UnsupportedOperationException if the provided class type isn't supported.
          */
         @NotNull
-        private Object readSequence(@NotNull Class<?> clazz) {
-            if (clazz == Object[].class || clazz == Object.class) {
+        private Object readSequence(@NotNull Class<?> targetSequenceType) {
+            if (targetSequenceType == Object[].class || targetSequenceType == Object.class) {
                 // TODO: Consider using reflection to handle all array types.
                 @NotNull List<Object> list = new ArrayList<>();
                 sequence(list, (l, v) -> {
@@ -3060,7 +3060,7 @@ public class TextWire extends YamlWireOut<TextWire> {
                         l.add(v.object(Object.class));
                     }
                 });
-                return clazz == Object[].class ? list.toArray() : list;
+                return targetSequenceType == Object[].class ? list.toArray() : list;
 
             // Handle sequences expected to be of type String[].
             } else if (clazz == String[].class) {

--- a/src/main/java/net/openhft/chronicle/wire/YamlLogging.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlLogging.java
@@ -54,10 +54,10 @@ public enum YamlLogging {
     /**
      * Sets the logging flags for all message types (reads/writes for both client and server).
      *
-     * @param flag The boolean value to set for all logging flags.
+     * @param enable The boolean value to set for all logging flags.
      */
-    public static void setAll(boolean flag) {
-        showServerReads = showServerWrites = clientWrites = clientReads = flag;
+    public static void setAll(boolean enable) {
+        showServerReads = showServerWrites = clientWrites = clientReads = enable;
     }
 
     /**
@@ -81,19 +81,19 @@ public enum YamlLogging {
     /**
      * Updates the message associated with a write operation.
      *
-     * @param s The new message to be set.
+     * @param message The new message to be set.
      */
-    public static void writeMessage(@NotNull String s) {
-        writeMessage = s;
+    public static void writeMessage(@NotNull String message) {
+        writeMessage = message;
     }
 
     /**
      * Sets the flag to determine whether server writes should be logged.
      *
-     * @param logging {@code true} to enable logging for server writes; {@code false} to disable.
+     * @param enable {@code true} to enable logging for server writes; {@code false} to disable.
      */
-    public static void showServerWrites(boolean logging) {
-        showServerWrites = logging;
+    public static void showServerWrites(boolean enable) {
+        showServerWrites = enable;
     }
 
     /**
@@ -136,28 +136,28 @@ public enum YamlLogging {
     /**
      * Sets the flag to determine whether heartbeats should be logged.
      *
-     * @param log {@code true} to enable heartbeat logging; {@code false} to disable.
+     * @param enable {@code true} to enable heartbeat logging; {@code false} to disable.
      */
-    public static void showHeartBeats(boolean log) {
-        showHeartBeats = log;
+    public static void showHeartBeats(boolean enable) {
+        showHeartBeats = enable;
     }
 
     /**
      * Sets the flag to determine whether client writes should be logged.
      *
-     * @param logging {@code true} to enable logging for client writes; {@code false} to disable.
+     * @param enable {@code true} to enable logging for client writes; {@code false} to disable.
      */
-    public static void showClientWrites(boolean logging) {
-        clientWrites = logging;
+    public static void showClientWrites(boolean enable) {
+        clientWrites = enable;
     }
 
     /**
      * Sets the flag to determine whether client reads should be logged.
      *
-     * @param logging {@code true} to enable logging for client reads; {@code false} to disable.
+     * @param enable {@code true} to enable logging for client reads; {@code false} to disable.
      */
-    public static void showClientReads(boolean logging) {
-        clientReads = logging;
+    public static void showClientReads(boolean enable) {
+        clientReads = enable;
     }
 
     /**
@@ -172,10 +172,10 @@ public enum YamlLogging {
     /**
      * Sets the flag to determine whether server reads should be logged.
      *
-     * @param logging {@code true} to enable logging for server reads; {@code false} to disable.
+     * @param enable {@code true} to enable logging for server reads; {@code false} to disable.
      */
-    public static void showServerReads(boolean logging) {
-        showServerReads = logging;
+    public static void showServerReads(boolean enable) {
+        showServerReads = enable;
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
@@ -96,11 +96,11 @@ public class YamlTokeniser {
     /**
      * Constructs a new YAML tokenizer with the specified input.
      *
-     * @param in The input source containing raw YAML content.
+     * @param inputStream The input source containing raw YAML content.
      */
-    public YamlTokeniser(BytesIn<?> in) {
+    public YamlTokeniser(BytesIn<?> inputStream) {
         reset();
-        this.in = in;
+        this.in = inputStream;
     }
 
     /**
@@ -430,15 +430,15 @@ public class YamlTokeniser {
      * This method is useful for flow constructs where we need to determine the
      * boundaries (like a list or map).
      *
-     * @param start The token to identify the start of the flow construct.
-     * @param end The character representing the end of the flow construct.
+     * @param flowStartToken The token to identify the start of the flow construct.
+     * @param flowEndChar The character representing the end of the flow construct.
      * @return The appropriate {@link YamlToken} after popping the context.
      */
-    private YamlToken flowPop(YamlToken start, char end) {
+    private YamlToken flowPop(YamlToken flowStartToken, char flowEndChar) {
         int pos = pushed.size();
-        while (context() != start) {
+        while (context() != flowStartToken) {
             if (contextSize() <= 1)
-                throw new IllegalArgumentException("Unexpected '" + end + '\'');
+                throw new IllegalArgumentException("Unexpected '" + flowEndChar + '\'');
             contextPop();
         }
         contextPop();
@@ -605,51 +605,51 @@ public class YamlTokeniser {
     /**
      * Handles and determines the indentation level and relevant token type based on context.
      *
-     * @param indented The token for the start of indentation context.
-     * @param key The key token type.
-     * @param push The token type to be pushed to the stack.
-     * @param indent The current indentation level.
+     * @param currentIndentedContextToken The token for the start of indentation context.
+     * @param keyDefinitionToken The key token type.
+     * @param nextTokenToParse The token type to be pushed to the stack.
+     * @param currentIndentLevel The current indentation level.
      * @return The next token after processing the current input.
      */
     private YamlToken indent(
-            YamlToken indented,
-            @NotNull YamlToken key,
-            @NotNull YamlToken push,
-            int indent) {
-        if (push != YamlToken.STREAM_START)
-            this.pushed.add(push);
+            YamlToken currentIndentedContextToken,
+            @NotNull YamlToken keyDefinitionToken,
+            @NotNull YamlToken nextTokenToParse,
+            int currentIndentLevel) {
+        if (nextTokenToParse != YamlToken.STREAM_START)
+            this.pushed.add(nextTokenToParse);
         if (isInFlow()) {
-            return key; // If we are inside a flow structure, return the key token.
+            return keyDefinitionToken; // If we are inside a flow structure, return the key token.
         }
         int pos = this.pushed.size();
 
         // Pop contexts until the current indent matches the existing context.
-        while (indent < contextIndent()) {
+        while (currentIndentLevel < contextIndent()) {
             contextPop();
         }
         int contextIndent = contextIndent();
 
         // Push the indented token if we are starting a new indentation level.
-        if (indented != null && indent != contextIndent)
-            this.pushed.add(indented);
-        this.pushed.add(key);
+        if (currentIndentedContextToken != null && currentIndentLevel != contextIndent)
+            this.pushed.add(currentIndentedContextToken);
+        this.pushed.add(keyDefinitionToken);
 
         // Reverse the order of the tokens in the pushed stack.
         reversePushed(pos);
 
         // Push a new context if we are starting a new indentation level.
-        if (indented != null && indent > contextIndent())
-            contextPush(indented, indent);
+        if (currentIndentedContextToken != null && currentIndentLevel > contextIndent())
+            contextPush(currentIndentedContextToken, currentIndentLevel);
         return popPushed();
     }
 
     /**
      * Reads plain scalar text from the YAML input, handling mappings and sequences.
      *
-     * @param indent2 The current indentation level.
+     * @param currentIndentLevel The current indentation level.
      * @return The token after processing the text.
      */
-    private YamlToken readText(int indent2) {
+    private YamlToken readText(int currentIndentLevel) {
         long pos = in.readPosition(); // Store the current position of input.
 
         blockQuote = 0;
@@ -659,7 +659,7 @@ public class YamlTokeniser {
         if (isFieldEnd()) {
             lastKeyPosition = pos;
             if (topContext().token != YamlToken.MAPPING_KEY)
-                return indent(YamlToken.MAPPING_START, YamlToken.MAPPING_KEY, YamlToken.TEXT, indent2);
+                return indent(YamlToken.MAPPING_START, YamlToken.MAPPING_KEY, YamlToken.TEXT, currentIndentLevel);
         }
 
         // By default, treat the scalar as plain text.
@@ -1061,15 +1061,15 @@ public class YamlTokeniser {
     /**
      * Extracts the text of the current block into the provided StringBuilder.
      *
-     * @param sb StringBuilder to which the block's text will be appended.
+     * @param outputBuilder StringBuilder to which the block's text will be appended.
      */
-    public void text(StringBuilder sb) {
+    public void text(StringBuilder outputBuilder) {
         // If blockEnd is not set and a temporary value exists, use that.
         if (blockEnd < 0 && temp != null) {
-            sb.append(temp);
+            outputBuilder.append(temp);
             return;
         }
-        sb.setLength(0);  // Clear the StringBuilder.
+        outputBuilder.setLength(0);  // Clear the StringBuilder.
 
         // Return if there is no text to parse or if last token doesn't allow text extraction.
         if (blockStart == blockEnd || NO_TEXT.contains(last))
@@ -1077,7 +1077,7 @@ public class YamlTokeniser {
         long pos = in.readPosition();
         try {
             in.readPosition(blockStart);
-            in.parseUtf8(sb, Math.toIntExact(blockEnd - blockStart));
+            in.parseUtf8(outputBuilder, Math.toIntExact(blockEnd - blockStart));
         } finally {
             // Reset the reading position.
             in.readPosition(pos);

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -105,13 +105,13 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     /**
      * Utility method to create a new YamlWire instance by reading bytes from a specified file.
      *
-     * @param name Name of the file from which bytes are read
+     * @param filePath Name of the file from which bytes are read
      * @return A new YamlWire instance initialized with bytes from the specified file
      * @throws IOException If there's an error in reading the file
      */
     @NotNull
-    public static YamlWire fromFile(String name) throws IOException {
-        return new YamlWire(BytesUtil.readFile(name), true);
+    public static YamlWire fromFile(String filePath) throws IOException {
+        return new YamlWire(BytesUtil.readFile(filePath), true);
     }
 
     /**
@@ -145,13 +145,13 @@ public class YamlWire extends YamlWireOut<YamlWire> {
      * This method adheres to the YAML 1.2 specification for escaped characters
      * (see <a href="https://yaml.org/spec/1.2.2/#escaped-characters">YAML Spec 1.2.2</a>).
      *
-     * @param sb The appendable containing characters to be unescaped.
-     * @param blockQuote The block quote character that determines the escaping scheme (' or ").
+     * @param targetBuffer The appendable containing characters to be unescaped.
+     * @param blockQuoteChar The block quote character that determines the escaping scheme (' or ").
      * @param <ACS> An appendable that also implements CharSequence interface.
      */
-    private static <ACS extends Appendable & CharSequence> void unescape(@NotNull ACS sb, char blockQuote) {
+    private static <ACS extends Appendable & CharSequence> void unescape(@NotNull ACS targetBuffer, char blockQuoteChar) {
         int end = 0;
-        int length = sb.length();
+        int length = targetBuffer.length();
         boolean skip = false;
         for (int i = 0; i < length; i++) {
             if (skip) {
@@ -159,11 +159,11 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                 continue;
             }
 
-            char ch = sb.charAt(i);
+            char ch = targetBuffer.charAt(i);
 
             // Processing escaped characters for double quotes
-            if (blockQuote == '\"' && ch == '\\' && i < length - 1) {
-                char ch3 = sb.charAt(++i);
+            if (blockQuoteChar == '\"' && ch == '\\' && i < length - 1) {
+                char ch3 = targetBuffer.charAt(++i);
                 switch (ch3) {
                     // Various cases for character unescaping based on YAML specification
                     case '0':
@@ -207,17 +207,17 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                         break;
                     case 'x':
                         ch = (char)
-                                (Character.getNumericValue(sb.charAt(++i)) * 16 +
-                                        Character.getNumericValue(sb.charAt(++i)));
+                                (Character.getNumericValue(targetBuffer.charAt(++i)) * 16 +
+                                        Character.getNumericValue(targetBuffer.charAt(++i)));
                         break;
 
                     // For Unicode escapes
                     case 'u':
                         ch = (char)
-                                (Character.getNumericValue(sb.charAt(++i)) * 4096 +
-                                        Character.getNumericValue(sb.charAt(++i)) * 256 +
-                                        Character.getNumericValue(sb.charAt(++i)) * 16 +
-                                        Character.getNumericValue(sb.charAt(++i)));
+                                (Character.getNumericValue(targetBuffer.charAt(++i)) * 4096 +
+                                        Character.getNumericValue(targetBuffer.charAt(++i)) * 256 +
+                                        Character.getNumericValue(targetBuffer.charAt(++i)) * 16 +
+                                        Character.getNumericValue(targetBuffer.charAt(++i)));
                         break;
                     default:
                         ch = ch3;
@@ -225,18 +225,18 @@ public class YamlWire extends YamlWireOut<YamlWire> {
             }
 
             // Processing escaped characters for single quotes
-            if (blockQuote == '\'' && ch == '\'' && i < length - 1) {
-                char ch2 = sb.charAt(i + 1);
+            if (blockQuoteChar == '\'' && ch == '\'' && i < length - 1) {
+                char ch2 = targetBuffer.charAt(i + 1);
                 if (ch2 == ch) {
                     skip = true;
                 }
             }
 
-            AppendableUtil.setCharAt(sb, end++, ch);
+            AppendableUtil.setCharAt(targetBuffer, end++, ch);
         }
-        if (length != sb.length())
-            throw new IllegalStateException("Length changed from " + length + " to " + sb.length() + " for " + sb);
-        AppendableUtil.setLength(sb, end);
+        if (length != targetBuffer.length())
+            throw new IllegalStateException("Length changed from " + length + " to " + targetBuffer.length() + " for " + targetBuffer);
+        AppendableUtil.setLength(targetBuffer, end);
     }
 
     /**
@@ -261,30 +261,30 @@ public class YamlWire extends YamlWireOut<YamlWire> {
      * as a date/time, based on the YAML specification. If none of these interpretations is successful,
      * it returns the original string content.
      *
-     * @param bq The block quote character (either ' or ") that initiated the string in YAML.
-     * @param s The StringBuilder containing the string to be interpreted.
+     * @param blockQuoteChar The block quote character (either ' or ") that initiated the string in YAML.
+     * @param inputTextBuilder The StringBuilder containing the string to be interpreted.
      * @return An Object which might be a Long, Double, Date, Time or the original String itself
      *         depending on successful interpretation.
      */
     @Nullable
-    static Object readNumberOrTextFrom(char bq, final @Nullable StringBuilder s) {
-        if (leaveUnparsed(bq, s))
-            return s;
+    static Object readNumberOrTextFrom(char blockQuoteChar, final @Nullable StringBuilder inputTextBuilder) {
+        if (leaveUnparsed(blockQuoteChar, inputTextBuilder))
+            return inputTextBuilder;
 
-        StringBuilder sb = s;
+        StringBuilder targetBuffer = inputTextBuilder;
         // YAML octal notation
         if (StringUtils.startsWith(s, "0o")) {
-            sb = new StringBuilder(s);
-            sb.deleteCharAt(1);
+            targetBuffer = new StringBuilder(s);
+            targetBuffer.deleteCharAt(1);
         }
 
         // Remove underscores if present, as they can be used in YAML as visual separators in numbers.
         if (s.indexOf("_") >= 0) {
-            sb = new StringBuilder(s);
-            removeUnderscore(sb);
+            targetBuffer = new StringBuilder(s);
+            removeUnderscore(targetBuffer);
         }
 
-        String ss = sb.toString();
+        String ss = targetBuffer.toString();
 
         // Attempt to parse as a long
         try {
@@ -322,16 +322,16 @@ public class YamlWire extends YamlWireOut<YamlWire> {
      *     <li>If the first character of the string is not a number, decimal point, or a sign.</li>
      * </ul>
      *
-     * @param bq The block quote character (either ' or ") that initiated the string in YAML.
-     * @param s The StringBuilder containing the string to check.
+     * @param blockQuoteChar The block quote character (either ' or ") that initiated the string in YAML.
+     * @param inputTextBuilder The StringBuilder containing the string to check.
      * @return True if the string should be left unparsed, otherwise false.
      */
-    private static boolean leaveUnparsed(char bq, @Nullable StringBuilder s) {
-        return s == null
-                || bq != 0
-                || s.length() < 1
-                || s.length() > 40
-                || "0123456789.+-".indexOf(s.charAt(0)) < 0;
+    private static boolean leaveUnparsed(char blockQuoteChar, @Nullable StringBuilder inputTextBuilder) {
+        return inputTextBuilder == null
+                || blockQuoteChar != 0
+                || inputTextBuilder.length() < 1
+                || inputTextBuilder.length() > 40
+                || "0123456789.+-".indexOf(inputTextBuilder.charAt(0)) < 0;
     }
 
     /**
@@ -716,11 +716,11 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     /**
      * Reads a field from the current YamlToken and appends its content to the provided StringBuilder.
      *
-     * @param sb StringBuilder instance to which the field content will be appended.
+     * @param targetBuffer StringBuilder instance to which the field content will be appended.
      * @return The same StringBuilder instance with the appended content.
      */
     @NotNull
-    protected StringBuilder readField(@NotNull StringBuilder sb) {
+    protected StringBuilder readField(@NotNull StringBuilder targetBuffer) {
         startEventIfTop();
 
         // If the current token indicates a key in a map
@@ -729,18 +729,18 @@ public class YamlWire extends YamlWireOut<YamlWire> {
 
             // Ensure the key is textual
             if (yt.current() == YamlToken.TEXT) {
-                String text = yt.text(); // Captures the key's text. Note: using sb here may modify its contents
-                sb.setLength(0);         // Reset the StringBuilder
-                sb.append(text);         // Append the key's text to the StringBuilder
-                unescape(sb, yt.blockQuote()); // Handle any escape sequences within the key
+                String text = yt.text(); // Captures the key's text. Note: using targetBuffer here may modify its contents
+                targetBuffer.setLength(0);         // Reset the StringBuilder
+                targetBuffer.append(text);         // Append the key's text to the StringBuilder
+                unescape(targetBuffer, yt.blockQuote()); // Handle any escape sequences within the key
                 yt.next();
             } else {
                 throw new IllegalStateException(yt.toString());
             }
         } else {
-            sb.setLength(0); // Clear the StringBuilder if the current token isn't a MAPPING_KEY
+            targetBuffer.setLength(0); // Clear the StringBuilder if the current token isn't a MAPPING_KEY
         }
-        return sb;
+        return targetBuffer;
     }
 
     @SuppressWarnings("fallthrough")
@@ -853,7 +853,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
             if (checkForMatch(keyName))
                 return valueIn;
 
-            if (!StringUtils.startsWith(sb, "-"))
+            if (!StringUtils.startsWith(targetBuffer, "-"))
                 keys.push(lastKeyPosition);
             // Avoid consuming '}' but consume to next mapping key
             valueIn.consumeAny(minIndent >= 0 ? minIndent : Integer.MAX_VALUE);
@@ -904,16 +904,16 @@ public class YamlWire extends YamlWireOut<YamlWire> {
 
         // If the next token is textual
         if (next == YamlToken.TEXT) {
-            sb.setLength(0);          // Reset the StringBuilder
-            sb.append(yt.text());     // Append the text of the next token to the StringBuilder
-            unescape(sb, yt.blockQuote()); // Handle any escape sequences within the text
+            targetBuffer.setLength(0);          // Reset the StringBuilder
+            targetBuffer.append(yt.text());     // Append the text of the next token to the StringBuilder
+            unescape(targetBuffer, yt.blockQuote()); // Handle any escape sequences within the text
             yt.next();
         } else {
             throw new IllegalStateException(next.toString());
         }
 
         // Compare the processed string in the StringBuilder with the expected keyName
-        return (sb.length() == 0 || StringUtils.isEqual(sb, keyName));
+        return (targetBuffer.length() == 0 || StringUtils.isEqual(targetBuffer, keyName));
     }
 
     @NotNull
@@ -1120,7 +1120,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
 
         // Clear the bytes buffer and internal StringBuilder
         bytes.clear();
-        sb.setLength(0);
+        targetBuffer.setLength(0);
 
         // Reset the YAML tokenizer and value states
         yt.reset();
@@ -1178,17 +1178,17 @@ public class YamlWire extends YamlWireOut<YamlWire> {
 
         @Nullable
         @Override
-        public StringBuilder textTo(@NotNull StringBuilder sb) {
-            sb.setLength(0);
-            @Nullable CharSequence cs = textTo0(sb);
+        public StringBuilder textTo(@NotNull StringBuilder targetBuffer) {
+            targetBuffer.setLength(0);
+            @Nullable CharSequence cs = textTo0(targetBuffer);
             yt.next();
             if (cs == null)
                 return null;
-            if (cs != sb) {
-                sb.setLength(0);
-                sb.append(cs);
+            if (cs != targetBuffer) {
+                targetBuffer.setLength(0);
+                targetBuffer.append(cs);
             }
-            return sb;
+            return targetBuffer;
         }
 
         @Nullable
@@ -1267,7 +1267,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
          * @return StringBuilder containing the text.
          */
         @Nullable
-        StringBuilder textTo0(@NotNull StringBuilder a) {
+        StringBuilder textTo0(@NotNull StringBuilder destinationBuilder) {
             consumePadding(); // consume any padding
 
             // if the current token is a sequence entry, move to the next token
@@ -1278,11 +1278,11 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                 // handle text or literal tokens
                 case TEXT:
                 case LITERAL:
-                    a.append(yt.text()); // append the text value
+                    destinationBuilder.append(yt.text()); // append the text value
 
                     // unescape the text value if needed
                     if (yt.current() == YamlToken.TEXT)
-                        unescape(a, yt.blockQuote());
+                        unescape(destinationBuilder, yt.blockQuote());
 
                     break;
 
@@ -1290,9 +1290,9 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                     // Handle YAML anchors, which can be referred to later as aliases
                     String alias = yt.text();
                     yt.next();
-                    textTo0(sb);
+                    textTo0(targetBuffer);
                     // Store the anchor for later reference
-                    anchorValues.put(alias, sb.toString());
+                    anchorValues.put(alias, targetBuffer.toString());
                     break;
 
                 case ALIAS:
@@ -1303,7 +1303,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                         throw new IllegalStateException("Unknown alias " + alias + " with no corresponding anchor");
 
                     yt.next();
-                    sb.append(o);
+                    targetBuffer.append(o);
                     break;
 
                 // handle tag tokens
@@ -1320,14 +1320,14 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                         yt.next();
                         final byte[] arr = (byte[]) decodeBinary(byte[].class);
                         for (byte b : arr) {
-                            a.append((char) b);
+                            destinationBuilder.append((char) b);
                         }
-                        return a;
+                        return destinationBuilder;
                     }
 
                     throw new UnsupportedOperationException(yt.toString());
             }
-            return a;
+            return destinationBuilder;
         }
 
         @NotNull
@@ -1359,14 +1359,14 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         public WireIn bytes(@NotNull ReadBytesMarshallable bytesConsumer) {
             consumePadding();
             // TODO needs to be made much more efficient.
-            @NotNull StringBuilder sb = acquireStringBuilder();
+            @NotNull StringBuilder targetBuffer = acquireStringBuilder();
             if (yt.current() == YamlToken.TAG) {
                 bytes.readSkip(1);
-                yt.text(sb);
+                yt.text(targetBuffer);
                 yt.next();
                 if (yt.current() != YamlToken.TEXT)
                     throw new UnsupportedOperationException(yt.toString());
-                @Nullable byte[] uncompressed = Compression.uncompress(sb, yt, t -> {
+                @Nullable byte[] uncompressed = Compression.uncompress(targetBuffer, yt, t -> {
                     @NotNull StringBuilder sb2 = acquireStringBuilder();
                     t.text(sb2);
                     return Base64.getDecoder().decode(sb2.toString());
@@ -1379,16 +1379,16 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                         bytes.releaseLast();
                     }
 
-                } else if (StringUtils.isEqual(sb, NULL_TAG)) {
+                } else if (StringUtils.isEqual(targetBuffer, NULL_TAG)) {
                     bytesConsumer.readMarshallable(null);
                     yt.next();
 
                 } else {
-                    throw new IORuntimeException("Unsupported type=" + sb);
+                    throw new IORuntimeException("Unsupported type=" + targetBuffer);
                 }
             } else {
-                textTo(sb);
-                Bytes<byte[]> bytes = Bytes.wrapForRead(sb.toString().getBytes(ISO_8859_1));
+                textTo(targetBuffer);
+                Bytes<byte[]> bytes = Bytes.wrapForRead(targetBuffer.toString().getBytes(ISO_8859_1));
                 try {
                     bytesConsumer.readMarshallable(bytes);
                 } finally {
@@ -2092,10 +2092,10 @@ public class YamlWire extends YamlWireOut<YamlWire> {
             else
                 usingMap.clear();
 
-            @NotNull StringBuilder sb = acquireStringBuilder();
+            @NotNull StringBuilder targetBuffer = acquireStringBuilder();
             switch (yt.current()) {
                 case TAG:
-                    return typedMap(kClass, vClass, usingMap, sb);
+                    return typedMap(kClass, vClass, usingMap, targetBuffer);
                 case MAPPING_START:
                     return marshallableAsMap(kClass, vClass, usingMap);
                 case SEQUENCE_START:
@@ -2111,22 +2111,22 @@ public class YamlWire extends YamlWireOut<YamlWire> {
          * @param kClazz The class type for map keys.
          * @param vClass The class type for map values.
          * @param usingMap The map to populate based on the YAML data.
-         * @param sb A StringBuilder instance used for temporary string operations.
+         * @param targetBuffer A StringBuilder instance used for temporary string operations.
          * @return Populated map from the YAML data or null.
          * @throws InvalidMarshallableException If there's a problem with marshalling.
          * @throws IORuntimeException If an unexpected YAML structure or tag is encountered.
          */
         @Nullable
-        private <K, V> Map<K, V> typedMap(@NotNull Class<K> kClazz, @NotNull Class<V> vClass, @NotNull Map<K, V> usingMap, @NotNull StringBuilder sb) throws InvalidMarshallableException {
+        private <K, V> Map<K, V> typedMap(@NotNull Class<K> kClazz, @NotNull Class<V> vClass, @NotNull Map<K, V> usingMap, @NotNull StringBuilder targetBuffer) throws InvalidMarshallableException {
             // Read the next YAML token into the provided StringBuilder.
-            yt.text(sb);
+            yt.text(targetBuffer);
             yt.next();
-            if (NULL_TAG.contentEquals(sb)) {
+            if (NULL_TAG.contentEquals(targetBuffer)) {
                 text();
                 return null; // Return null to indicate absence of a value.
 
             // If the current token indicates a sequence map...
-            } else if (SEQ_MAP.contentEquals(sb)) {
+            } else if (SEQ_MAP.contentEquals(targetBuffer)) {
                 consumePadding();
 
                 // Verify that the next token is the start of a sequence.
@@ -2147,7 +2147,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
 
             } else {
                 // If the token isn't recognized, throw an exception.
-                throw new IORuntimeException("Unsupported type :" + sb);
+                throw new IORuntimeException("Unsupported type :" + targetBuffer);
             }
         }
 
@@ -2277,36 +2277,36 @@ public class YamlWire extends YamlWireOut<YamlWire> {
          * Depending on the encountered token, various internal methods are invoked to parse the object correctly.
          * If a YAML ANCHOR is encountered, it's mapped to the parsed object for potential future ALIAS references.
          *
-         * @param using The object to potentially reuse when reading. Might be null.
+         * @param reusableInstance The object to potentially reuse when reading. Might be null.
          * @param strategy The serialization strategy to employ while reading the object.
-         * @param type Expected type of the object to be read. If null, the method will attempt to infer the type.
+         * @param defaultType Expected type of the object to be read. If null, the method will attempt to infer the type.
          * @return The read object, possibly of the expected type. Might be null if the YAML token is NONE.
          * @throws InvalidMarshallableException if any error occurs while parsing or constructing the object.
          */
         @SuppressWarnings("fallthrough")
         @Nullable
-        Object objectWithInferredType0(Object using, @NotNull SerializationStrategy strategy, Class<?> type) throws InvalidMarshallableException {
-            boolean bestEffort = type != null;
+        Object objectWithInferredType0(Object reusableInstance, @NotNull SerializationStrategy strategy, Class<?> defaultType) throws InvalidMarshallableException {
+            boolean bestEffort = defaultType != null;
 
             // Handle type declaration, if present
             if (yt.current() == YamlToken.TAG) {
                 Class<?> aClass = typePrefix();
-                if (type == null || type == Object.class || type.isInterface())
-                    type = aClass;
+                if (defaultType == null || defaultType == Object.class || defaultType.isInterface())
+                    defaultType = aClass;
             }
 
             switch (yt.current()) {
                 case MAPPING_START:
                     // Parse YAML mapping, considering the expected type
-                    if (type != null) {
+                    if (defaultType != null) {
                         // Create new TreeMap if a sorted map is expected
-                        if (type == SortedMap.class && !(using instanceof SortedMap))
-                            using = new TreeMap();
+                        if (defaultType == SortedMap.class && !(reusableInstance instanceof SortedMap))
+                            reusableInstance = new TreeMap();
                         // Handle map-specific types
-                        if (type == Object.class || Map.class.isAssignableFrom(type) || using instanceof Map)
-                            return map(Object.class, Object.class, (Map) using);
+                        if (defaultType == Object.class || Map.class.isAssignableFrom(defaultType) || reusableInstance instanceof Map)
+                            return map(Object.class, Object.class, (Map) reusableInstance);
                     }
-                    return valueIn.object(using, type, bestEffort);
+                    return valueIn.object(reusableInstance, defaultType, bestEffort);
 
                 case SEQUENCE_START:
                     // Read a YAML sequence
@@ -2327,7 +2327,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                     // Handle YAML anchors, which can be referred to later as aliases
                     String alias = yt.text();
                     yt.next();
-                    o = valueIn.object(using, type);
+                    o = valueIn.object(reusableInstance, defaultType);
                     // Store the anchor for later reference
                     anchorValues.put(alias, o);
                     return o;
@@ -2373,7 +2373,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         @Nullable
         protected Object readNumberOrText() {
             // Determine the kind of quote used for the YAML block
-            char bq = yt.blockQuote();
+            char blockQuoteChar = yt.blockQuote();
             // Extract the text content into a StringBuilder
             @Nullable StringBuilder s = textTo0(acquireStringBuilder());
             if (yt.current() == YamlToken.LITERAL)
@@ -2382,7 +2382,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                 return true;
             if (StringUtils.isEqual(s, "false"))
                 return false;
-            return readNumberOrTextFrom(bq, s);
+            return readNumberOrTextFrom(blockQuoteChar, s);
         }
 
         /**

--- a/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
@@ -201,8 +201,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
 
     @NotNull
     @Override
-    public T writeComment(@NotNull CharSequence s) {
-        valueOut.writeComment(s);
+    public T writeComment(@NotNull CharSequence commentText) {
+        valueOut.writeComment(commentText);
         return (T) this;
     }
 
@@ -219,17 +219,17 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
      * If the sequence requires quotes, it will be enclosed with the appropriate quote character;
      * otherwise, the sequence will be escaped without quotes.
      *
-     * @param s The CharSequence to be escaped.
+     * @param textToEscape The CharSequence to be escaped.
      */
-    void escape(@NotNull CharSequence s) {
-        @NotNull Quotes quotes = needsQuotes(s);
-        if (quotes == Quotes.NONE) {
-            escape0(s, quotes);
+    void escape(@NotNull CharSequence textToEscape) {
+        @NotNull Quotes quoteStyle = needsQuotes(textToEscape);
+        if (quoteStyle == Quotes.NONE) {
+            escape0(textToEscape, quoteStyle);
             return;
         }
-        bytes.writeUnsignedByte(quotes.q);
-        escape0(s, quotes);
-        bytes.writeUnsignedByte(quotes.q);
+        bytes.writeUnsignedByte(quoteStyle.q);
+        escape0(textToEscape, quoteStyle);
+        bytes.writeUnsignedByte(quoteStyle.q);
     }
 
     // https://yaml.org/spec/1.2.2/#escaped-characters
@@ -237,12 +237,12 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
      * Helper method to escape special characters in the given CharSequence {@code s} based on the requirements of the YAML format.
      * The method handles the specific escaping requirements for various control and special characters.
      *
-     * @param s The CharSequence to be escaped.
-     * @param quotes The type of quotes used to determine how certain characters are escaped.
+     * @param textToEscape The CharSequence to be escaped.
+     * @param quoteStyle The quote style used to determine how certain characters are escaped.
      */
-    protected void escape0(@NotNull CharSequence s, @NotNull Quotes quotes) {
-        for (int i = 0; i < s.length(); i++) {
-            char ch = s.charAt(i);
+    protected void escape0(@NotNull CharSequence textToEscape, @NotNull Quotes quoteStyle) {
+        for (int i = 0; i < textToEscape.length(); i++) {
+            char ch = textToEscape.charAt(i);
             switch (ch) {
                 case '\0':
                     bytes.append("\\0");  // Null character
@@ -272,16 +272,16 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
                     bytes.append("\\e");  // Escape
                     break;
                 case '"':
-                    // Handling double quotes
-                    if (ch == quotes.q) {
+                    // Handling double quoteStyle
+                    if (ch == quoteStyle.q) {
                         bytes.writeUnsignedByte('\\').writeUnsignedByte(ch);
                     } else {
                         bytes.writeUnsignedByte(ch);
                     }
                     break;
                 case '\'':
-                    // Handling single quotes
-                    if (ch == quotes.q) {
+                    // Handling single quoteStyle
+                    if (ch == quoteStyle.q) {
                         bytes.writeUnsignedByte('\\').writeUnsignedByte(ch);
                     } else {
                         bytes.writeUnsignedByte(ch);
@@ -319,54 +319,54 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
      * Appends a 2-character hexadecimal representation of the given character {@code ch} to the output bytes.
      * This is used for character escaping.
      *
-     * @param ch The character to be converted to hexadecimal.
+     * @param characterToEncode The character to be converted to hexadecimal.
      */
-    private void appendX2(char ch) {
+    private void appendX2(char characterToEncode) {
         bytes.append('\\');
         bytes.append('x');
-        bytes.append(HEXADECIMAL[(ch >> 4) & 0xF]);
-        bytes.append(HEXADECIMAL[ch & 0xF]);
+        bytes.append(HEXADECIMAL[(characterToEncode >> 4) & 0xF]);
+        bytes.append(HEXADECIMAL[characterToEncode & 0xF]);
     }
 
     /**
      * Appends a 4-character hexadecimal Unicode representation of the given character {@code ch} to the output bytes.
      * This is used for character escaping.
      *
-     * @param ch The character to be converted to hexadecimal Unicode representation.
+     * @param characterToEncode The character to be converted to hexadecimal Unicode representation.
      */
-    protected void appendU4(char ch) {
+    protected void appendU4(char characterToEncode) {
         bytes.append('\\');
         bytes.append('u');
-        bytes.append(HEXADECIMAL[ch >> 12]);
-        bytes.append(HEXADECIMAL[(ch >> 8) & 0xF]);
-        bytes.append(HEXADECIMAL[(ch >> 4) & 0xF]);
-        bytes.append(HEXADECIMAL[ch & 0xF]);
+        bytes.append(HEXADECIMAL[characterToEncode >> 12]);
+        bytes.append(HEXADECIMAL[(characterToEncode >> 8) & 0xF]);
+        bytes.append(HEXADECIMAL[(characterToEncode >> 4) & 0xF]);
+        bytes.append(HEXADECIMAL[characterToEncode & 0xF]);
     }
 
     /**
-     * Determines the type of quotes (if any) required for the given CharSequence {@code s} based on the YAML format's escaping requirements.
+     * Determines the type of quotes (if any) required for the given CharSequence {@code text} based on the YAML format's escaping requirements.
      * This method decides between using no quotes, single quotes, or double quotes.
      *
-     * @param s The CharSequence to be analyzed.
+     * @param text The CharSequence to be analysed.
      * @return The type of quotes required.
      */
     @NotNull
-    protected Quotes needsQuotes(@NotNull CharSequence s) {
-        @NotNull Quotes quotes = Quotes.NONE;
+    protected Quotes needsQuotes(@NotNull CharSequence text) {
+        @NotNull Quotes quoteStyle = Quotes.NONE;
 
-        // Empty strings require double quotes.
-        if (s.length() == 0)
+        // Empty strings require double quoteStyle.
+        if (text.length() == 0)
             return Quotes.DOUBLE;
 
-        // If string starts with special characters or ends with whitespace, use double quotes.
+        // If string starts with special characters or ends with whitespace, use double quoteStyle.
         if (STARTS_QUOTE_CHARS.get(s.charAt(0)) ||
                 Character.isWhitespace(s.charAt(s.length() - 1)))
             return Quotes.DOUBLE;
         boolean hasSingleQuote = false;
-        for (int i = 0; i < s.length(); i++) {
-            char ch = s.charAt(i);
+        for (int i = 0; i < text.length(); i++) {
+            char ch = text.charAt(i);
 
-            // Characters in QUOTE_CHARS or outside ASCII range need double quotes.
+            // Characters in QUOTE_CHARS or outside ASCII range need double quoteStyle.
             if (QUOTE_CHARS.get(ch) || ch < ' ' || ch > 127)
                 return Quotes.DOUBLE;
 
@@ -374,18 +374,18 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
             if (ch == '\'')
                 hasSingleQuote = true;
 
-            // If a double quote is found followed by a single quote, return double quotes.
+            // If a double quote is found followed by a single quote, return double quoteStyle.
             if (ch == '"') {
                 if (i < s.length() - 1 && s.charAt(i + 1) == '\'')
                     return Quotes.DOUBLE;
-                quotes = Quotes.SINGLE;
+                quoteStyle = Quotes.SINGLE;
             }
         }
 
-        // If only single quotes are found, no quotes are needed.
+        // If only single quoteStyle are found, no quoteStyle are needed.
         if (hasSingleQuote)
             return Quotes.NONE;
-        return quotes;
+        return quoteStyle;
     }
 
     /**
@@ -633,14 +633,14 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          */
         @NotNull
         @Override
-        public T bool(@Nullable Boolean flag) {
+        public T bool(@Nullable Boolean value) {
             if (dropDefault) {
-                if (flag == null)
+                if (value == null)
                     return wireOut();
                 writeSavedEventName();
             }
             prependSeparator();
-            append(flag == null ? nullOut() : flag ? "true" : "false");
+            append(value == null ? nullOut() : value ? "true" : "false");
             elementSeparator();
             return wireOut();
         }
@@ -663,17 +663,17 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          */
         @NotNull
         @Override
-        public T text(@Nullable CharSequence s) {
+        public T text(@Nullable CharSequence value) {
             if (dropDefault) {
-                if (s == null)
+                if (value == null)
                     return wireOut();
                 writeSavedEventName();
             }
             prependSeparator();
-            if (s == null) {
+            if (value == null) {
                 append(nullOut());
             } else {
-                escape(s);
+                escape(value);
             }
             elementSeparator();
             return wireOut();
@@ -687,18 +687,18 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          */
         @NotNull
         @Override
-        public T bytes(@Nullable BytesStore<?, ?> fromBytes) {
+        public T bytes(@Nullable BytesStore<?, ?> value) {
             if (dropDefault) {
-                if (fromBytes == null)
+                if (value == null)
                     return wireOut();
                 writeSavedEventName();
             }
-            if (isText(fromBytes))
-                return (T) text(fromBytes);
+            if (isText(value))
+                return (T) text(value);
 
-            int length = Maths.toInt32(fromBytes.readRemaining());
+            int length = Maths.toInt32(value.readRemaining());
             @NotNull byte[] byteArray = new byte[length];
-            fromBytes.copyTo(byteArray);
+            value.copyTo(byteArray);
 
             return bytes(byteArray);
         }
@@ -935,20 +935,20 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          * The method appends the timestamp as a comment in YAML, depending on the range and precision
          * of the given timestamp value. The timestamp could be in milliseconds or with nanosecond precision.
          *
-         * @param i64 The timestamp value to be appended.
+         * @param epochNanosOrMillis The timestamp value to be appended.
          */
-        public void addTimeStamp(long i64) {
+        public void addTimeStamp(long epochNanosOrMillis) {
             // Check if the timestamp is in a millisecond precision range (e.g., between 1e12 and 4.111e12)
-            if ((long) 1e12 < i64 && i64 < (long) 4.111e12) {
+            if ((long) 1e12 < epochNanosOrMillis && epochNanosOrMillis < (long) 4.111e12) {
                 // Append the date and time in milliseconds as a comment in the output
                 bytes.append(", # ");
-                bytes.appendDateMillis(i64);
+                bytes.appendDateMillis(epochNanosOrMillis);
                 bytes.append("T");
-                bytes.appendTimeMillis(i64);
+                bytes.appendTimeMillis(epochNanosOrMillis);
                 sep = NEW_LINE;
-            } else if ((long) 1e18 < i64 && i64 < (long) 4.111e18) {
-                long millis = i64 / 1_000_000;
-                long nanos = i64 % 1_000_000;
+            } else if ((long) 1e18 < epochNanosOrMillis && epochNanosOrMillis < (long) 4.111e18) {
+                long millis = epochNanosOrMillis / 1_000_000;
+                long nanos = epochNanosOrMillis % 1_000_000;
                 bytes.append(", # ");
                 bytes.appendDateMillis(millis);
                 bytes.append("T");
@@ -1067,16 +1067,16 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          * Writes a special double value, e.g. NaN, to bytes in the context of Yaml Wire. For now this
          * remains as an unquoted string representation.
          */
-        protected void writeSpecialDoubleValueToBytes(Bytes<?> bytes, double value) {
-            bytes.append(Double.toString(value));
+        protected void writeSpecialDoubleValueToBytes(Bytes<?> outputBytes, double value) {
+            outputBytes.append(Double.toString(value));
         }
 
         /**
          * Writes a special double value, e.g. NaN, to bytes in the context of Yaml Wire. For now this
          * remains as an unquoted string representation.
          */
-        protected void writeSpecialFloatValueToBytes(Bytes<?> bytes, float value) {
-            bytes.append(Float.toString(value));
+        protected void writeSpecialFloatValueToBytes(Bytes<?> outputBytes, float value) {
+            outputBytes.append(Float.toString(value));
         }
 
         @NotNull
@@ -1116,33 +1116,33 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          * It handles null values and applies necessary formatting based on the needsQuotes method.
          * If the value is set to drop by default, the saved event name is written.
          *
-         * @param stringable The object to convert to a string and process.
+         * @param valueToConvert The object to convert to a string and process.
          * @return An instance of T, typically representing the current wire output state.
          */
         @NotNull
-        private T asText(@Nullable Object stringable) {
+        private T asText(@Nullable Object valueToConvert) {
             // Check if defaults should be dropped and handle accordingly
             if (dropDefault) {
-                if (stringable == null)
+                if (valueToConvert == null)
                     return wireOut();
                 writeSavedEventName();
             }
 
-            // Handle null stringable objects
-            if (stringable == null) {
+            // Handle null valueToConvert objects
+            if (valueToConvert == null) {
                 nu11();
             } else {
                 // Add necessary separators
                 prependSeparator();
 
                 // Convert the object to its string representation
-                final String s = stringable.toString();
+                final String s = valueToConvert.toString();
 
-                // Determine if the string needs quotes
-                final Quotes quotes = needsQuotes(s);
+                // Determine if the string needs quoteStyle
+                final Quotes quoteStyle = needsQuotes(s);
 
-                // Append the string to the wire output with necessary quotes
-                asTestQuoted(s, quotes);
+                // Append the string to the wire output with necessary quoteStyle
+                asTestQuoted(s, quoteStyle);
 
                 // Add element separator after processing the string
                 elementSeparator();
@@ -1152,20 +1152,20 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         }
 
         /**
-         * Appends the provided string to the wire output, with or without quotes based on the provided quote preference.
+         * Appends the provided string to the wire output, with or without quoteStyle based on the provided quote preference.
          * If the quote preference is NONE, the string is added directly to the wire output.
          * Otherwise, the string is escaped based on the provided quote preference.
          *
          * @param s      The string to append.
-         * @param quotes The quote preference for the string.
+         * @param quoteStyle The quote preference for the string.
          */
-        protected void asTestQuoted(String s, Quotes quotes) {
-            // Check if the string needs quotes
-            if (quotes == Quotes.NONE) {
+        protected void asTestQuoted(String s, Quotes quoteStyle) {
+            // Check if the string needs quoteStyle
+            if (quoteStyle == Quotes.NONE) {
                 append(s);
             } else {
                 // Escape the string based on the provided quote preference
-                escape0(s, quotes);
+                escape0(s, quoteStyle);
             }
         }
 
@@ -1336,9 +1336,9 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          * Before writing the block starter, any necessary separators and whitespace are added.
          * The method also pushes the current state to remember the context.
          *
-         * @param c The character that starts the block.
+         * @param blockStartChar The character that starts the block.
          */
-        public void startBlock(char c) {
+        public void startBlock(char blockStartChar) {
             // If defaults are to be dropped, save the event name
             if (dropDefault) {
                 writeSavedEventName();
@@ -1356,7 +1356,7 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
             pushState();
 
             // Write the starting block character
-            bytes.writeUnsignedByte(c);
+            bytes.writeUnsignedByte(blockStartChar);
         }
 
         @NotNull
@@ -1387,30 +1387,30 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          * Ends a block with the given character, typically a closing bracket or brace.
          * Removes any double newlines to ensure a clean block closure.
          *
-         * @param c The character that ends the block.
+         * @param blockEndChar The character that ends the block.
          */
-        public void endBlock(char c) {
+        public void endBlock(char blockEndChar) {
             BytesUtil.combineDoubleNewline(bytes);
-            bytes.writeUnsignedByte(c);
+            bytes.writeUnsignedByte(blockEndChar);
         }
 
         /**
          * Adds a newline at the specified position if applicable.
          *
-         * @param pos The position after which the newline should be added.
+         * @param previousWritePosition The position after which the newline should be added.
          */
-        protected void addNewLine(long pos) {
-            if (bytes.writePosition() > pos + 1)
+        protected void addNewLine(long previousWritePosition) {
+            if (bytes.writePosition() > previousWritePosition + 1)
                 bytes.writeUnsignedByte('\n');
         }
 
         /**
          * Adds a space at the specified position if applicable.
          *
-         * @param pos The position after which the space should be added.
+         * @param previousWritePosition The position after which the space should be added.
          */
-        protected void addSpace(long pos) {
-            if (bytes.writePosition() > pos + 1)
+        protected void addSpace(long previousWritePosition) {
+            if (bytes.writePosition() > previousWritePosition + 1)
                 bytes.writeUnsignedByte(' ');
         }
 
@@ -1660,16 +1660,16 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          * Writes a given CharSequence name to the Yaml output. If the default value is dropped,
          * the event name is set to the given name.
          *
-         * @param name The CharSequence name to write.
+         * @param fieldName The CharSequence name to write.
          * @return Returns an instance of the current object, supporting chained method calls.
          */
         @NotNull
-        public YamlValueOut write(@NotNull CharSequence name) {
+        public YamlValueOut write(@NotNull CharSequence fieldName) {
             if (dropDefault) {
-                eventName = name.toString();
+                eventName = fieldName.toString();
             } else {
                 prependSeparator();
-                escape(name);
+                escape(fieldName);
                 fieldValueSeperator();
             }
             return this;
@@ -1730,9 +1730,9 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
          * Writes a comment to the Yaml output. If a comment annotation exists,
          * specific formatting is applied. Otherwise, a standard comment format is used.
          *
-         * @param s The comment text to write.
+         * @param commentText The comment text to write.
          */
-        public void writeComment(@NotNull CharSequence s) {
+        public void writeComment(@NotNull CharSequence commentText) {
 
             if (hasCommentAnnotation) {
                 // Ensure the separator ends with a newline character
@@ -1752,7 +1752,7 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
 
             writeTwo('#', ' ');
 
-            append(s);
+            append(commentText);
             bytes.writeUnsignedByte('\n');
             sep = EMPTY_AFTER_COMMENT;
         }


### PR DESCRIPTION
## Summary
- rename file path variables and builder buffers for clarity
- rename quoting, block handling, and logging parameters
- update helper methods to use descriptive names

## Testing
- `mvn -q verify` *(fails: mvn not found)*