### PR TITLE
Add automatic section numbering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,3 +159,15 @@ section:: Top Level Section
 ### Emphasis and Bold Text
 
 In AsciiDoc, an underscore `_` is _emphasis_; `*text*` is *bold*.
+
+### Section Numbering
+
+Use automatic section numbering for all `.adoc` files.
+
+* Add `:sectnums:` to the document header.
+* Do not prefix section titles with manual numbers.
+
+```asciidoc
+= Document Title
+:sectnums:
+```

--- a/EventsByMethod.adoc
+++ b/EventsByMethod.adoc
@@ -1,6 +1,7 @@
 = Events by Method
 Peter Lawrey
 
+:sectnums:
 Chronicle favours modelling events as asynchronous method calls.
 This document explores the 'Events by Method' paradigm in Chronicle Wire, demonstrating how to model, process and test events represented as asynchronous Java method calls, and how to leverage different wire formats for these events.
 This has a number of advantages:

--- a/README.adoc
+++ b/README.adoc
@@ -3,6 +3,7 @@ Chronicle Software
 :toc: macro
 :toclevels: 2
 :icons: font
+:sectnums:
 
 image:https://maven-badges.herokuapp.com/maven-central/net.openhft/chronicle-wire/badge.svg[link=https://maven-badges.herokuapp.com/maven-central/net.openhft/chronicle-wire]
 image:https://javadoc.io/badge2/net.openhft/chronicle-wire/javadoc.svg[link="https://www.javadoc.io/doc/net.openhft/chronicle-wire/latest/index.html"]

--- a/YAML2SpecificationCompliance.adoc
+++ b/YAML2SpecificationCompliance.adoc
@@ -2,6 +2,7 @@
 :toc: manual
 :css-signature: demo
 :toc-placement: preamble
+:sectnums:
 
 == YAML 1.2.2 Specification Compliance
 

--- a/src/main/adoc/index.adoc
+++ b/src/main/adoc/index.adoc
@@ -3,6 +3,7 @@
 :toc: left
 :toclevels: 2
 :source-highlighter: rouge
+:sectnums:
 
 Chronicle Wire is a high-performance, low-latency serialisation library that forms part of the OpenHFT stack. This index links to the documentation set.
 

--- a/src/main/adoc/project-requirements.adoc
+++ b/src/main/adoc/project-requirements.adoc
@@ -1,14 +1,15 @@
 = Project Requirements: Chronicle Wire Documentation Enhancement
 :toc:
 :source-highlighter: rouge
+:sectnums:
 
 To outline the detailed requirements for creating comprehensive and technically rich documentation for the Chronicle Wire library, aimed at improving user understanding, adoption, and effective utilization.
 
-== 1. Introduction
+== Introduction
 
 This document specifies the detailed requirements for a significant enhancement of the documentation for the Chronicle Wire library. Chronicle Wire is a foundational component within the OpenHFT (Open High-Frequency Trading) ecosystem, designed for high-performance, low-latency data serialization and deserialization. The current initiative aims to produce documentation that is technically deep, practically useful, and addresses the needs of a diverse developer audience. This enhancement will be based on an exhaustive technical review of Chronicle Wire, covering its architecture, features, diverse use cases within OpenHFT (including inter-process communication (IPC), object serialization, low-latency systems design, and data persistence strategies), and a thorough comparative analysis against other prominent serialization libraries. The ultimate goal is to establish this documentation as the authoritative resource for Chronicle Wire.
 
-== 2. Goals
+== Goals
 
 The overarching goals for this documentation enhancement are:
 
@@ -36,11 +37,11 @@ Maximized Accessibility and User Experience ::
 * Ensure the documentation is structured logically and is easily navigable for developers with varying levels of familiarity with OpenHFT, Java, and serialization technologies.
 * Cater to different learning styles by incorporating diagrams, flowcharts, and concise summaries alongside detailed explanations.
 
-== 3. Scope of Documentation
+== Scope of Documentation
 
 The documentation shall comprehensively cover the following key areas:
 
-=== 3.1. Core Chronicle Wire Concepts
+=== Core Chronicle Wire Concepts
 
 Comprehensive Overview ::
 * **Introduction:** What Chronicle Wire is, its origin within OpenHFT, and the core problems it solves (e.g., performance bottlenecks of standard Java serialization, need for format flexibility).
@@ -97,7 +98,7 @@ Low-Latency and High-Performance Features ::
 * **`SingleThreadedChecked`:** Explanation of its role and how to ensure thread safety when using Wire and related components.
 * **Trivially Copyable Objects:** Explanation and use cases for this optimization.
 
-=== 3.2. Chronicle Wire Usage in OpenHFT Ecosystem Components
+=== Chronicle Wire Usage in OpenHFT Ecosystem Components
 
 
 *Chronicle Queue (v5.x and relevant versions) ::
@@ -134,7 +135,7 @@ Chronicle Services ::
 * **State Aggregation and Replay:** How services deserialize events using Wire to reconstruct state or replay business logic.
 * **Conceptual Example:** A detailed walkthrough of a simple event-sourced service (e.g., an "Order Management" service with `OrderCreated`, `OrderUpdated` events defined as `Marshallable` objects), showing event definition, publishing to a queue, and a handler processing these events.
 
-=== 3.3. Rich Code Examples and Tutorials
+=== Rich Code Examples and Tutorials
 
 Variety and Scope ::
 * **Basic Serialization:** Simple POJOs with various `WireType`s (YAML, JSON, Binary).
@@ -153,7 +154,7 @@ Best Practices Integration :: Code examples should subtly (or explicitly) demons
 
 Runnable Format :: Provide examples as complete, runnable Java files or easily copy-pasteable snippets that can be integrated into a user's project. Accompanying `pom.xml` dependencies for OpenHFT components should be noted.
 
-=== 3.4. Comprehensive Comparison with Other Serialization Libraries
+=== Comprehensive Comparison with Other Serialization Libraries
 
 Detailed Comparison Aspects (for each library vs. Chronicle Wire) ::
 * **Data Format & Flexibility:**
