### PR TITLE
Improve WireToOutputStream Javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/WireToOutputStream.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireToOutputStream.java
@@ -23,28 +23,52 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
 /**
- * This class bridges between a Wire object and a traditional OutputStream.
+ * Provides a bridge to write structured data in Chronicle Wire format to a
+ * standard Java {@link OutputStream}.
  * <p>
- * The class facilitates writing data to an OutputStream using the Wire format. It uses
- * an intermediate {@link Bytes} buffer to temporarily hold data in the Wire format
- * before flushing it to the actual OutputStream.
+ * Data is first serialised into an internal {@link Wire} backed by an
+ * in-memory {@link Bytes} buffer. When {@link #flush()} is invoked the content
+ * of this buffer is written as one binary message to the wrapped output
+ * stream. The message is prefixed with its length as a four byte integer.
+ * <p>
+ * This is useful when integrating Chronicle Wire with sinks such as network
+ * sockets or files that require messages framed with explicit length
+ * prefixes. The provided {@link OutputStream} is not closed by this class;
+ * managing its lifecycle is the caller's responsibility.
+ *
+ * @see Wire
+ * @see OutputStream
+ * @see DataOutputStream
  */
 public class WireToOutputStream {
 
-    // Internal byte buffer to temporarily hold data in Wire format.
+    /**
+     * Internal, elastically-sized heap {@link Bytes} buffer that backs the
+     * {@link #wire}. Data is serialised into this buffer before being flushed.
+     */
     private final Bytes<ByteBuffer> bytes = Bytes.elasticHeapByteBuffer(128);
 
-    // The Wire object responsible for handling the data.
+    /**
+     * The internal {@link Wire} instance into which data is serialised. Its
+     * type is determined by the {@code wireType} passed to the constructor.
+     */
     private final Wire wire;
 
-    // The DataOutputStream to which the data in Wire format is written.
+    /**
+     * The {@link DataOutputStream} wrapping the user-provided
+     * {@link OutputStream}, used for conveniently writing primitive data such as
+     * the message length.
+     */
     private final DataOutputStream dos;
 
     /**
-     * Constructs a new instance with the specified WireType and OutputStream.
+     * Creates a new bridge for the given wire type and output stream.
      *
-     * @param wireType The type of Wire to be used.
-     * @param os The OutputStream to which the data in Wire format will be written.
+     * @param wireType the {@link WireType} used to serialise data into the
+     *                 internal buffer (for example Binary, Text or JSON).
+     * @param os       the {@link OutputStream} to which length-prefixed messages
+     *                 will be written when {@link #flush()} is called. This
+     *                 stream is not closed by this class.
      */
     public WireToOutputStream(WireType wireType, OutputStream os) {
         wire = wireType.apply(bytes);
@@ -52,11 +76,12 @@ public class WireToOutputStream {
     }
 
     /**
-     * Retrieves the Wire object for writing data.
+     * Returns the internal {@link Wire} prepared for a new message.
      * <p>
-     * This method also clears any previous data in the Wire.
+     * The backing buffer is cleared before the wire is returned. Any data not
+     * yet flushed will be lost.
      *
-     * @return The Wire object to be used for writing data.
+     * @return the cleared {@link Wire} ready for serialisation.
      */
     public Wire getWire() {
         wire.clear();
@@ -64,12 +89,13 @@ public class WireToOutputStream {
     }
 
     /**
-     * Flushes the data in Wire format to the underlying OutputStream.
+     * Writes the data currently in the wire buffer to the underlying output
+     * stream.
      * <p>
-     * The method writes the length of the data followed by the actual data to
-     * the OutputStream. After the flush, the internal buffer is ready to hold new data.
+     * A four byte length is written first, followed by the serialised bytes.
+     * The content remains in the buffer until {@link #getWire()} is called.
      *
-     * @throws IOException If an I/O error occurs.
+     * @throws IOException if an I/O error occurs while writing.
      */
     public void flush() throws IOException {
         int length = Math.toIntExact(bytes.readRemaining());


### PR DESCRIPTION
## Summary
- expand class-level docs for WireToOutputStream
- describe fields, constructor and methods in more detail

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cb46933cc83298bd75cc3d87422f3