### PR TITLE
Improve docs and apply British English

### DIFF
--- a/EventsByMethod.adoc
+++ b/EventsByMethod.adoc
@@ -1,6 +1,11 @@
 = Events by Method
 Peter Lawrey
 
+:toc:
+:toclevels: 2
+:source-highlighter: rouge
+:icons: font
+
 Chronicle favours modelling events as asynchronous method calls.
 This document explores the 'Events by Method' paradigm in Chronicle Wire, demonstrating how to model, process and test events represented as asynchronous Java method calls, and how to leverage different wire formats for these events.
 This has a number of advantages:
@@ -89,7 +94,7 @@ Some advantages of Binary YAML are:
 
 Some advantages of Trivially Copyable Objects
 
-. Raw memory copy for serialization/deserialization.
+. Raw memory copy for serialisation/deserialisation.
 . Compact memory structure provided fields don't vary in size much.
 . Works provided the writer/reader arrange the fields the same way.
 . Better performance than Binary YAML (about half the latency).

--- a/README.adoc
+++ b/README.adoc
@@ -73,8 +73,8 @@ This library requires Java 8. Support for `C++`, `ruby` and `python` is availabl
 The text formats include:
 
 * `YAML` - subset of mapping structures included
-* `JSON` - superset to support serialization
-* `CSV` - superset to support serialization
+* `JSON` - superset to support serialisation
+* `CSV` - superset to support serialisation
 * `XML` - planned
 
 Options include:
@@ -121,11 +121,15 @@ Add the dependency to your project.
 </dependency>
 ----
 
+Replace `REPLACE_WITH_VERSION` with the latest version published to Maven Central.
+
 .Gradle
 [source,groovy]
 ----
 implementation 'net.openhft:chronicle-wire:REPLACE_WITH_VERSION'
 ----
+
+Replace `REPLACE_WITH_VERSION` with the latest version published to Maven Central.
 
 .Simple Example
 [source,java]
@@ -144,8 +148,10 @@ System.out.println(bytes.toString());
 |WireType |Human Readable |Self Describing |Typical Use |Notes
 |TEXT |Yes |Partial |Debugging, simple configs |YAML based
 |YAML |Yes |Yes |Full YAML subset |Retains types
+|YAML_RETAIN_TYPE |Yes |Yes |YAML with explicit type tags |Polymorphic data
 |YAML_ONLY |Yes |Yes |Pure YAML output |No envelopes
 |JSON |Yes |Yes |JSON interop |Web friendly
+|JSON_RETAIN_TYPE |Yes |Yes |JSON with explicit type tags |Polymorphic data
 |JSON_ONLY |Yes |Yes |JSON without envelopes |
 |BINARY |No |Yes |General binary |Good balance
 |BINARY_LIGHT |No |Yes |Optimised binary |Common default

--- a/src/main/adoc/project-requirements.adoc
+++ b/src/main/adoc/project-requirements.adoc
@@ -6,14 +6,14 @@ To outline the detailed requirements for creating comprehensive and technically 
 
 == 1. Introduction
 
-This document specifies the detailed requirements for a significant enhancement of the documentation for the Chronicle Wire library. Chronicle Wire is a foundational component within the OpenHFT (Open High-Frequency Trading) ecosystem, designed for high-performance, low-latency data serialization and deserialization. The current initiative aims to produce documentation that is technically deep, practically useful, and addresses the needs of a diverse developer audience. This enhancement will be based on an exhaustive technical review of Chronicle Wire, covering its architecture, features, diverse use cases within OpenHFT (including inter-process communication (IPC), object serialization, low-latency systems design, and data persistence strategies), and a thorough comparative analysis against other prominent serialization libraries. The ultimate goal is to establish this documentation as the authoritative resource for Chronicle Wire.
+This document specifies the detailed requirements for a significant enhancement of the documentation for the Chronicle Wire library. Chronicle Wire is a foundational component within the OpenHFT (Open High-Frequency Trading) ecosystem, designed for high-performance, low-latency data serialisation and deserialisation. The current initiative aims to produce documentation that is technically deep, practically useful, and addresses the needs of a diverse developer audience. This enhancement will be based on an exhaustive technical review of Chronicle Wire, covering its architecture, features, diverse use cases within OpenHFT (including inter-process communication (IPC), object serialisation, low-latency systems design, and data persistence strategies), and a thorough comparative analysis against other prominent serialisation libraries. The ultimate goal is to establish this documentation as the authoritative resource for Chronicle Wire.
 
 == 2. Goals
 
 The overarching goals for this documentation enhancement are:
 
 Unparalleled Clarity and Technical Depth ::
-* Provide exhaustive, unambiguous explanations of Chronicle Wire's internal architecture, fundamental concepts (e.g., `Wire`, `Bytes`, `Marshallable`), and the nuances of each supported serialization format.
+* Provide exhaustive, unambiguous explanations of Chronicle Wire's internal architecture, fundamental concepts (e.g., `Wire`, `Bytes`, `Marshallable`), and the nuances of each supported serialisation format.
 * Elucidate the "why" behind design decisions, not just the "how."
 
 Actionable Practical Guidance ::
@@ -29,11 +29,11 @@ Comprehensive Use Case Illustration ::
 ** Configuration management using YAML/JSON wire formats.
 
 Insightful Comparative Analysis ::
-* Deliver a detailed, evidence-based comparison of Chronicle Wire with other leading serialization libraries (Kryo, Google Protocol Buffers, Jackson, Java Built-in Serialization).
+* Deliver a detailed, evidence-based comparison of Chronicle Wire with other leading serialisation libraries (Kryo, Google Protocol Buffers, Jackson, Java Built-in Serialisation).
 * Focus on quantitative (performance benchmarks) and qualitative (usability, schema evolution, integration) aspects to help users make informed decisions.
 
 Maximized Accessibility and User Experience ::
-* Ensure the documentation is structured logically and is easily navigable for developers with varying levels of familiarity with OpenHFT, Java, and serialization technologies.
+* Ensure the documentation is structured logically and is easily navigable for developers with varying levels of familiarity with OpenHFT, Java, and serialisation technologies.
 * Cater to different learning styles by incorporating diagrams, flowcharts, and concise summaries alongside detailed explanations.
 
 == 3. Scope of Documentation
@@ -43,11 +43,11 @@ The documentation shall comprehensively cover the following key areas:
 === 3.1. Core Chronicle Wire Concepts
 
 Comprehensive Overview ::
-* **Introduction:** What Chronicle Wire is, its origin within OpenHFT, and the core problems it solves (e.g., performance bottlenecks of standard Java serialization, need for format flexibility).
+* **Introduction:** What Chronicle Wire is, its origin within OpenHFT, and the core problems it solves (e.g., performance bottlenecks of standard Java serialisation, need for format flexibility).
 * **Design Philosophy:** In-depth discussion of low latency, minimal garbage creation, off-heap memory utilization, format agnosticism, and schema flexibility as primary design tenets.
 * **Key Abstractions:** Detailed explanation of `Bytes`, `Wire`, `WireIn`, `WireOut`, `DocumentContext`, `Marshallable`, `SelfDescribingMarshallable`, and `BytesMarshallable`.
 
