### PR TITLE
Improve InputStreamToWire Javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/InputStreamToWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/InputStreamToWire.java
@@ -24,26 +24,50 @@ import java.io.StreamCorruptedException;
 import java.nio.ByteBuffer;
 
 /**
- * The InputStreamToWire class provides functionality to read data from an InputStream and convert it to a Wire representation.
- * This class encapsulates Bytes, Wire, and DataInputStream instances to achieve this conversion, ensuring the data
- * integrity and readability in the wire format.
+ * Provides a bridge to read structured data in Chronicle Wire format from a
+ * standard Java {@link InputStream}. The stream is expected to contain a
+ * sequence of messages, each prefixed with its length as a 4-byte integer. The
+ * payload of each message is read into an internal {@link Bytes} buffer and
+ * presented through a {@link Wire} implementation for deserialisation.
+ * <p>
+ * The provided {@code InputStream} is not closed by this class; callers remain
+ * responsible for its lifecycle. This class is useful when Chronicle Wire needs
+ * to consume data from sources such as network sockets or files where frames are
+ * delimited with explicit length prefixes.
+ *
+ * @see Wire
+ * @see InputStream
+ * @see DataInputStream
  */
 public class InputStreamToWire {
 
-    // Bytes object used to hold data with elastic memory management
+    /**
+     * Internal {@link Bytes} buffer, elastically sized on the heap, used to
+     * store the binary data of a single message read from {@link #dis} before it
+     * is processed by {@link #wire}.
+     */
     private final Bytes<ByteBuffer> bytes = Bytes.elasticHeapByteBuffer(128);
 
-    // Wire object responsible for representing the data in wire format
+    /**
+     * The {@link Wire} instance that represents the data of the current message
+     * according to the {@code wireType} supplied at construction time.
+     */
     private final Wire wire;
 
-    // DataInputStream object to read binary data from an input stream
+    /**
+     * {@link DataInputStream} wrapping the caller's {@link InputStream} to
+     * simplify reading the length and payload bytes.
+     */
     private final DataInputStream dis;
 
     /**
-     * Constructor for the InputStreamToWire class, initializing it with the specified WireType and InputStream.
+     * Creates a new instance configured with the given wire type and input
+     * stream.
      *
-     * @param wireType The type of wire to use for data representation.
-     * @param is The input stream from which data will be read.
+     * @param wireType the {@link WireType} used to interpret the message
+     *                 payloads
+     * @param is       the {@link InputStream} supplying length-prefixed binary
+     *                 data; it is not closed by this class
      */
     public InputStreamToWire(WireType wireType, InputStream is) {
         wire = wireType.apply(bytes);
@@ -51,14 +75,18 @@ public class InputStreamToWire {
     }
 
     /**
-     * Reads data from the encapsulated DataInputStream and populates the Wire object with it.
-     * The method first clears any existing data in the wire, then reads the data's length from the stream.
-     * It then ensures sufficient capacity in the bytes object, reads the binary data into the bytes, and sets the
-     * appropriate read position. Finally, it returns the populated wire.
+     * Reads the next length-prefixed message from the input stream and makes
+     * it available through the internal {@link Wire} instance. The wire and its
+     * backing buffer are cleared before reading the 4-byte length header. A
+     * negative length results in a {@link StreamCorruptedException}. After the
+     * bytes are read, the wire is positioned at the start of the message
+     * payload.
      *
-     * @return The populated Wire object.
-     * @throws IOException If any I/O errors occur.
-     * @throws StreamCorruptedException If the read data length is negative, indicating a corrupted stream.
+     * @return the internal {@link Wire} ready for deserialisation; the same
+     *         instance is reused for each call
+     * @throws IOException              if an I/O error occurs
+     * @throws java.io.EOFException     if the stream ends unexpectedly
+     * @throws StreamCorruptedException if a negative length is encountered
      */
     public Wire readOne() throws IOException {
         wire.clear();


### PR DESCRIPTION
## Summary
- clarify class purpose and use of InputStream
- document internal fields and constructor parameters
- describe readOne semantics and error handling

## Testing
- `mvn -q verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cb44f1b348329bab3c27b6a09bc27