### PR TITLE
Improve AsciiDoc navigation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -157,6 +157,7 @@ System.out.println(bytes.toString());
 
 == Documentation
 
+* link:src/main/adoc/index.adoc[Documentation Index]
 * link:src/main/adoc/wire-architecture.adoc[Architectural Overview]
 * link:src/main/adoc/wire-schema-evolution.adoc[Schema Evolution Deep Dive]
 * link:src/main/adoc/wire-cookbook.adoc[Cookbook]

--- a/src/main/adoc/index.adoc
+++ b/src/main/adoc/index.adoc
@@ -31,3 +31,12 @@ link:wire-glossary.adoc[Chronicle Wire Glossary] ::
 
 link:project-requirements.adoc[Project Requirements: Chronicle Wire Documentation Enhancement] ::
   Outlines the requirements for improving this documentation set.
+
+link:../../EventsByMethod.adoc[Events by Method Guide] ::
+  Explains the event-driven approach via asynchronous method calls.
+
+link:../../YAML2SpecificationCompliance.adoc[YAML 1.2 Compliance Notes] ::
+  Details how Chronicle Wire aligns with the YAML 1.2 specification.
+
+link:../../systemProperties.adoc[System Properties Guide] ::
+  Lists Java system properties influencing Chronicle components.


### PR DESCRIPTION
## Summary
- link README to the central documentation index
- extend `index.adoc` with links to root-level guides

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b20d4dd5c8329a20b1cc7de770cae