-Supported Serialization Formats (`WireType`) ::
+Supported Serialisation Formats (`WireType`) ::
 * For each `WireType` (YAML, JSON, JSON_ONLY, BINARY, BINARY_LIGHT, FIELDLESS_BINARY, TEXT, RAW, CSV, READ_ANY):
 ** **Detailed Explanation:** Underlying structure, specific features (e.g., human readability, self-description, compactness). For binary formats, discuss aspects like stop-bit encoding for integers.
 ** **Instantiation and Usage:** How to create and use each `Wire` type with `Bytes`.
@@ -59,9 +59,9 @@ Supported Serialization Formats (`WireType`) ::
 The `Marshallable` Ecosystem ::
 * **`Marshallable` Interface:** Deep dive into how to implement it, the role of `readMarshallable` and `writeMarshallable` methods (both explicit and default-generated).
 * **`SelfDescribingMarshallable`:** Benefits of extending this class (automatic `toString()`, `equals()`, `hashCode()`, schema information in text formats), and how these methods are generated from the serialized form.
-* **`BytesMarshallable`:** When and how to use it for finer-grained control over serialization, direct `Bytes` manipulation, and potential performance gains/trade-offs compared to `Marshallable`. Examples of manual field writing/reading.
-* **Automatic Serialization:** Explanation of the mechanisms used (reflection, runtime code generation via `WireMarshaller`) and their performance characteristics.
-* **Object Graph Serialization:** How Chronicle Wire handles nested `Marshallable` objects, collections of `Marshallable` objects, and object references (if applicable, or limitations thereof).
+* **`BytesMarshallable`:** When and how to use it for finer-grained control over serialisation, direct `Bytes` manipulation, and potential performance gains/trade-offs compared to `Marshallable`. Examples of manual field writing/reading.
+* **Automatic Serialisation:** Explanation of the mechanisms used (reflection, runtime code generation via `WireMarshaller`) and their performance characteristics.
+* **Object Graph Serialisation:** How Chronicle Wire handles nested `Marshallable` objects, collections of `Marshallable` objects, and object references (if applicable, or limitations thereof).
 
 Schema Evolution and Versioning ::
 * **Detailed Mechanisms:** How Chronicle Wire supports schema changes (adding, removing, reordering fields) in self-describing formats.
@@ -72,11 +72,11 @@ Schema Evolution and Versioning ::
 * **Limitations:** Any scenarios where schema evolution might be problematic or require manual intervention (e.g., changing field types significantly).
 * **Comparison:** Explicit comparison of Wire's schema evolution capabilities with those of Protobuf and Avro.
 
-Annotations for Fine-Grained Control and Customization ::
+Annotations for Fine-Grained Control and Customisation ::
 * For each key annotation (e.g., `@LongConversion`, `@NanoTime`, `@Base64`, `@Base85`, `@ShortText`, `@MaxUtf8Len`, `@Comment`, `@DeprecatedWireBy`, `@FieldNumber`, `@ForceMicroTimestamp`, `@DefaultValue`):
 ** **Purpose and Functionality:** Clear explanation of what the annotation does.
 ** **Parameters:** Description of any parameters the annotation takes.
-** **Impact:** How it affects serialization in different `WireType`s (e.g., text vs. binary representation).
+** **Impact:** How it affects serialisation in different `WireType`s (e.g., text vs. binary representation).
 ** **Use Cases:** Practical examples illustrating when and how to use the annotation.
 ** **Example Code:** Snippets demonstrating its application.
 * **Custom Converters:** Detailed guide on creating and using custom `LongConverter` implementations or other relevant converters.
@@ -95,7 +95,7 @@ Low-Latency and High-Performance Features ::
 * **Object Reuse:** Advanced patterns for object pooling and reuse with `Marshallable.reset()` or similar techniques to reduce allocations in critical loops.
 * **Flyweights and `Chronicle-Values`:** If applicable, how Chronicle Wire can interact with or support `Chronicle-Values` for ultra-low-latency access to off-heap data structures.
 * **`SingleThreadedChecked`:** Explanation of its role and how to ensure thread safety when using Wire and related components.
-* **Trivially Copyable Objects:** Explanation and use cases for this optimization.
+* **Trivially Copyable Objects:** Explanation and use cases for this optimisation.
 
 === 3.2. Chronicle Wire Usage in OpenHFT Ecosystem Components
 
@@ -106,7 +106,7 @@ Low-Latency and High-Performance Features ::
 * **`MethodWriter` and `MethodReader` Deep Dive:**
 ** **Mechanism:** How interfaces are proxied, method calls are intercepted, method names/IDs and arguments are serialized to the queue.
 ** **Method ID Generation:** How method identifiers are derived and used.
-** **Argument/Return Type Handling:** Supported types, serialization of complex `Marshallable` arguments.
+** **Argument/Return Type Handling:** Supported types, serialisation of complex `Marshallable` arguments.
 ** **Exception Handling:** How exceptions on the writer or reader side are propagated or handled.
 ** **Use Cases:** Building high-performance event-driven systems, microservices communication, task distribution.
 ** **Code Examples:** Comprehensive examples of defining service interfaces, `Marshallable` DTOs, and implementing writers and readers.
@@ -114,7 +114,7 @@ Low-Latency and High-Performance Features ::
 * **Inspection and Debugging:** How tools (like queue dumpers) use Chronicle Wire's flexibility to read binary queue data and display it in human-readable formats (e.g., YAML).
 
 Chronicle Map (v3.x and relevant versions) ::
-* **Key/Value Serialization:** How Chronicle Wire is used for serializing custom Java objects used as keys or values when storing them off-heap.
+* **Key/Value Serialisation:** How Chronicle Wire is used for serializing custom Java objects used as keys or values when storing them off-heap.
 * **Integration with `ChronicleMapBuilder`:** Specifying `Marshallable` types for keys/values.
 * **`BytesMarshallable` vs. `Marshallable`:**
 ** **Detailed Comparison:** Performance characteristics, storage efficiency, ease of use, schema evolution capabilities for each in the context of Chronicle Map.
@@ -129,7 +129,7 @@ Chronicle Network (and related TCP/UDP libraries) ::
 * **Low-Latency Network Messaging:** Achieving high throughput and low latency in networked applications using Chronicle Wire.
 
 Chronicle Services ::
-* **Event Serialization:** How `Marshallable` objects are used to define and serialize domain events in event sourcing architectures.
+* **Event Serialisation:** How `Marshallable` objects are used to define and serialize domain events in event sourcing architectures.
 * **Event Storage:** Leveraging Chronicle Queue (and thus Wire) for persisting event streams.
 * **State Aggregation and Replay:** How services deserialize events using Wire to reconstruct state or replay business logic.
 * **Conceptual Example:** A detailed walkthrough of a simple event-sourced service (e.g., an "Order Management" service with `OrderCreated`, `OrderUpdated` events defined as `Marshallable` objects), showing event definition, publishing to a queue, and a handler processing these events.
@@ -137,23 +137,23 @@ Chronicle Services ::
 === 3.3. Rich Code Examples and Tutorials
 
 Variety and Scope ::