@@ -197,7 +198,7 @@ Presentation Format ::
 * **Structured Tables:** Use detailed comparison tables for a clear, side-by-side view of features, performance metrics, and qualitative aspects.
 * **Narrative Summaries:** Accompany tables with narrative explanations highlighting key differences and trade-offs.
 
-== 4. Non-Functional Requirements
+== Non-Functional Requirements
 
 Accuracy and Currency ::
 * All technical information, API descriptions, and code examples must be rigorously verified for accuracy against the latest stable release of Chronicle Wire and relevant OpenHFT components.
@@ -224,7 +225,7 @@ Maintainability and Extensibility ::
 
 Consistency :: Maintain consistent terminology, formatting, and style throughout the documentation.
 
-== 5. Deliverables
+== Deliverables
 
 Primary AsciiDoc Document(s) ::
 * A main AsciiDoc files `src/main/adoc` serving as the entry point and containing the overall structure.
@@ -240,7 +241,7 @@ Diagrams and Illustrations ::
 Comparison Data ::
 * Clearly presented comparison tables and benchmark summaries within the AsciiDoc.
 
-== 6. Target Audience
+== Target Audience
 
 The documentation should cater to a diverse technical audience, including:
 
@@ -259,7 +260,7 @@ Performance Engineers ::
 Developers Evaluating Serialization Libraries ::
 * **Goal:** Obtain a balanced, technically sound comparison to make an informed choice for their specific project needs.
 
-== 7. Assumptions
+== Assumptions
 
 Reader's Background :: The documentation will assume readers have a solid understanding of Java programming concepts. Familiarity with general serialization concepts is helpful but not strictly required for introductory sections.
 

--- a/src/main/adoc/wire-annotations.adoc
+++ b/src/main/adoc/wire-annotations.adoc
@@ -3,9 +3,10 @@
 :toc: 
 :source-highlighter: rouge
 
+:sectnums:
 Purpose: To provide a comprehensive user guide and reference for all standard annotations available in Chronicle Wire, detailing their purpose, usage, and impact on serialisation.
 
-== 1. Introduction
+== Introduction
 
 Chronicle Wire leverages Java annotations to provide developers with fine-grained control over the serialisation and deserialisation process. Annotations offer a declarative way to customise data representation, optimise for performance or size, add metadata, and aid in schema evolution, often without needing to write complex custom marshalling logic.
 
@@ -19,7 +20,7 @@ This document serves as a comprehensive guide to the standard annotations provid
 
 Understanding these annotations is key to effectively tailoring Chronicle Wire to your specific application needs, whether for human readability, extreme performance, or robust data versioning. This guide aims to fulfil the requirements for such documentation by being that guide.
 
-== 2. Core Annotation Categories
+== Core Annotation Categories
 
 Chronicle Wire annotations can be broadly categorised based on their primary function:
 
@@ -29,11 +30,11 @@ Chronicle Wire annotations can be broadly categorised based on their primary fun
 
 This guide will explore annotations primarily from the first two categories.
 
-== 3. Data Conversion & Formatting Annotations
+== Data Conversion & Formatting Annotations
 
 These annotations are crucial for controlling the on-wire representation of your data.
 
-=== 3.1. `@LongConversion` and Derivative Converters
+=== `@LongConversion` and Derivative Converters
 
 Purpose ::
 The `@LongConversion` annotation is a powerful meta-annotation used to specify that a `long` field in Java should be converted to and from a different representation (typically a String) when serialised to text-based wire formats, while remaining a `long` in binary formats. This is extremely useful for compactly storing short textual identifiers or codes within an 8-byte long.
