### PR TITLE
Improve Javadoc for WireObjectOutput

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/WireObjectOutput.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireObjectOutput.java
@@ -23,14 +23,20 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * This is the WireObjectOutput class that implements the ObjectOutput interface.
- * It is designed to write objects and data to a WireOut instance. The class provides
- * methods to write an object, bytes, and other basic data types, ensuring that the data is
- * written correctly to the underlying wire instance.
+ * Adapter that writes data to a {@link WireOut} using the
+ * {@link java.io.ObjectOutput} API.
+ * <p>
+ * Calls are forwarded to {@link WireOut#getValueOut()} and encoded according to
+ * the underlying wire type. This class is package-private and intended for
+ * internal use when third‑party code expects an {@code ObjectOutput}.
  */
 class WireObjectOutput implements ObjectOutput {
+    /** The target wire for all writes. */
     private final WireOut wire;
 
+    /**
+     * @param wire the wire instance to adapt
+     */
     WireObjectOutput(WireOut wire) {
         this.wire = wire;
     }
@@ -45,16 +51,25 @@ class WireObjectOutput implements ObjectOutput {
         valueOut.object(obj);
     }
 
+    /**
+     * Writes one unsigned byte via {@link ValueOut#uint8(long)}.
+     */
     @Override
     public void write(int b) {
         wire.getValueOut().uint8(b);
     }
 
+    /**
+     * Writes the whole array via {@link ValueOut#bytes(byte[])}.
+     */
     @Override
     public void write(byte[] b) {
         wire.getValueOut().bytes(b);
     }
 
+    /**
+     * Writes a sub‑array of bytes.
+     */
     @Override
     public void write(byte[] b, int off, int len) {
         if (off == 0 && len == b.length)
@@ -63,66 +78,101 @@ class WireObjectOutput implements ObjectOutput {
             wire.getValueOut().bytes(Bytes.wrapForRead(b).readPositionRemaining(off, len));
     }
 
+    /** No-op. */
     @Override
     public void flush() {
         // Do nothing
     }
 
+    /** No-op. */
     @Override
     public void close() {
         // Do nothing
     }
 
+    /**
+     * Writes a boolean via {@link ValueOut#bool(boolean)}.
+     */
     @Override
     public void writeBoolean(boolean v) {
         wire.getValueOut().bool(v);
     }
 
+    /**
+     * Writes a signed byte via {@link ValueOut#int8(long)}.
+     */
     @Override
     public void writeByte(int v) {
         wire.getValueOut().int8(v);
     }
 
+    /**
+     * Writes a 16‑bit signed value via {@link ValueOut#int16(long)}.
+     */
     @Override
     public void writeShort(int v) {
         wire.getValueOut().int16(v);
     }
 
+    /**
+     * Writes a 16‑bit Unicode character via {@link ValueOut#uint16(long)}.
+     */
     @Override
     public void writeChar(int v) {
         wire.getValueOut().uint16(v);
     }
 
+    /**
+     * Writes a 32‑bit integer via {@link ValueOut#uint16(long)}.
+     */
     @Override
     public void writeInt(int v) {
         wire.getValueOut().uint16(v);
     }
 
+    /**
+     * Writes a 64‑bit integer via {@link ValueOut#int64(long)}.
+     */
     @Override
     public void writeLong(long v) {
         wire.getValueOut().int64(v);
     }
 
+    /**
+     * Writes a 32‑bit floating‑point value via {@link ValueOut#float32(float)}.
+     */
     @Override
     public void writeFloat(float v) {
         wire.getValueOut().float32(v);
     }
 
+    /**
+     * Writes a 64‑bit floating‑point value via {@link ValueOut#float64(double)}.
+     */
     @Override
     public void writeDouble(double v) {
         wire.getValueOut().float64(v);
     }
 
+    /**
+     * Writes a string in ISO‑8859‑1 via {@link ValueOut#text(CharSequence)}.
+     */
     @Override
     public void writeBytes(@NotNull String s) {
         wire.getValueOut().text(s);
     }
 
+    /**
+     * Writes a string as a sequence of UTF‑1 characters.
+     */
     @Override
     public void writeChars(@NotNull String s) {
         wire.getValueOut().text(s);
     }
 
+    /**
+     * Writes a UTF‑8 string via {@link ValueOut#text(CharSequence)}.
+     */
     @Override
     public void writeUTF(@NotNull String s) {
         wire.getValueOut().text(s);


### PR DESCRIPTION
## Summary
- document `WireObjectOutput` with details about its use as an ObjectOutput adapter
- note delegation to `WireOut` and improve method docs

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cb498fe448329838187d4202b4cdf