-* **Basic Serialization:** Simple POJOs with various `WireType`s (YAML, JSON, Binary).
-* **Complex Objects:** Serialization of objects with nested `Marshallable` instances, collections (lists, maps) of primitives and `Marshallable` types.
+* **Basic Serialisation:** Simple POJOs with various `WireType`s (YAML, JSON, Binary).
+* **Complex Objects:** Serialisation of objects with nested `Marshallable` instances, collections (lists, maps) of primitives and `Marshallable` types.
 * **`MethodWriter`/`Reader`:** End-to-end examples for IPC with Chronicle Queue.
 * **Custom Converters and Annotations:** Demonstrating practical use of `@LongConversion`, `@NanoTime`, etc.
 * **Schema Evolution:** Examples showing how to add, remove, or reorder fields in a `Marshallable` class and still read old data or allow new clients to read old data.
-* **Off-Heap Serialization:** Examples of writing/reading `Marshallable` objects directly to/from off-heap `Bytes`.
-* **Error Handling:** Demonstrating how to handle common serialization/deserialization exceptions.
+* **Off-Heap Serialisation:** Examples of writing/reading `Marshallable` objects directly to/from off-heap `Bytes`.
+* **Error Handling:** Demonstrating how to handle common serialisation/deserialisation exceptions.
 
 Clarity and Readability :: All examples must be well-commented, self-contained where possible, and focused on illustrating specific concepts.
 
-Completeness :: Provide both the serialization (writing) and deserialization (reading) parts of the code.
+Completeness :: Provide both the serialisation (writing) and deserialisation (reading) parts of the code.
 
 Best Practices Integration :: Code examples should subtly (or explicitly) demonstrate recommended patterns and best practices.
 
 Runnable Format :: Provide examples as complete, runnable Java files or easily copy-pasteable snippets that can be integrated into a user's project. Accompanying `pom.xml` dependencies for OpenHFT components should be noted.
 
-=== 3.4. Comprehensive Comparison with Other Serialization Libraries
+=== 3.4. Comprehensive Comparison with Other Serialisation Libraries
 
 Detailed Comparison Aspects (for each library vs. Chronicle Wire) ::
 * **Data Format & Flexibility:**
@@ -162,11 +162,11 @@ Detailed Comparison Aspects (for each library vs. Chronicle Wire) ::
 ** Cross-language interoperability and support.
 ** Ease of switching between different representations (e.g., binary for speed, text for debug).
 * **Performance & Efficiency (Quantitative):**
-** **Serialization Speed:** Time taken to serialize objects (e.g., ns/op, msgs/sec). Specify object complexity (simple POJO, complex graph).
-** **Deserialization Speed:** Time taken to deserialize objects.
+** **Serialisation Speed:** Time taken to serialize objects (e.g., ns/op, msgs/sec). Specify object complexity (simple POJO, complex graph).
+** **Deserialisation Speed:** Time taken to deserialize objects.
 ** **Serialized Output Size:** Compactness of the serialized form in bytes for typical objects.
-** **CPU Usage:** Relative CPU cycles consumed during serialization/deserialization.
-** **GC Impact:** Allocation rates, frequency and duration of GC pauses attributable to serialization activity.
+** **CPU Usage:** Relative CPU cycles consumed during serialisation/deserialisation.
+** **GC Impact:** Allocation rates, frequency and duration of GC pauses attributable to serialisation activity.
 _Data should be sourced from existing reputable benchmarks (e.g., Sumit Mundra blog, Micronaut SerDe, InfoQ, Alibaba Cloud) with clear attribution and discussion of test conditions and object models used. Acknowledge that a single definitive benchmark for all aspects across all libraries may not exist._
 * **Schema Definition & Evolution:**
 ** **Schema Definition:** How the data structure is defined (e.g., Java class, .proto IDL, JSON Schema).