@@ -52,7 +53,7 @@ Use Case :: Storing short alphanumeric IDs, symbols, or codes (e.g., currency pa
 Example ::
 While `@LongConversion` is the base, Chronicle Wire provides several convenient pre-defined annotations that use specific converters:
 
-==== 3.1.1. `@BaseN` Converters (`@Base32`, `@Base64`, `@Base85`)
+==== `@BaseN` Converters (`@Base32`, `@Base64`, `@Base85`)
 
 Annotations :: `@Base32`, `@Base64`, `@Base85` (these are meta-annotated with `@LongConversion` pointing to respective `BaseNLongConverter` implementations).
 
@@ -91,7 +92,7 @@ public class StockInfo extends SelfDescribingMarshallable {
 // In Binary: stockSymbol is an 8-byte long
 ----
 
-=== 3.2. Timestamp Converters (`@NanoTime`)
+=== Timestamp Converters (`@NanoTime`)
 
 Annotations :: `@NanoTime`
 
@@ -130,11 +131,11 @@ public class LogEntry extends SelfDescribingMarshallable {
 // }
 ----
 
-== 4. Schema Definition & Metadata Annotations
+== Schema Definition & Metadata Annotations
 
 These annotations provide additional information about fields or types, primarily aiding in schema evolution, binary format stability, or human-readable documentation.
 
-=== 4.1. `@FieldNumber`
+=== `@FieldNumber`
 
 Status :: Road Map
 
@@ -170,7 +171,7 @@ public class FinancialInstrument extends SelfDescribingMarshallable {
 
 IMPORTANT: Ensure field numbers are unique within a class hierarchy if polymorphism and shared binary formats are involved.
 
-=== 4.2. `@Comment`
+=== `@Comment`
 
 Purpose :: To add a descriptive comment to a field, which will be included in some text-based wire formats, typically YAML.
 
@@ -209,7 +210,7 @@ public class AppConfig extends SelfDescribingMarshallable {
 // }
 ----
 
-=== 4.3. `@DefaultValue`
+=== `@DefaultValue`
 
 Status :: Road Map
 
@@ -243,7 +244,7 @@ public class SystemSettings extends SelfDescribingMarshallable {
 }
 ----
 
-=== 4.4. `@DeprecatedWireKey` (and similar for field renaming)
+=== `@DeprecatedWireKey` (and similar for field renaming)
 
 Status :: Road Map
 
@@ -275,7 +276,7 @@ public class UserDetails extends SelfDescribingMarshallable {
 ----
 NOTE: The exact mechanism for field renaming with backward compatibility can vary. `Wires.FIELD_RENAME_MAP` or programmatic remapping using `WireParselet` might be used. Always consult the specific Chronicle Wire version documentation for the recommended approach to field renaming.
 
-== 5. Best Practices for Using Annotations
+== Best Practices for Using Annotations
 
 * **Be Purposeful:** Use annotations where they add clear value, such as improving readability in text formats (`@Comment`, `@NanoTime`), optimising binary size/performance (`@LongConversion`, `@FieldNumber`), or ensuring schema stability (`@FieldNumber`).
 * **Understand Format Impact:** Be aware that some annotations only affect text formats (e.g., `@Comment`), while others primarily impact binary formats (e.g., `@FieldNumber`'s core use).

--- a/src/main/adoc/wire-architecture.adoc
+++ b/src/main/adoc/wire-architecture.adoc
@@ -3,9 +3,10 @@
 :toc:
 :source-highlighter: rouge
 
+:sectnums:
 Purpose: To provide a comprehensive understanding of the internal architecture of the Chronicle Wire library, its components, and design principles.
 
-== 1. Introduction
+== Introduction
 
 Chronicle Wire is a high-performance, low-latency serialization and deserialization library, forming a foundational part of the OpenHFT (Open High-Frequency Trading) ecosystem. Its architecture is meticulously designed to support demanding applications that require minimal garbage collection, high throughput, and flexible data representation. This document outlines the key architectural components, design principles, and interactions within Chronicle Wire.
 
@@ -16,7 +17,7 @@ The primary architectural goals of Chronicle Wire are:
 * **Extensibility:** Provide mechanisms for custom data type handling and new wire format implementations.
 * **Schema Evolution:** Offer robust support for evolving data schemas over time without breaking compatibility.
 
-== 2. Core Design Principles
+== Core Design Principles
 
 The architecture of Chronicle Wire is guided by several core design principles:
 
@@ -26,7 +27,7 @@ The architecture of Chronicle Wire is guided by several core design principles:
 * **Self-Describing Data (Optional):** Support for both self-describing formats (which include field names or identifiers, aiding schema evolution and debugging) and more compact, non-self-describing formats (for maximum performance where schemas are implicitly shared).
 * **Streaming API:** Provide a streaming approach to reading and writing data, allowing for efficient processing of large data structures or sequences of messages.
 
-== 3. Architectural Layers and Components
+== Architectural Layers and Components
 
 Chronicle Wire's architecture can be conceptualized in several layers, with well-defined components interacting across these layers.
 
@@ -89,13 +90,13 @@ Underlying I/O or Storage Layer ::
 ** Memory-mapped files (as used by Chronicle Queue for persistence).
 ** Network sockets (as used by Chronicle Network for IPC).
 
-== 4. Key Abstractions in Detail
+== Key Abstractions in Detail
 
-=== 4.1. `Bytes` and `BytesStore`
+=== `Bytes` and `BytesStore`
 
 The `Bytes` abstraction is fundamental. It provides a mutable, resizable view over a `BytesStore`. `Wire` implementations use `Bytes` to read from and write to the underlying byte sequence without needing to know if it's on-heap, off-heap, or file-backed. This decoupling is crucial for performance and flexibility.
 
-=== 4.2. `Wire` and `WireType`
+=== `Wire` and `WireType`
 
 The `Wire` interface abstracts the process of serializing and deserializing structured data. An application obtains a `Wire` instance, typically specifying a `WireType` and providing a `Bytes` buffer.
 
@@ -164,7 +165,7 @@ Wire binaryWire = WireType.BINARY_LIGHT.apply(bytes);
 
 The `WireType` enum acts as a factory and configuration point for different wire formats. It allows the application to easily switch between, for example, human-readable YAML for debugging and compact Binary for production performance, using the same serialization logic.
 
-=== 4.3. `Marshallable`
+=== `Marshallable`
 
 The `Marshallable` interface is a marker interface that, when implemented by a POJO, allows Chronicle Wire to automatically serialize its fields.
 
@@ -175,11 +176,11 @@ Often, developers extend `SelfDescribingMarshallable`, which provides default im
 
 For performance-critical scenarios where reflection or default marshalling overhead is too high, `BytesMarshallable` allows direct control over byte-level serialization.
 
-=== 4.4. `DocumentContext`
+=== `DocumentContext`
 
 When streaming multiple objects or messages, `DocumentContext` is used to manage the boundaries and metadata of each individual "document" written to or read from the wire.
 
-== 5. Marshalling Process
+== Marshalling Process
 
 Chronicle Wire supports two main ways to marshal data:
 
@@ -206,7 +207,7 @@ wire.write("trade")
 ----
 * This provides fine-grained control and is useful for dynamic schemas or when not using `Marshallable` POJOs.
 
-== 6. Serialization Formats (`WireType`) and Flexibility
+== Serialization Formats (`WireType`) and Flexibility
 
 [mermaid]
 ----
@@ -242,7 +243,7 @@ The power of Chronicle Wire's architecture lies in its ability to switch `WireTy
 ** `RAW`: Essentially a "pass-through" for raw byte sequences, often used with `BytesMarshallable`.
 * `READ_ANY`: A special `WireType` that can attempt to detect and read data from any of the known formats, useful for flexible consumers.
 
-== 7. Schema Evolution
+== Schema Evolution
 
 Chronicle Wire's architecture supports schema evolution primarily through its self-describing formats:
 
@@ -253,7 +254,7 @@ Chronicle Wire's architecture supports schema evolution primarily through its se
 
 `FIELDLESS_BINARY` is an exception; it is very sensitive to schema changes (field order, type, and count must match).
 
-== 8. Performance in Architecture
+== Performance in Architecture
 
 Several architectural choices contribute to Chronicle Wire's high performance:
 
@@ -263,7 +264,7 @@ Several architectural choices contribute to Chronicle Wire's high performance:
 * **Object Reuse:** `DocumentContext` and other internal components are often pooled or designed for reuse. `Marshallable` objects can implement `reset()` methods for pooling.
 * **Minimal Abstraction Overhead:** While providing a clean API, the internal paths are optimized to reduce layers of indirection during actual data processing.
 
-== 9. Integration with OpenHFT Ecosystem
+== Integration with OpenHFT Ecosystem
 
 [mermaid]
 ----
@@ -290,7 +291,7 @@ Chronicle Wire is the serialization backbone for many other OpenHFT libraries:
 
 This tight integration ensures that the performance benefits of Wire are propagated throughout the OpenHFT stack.
 
-== 10. Conclusion
+== Conclusion
 
 Chronicle Wire's architecture is a sophisticated blend of flexibility and high-performance engineering. By abstracting data formats behind a unified `Wire` API, leveraging `Chronicle Bytes` for efficient memory management, and providing robust marshalling capabilities for POJOs, it serves as a critical enabling technology for low-latency Java applications. Its design prioritizes minimizing garbage collection and CPU overhead, making it suitable for the most demanding use cases in financial systems and other real-time data processing environments. Understanding its layered architecture and core abstractions is key to effectively utilizing its power.
 

--- a/src/main/adoc/wire-cookbook.adoc
+++ b/src/main/adoc/wire-cookbook.adoc
@@ -3,8 +3,9 @@
 :source-highlighter: rouge
 
 Purpose :: To provide a collection of practical recipes for common tasks and advanced techniques when using the Chronicle Wire library.
+:sectnums:
 
-== 1. Introduction
+== Introduction
 
 This cookbook offers a series of focused, problem-solution style recipes to help you effectively use Chronicle Wire. Each recipe addresses a specific task or challenge, providing code examples and explanations. Whether you're new to Chronicle Wire or looking for advanced techniques, these recipes aim to provide quick and actionable guidance.
 
@@ -30,9 +31,9 @@ The diagram above illustrates the basic serialization and deserialization proces
 
 TIP: For a foundational understanding of Chronicle Wire's architecture and core concepts, please refer to the main Chronicle Wire documentation and architectural overview.
 
-== 2. Basic Serialization and Deserialization
+== Basic Serialization and Deserialization
 
-=== 2.1. Recipe: Serializing a Simple POJO to Various Formats
+=== Recipe: Serializing a Simple POJO to Various Formats
 
 *Problem:*
 You have a simple Plain Old Java Object (POJO) and you want to serialize it into different formats like YAML, JSON, and Binary using Chronicle Wire.
@@ -113,7 +114,7 @@ public class BasicSerializationDemo {
 Discussion ::
 `SelfDescribingMarshallable` automatically handles the serialization of fields. By simply changing the `WireType` (e.g., `YAML_ONLY`, `JSON_ONLY`, `BINARY_LIGHT`), you can control the output format without altering the `MyData` class or the core serialization call (`getValueOut().object(data)`). `*_ONLY` variants like `YAML_ONLY` or `JSON_ONLY` are often preferred for cleaner output when not needing to retain full type information for dynamic deserialization into differing types (though `YAML` and `JSON` wire types can be configured to include type information if needed).
 
-=== 2.2. Recipe: Deserializing Data into a POJO
+=== Recipe: Deserializing Data into a POJO
 
 *Problem:*
 You have serialized data (e.g., in YAML or Binary format) and want to deserialize it back into an instance of your POJO.
@@ -176,9 +177,9 @@ public class BasicDeserializationDemo {
 `getValueIn().object(MyData.class)` is the key call for deserialization. Chronicle Wire reads the data and populates a new instance of `MyData`. For text formats like YAML, the `!MyData` type hint helps in identifying the target class, though providing the class explicitly in `object()` is robust. For binary formats, if type information isn't inherently part of the stream for the specific `WireType` chosen, providing the target class is essential. `SelfDescribingMarshallable` with `BINARY_LIGHT` typically includes type information or field names/numbers allowing for successful deserialization.
 
 [[working_with_annotations]]
-== 3. Working with Annotations
+== Working with Annotations
 
-=== 3.1. Recipe: Using `@LongConversion` for Compact String Storage
+=== Recipe: Using `@LongConversion` for Compact String Storage
 
 *Problem:*
 You have a short string identifier (e.g., a symbol or ID up to 10-11 characters using a Base85-like alphabet) that you want to represent as a `long` in your Java object for efficiency, but display as a String in human-readable formats (like YAML).
@@ -266,7 +267,7 @@ public class LongConversionDemo {
 Discussion ::
 In the YAML output, `symbol` appears as a string "AAPL". However, in the `CompactIdData` object and in the binary wire format, it's stored as an 8-byte `long`. This technique is excellent for performance-sensitive applications that deal with many short textual identifiers, saving space and potentially speeding up comparisons/hashing if the `long` form is used internally. Chronicle Wire provides several built-in converters (`Base32`, `Base64`, `Base85`, etc.).
 
-=== 3.2. Recipe: Formatting Timestamps with `@NanoTime`
+=== Recipe: Formatting Timestamps with `@NanoTime`
 
 *Problem:*
 You want to store a timestamp as a `long` (nanoseconds since epoch) for precision and performance, but have it automatically formatted as a human-readable ISO date-time string in text-based wire formats.
@@ -331,9 +332,9 @@ public class NanoTimeDemo {
 The `@NanoTime` annotation (and similarly `@MillisTime` for millisecond precision) ensures that the `long` timestamp is converted to/from a standard ISO 8601 string representation in text formats like YAML or JSON, while remaining a `long` in binary formats and in the Java object. This provides both human readability for logs/configs and numerical efficiency for processing.
 
 [[schema_evolution]]
-== 4. Schema Evolution
+== Schema Evolution
 
-=== 4.1. Recipe: Adding a New Field (Backward Compatibility)
+=== Recipe: Adding a New Field (Backward Compatibility)
 
 *Problem:*
 You have an existing `Marshallable` class and need to add a new field. You want older versions of your application (that don't know about the new field) to still be able to read data written by the new version, and new versions to read old data.
@@ -445,9 +446,9 @@ public class SchemaEvolutionDemo {
 *Discussion:*
 When new code reads old data (V1 data into `VersionedDataV2`), the `newField` in `VersionedDataV2` will be initialized to its Java default value (0 for `int`, `null` for objects, `false` for `boolean`). When old code (expecting `VersionedDataV1`) reads data written by new code (V2 data), it will simply ignore the `newField` it doesn't recognize. This works seamlessly for most self-describing `WireType`s. Using consistent class aliasing (e.g., `Wires.CLASS_ALIASES.addAlias(VersionedDataV2.class, "VersionedData")`) can be important if you rely on type information in the stream (like `!VersionedData`) rather than always specifying the concrete class on deserialization.
 
-== 5. Working with `DocumentContext`
+== Working with `DocumentContext`
 
-=== 5.1. Recipe: Writing and Reading Multiple Documents
+=== Recipe: Writing and Reading Multiple Documents
 
 *Problem:*
 You need to write a sequence of distinct messages or objects to a single `Bytes` buffer or stream, and then read them back one by one.
@@ -528,9 +529,9 @@ public class MultiDocumentDemo {
 *Discussion:*
 The `try-with-resources` block ensures that each `DocumentContext` is properly closed. When `writingDocument()`'s context is closed, metadata (like message length) is written, allowing the reader to correctly identify document boundaries. `readingDocument()` returns a context; `dc.isPresent()` tells you if a document was found. `dc.isData()` or `dc.isMetaData()` can be used to distinguish message types, a pattern heavily used by Chronicle Queue.
 
-== 6. Advanced & Performance
+== Advanced & Performance
 
-=== 6.1. Recipe: Implementing `BytesMarshallable` for Maximum Control
+=== Recipe: Implementing `BytesMarshallable` for Maximum Control
 
 *Problem:*
 You need the absolute best performance or have a very specific binary layout in mind, and the overhead of `Marshallable` (even with code generation) is too much, or you need to interact with raw `Bytes` directly.

--- a/src/main/adoc/wire-error-handling.adoc
+++ b/src/main/adoc/wire-error-handling.adoc
@@ -3,8 +3,9 @@
 :source-highlighter: rouge
 
 Purpose: To provide a comprehensive guide on handling errors, diagnosing issues, and debugging when using the Chronicle Wire library.
+:sectnums:
 
-== 1. Introduction
+== Introduction
 
 Effective error handling and diagnostics are crucial when working with any serialisation library, especially in high-performance systems where Chronicle Wire is often employed.
 Unexpected data, schema mismatches, or resource issues can lead to runtime problems.
@@ -19,11 +20,11 @@ We will cover:
 
 Understanding these aspects will help you build more resilient and maintainable applications with Chronicle Wire.
 
-== 2. Common Exceptions in Chronicle Wire and `chronicle-bytes`
+== Common Exceptions in Chronicle Wire and `chronicle-bytes`
 
 While Chronicle Wire itself might throw specific exceptions, many issues manifest as exceptions from the `chronicle-bytes` library it uses for low-level I/O, or as standard Java exceptions.
 
-=== 2.1. `java.nio.BufferUnderflowException` (from `chronicle-bytes`)
+=== `java.nio.BufferUnderflowException` (from `chronicle-bytes`)
 
 Cause :: This exception typically occurs during a read operation when an attempt is made to read more data from a `Bytes` buffer than is currently available (i.e., trying to read beyond the current `readLimit()` or `writePosition()`).
 
@@ -39,7 +40,7 @@ Debugging/Handling ::
 * Ensure `DocumentContext.isPresent()` is true before attempting to read from its `wire()`.
 * When reading from a shared `Bytes` (e.g., in Chronicle Queue), ensure the write operation was completed and committed.
 
-=== 2.2. `java.nio.BufferOverflowException` (from `chronicle-bytes`)
+=== `java.nio.BufferOverflowException` (from `chronicle-bytes`)
 
 Cause :: Occurs during a write operation when an attempt is made to write more data into a `Bytes` buffer than its current capacity or limit allows, and the buffer is not elastic or cannot expand further.
 
@@ -53,7 +54,7 @@ Debugging/Handling ::
 * Check the `bytes.isElastic()` and `bytes.realCapacity()` methods.
 * Catch the exception and potentially try to resize the buffer or handle the oversized data (e.g., by logging an error or truncating if appropriate).
 
-=== 2.3. `java.io.EOFException` (often wrapped or from `chronicle-bytes` stream utilities)
+=== `java.io.EOFException` (often wrapped or from `chronicle-bytes` stream utilities)
 
 Cause :: Signals that an end of file or end of stream has been reached unexpectedly during an input operation.
 
@@ -66,7 +67,7 @@ Debugging/Handling ::
 * Similar to `BufferUnderflowException`, ensure data integrity and availability.
 * Implement proper end-of-stream detection logic in your application.
 
-=== 2.4. `java.lang.IllegalStateException`
+=== `java.lang.IllegalStateException`
 
 Cause :: This is a general-purpose exception indicating that a method has been invoked at an illegal or inappropriate time, or that the object is not in an appropriate state for the requested operation.
 
@@ -82,7 +83,7 @@ Debugging/Handling ::
 * Check for thread-safety issues if in a concurrent environment.
 The exception message often provides more specific details.
 
-=== 2.5. `net.openhft.chronicle.wire.InvalidMarshallableException`
+=== `net.openhft.chronicle.wire.InvalidMarshallableException`
 
 Cause :: Thrown when there's a problem serialising or deserialising a `Validatable` object, often related to schema inconsistencies or unexpected data.
 
@@ -97,7 +98,7 @@ Debugging/Handling ::
 * Verify class definitions on both writing and reading sides, especially field names and types.
 * Check if schema evolution rules are being followed.
 
-=== 2.6. `java.lang.ClassNotFoundException` or `java.lang.NoClassDefFoundError`
+=== `java.lang.ClassNotFoundException` or `java.lang.NoClassDefFoundError`
 
 Cause :: Occurs during deserialisation when type information is present in the wire format (e.g., `!com.example.MyClass {}` in YAML from `YAML_RETAIN_TYPE`) but the specified class cannot be found on the classpath of the reading application.
 
@@ -110,7 +111,7 @@ Debugging/Handling ::
 * Ensure all necessary classes are available on the classpath of the deserialising application.
 * Use Chronicle Wire's class aliasing (`Wires.CLASS_ALIASES.addAlias(...)`) to map serialized type names to actual classes, which can help decouple serialized names from actual class names.
 
-=== 2.7. `java.lang.IllegalArgumentException`
+=== `java.lang.IllegalArgumentException`
 
 Cause :: Often thrown when a method receives an argument that is invalid or inappropriate for its intended use.
 
@@ -123,11 +124,11 @@ Debugging/Handling ::
 * Check the arguments being passed to Chronicle Wire/Bytes methods.
 * Read the exception message carefully as it usually indicates which argument was problematic.
 
-== 3. Troubleshooting Deserialisation Issues
+== Troubleshooting Deserialisation Issues
 
 Deserialisation is often where subtle data or schema issues become apparent.
 
-=== 3.1. Schema Mismatches
+=== Schema Mismatches
 
 * **Symptoms:** `InvalidMarshallableException`, unexpected `null` values, incorrect field values, or even `BufferUnderflowException` if field count/size changes drastically with formats like `FIELDLESS_BINARY`.
 * **Diagnosis:**
@@ -140,7 +141,7 @@ Look for differences in field names, types, order (if using `FIELDLESS_BINARY`),
 * Implement proper schema evolution strategies (see Chronicle Wire documentation on schema evolution).
 * For `FIELDLESS_BINARY`, ensure strict schema identity or implement a versioning/migration path.
 
-=== 3.2. Corrupted Data or Framing Errors
+=== Corrupted Data or Framing Errors
 
 * **Symptoms:** `EOFException`, `BufferUnderflowException`, `InvalidMarshallableException` with cryptic messages, or reading garbage data.
 * **Diagnosis:**
@@ -154,7 +155,7 @@ If you have custom framing, ensure it's correct.
 * Use `DocumentContext` correctly with `try-with-resources` to ensure proper document finalisation and reading.
 * Investigate the source of potential data corruption (network issues, disk errors, bugs in writing logic).
 
-=== 3.3. Class Aliasing and Polymorphism Issues
+=== Class Aliasing and Polymorphism Issues
 
 * **Symptoms:** `ClassNotFoundException`, or deserialisation into a base type instead of the expected subtype.
 * **Diagnosis:**
@@ -166,17 +167,17 @@ If you have custom framing, ensure it's correct.
 * Use `WireType`s that retain type information when deserialising polymorphic types.
 * Explicitly pass the concrete class to `valueIn.object(SpecificType.class)` if type information is not in the stream.
 
-=== 3.4. Missing No-Argument Constructor
+=== Missing No-Argument Constructor
 
 * **Symptoms:** Exception during object instantiation, often a `NoSuchMethodException` wrapped in a Wire exception.
 * **Diagnosis:** Chronicle Wire (like many serialisation libraries) may require a no-argument constructor to instantiate objects before populating them, especially when using reflection-based or generated marshallers. Generally, it doesn't need a no-argument constructor for `BytesMarshallable` classes. However, this will result in `transient` fields not being set, which can lead to unexpected `null` values or default values in the deserialised object.
 * **Solutions:** Add a public or protected no-argument constructor to your `Marshallable` classes. The access level is ignored, so `private` or package-local can be used.
 
-== 4. Troubleshooting Serialisation Issues
+== Troubleshooting Serialisation Issues
 
 Issues during serialisation are often more straightforward but can still occur.
 
-=== 4.1. Buffer Overflow
+=== Buffer Overflow
 
 * **Symptoms:** `BufferOverflowException`.
 * **Diagnosis:** The data being written is larger than the `Bytes` buffer's current capacity.
@@ -185,7 +186,7 @@ Issues during serialisation are often more straightforward but can still occur.
 * If using fixed-size buffers, ensure they are pre-allocated with sufficient capacity.
 Estimate maximum message size.
 
-=== 4.2. Invalid Data for Fields/Annotations
+=== Invalid Data for Fields/Annotations
 
 * **Symptoms:** `IllegalArgumentException`, `IllegalStateException`, or exceptions from annotation converters (e.g., `Base85LongConverter` failing to parse an invalid character).
 * **Diagnosis:** An attempt was made to write data that violates constraints.
@@ -196,16 +197,16 @@ Estimate maximum message size.
 * Ensure data conforms to the constraints imposed by annotations.
 * Handle exceptions from converters gracefully.
 
-=== 4.3. Custom `Marshallable` Implementation Bugs
+=== Custom `Marshallable` Implementation Bugs
 
 * **Symptoms:** Incorrect data written, `NullPointerException`, or other unexpected exceptions originating from your `writeMarshallable()` method.
 * **Diagnosis:** Step through your custom `writeMarshallable()` logic in a debugger.
 Log the values being written.
 * **Solutions:** Carefully review and test your custom marshalling logic, ensuring all fields are written correctly and in the intended order (especially for `BytesMarshallable`).
 
-== 5. Debugging Techniques
+== Debugging Techniques
 
-=== 5.1. Dump to YAML/Text
+=== Dump to YAML/Text
 
 One of the most powerful features of Chronicle Wire for debugging is its ability to switch formats.
 * **Writing:** If you suspect issues with binary serialisation, temporarily change the `WireType` to `YAML_ONLY` or `JSON_ONLY` and print the `Bytes.toString()`.
@@ -229,29 +230,29 @@ try {
 // Remember to release binaryBytes if it's reference counted
 ----
 
-=== 5.2. Logging `Bytes` Content
+=== Logging `Bytes` Content
 
 * `bytes.toHexString()`: Provides a hexadecimal dump of the buffer's content.
 Useful for inspecting binary data at a low level.
 * `bytes.toDebugString()`: Can provide more detailed internal state of the `Bytes` object.
 * `bytes.readRemaining()` / `bytes.writeRemaining()`: Check remaining capacity.
 
-=== 5.3. Using a Debugger
+=== Using a Debugger
 
 Step through the Chronicle Wire API calls, and especially into your custom `readMarshallable()` / `writeMarshallable()` methods if you have them.
 Inspect the state of `Wire`, `Bytes`, and your objects.
 
-=== 5.4. `Wires.GENERATE_TUPLES` (Legacy/Specific Use)
+=== `Wires.GENERATE_TUPLES` (Legacy/Specific Use)
 
 In some older versions or specific contexts, setting `Wires.GENERATE_TUPLES = true;` would cause complex objects to be written as a "tuple" of their fields, which could be easier to debug in text.
 Check current documentation if this flag is still relevant or has alternatives.
 
-=== 5.5. Isolate the Problem
+=== Isolate the Problem
 
 Try to create a minimal, reproducible example of the error.
 Serialize and deserialize a problematic object in a simple test case to rule out environmental factors.
 
-== 6. Error Handling Best Practices
+== Error Handling Best Practices
 
 * **Use `try-with-resources` for `DocumentContext`:** Ensures proper resource management and finalisation of documents.
 [source,java]
@@ -268,13 +269,13 @@ try (DocumentContext dc = wire.writingDocument()) {
 * **Logging:** Log errors with sufficient context (e.g., the data being processed if it's not too large or sensitive, relevant identifiers, stack traces).
 * **Resource Management:** Always release `Bytes` buffers obtained from `Bytes.elasticByteBuffer()` or `Bytes.allocateDirect()` using `bytes.releaseLast()` when they are no longer needed, especially for direct/off-heap memory, to prevent memory leaks.
 
-== 7. Related Errors in Integrated Systems
+== Related Errors in Integrated Systems
 
 When Chronicle Wire is used within larger systems like Chronicle Queue or Chronicle Network, errors might originate from those systems but relate to the data being processed by Wire.
 
 * **Network Errors (`java.net.SocketException`, etc.):** If using Wire over a network, underlying network issues can interrupt data streams, leading to partial messages and subsequent Wire deserialisation errors.
 
-== 8. Conclusion
+== Conclusion
 
 Robust error handling is key to building reliable systems with Chronicle Wire.
 By understanding common exceptions, employing effective debugging techniques, and following best practices, developers can quickly diagnose and resolve issues, ensuring their applications are resilient and maintainable.

--- a/src/main/adoc/wire-faq.adoc
+++ b/src/main/adoc/wire-faq.adoc
@@ -3,6 +3,7 @@
 :source-highlighter: rouge
 
 Purpose: To provide answers to frequently asked questions about the Chronicle Wire library.
+:sectnums:
 
 [qanda]
 == Basics & Core Concepts

--- a/src/main/adoc/wire-glossary.adoc
+++ b/src/main/adoc/wire-glossary.adoc
@@ -2,6 +2,7 @@
 = Chronicle Wire Glossary
 :source-highlighter: rouge
 
+:sectnums:
 Purpose: To provide clear definitions for common terms and concepts used in Chronicle Wire and its related ecosystem.
 
 [glossary]

--- a/src/main/adoc/wire-schema-evolution.adoc
+++ b/src/main/adoc/wire-schema-evolution.adoc
@@ -3,8 +3,9 @@
 :source-highlighter: rouge
 
 Purpose: To provide an in-depth exploration of schema evolution capabilities and mechanisms within Chronicle Wire, including implementation details and advanced strategies.
+:sectnums:
 
-== 1. Introduction to Schema Evolution in Chronicle Wire
+== Introduction to Schema Evolution in Chronicle Wire
 
 Schema evolution is the ability of a system to handle changes in data structures over time. As applications evolve, their data models (schemas) often need to change – fields might be added, removed, renamed, or have their types altered. For systems that store data long-term or communicate across different service versions, managing these changes without breaking compatibility or losing data is crucial.
 
@@ -15,7 +16,7 @@ Chronicle Wire's approach to schema evolution is rooted in its flexible, format-
 
 This document delves into the mechanisms Chronicle Wire employs for schema evolution, the role of different wire formats and annotations, and strategies for managing data model changes effectively.
 
-== 2. Mechanisms in Self-Describing Formats
+== Mechanisms in Self-Describing Formats
 
 [mermaid]
 ----
@@ -40,7 +41,7 @@ graph TD
 
 Self-describing formats are key to Chronicle Wire's schema evolution capabilities. These include text formats (YAML, JSON) and binary formats that embed field identifiers (like `BINARY_LIGHT`).
 
-=== 2.1. Field Identification
+=== Field Identification
 
 The ability to identify fields within the serialised data stream independently of their physical order in the class definition is fundamental.
 
@@ -75,7 +76,7 @@ graph TD
     end
 ----
 
-=== 2.2. Handling Unknown Fields (Forward Compatibility)
+=== Handling Unknown Fields (Forward Compatibility)
 
 *Forward compatibility* means that older code (a reader with an older schema version) can process data written by newer code (a writer with a newer schema version that includes additional fields).
 
@@ -89,7 +90,7 @@ Mechanism ::
 
 Impact :: This allows older services to continue functioning even when new fields are introduced by other services, promoting interoperability in evolving distributed systems. Performance impact of skipping is generally minimal unless there are very many large unknown fields.
 
-=== 2.3. Handling Missing Fields (Backward Compatibility)
+=== Handling Missing Fields (Backward Compatibility)
 
 *Backward compatibility* means that newer code (a reader with a newer schema version that expects more fields) can process data written by older code (a writer with an older schema version that omits some of these fields).
 
@@ -115,11 +116,11 @@ if (this.myList == null) {
 }
 ----
 
-=== 2.4. Reordering Fields
+=== Reordering Fields
 
 In self-describing formats (text or binary with field names/numbers), the physical order of fields in the serialised data stream generally does *not* need to match the declaration order in the Java class. Deserialisation maps fields based on their identified names or numbers. This provides flexibility in how data is written or how classes are refactored.
 
-=== 2.5. Changing Field Types (The Most Challenging Aspect)
+=== Changing Field Types (The Most Challenging Aspect)
 
 Changing the data type of an existing field is the most complex part of schema evolution and often requires careful planning and potentially custom code. Chronicle Wire provides limited automatic coercion.
 
@@ -147,7 +148,7 @@ Strategy :: When a field type must change, the safest approach is often to:
 . Eventually, phase out the old field after all data has been migrated and all readers understand the new field.
 . Alternatively, implement custom logic in `readMarshallable` to handle the conversion.
 
-== 3. `FIELDLESS_BINARY` and Schema (In)flexibility
+== `FIELDLESS_BINARY` and Schema (In)flexibility
 
 The `FIELDLESS_BINARY` `WireType` is designed for extreme performance and compactness by omitting all field names and numbers.
 
@@ -184,11 +185,11 @@ Separate Data Stores :: Use different Chronicle Queues, Chronicle Maps, or files
 Deployment Strategies :: Use blue/green deployments or similar techniques to switch over to new versions of services and their data formats simultaneously.
 
 [[role_of_annotations_in_schema_evolution]]
-== 4. Role of Annotations in Schema Evolution
+== Role of Annotations in Schema Evolution
 
 Annotations provide metadata that Chronicle Wire uses to manage schema evolution.
 
-=== 4.1. `@FieldNumber(int value)`
+=== `@FieldNumber(int value)`
 
 Status:: Road Map
 
@@ -197,7 +198,7 @@ Status:: Road Map
 * **Benefit:** This decouples the on-wire field identifier from the Java field's textual name, allowing the Java field to be renamed without breaking binary compatibility. The numeric ID remains the contract.
 * **Requirement:** Field numbers must be unique within the scope of the class being serialised.
 
-=== 4.2. `@DeprecatedWireKey(String[] oldKeys)` (and alternatives like `Wires.FIELD_RENAME_MAP`)
+=== `@DeprecatedWireKey(String[] oldKeys)` (and alternatives like `Wires.FIELD_RENAME_MAP`)
 
 Status:: Road Map
 
@@ -207,13 +208,13 @@ Status:: Road Map
 * **Benefit:** Allows graceful renaming of fields in Java code while still being able to read older data that uses the previous field names.
 * **Note:** When writing, the *current* Java field name is typically used.
 
-=== 4.3. `@DefaultValue(String value)`
+=== `@DefaultValue(String value)`
 
 Status:: Road Map
 
 * **Reiteration:** As stated before, this is largely documentary. It does *not* cause Chronicle Wire's core deserialisation logic to parse this string and inject it if a field is missing. Java's default initialisation (`0`, `null`, `false`) applies to missing fields. Custom logic in `readMarshallable` or a post-deserialisation step is needed to use this annotation's value.
 
-== 5. Advanced Strategies and Implementation Considerations
+== Advanced Strategies and Implementation Considerations
 
 For complex schema migrations beyond simple field additions/removals or renames supported by annotations, more advanced strategies are required.
 
@@ -264,7 +265,7 @@ Diagnostic Flags (e.g., `Wires.WARN_ON_UNUSED_NOTES`) ::
 ClassAlias` and Evolution ::
 ** When class names or packages are refactored, `Wires.CLASS_ALIASES.addAlias(NewClass.class, "OldSerializedName")` or `Wires.CLASS_ALIASES.addAlias(NewClass.class, OldClass.class.getName())` allows data serialised with the old class name (if the name was embedded, e.g., in YAML with type retention) to be deserialised into the new class. This decouples the on-wire type identifier from the physical Java class name.
 
-== 6. Best Practices for Evolvable Schemas
+== Best Practices for Evolvable Schemas
 
 Prefer Self-Describing Formats :: For data that is expected to evolve or be long-lived, use self-describing `WireType`s (YAML, JSON, `BINARY_LIGHT`). Avoid `FIELDLESS_BINARY` unless the schema is extremely stable and performance is paramount.
 
@@ -284,7 +285,7 @@ Idempotent `readMarshallable` :: If implementing custom logic, strive to make `r
 
 Document Your Schemas and Changes :: Maintain clear documentation (even if informal) about your `Marshallable` object structures and how they are intended to evolve.
 
-== 7. Limitations
+== Limitations
 
 While Chronicle Wire offers considerable flexibility, it's important to understand its limitations regarding automatic schema evolution:
 

--- a/src/main/adoc/wire-visual-guide.adoc
+++ b/src/main/adoc/wire-visual-guide.adoc
@@ -3,14 +3,15 @@
 :source-highlighter: rouge
 
 Purpose: To provide visual representations of key concepts, processes, and components in the Chronicle Wire library.
+:sectnums:
 
-== 1. Introduction
+== Introduction
 
 This document contains diagrams and visual aids to help understand the Chronicle Wire library. It complements the text-based documentation by providing visual representations of key concepts, processes, and components.
 
-== 2. Architectural Overview
+== Architectural Overview
 
-=== 2.1. Layered Architecture
+=== Layered Architecture
 
 [mermaid]
 ----
@@ -34,7 +35,7 @@ graph TD
     class E ioLayer;
 ----
 
-=== 2.2. Core Components
+=== Core Components
 
 [mermaid]
 ----
@@ -89,7 +90,7 @@ classDiagram
     WireType --> Wire : creates
 ----
 
-== 3. Serialization and Deserialization Process
+== Serialization and Deserialization Process
 
 [mermaid]
 ----
@@ -109,7 +110,7 @@ graph TD
     end
 ----
 
-== 4. Wire Format Comparison
+== Wire Format Comparison
 
 [mermaid]
 ----
@@ -137,7 +138,7 @@ graph LR
 ----
 
 [[schema_evolution]]
-== 5. Schema Evolution
+== Schema Evolution
 
 [mermaid]
 ----
@@ -160,7 +161,7 @@ graph TD
     end
 ----
 
-== 6. Integration with OpenHFT Ecosystem
+== Integration with OpenHFT Ecosystem
 
 [mermaid]
 ----

--- a/src/main/java/net/openhft/chronicle/wire/domestic/reduction/README.adoc
+++ b/src/main/java/net/openhft/chronicle/wire/domestic/reduction/README.adoc
@@ -4,6 +4,7 @@ Per Minborg
 :toc: macro
 :toclevels: 3
 :icons: font
+:sectnums:
 
 toc::[]
 

--- a/src/main/java/net/openhft/chronicle/wire/domestic/stream/README.adoc
+++ b/src/main/java/net/openhft/chronicle/wire/domestic/stream/README.adoc
@@ -4,6 +4,7 @@ Per Minborg
 :toc: macro
 :toclevels: 3
 :icons: font
+:sectnums:
 
 toc::[]
 


### PR DESCRIPTION
## Summary
- enable `:sectnums:` in main documentation files
- strip manual numbers from section titles
- note section-numbering rule in `AGENTS.md`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b22e1671c8329913308e9d8637dd8