### PR TITLE
Fix documentation links and anchors

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@ Chronicle Software
 
 image:https://maven-badges.herokuapp.com/maven-central/net.openhft/chronicle-wire/badge.svg[link=https://maven-badges.herokuapp.com/maven-central/net.openhft/chronicle-wire]
 image:https://javadoc.io/badge2/net.openhft/chronicle-wire/javadoc.svg[link="https://www.javadoc.io/doc/net.openhft/chronicle-wire/latest/index.html"]
-image:https://img.shields.io/github/license/OpenHFT/Chronicle-Wire[GitHub]
+image:https://img.shields.io/github/license/OpenHFT/Chronicle-Wire[GitHub License]
 image:https://img.shields.io/badge/release%20notes-subscribe-brightgreen[link="https://chronicle.software/release-notes/"]
 image:https://sonarcloud.io/api/project_badges/measure?project=OpenHFT_Chronicle-Wire&metric=alert_status[link="https://sonarcloud.io/dashboard?id=OpenHFT_Chronicle-Wire"]
 

--- a/src/main/adoc/wire-annotations.adoc
+++ b/src/main/adoc/wire-annotations.adoc
@@ -289,7 +289,7 @@ This guide provides a solid foundation for understanding and utilising the annot
 == Related Topics
 
 * link:wire-architecture.adoc[Architecture Overview] - Understand the internal architecture of Chronicle Wire
-* link:wire-cookbook.adoc#_3_working_with_annotations[Working with Annotations] - Practical examples of using annotations
-* link:wire-schema-evolution.adoc#_4_role_of_annotations_in_schema_evolution[Role of Annotations in Schema Evolution] - How annotations help with schema evolution
+* link:wire-cookbook.adoc#working_with_annotations[Working with Annotations] - Practical examples of using annotations
+* link:wire-schema-evolution.adoc#role_of_annotations_in_schema_evolution[Role of Annotations in Schema Evolution] - How annotations help with schema evolution
 * link:wire-error-handling.adoc[Error Handling and Diagnostics] - Troubleshooting and error handling
 * link:index.adoc[Documentation Home] - Return to the main documentation page

--- a/src/main/adoc/wire-cookbook.adoc
+++ b/src/main/adoc/wire-cookbook.adoc
@@ -175,6 +175,7 @@ public class BasicDeserializationDemo {
 *Discussion:*
 `getValueIn().object(MyData.class)` is the key call for deserialization. Chronicle Wire reads the data and populates a new instance of `MyData`. For text formats like YAML, the `!MyData` type hint helps in identifying the target class, though providing the class explicitly in `object()` is robust. For binary formats, if type information isn't inherently part of the stream for the specific `WireType` chosen, providing the target class is essential. `SelfDescribingMarshallable` with `BINARY_LIGHT` typically includes type information or field names/numbers allowing for successful deserialization.
 
+[[working_with_annotations]]
 == 3. Working with Annotations
 
 === 3.1. Recipe: Using `@LongConversion` for Compact String Storage
@@ -329,6 +330,7 @@ public class NanoTimeDemo {
 *Discussion:*
 The `@NanoTime` annotation (and similarly `@MillisTime` for millisecond precision) ensures that the `long` timestamp is converted to/from a standard ISO 8601 string representation in text formats like YAML or JSON, while remaining a `long` in binary formats and in the Java object. This provides both human readability for logs/configs and numerical efficiency for processing.
 
+[[schema_evolution]]
 == 4. Schema Evolution
 
 === 4.1. Recipe: Adding a New Field (Backward Compatibility)

--- a/src/main/adoc/wire-schema-evolution.adoc
+++ b/src/main/adoc/wire-schema-evolution.adoc
@@ -183,6 +183,7 @@ Separate Data Stores :: Use different Chronicle Queues, Chronicle Maps, or files
 
 Deployment Strategies :: Use blue/green deployments or similar techniques to switch over to new versions of services and their data formats simultaneously.
 
+[[role_of_annotations_in_schema_evolution]]
 == 4. Role of Annotations in Schema Evolution
 
 Annotations provide metadata that Chronicle Wire uses to manage schema evolution.
@@ -297,7 +298,7 @@ By understanding these mechanisms, limitations, and best practices, developers c
 
 * link:wire-architecture.adoc[Architecture Overview] - Understand the internal architecture of Chronicle Wire
 * link:wire-annotations.adoc[Annotations Guide] - Learn about annotations for fine-tuning serialization
-* link:wire-cookbook.adoc#_4_schema_evolution[Schema Evolution Examples] - Practical examples of schema evolution
+* link:wire-cookbook.adoc#schema_evolution[Schema Evolution Examples] - Practical examples of schema evolution
 * link:wire-error-handling.adoc[Error Handling and Diagnostics] - Troubleshooting and error handling
-* link:wire-visual-guide.adoc#_5_schema_evolution[Visual Guide: Schema Evolution] - Diagrams illustrating schema evolution concepts
+* link:wire-visual-guide.adoc#schema_evolution[Visual Guide: Schema Evolution] - Diagrams illustrating schema evolution concepts
 * link:index.adoc[Documentation Home] - Return to the main documentation page

--- a/src/main/adoc/wire-visual-guide.adoc
+++ b/src/main/adoc/wire-visual-guide.adoc
@@ -136,6 +136,7 @@ graph LR
     end
 ----
 
+[[schema_evolution]]
 == 5. Schema Evolution
 
 [mermaid]


### PR DESCRIPTION
## Summary
- correct README badge alt text
- update internal AsciiDoc links to use explicit anchors
- add explicit anchors to relevant sections

## Testing
- `mvn -q verify` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683b207a9b98832994d958ae23b5f32d