@@ -174,7 +174,7 @@ _Data should be sourced from existing reputable benchmarks (e.g., Sumit Mundra b
 ** **Backward Compatibility:** Ability of new code to read old data.
 ** **Forward Compatibility:** Ability of old code to read new data (or ignore new fields).
 ** **Ease of Evolving Schemas:** Process and complexity of adding, removing, renaming, or retyping fields.
-** **Handling of Unknown/Missing Fields:** Default behavior.
+** **Handling of Unknown/Missing Fields:** Default behaviour.
 * **Ease of Use & Developer Experience:**
 ** **API Intuitiveness and Verbosity:** How straightforward the API is for common tasks.
 ** **Learning Curve:** Time and effort required for a developer to become proficient.
@@ -188,7 +188,7 @@ _Data should be sourced from existing reputable benchmarks (e.g., Sumit Mundra b
 ** **Compatibility with Popular Java Frameworks:** Ease of integration with frameworks like Spring, Guice, etc.
 ** **Ecosystem Tools:** Availability of supporting tools for schema management, debugging, etc.
 * **Debugging and Diagnostics:**
-** **Ease of Troubleshooting:** How easy it is to diagnose serialization errors (e.g., malformed data, version mismatches).
+** **Ease of Troubleshooting:** How easy it is to diagnose serialisation errors (e.g., malformed data, version mismatches).
 ** **Exception Clarity:** Informativeness of exceptions thrown.
 * **Specific Strengths and Weaknesses:** Summary of unique advantages and disadvantages.
 * **Best Use Cases/Niches:** Typical scenarios where each library excels.
@@ -245,23 +245,23 @@ Comparison Data ::
 The documentation should cater to a diverse technical audience, including:
 
 Java Developers New to OpenHFT ::
-* **Goal:** Understand Chronicle Wire's purpose, basic usage for serialization, and how it compares to libraries they already know (like Jackson or Java Serializable).
+* **Goal:** Understand Chronicle Wire's purpose, basic usage for serialisation, and how it compares to libraries they already know (like Jackson or Java Serializable).
 
 Experienced OpenHFT Users (Chronicle Queue/Map Developers) ::
-* **Goal:** Gain deeper insights into the underlying serialization mechanisms (Wire) they are implicitly using, learn advanced customization techniques, and optimize Wire usage for performance.
+* **Goal:** Gain deeper insights into the underlying serialisation mechanisms (Wire) they are implicitly using, learn advanced customisation techniques, and optimise Wire usage for performance.
 
 System Architects and Technical Leads ::
 * **Goal:** Evaluate Chronicle Wire for new projects, understand its performance characteristics, schema evolution capabilities, and suitability for low-latency, high-throughput distributed systems.
 
 Performance Engineers ::
-* **Goal:** Understand low-level details of Wire's performance features, GC implications, and how to use it for extreme optimization.
+* **Goal:** Understand low-level details of Wire's performance features, GC implications, and how to use it for extreme optimisation.
 
-Developers Evaluating Serialization Libraries ::
+Developers Evaluating Serialisation Libraries ::
 * **Goal:** Obtain a balanced, technically sound comparison to make an informed choice for their specific project needs.
 
 == 7. Assumptions
 
-Reader's Background :: The documentation will assume readers have a solid understanding of Java programming concepts. Familiarity with general serialization concepts is helpful but not strictly required for introductory sections.
+Reader's Background :: The documentation will assume readers have a solid understanding of Java programming concepts. Familiarity with general serialisation concepts is helpful but not strictly required for introductory sections.
 
 Access to Resources :: Development of this documentation will have access to the Chronicle Wire source code, existing (even if sparse) documentation, community forums, and potentially core OpenHFT developers for clarification.
 

--- a/src/main/adoc/wire-architecture.adoc
+++ b/src/main/adoc/wire-architecture.adoc
@@ -7,11 +7,11 @@ Purpose: To provide a comprehensive understanding of the internal architecture o
 
 == 1. Introduction
 
-Chronicle Wire is a high-performance, low-latency serialization and deserialization library, forming a foundational part of the OpenHFT (Open High-Frequency Trading) ecosystem. Its architecture is meticulously designed to support demanding applications that require minimal garbage collection, high throughput, and flexible data representation. This document outlines the key architectural components, design principles, and interactions within Chronicle Wire.
+Chronicle Wire is a high-performance, low-latency serialisation and deserialisation library, forming a foundational part of the OpenHFT (Open High-Frequency Trading) ecosystem. Its architecture is meticulously designed to support demanding applications that require minimal garbage collection, high throughput, and flexible data representation. This document outlines the key architectural components, design principles, and interactions within Chronicle Wire.
 
 The primary architectural goals of Chronicle Wire are:
 
-* **Performance:** Achieve extremely low latency and high throughput for data serialization and deserialization, minimizing CPU overhead and GC pauses.
+* **Performance:** Achieve extremely low latency and high throughput for data serialisation and deserialisation, minimizing CPU overhead and GC pauses.
 * **Flexibility:** Support multiple data formats (e.g., YAML, JSON, Binary) through a unified API, allowing developers to switch formats without code changes.
 * **Extensibility:** Provide mechanisms for custom data type handling and new wire format implementations.
 * **Schema Evolution:** Offer robust support for evolving data schemas over time without breaking compatibility.
@@ -20,9 +20,9 @@ The primary architectural goals of Chronicle Wire are:
 
 The architecture of Chronicle Wire is guided by several core design principles:
 
-* **Zero/Minimal Garbage Creation:** Extensive use of off-heap memory (`Chronicle Bytes`) and object pooling/reuse techniques to avoid generating garbage during critical serialization/deserialization paths.
+* **Zero/Minimal Garbage Creation:** Extensive use of off-heap memory (`Chronicle Bytes`) and object pooling/reuse techniques to avoid generating garbage during critical serialisation/deserialisation paths.
 * **Direct Memory Access:** Leverage `sun.misc.Unsafe` (where available and appropriate) for direct memory operations, bypassing Java heap overhead for raw data handling.
-* **Format Agnosticism:** Abstract the serialization logic from the specific data format. The application interacts with a common `Wire` API, while the underlying implementation handles the format-specific encoding/decoding.
+* **Format Agnosticism:** Abstract the serialisation logic from the specific data format. The application interacts with a common `Wire` API, while the underlying implementation handles the format-specific encoding/decoding.
 * **Self-Describing Data (Optional):** Support for both self-describing formats (which include field names or identifiers, aiding schema evolution and debugging) and more compact, non-self-describing formats (for maximum performance where schemas are implicitly shared).
 * **Streaming API:** Provide a streaming approach to reading and writing data, allowing for efficient processing of large data structures or sequences of messages.
 
@@ -59,13 +59,13 @@ Application Layer ::
 Chronicle Wire API Layer ::
 * This is the primary interface for developers interacting with the library.
 * Key components:
-** `Marshallable`: An interface (or its base class `SelfDescribingMarshallable`) that domain objects implement to enable automatic serialization of their fields.
-** `BytesMarshallable`: A lower-level interface for objects that manage their own serialization directly to/from `Bytes`.
+** `Marshallable`: An interface (or its base class `SelfDescribingMarshallable`) that domain objects implement to enable automatic serialisation of their fields.
+** `BytesMarshallable`: A lower-level interface for objects that manage their own serialisation directly to/from `Bytes`.
 ** `Wire`: The central interface for reading and writing structured data. It provides methods to obtain `ValueIn` (for reading) and `ValueOut` (for writing).
 ** `WireIn` / `WireOut`: Interfaces defining methods for reading/writing various data types and structures (e.g., `read("fieldName")`, `write("fieldName")`).
 ** `ValueIn` / `ValueOut`: Fluent APIs for reading/writing individual values or nested structures.
 ** `DocumentContext`: Manages the boundaries of a "document" or "message" on the wire, crucial for streaming multiple messages.
-** `WireType`: An enum that specifies the desired serialization format (e.g., `YAML`, `BINARY`, `JSON`). This determines which concrete `Wire` implementation is used.
+** `WireType`: An enum that specifies the desired serialisation format (e.g., `YAML`, `BINARY`, `JSON`). This determines which concrete `Wire` implementation is used.
 
 Wire Format Implementation Layer ::
 * This layer contains concrete implementations of the `Wire` interface for each supported data format.
@@ -157,12 +157,13 @@ classDiagram
 // Example: Obtaining a YAML Wire
 Bytes<?> bytes = Bytes.elasticByteBuffer();
 Wire yamlWire = WireType.YAML_RETAIN_TYPE.apply(bytes);
+// YAML_RETAIN_TYPE is the standard YAML configuration with type hints enabled.
 
 // Example: Obtaining a Binary Wire
 Wire binaryWire = WireType.BINARY_LIGHT.apply(bytes);
 ----
 
-The `WireType` enum acts as a factory and configuration point for different wire formats. It allows the application to easily switch between, for example, human-readable YAML for debugging and compact Binary for production performance, using the same serialization logic.
+The `WireType` enum acts as a factory and configuration point for different wire formats. It allows the application to easily switch between, for example, human-readable YAML for debugging and compact Binary for production performance, using the same serialisation logic.
 
 === 4.3. `Marshallable`
 
@@ -173,7 +174,7 @@ The `Marshallable` interface is a marker interface that, when implemented by a P
 
 Often, developers extend `SelfDescribingMarshallable`, which provides default implementations for these methods (using reflection or generated code) and also includes helpful `toString()`, `equals()`, and `hashCode()` methods based on the object's serialized form.
 
-For performance-critical scenarios where reflection or default marshalling overhead is too high, `BytesMarshallable` allows direct control over byte-level serialization.
+For performance-critical scenarios where reflection or default marshalling overhead is too high, `BytesMarshallable` allows direct control over byte-level serialisation.
 
 === 4.4. `DocumentContext`
 
@@ -206,7 +207,7 @@ wire.write("trade")
 ----
 * This provides fine-grained control and is useful for dynamic schemas or when not using `Marshallable` POJOs.
 
-== 6. Serialization Formats (`WireType`) and Flexibility
+== 6. Serialisation Formats (`WireType`) and Flexibility
 
 [mermaid]
 ----
@@ -235,7 +236,7 @@ graph LR
 
 The power of Chronicle Wire's architecture lies in its ability to switch `WireType` implementations transparently. The same `Marshallable` object or the same sequence of fluent API calls will produce different byte outputs (YAML, JSON, Binary) depending on the `Wire` instance used.
 
-* **Text Formats (YAML, JSON, TEXT):** Human-readable, self-describing. Excellent for debugging, configuration, and interoperability where performance is less critical. `YAML_RETAIN_TYPE` and `JSON_RETAIN_TYPE` include type information (e.g., `!Car {}`) allowing for polymorphic deserialization.
+* **Text Formats (YAML, JSON, TEXT):** Human-readable, self-describing. Excellent for debugging, configuration, and interoperability where performance is less critical. `YAML_RETAIN_TYPE` and `JSON_RETAIN_TYPE` are configurations of YAML and JSON that include type information (e.g., `!Car {}`) allowing for polymorphic deserialisation.
 * **Binary Formats (`BINARY`, `BINARY_LIGHT`, `FIELDLESS_BINARY`, `RAW`):**
 ** `BINARY_LIGHT` (and `BINARY`): Compact, efficient, self-describing to a degree (field numbers or names can be included). Good balance of performance and schema flexibility.
 ** `FIELDLESS_BINARY`: Extremely compact as it omits field names/numbers, relying on the reader and writer agreeing on the field order. Highest performance for stable, internal schemas.
@@ -248,7 +249,7 @@ Chronicle Wire's architecture supports schema evolution primarily through its se
 
 * **Adding Fields:** New fields added to a `Marshallable` class will be written by new writers. Older readers will ignore these new fields if they are not present in their class definition.
 * **Removing Fields:** Fields removed from a `Marshallable` class will not be written by new writers. Older readers expecting these fields will typically see them as `null` or default values if the data was written by a newer writer.
-* **Reordering Fields:** In text formats (YAML, JSON) and binary formats that use field names, the order of fields generally does not matter for deserialization.
+* **Reordering Fields:** In text formats (YAML, JSON) and binary formats that use field names, the order of fields generally does not matter for deserialisation.
 * **Field Numbers (`@FieldNumber`):** For binary formats, annotating fields with stable `@FieldNumber` allows renaming fields in the Java class without breaking wire compatibility, as the numeric tag remains the same.
 
 `FIELDLESS_BINARY` is an exception; it is very sensitive to schema changes (field order, type, and count must match).
@@ -258,10 +259,10 @@ Chronicle Wire's architecture supports schema evolution primarily through its se
 Several architectural choices contribute to Chronicle Wire's high performance:
 
 * **`Chronicle Bytes`:** Off-heap storage and direct memory access via `Bytes` minimizes GC overhead.
-* **Specialized `Wire` Implementations:** Each format has an optimized encoder/decoder. Binary formats, in particular, use techniques like stop-bit encoding for integers to reduce data size without CPU-intensive compression.
+* **Specialized `Wire` Implementations:** Each format has an optimised encoder/decoder. Binary formats, in particular, use techniques like stop-bit encoding for integers to reduce data size without CPU-intensive compression.
 * **Code Generation for `Marshallable`:** Avoids reflection overhead in critical paths.
 * **Object Reuse:** `DocumentContext` and other internal components are often pooled or designed for reuse. `Marshallable` objects can implement `reset()` methods for pooling.
-* **Minimal Abstraction Overhead:** While providing a clean API, the internal paths are optimized to reduce layers of indirection during actual data processing.
+* **Minimal Abstraction Overhead:** While providing a clean API, the internal paths are optimised to reduce layers of indirection during actual data processing.
 
 == 9. Integration with OpenHFT Ecosystem
 
@@ -281,7 +282,7 @@ graph TD
     end
 ----
 
-Chronicle Wire is the serialization backbone for many other OpenHFT libraries:
+Chronicle Wire is the serialisation backbone for many other OpenHFT libraries:
 
 * **Chronicle Queue:** Uses Wire to serialize messages into queue excerpts. The `MethodWriter` and `MethodReader` patterns in Chronicle Queue are built on top of Wire's ability to serialize method calls and their arguments.
 * **Chronicle Map:** Uses Wire to serialize keys and values for storage in its off-heap hash map.
@@ -297,7 +298,7 @@ Chronicle Wire's architecture is a sophisticated blend of flexibility and high-p
 == Related Topics
 
 * link:wire-cookbook.adoc[Cookbook] - Practical recipes for using Chronicle Wire
-* link:wire-annotations.adoc[Annotations Guide] - Learn about annotations for fine-tuning serialization
+* link:wire-annotations.adoc[Annotations Guide] - Learn about annotations for fine-tuning serialisation
 * link:wire-schema-evolution.adoc[Schema Evolution] - How to evolve your data structures over time
 * link:wire-glossary.adoc[Glossary] - Definitions of key terms used in this document
 * link:wire-visual-guide.adoc[Visual Guide] - Diagrams and visual aids for understanding Chronicle Wire

--- a/src/main/adoc/wire-cookbook.adoc
+++ b/src/main/adoc/wire-cookbook.adoc
@@ -11,26 +11,26 @@ This cookbook offers a series of focused, problem-solution style recipes to help
 [mermaid]
 ----
 graph TD
-    subgraph "Serialization Process"
+    subgraph "Serialisation Process"
         A[Java Object] -->|"implements Marshallable"| B[Marshallable Object]
         B -->|"writeMarshallable()"| C[Wire]
         C -->|"WireType (YAML, JSON, Binary)"| D[Bytes]
         D -->|"Store/Transmit"| E[Persistence/Network]
     end
 
-    subgraph "Deserialization Process"
+    subgraph "Deserialisation Process"
         F[Persistence/Network] -->|"Read"| G[Bytes]
-        G -->|"WireType (same as serialization)"| H[Wire]
+        G -->|"WireType (same as serialisation)"| H[Wire]
         H -->|"readMarshallable()"| I[Marshallable Object]
         I -->|"Field Population"| J[Java Object]
     end
 ----
 
-The diagram above illustrates the basic serialization and deserialization process in Chronicle Wire. Objects implementing the `Marshallable` interface can be written to a `Wire` instance, which uses a specific `WireType` to determine the format (YAML, JSON, Binary, etc.). The data is then stored in a `Bytes` buffer, which can be persisted or transmitted. The deserialization process reverses these steps.
+The diagram above illustrates the basic serialisation and deserialisation process in Chronicle Wire. Objects implementing the `Marshallable` interface can be written to a `Wire` instance, which uses a specific `WireType` to determine the format (YAML, JSON, Binary, etc.). The data is then stored in a `Bytes` buffer, which can be persisted or transmitted. The deserialisation process reverses these steps.
 
 TIP: For a foundational understanding of Chronicle Wire's architecture and core concepts, please refer to the main Chronicle Wire documentation and architectural overview.
 
-== 2. Basic Serialization and Deserialization
+== 2. Basic Serialisation and Deserialisation
 
 === 2.1. Recipe: Serializing a Simple POJO to Various Formats
 
@@ -60,7 +60,7 @@ public class MyData extends SelfDescribingMarshallable {
         this.value = value;
     }
 
-    // Getters are good practice, though not strictly required for basic serialization
+    // Getters are good practice, though not strictly required for basic serialisation
     // if fields are public or Wire has access. Private fields with no access
     // might require getters/setters or specific configuration.
     public String message() { return message; }
@@ -77,7 +77,7 @@ import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.wire.Wire;
 import net.openhft.chronicle.wire.WireType;
 
-public class BasicSerializationDemo {
+public class BasicSerialisationDemo {
     public static void main(String[] args) {
         MyData data = new MyData("Hello Wire!", 123, 45.67);
 
@@ -111,7 +111,7 @@ public class BasicSerializationDemo {
 ----
 
 Discussion ::
-`SelfDescribingMarshallable` automatically handles the serialization of fields. By simply changing the `WireType` (e.g., `YAML_ONLY`, `JSON_ONLY`, `BINARY_LIGHT`), you can control the output format without altering the `MyData` class or the core serialization call (`getValueOut().object(data)`). `*_ONLY` variants like `YAML_ONLY` or `JSON_ONLY` are often preferred for cleaner output when not needing to retain full type information for dynamic deserialization into differing types (though `YAML` and `JSON` wire types can be configured to include type information if needed).
+`SelfDescribingMarshallable` automatically handles the serialisation of fields. By simply changing the `WireType` (e.g., `YAML_ONLY`, `JSON_ONLY`, `BINARY_LIGHT`), you can control the output format without altering the `MyData` class or the core serialisation call (`getValueOut().object(data)`). `*_ONLY` variants like `YAML_ONLY` or `JSON_ONLY` are often preferred for cleaner output when not needing to retain full type information for dynamic deserialisation into differing types (though `YAML` and `JSON` wire types can be configured to include type information if needed).
 
 === 2.2. Recipe: Deserializing Data into a POJO
 
@@ -130,7 +130,7 @@ import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.wire.Wire;
 import net.openhft.chronicle.wire.WireType;
 
-public class BasicDeserializationDemo {
+public class BasicDeserialisationDemo {
     public static void main(String[] args) {
         // --- YAML Example ---
         String yamlInput = "!MyData {\n" +
@@ -173,7 +173,7 @@ public class BasicDeserializationDemo {
 ----
 
 *Discussion:*
-`getValueIn().object(MyData.class)` is the key call for deserialization. Chronicle Wire reads the data and populates a new instance of `MyData`. For text formats like YAML, the `!MyData` type hint helps in identifying the target class, though providing the class explicitly in `object()` is robust. For binary formats, if type information isn't inherently part of the stream for the specific `WireType` chosen, providing the target class is essential. `SelfDescribingMarshallable` with `BINARY_LIGHT` typically includes type information or field names/numbers allowing for successful deserialization.
+`getValueIn().object(MyData.class)` is the key call for deserialisation. Chronicle Wire reads the data and populates a new instance of `MyData`. For text formats like YAML, the `!MyData` type hint helps in identifying the target class, though providing the class explicitly in `object()` is robust. For binary formats, if type information isn't inherently part of the stream for the specific `WireType` chosen, providing the target class is essential. `SelfDescribingMarshallable` with `BINARY_LIGHT` typically includes type information or field names/numbers allowing for successful deserialisation.
 
 == 3. Working with Annotations
 
@@ -316,7 +316,7 @@ public class NanoTimeDemo {
         yamlBytes.releaseLast();
 
         // Deserialize (timestamp will be read back as long)
-        Bytes<?> yamlBytesIn = Bytes.fromString(yamlBytes.toString()); // Create new Bytes from string for deserialization
+        Bytes<?> yamlBytesIn = Bytes.fromString(yamlBytes.toString()); // Create new Bytes from string for deserialisation
         Wire yamlWireIn = WireType.YAML_ONLY.apply(yamlBytesIn);
         EventData deserializedEvent = yamlWireIn.getValueIn().object(EventData.class);
         System.out.println("\nDeserialized Timestamp (long): " + deserializedEvent.timestampNanos());
@@ -441,7 +441,7 @@ public class SchemaEvolutionDemo {
 ----
 
 *Discussion:*
-When new code reads old data (V1 data into `VersionedDataV2`), the `newField` in `VersionedDataV2` will be initialized to its Java default value (0 for `int`, `null` for objects, `false` for `boolean`). When old code (expecting `VersionedDataV1`) reads data written by new code (V2 data), it will simply ignore the `newField` it doesn't recognize. This works seamlessly for most self-describing `WireType`s. Using consistent class aliasing (e.g., `Wires.CLASS_ALIASES.addAlias(VersionedDataV2.class, "VersionedData")`) can be important if you rely on type information in the stream (like `!VersionedData`) rather than always specifying the concrete class on deserialization.
+When new code reads old data (V1 data into `VersionedDataV2`), the `newField` in `VersionedDataV2` will be initialized to its Java default value (0 for `int`, `null` for objects, `false` for `boolean`). When old code (expecting `VersionedDataV1`) reads data written by new code (V2 data), it will simply ignore the `newField` it doesn't recognize. This works seamlessly for most self-describing `WireType`s. Using consistent class aliasing (e.g., `Wires.CLASS_ALIASES.addAlias(VersionedDataV2.class, "VersionedData")`) can be important if you rely on type information in the stream (like `!VersionedData`) rather than always specifying the concrete class on deserialisation.
 
 == 5. Working with `DocumentContext`
 
@@ -573,7 +573,13 @@ public class PerfCriticalData implements BytesMarshallable {
     public int id() { return id; }
     public long value() { return value; }
 
-    // A generic equals, hashCode, toString are inherited and don't need to be overridden
+    @Override
+    public String toString() {
+        return "PerfCriticalData{" +
+                "id=" + id +
+                ", value=0x" + Long.toHexString(value) +
+                '}';
+    }
 }
 ----
 
@@ -603,7 +609,6 @@ public class BytesMarshallableDemo {
         // For BytesMarshallable, often you pass an instance to be populated.
 
         System.out.println("Read back: " + dataIn);
-        System.out.println("ID: " + dataIn.getId() + ", Value: " + Long.toHexString(dataIn.getValue()));
 
         bytes.releaseLast();
     }
@@ -618,7 +623,7 @@ NOTE: This cookbook provides a starting point. Many more recipes can be develope
 == Related Topics
 
 * link:wire-architecture.adoc[Architecture Overview] - Understand the internal architecture of Chronicle Wire
-* link:wire-annotations.adoc[Annotations Guide] - Learn about annotations for fine-tuning serialization
+* link:wire-annotations.adoc[Annotations Guide] - Learn about annotations for fine-tuning serialisation
 * link:wire-schema-evolution.adoc[Schema Evolution] - How to evolve your data structures over time
 * link:wire-error-handling.adoc[Error Handling and Diagnostics] - Troubleshooting and error handling
 * link:wire-faq.adoc[FAQ] - Answers to frequently asked questions

--- a/src/main/adoc/wire-faq.adoc
+++ b/src/main/adoc/wire-faq.adoc
@@ -8,16 +8,16 @@ Purpose: To provide answers to frequently asked questions about the Chronicle Wi
 == Basics & Core Concepts
 
 What is Chronicle Wire? ::
-Chronicle Wire is an open-source Java library from the OpenHFT ecosystem designed for high-performance, low-latency serialization and deserialization. It supports multiple data formats through a unified API.
+Chronicle Wire is an open-source Java library from the OpenHFT ecosystem designed for high-performance, low-latency serialisation and deserialisation. It supports multiple data formats through a unified API.
 
-Why should I use Chronicle Wire over standard Java Serialization? ::
-Chronicle Wire offers significantly better performance (lower latency, higher throughput), minimal garbage creation, greater flexibility with multiple data formats, and more robust schema evolution capabilities compared to standard Java Serialization.
+Why should I use Chronicle Wire over standard Java Serialisation? ::
+Chronicle Wire offers significantly better performance (lower latency, higher throughput), minimal garbage creation, greater flexibility with multiple data formats, and more robust schema evolution capabilities compared to standard Java Serialisation.
 
 What are the main design goals of Chronicle Wire? ::
 Low latency, minimal garbage collection, format agnosticism (support for YAML, JSON, Binary, etc.), and efficient handling of off-heap memory.
 
 What does "format-agnostic" mean in the context of Chronicle Wire? ::
-It means you can write your serialization/deserialization logic once (e.g., using `Marshallable` objects) and then switch the underlying data format (e.g., from YAML to Binary) by simply changing the `WireType` without altering your core application code.
+It means you can write your serialisation/deserialisation logic once (e.g., using `Marshallable` objects) and then switch the underlying data format (e.g., from YAML to Binary) by simply changing the `WireType` without altering your core application code.
 
 What is `Bytes` in Chronicle Wire? ::
 `Bytes` (from the `chronicle-bytes` library) is a core abstraction representing a sequence of bytes. It can wrap on-heap byte arrays, off-heap direct memory, or memory-mapped files. Chronicle Wire implementations read from and write to `Bytes` instances.
@@ -26,7 +26,7 @@ What is a `Wire` instance? ::
 A `Wire` instance is the primary interface for reading and writing structured data in a specific format (like YAML, JSON, or Binary). You obtain it by applying a `WireType` to a `Bytes` buffer.
 
 What is `WireType`? ::
-`WireType` is an enum that defines the different serialization formats supported by Chronicle Wire (e.g., `YAML_ONLY`, `JSON_ONLY`, `BINARY_LIGHT`, `FIELDLESS_BINARY`). It also acts as a factory for creating `Wire` instances.
+`WireType` is an enum that defines the different serialisation formats supported by Chronicle Wire (e.g., `YAML_ONLY`, `JSON_ONLY`, `BINARY_LIGHT`, `FIELDLESS_BINARY`). It also acts as a factory for creating `Wire` instances.
 
 What is `DocumentContext`? ::
 `DocumentContext` is used to manage the boundaries of individual messages or "documents" when streaming multiple items to or from a `Wire`. It's crucial for ensuring messages are correctly framed, especially in binary formats or when used with Chronicle Queue.
@@ -37,7 +37,7 @@ What is the `Marshallable` interface? ::
 It's an interface that your POJOs can implement to indicate they can be serialized and deserialized by Chronicle Wire. It has `readMarshallable(WireIn)` and `writeMarshallable(WireOut)` methods.
 
 What is `SelfDescribingMarshallable`? ::
-It's a convenient abstract base class that implements `Marshallable`. It automatically provides serialization/deserialization logic for fields (via reflection or code generation) and also generates `toString()`, `equals()`, and `hashCode()` methods based on the object's fields.
+It's a convenient abstract base class that implements `Marshallable`. It automatically provides serialisation/deserialisation logic for fields (via reflection or code generation) and also generates `toString()`, `equals()`, and `hashCode()` methods based on the object's fields.
 
 What is `BytesMarshallable`? ::
 It's a lower-level interface for objects that need complete control over their binary representation. Implementors read/write directly from/to `BytesIn`/`BytesOut`, bypassing some of Wire's higher-level mechanisms for maximum performance or custom formats.
@@ -46,13 +46,13 @@ How does Chronicle Wire serialize fields in a `Marshallable` object? ::
 By default (especially with `SelfDescribingMarshallable`), it can use reflection or, for better performance, generate bytecode at runtime (`WireMarshaller`) to directly access and serialize/deserialize fields.
 
 Do I need getters and setters for `Marshallable` objects? ::
-Not strictly for serialization if fields are public or default access within the same package. However, for private fields or to follow JavaBean conventions, getters/setters are good practice. Chronicle Wire's generated marshallers can often access private fields if permissions allow.
+Not strictly for serialisation if fields are public or default access within the same package. However, for private fields or to follow JavaBean conventions, getters/setters are good practice. Chronicle Wire's generated marshallers can often access private fields if permissions allow.
 
 Can I serialize collections (Lists, Maps) with Chronicle Wire? ::
 Yes. Chronicle Wire can serialize collections containing primitives, strings, or other `Marshallable` objects. It has specific methods on `ValueOut` (e.g., `sequence()`, `marshallableAsMap()`) and `ValueIn` to handle them.
 
 How are null values handled? ::
-Chronicle Wire can represent nulls. In text formats, it might be explicit (e.g., `fieldName: !!null ""`). In binary, it's handled with special markers or by omitting fields. The behavior can sometimes depend on the `WireType`.
+Chronicle Wire can represent nulls. In text formats, it might be explicit (e.g., `fieldName: !!null ""`). In binary, it's handled with special markers or by omitting fields. The behaviour can sometimes depend on the `WireType`.
 
 == API Usage
 
@@ -74,7 +74,7 @@ It ensures that the `DocumentContext` is closed properly. For writing, closing t
 Can Chronicle Wire serialize enums? ::
 Yes, enums can be serialized. They are typically written as their string name in text formats or as an ordinal/name in binary.
 
-== Serialization Formats
+== Serialisation Formats
 
 Which `WireType` should I choose for human-readable output? ::
 `YAML_ONLY` or `JSON_ONLY` are good choices for pure YAML or JSON output respectively.
@@ -89,12 +89,12 @@ Can I read data written in one `WireType` with another? ::
 Sometimes, yes. For example, binary data written with `BINARY_LIGHT` can often be "dumped" or inspected using `YAML_ONLY` because `BINARY_LIGHT` can be self-describing. `READ_ANY` wire type attempts to auto-detect the format. However, you cannot reliably read `FIELDLESS_BINARY` as YAML, for instance.
 
 How does `YAML_RETAIN_TYPE` or `JSON_RETAIN_TYPE` work? ::
-These wire types include explicit type information (e.g., `!com.example.MyClass {}` in YAML) in the output. This allows for deserialization of polymorphic types or when the concrete class is not known by the reader beforehand.
+These wire types include explicit type information (e.g., `!com.example.MyClass {}` in YAML) in the output. This allows for deserialisation of polymorphic types or when the concrete class is not known by the reader beforehand.
 
 == Annotations
 
 What is the purpose of annotations in Chronicle Wire? ::
-Annotations provide a declarative way to customize serialization behavior, such as data conversion, formatting, or providing metadata for schema evolution, without writing extensive custom marshalling code.
+Annotations provide a declarative way to customise serialisation behaviour, such as data conversion, formatting, or providing metadata for schema evolution, without writing extensive custom marshalling code.
 
 How does `@LongConversion` (e.g., `@Base64`, `@Base85`) work? ::
 It allows you to store a short string (packed into a `long`) efficiently in binary while representing it as a human-readable string in text formats. For example, `@ShortText long myId;` will store up to 10 characters in an 8-byte long.
@@ -140,7 +140,7 @@ It's designed to create minimal or zero garbage in its critical paths, especiall
 What is "off-heap" memory and how does Wire use it? ::
 Off-heap memory is Java direct memory allocated outside the JVM's garbage-collected heap. Chronicle Wire, through `chronicle-bytes`, can serialize directly to and deserialize directly from off-heap `Bytes` buffers, reducing GC pressure.
 
-How can I optimize Chronicle Wire performance? ::
+How can I optimise Chronicle Wire performance? ::
 * Choose efficient binary `WireType`s (`BINARY_LIGHT`, `FIELDLESS_BINARY`).
 * Use off-heap `Bytes`.
 * Reuse `Marshallable` objects if possible (e.g., with a `reset()` method).
@@ -153,20 +153,20 @@ Performance comparisons depend heavily on the specific use case, data structures
 == Integration
 
 How is Chronicle Wire used in Chronicle Queue? ::
-Chronicle Wire is the serialization engine for messages stored in Chronicle Queue. It serializes data into queue excerpts (typically in `BINARY_LIGHT` format). The `MethodWriter` and `MethodReader` patterns in Queue use Wire to serialize method calls and arguments.
+Chronicle Wire is the serialisation engine for messages stored in Chronicle Queue. It serializes data into queue excerpts (typically in `BINARY_LIGHT` format). The `MethodWriter` and `MethodReader` patterns in Queue use Wire to serialize method calls and arguments.
 
 How is Chronicle Wire used in Chronicle Map? ::
 Chronicle Wire is used to serialize keys and values when they are custom Java objects being stored in an off-heap Chronicle Map. Users typically make their keys/values `Marshallable` or `BytesMarshallable`.
 
 Can I use Chronicle Wire for network communication? ::
-Yes. While Wire itself is a serialization library, it's used by `chronicle-network` (and related OpenHFT networking components) to marshal data for sending over TCP/IP or UDP.
+Yes. While Wire itself is a serialisation library, it's used by `chronicle-network` (and related OpenHFT networking components) to marshal data for sending over TCP/IP or UDP.
 
 Can I use Chronicle Wire for configuration files? ::
 Yes, `YAML_ONLY` Wire is excellent for creating and parsing human-readable configuration files. Your configuration DTOs can implement `Marshallable`.
 
 == Troubleshooting & Debugging
 
-My deserialization is failing, what could be wrong? ::
+My deserialisation is failing, what could be wrong? ::
 Common causes include:
 * Schema mismatch (fields added/removed/changed type, especially with non-flexible formats like `FIELDLESS_BINARY`).
 * Incorrect `WireType` used for reading data written in a different, incompatible format.
@@ -189,10 +189,10 @@ Are there any common pitfalls when using Chronicle Wire? ::
 == Advanced Topics
 
 What are "trivially copyable objects" in Chronicle Wire? ::
-This is an optimization where, if an object's serialized form is a direct memory copy of its in-memory layout (e.g., a class with only primitive fields laid out appropriately for `BytesMarshallable`), serialization/deserialization can be extremely fast, almost a `memcpy`.
+This is an optimisation where, if an object's serialized form is a direct memory copy of its in-memory layout (e.g., a class with only primitive fields laid out appropriately for `BytesMarshallable`), serialisation/deserialisation can be extremely fast, almost a `memcpy`.
 
 Can I create custom `WireType` implementations? ::
-Yes, the architecture is extensible, but this is an advanced task requiring a deep understanding of the `Wire` interface and serialization principles.
+Yes, the architecture is extensible, but this is an advanced task requiring a deep understanding of the `Wire` interface and serialisation principles.
 
 How does Chronicle Wire handle circular dependencies in object graphs? ::
 Standard Chronicle Wire object marshalling is primarily designed for tree-like structures or DAGs. Deeply nested circular dependencies can cause issues (like `StackOverflowError`) if not handled carefully. For complex graphs, you might need custom marshalling logic or to break cycles.

--- a/src/main/adoc/wire-glossary.adoc
+++ b/src/main/adoc/wire-glossary.adoc
@@ -1,6 +1,9 @@
 
 = Chronicle Wire Glossary
+:toc:
+:toclevels: 2
 :source-highlighter: rouge
+:icons: font
 
 Purpose: To provide clear definitions for common terms and concepts used in Chronicle Wire and its related ecosystem.
 

--- a/src/main/adoc/wire-schema-evolution.adoc
+++ b/src/main/adoc/wire-schema-evolution.adoc
@@ -59,7 +59,7 @@ Text Formats (YAML, JSON, TEXT) ::
 ----
 graph TD
     subgraph "Field Identification in Different Formats"
-        A[Java Class Definition] --> B[Serialization]
+        A[Java Class Definition] --> B[Serialisation]
         B --> C{Wire Format}
         C -->|YAML/JSON| D[Text Format]
         C -->|BINARY_LIGHT| E[Binary Format]
@@ -296,7 +296,7 @@ By understanding these mechanisms, limitations, and best practices, developers c
 == Related Topics
 
 * link:wire-architecture.adoc[Architecture Overview] - Understand the internal architecture of Chronicle Wire
-* link:wire-annotations.adoc[Annotations Guide] - Learn about annotations for fine-tuning serialization
+* link:wire-annotations.adoc[Annotations Guide] - Learn about annotations for fine-tuning serialisation
 * link:wire-cookbook.adoc#_4_schema_evolution[Schema Evolution Examples] - Practical examples of schema evolution
 * link:wire-error-handling.adoc[Error Handling and Diagnostics] - Troubleshooting and error handling
 * link:wire-visual-guide.adoc#_5_schema_evolution[Visual Guide: Schema Evolution] - Diagrams illustrating schema evolution concepts

--- a/src/main/adoc/wire-visual-guide.adoc
+++ b/src/main/adoc/wire-visual-guide.adoc
@@ -89,21 +89,21 @@ classDiagram
     WireType --> Wire : creates
 ----
 
-== 3. Serialization and Deserialization Process
+== 3. Serialisation and Deserialisation Process
 
 [mermaid]
 ----
 graph TD
-    subgraph "Serialization Process"
+    subgraph "Serialisation Process"
         A[Java Object] -->|"implements Marshallable"| B[Marshallable Object]
         B -->|"writeMarshallable()"| C[Wire]
         C -->|"WireType (YAML, JSON, Binary)"| D[Bytes]
         D -->|"Store/Transmit"| E[Persistence/Network]
     end
     
-    subgraph "Deserialization Process"
+    subgraph "Deserialisation Process"
         F[Persistence/Network] -->|"Read"| G[Bytes]
-        G -->|"WireType (same as serialization)"| H[Wire]
+        G -->|"WireType (same as serialisation)"| H[Wire]
         H -->|"readMarshallable()"| I[Marshallable Object]
         I -->|"Field Population"| J[Java Object]
     end
@@ -181,7 +181,7 @@ graph TD
 
 * link:wire-architecture.adoc[Architecture Overview] - Understand the internal architecture of Chronicle Wire
 * link:wire-cookbook.adoc[Cookbook] - Practical recipes for using Chronicle Wire
-* link:wire-annotations.adoc[Annotations Guide] - Learn about annotations for fine-tuning serialization
+* link:wire-annotations.adoc[Annotations Guide] - Learn about annotations for fine-tuning serialisation
 * link:wire-schema-evolution.adoc[Schema Evolution] - How to evolve your data structures over time
 * link:wire-error-handling.adoc[Error Handling and Diagnostics] - Troubleshooting and error handling
 * link:wire-faq.adoc[FAQ] - Answers to frequently asked questions


### PR DESCRIPTION
## Summary
- standardise on British English spelling across docs
- add WireType rows for YAML/JSON type retention
- include :toc: and attributes in EventsByMethod and glossary
- clarify YAML_RETAIN_TYPE usage
- implement `toString()` in cookbook example
- note placeholder version replacement in README

## Testing
- `mvn -q verify` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b205756e48329a6dd8e9e92a2623f