### PR TITLE
Improve RawWire Javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/RawWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/RawWire.java
@@ -45,9 +45,14 @@ import java.util.UUID;
 import java.util.function.*;
 
 /**
- * Represents a wire type that focuses on writing pure data, omitting any metadata.
- * The {@code RawWire} class is specifically designed for efficient binary serialization
- * where headers and other metadata might not be necessary.
+ * Wire implementation that serialises values in sequence without any field names.
+ *
+ * <p>The reader must know the exact order and types of values because
+ * {@code RawWire} omits all metadata. This yields a compact byte stream but
+ * leaves little room for schema evolution.</p>
+ *
+ * <p>Used for performance-critical exchanges where writer and reader share a
+ * fixed layout. Unlike {@link BinaryWire} no field identifiers are emitted.</p>
  */
 @SuppressWarnings({"rawtypes", "unchecked", "this-escape"})
 public class RawWire extends AbstractWire implements Wire {
@@ -66,10 +71,23 @@ public class RawWire extends AbstractWire implements Wire {
     @Nullable
     private StringBuilder lastSB;
 
+    /**
+     * Creates a {@code RawWire} backed by the given buffer. Strings are encoded
+     * using 8-bit length prefixes.
+     *
+     * @param bytes the {@link Bytes} store to read from and write to
+     */
     public RawWire(@NotNull Bytes<?> bytes) {
         this(bytes, true);
     }
 
+    /**
+     * Creates a new instance with explicit control over text encoding.
+     *
+     * @param bytes   the underlying buffer
+     * @param use8bit when {@code true}, text is written with 8-bit length
+     *                prefixes, otherwise UTF-8 with stop-bit lengths is used
+     */
     public RawWire(@NotNull Bytes<?> bytes, boolean use8bit) {
         super(bytes, use8bit);
     }
@@ -89,6 +107,10 @@ public class RawWire extends AbstractWire implements Wire {
         return true;
     }
 
+    /**
+     * Begins a document for raw value writing. The {@code metaData} flag is
+     * ignored as this format stores no metadata.
+     */
     @NotNull
     @Override
     public DocumentContext writingDocument(boolean metaData) {
@@ -110,6 +132,10 @@ public class RawWire extends AbstractWire implements Wire {
         return readContext;
     }
 
+    /**
+     * Starts reading at the specified position of the underlying bytes.
+     * This method assumes the caller knows the location of a document.
+     */
     @NotNull
     @Override
     public DocumentContext readingDocument(long readLocation) {
@@ -122,6 +148,10 @@ public class RawWire extends AbstractWire implements Wire {
         return readContext;
     }
 
+    /**
+     * No padding bytes are expected in this format, so this method does
+     * nothing.
+     */
     @Override
     public void consumePadding() {
         // Do nothing
@@ -136,6 +166,10 @@ public class RawWire extends AbstractWire implements Wire {
         return Wires.fromSizePrefixedBlobs(bytes, start);
     }
 
+    /**
+     * Copies the underlying bytes to another wire. Only safe when the target is
+     * also a {@code RawWire} as no metadata accompanies the data.
+     */
     @Override
     public void copyTo(@NotNull WireOut wire) {
         if (wire instanceof RawWire) {
@@ -153,6 +187,10 @@ public class RawWire extends AbstractWire implements Wire {
         return valueIn;
     }
 
+    /**
+     * Returns the input for the next value. The key is ignored because no field
+     * names are stored.
+     */
     @NotNull
     @Override
     public ValueIn read(@NotNull WireKey key) {
@@ -160,6 +198,10 @@ public class RawWire extends AbstractWire implements Wire {
         return valueIn;
     }
 
+    /**
+     * Reads the next event name as text. Since names are written without a
+     * prefix, the caller must know an event is expected.
+     */
     @NotNull
     @Override
     public ValueIn readEventName(@NotNull StringBuilder name) {
@@ -177,6 +219,10 @@ public class RawWire extends AbstractWire implements Wire {
         return valueIn.object(expectedClass);
     }
 
+    /**
+     * Returns the input for the next value and stores the name locally for
+     * possible nested objects. The name itself is not read from the wire.
+     */
     @NotNull
     @Override
     public ValueIn read(@NotNull StringBuilder name) {
@@ -237,6 +283,9 @@ public class RawWire extends AbstractWire implements Wire {
         return valueOut;
     }
 
+    /**
+     * Prepares to write an event name. The supplied key is ignored.
+     */
     @NotNull
     @Override
     public ValueOut writeEventName(@NotNull WireKey key) {
@@ -263,12 +312,18 @@ public class RawWire extends AbstractWire implements Wire {
         // Do nothing
     }
 
+    /**
+     * Returns the output for the next value. The key parameter is ignored.
+     */
     @NotNull
     @Override
     public ValueOut write(@NotNull WireKey key) {
         return valueOut;
     }
 
+    /**
+     * Returns the output for the next value. The name is not written.
+     */
     @NotNull
     @Override
     public ValueOut write(@NotNull CharSequence name) {
@@ -319,11 +374,16 @@ public class RawWire extends AbstractWire implements Wire {
     }
 
     /**
-     * An inner class that facilitates the writing of raw values to the wire.
+     * {@link ValueOut} implementation that writes values directly to the byte
+     * stream without preceding field names or type information.
      */
     class RawValueOut implements ValueOut {
 
         @NotNull
+        /**
+         * Writes a boolean value directly to the stream. A {@code null} value
+         * is encoded using {@link BinaryWireCode#NULL}.
+         */
         @Override
         public WireOut bool(@Nullable Boolean flag) {
             if (flag == null)
@@ -333,6 +393,10 @@ public class RawWire extends AbstractWire implements Wire {
             return RawWire.this;
         }
 
+        /**
+         * Writes text directly to the stream without a field name. Encoding is
+         * determined by the {@code use8bit} flag.
+         */
         @NotNull
         @Override
         public WireOut text(@Nullable CharSequence s) {
@@ -709,10 +773,9 @@ public class RawWire extends AbstractWire implements Wire {
     }
 
     /**
-     * The {@code RawValueIn} class implements the {@link ValueIn} interface,
-     * providing functionality for reading values from a binary wire format.
-     * Internally, it maintains a state stack that facilitates tracking
-     * and managing nested serialized objects or contexts.
+     * {@link ValueIn} implementation that reads values in the order they were
+     * written, without field names or type codes. A small state stack helps with
+     * nested marshallables.
      */
     class RawValueIn implements ValueIn {
         final ValueInStack stack = new ValueInStack();


### PR DESCRIPTION
## Summary
- clarify RawWire class-level Javadoc
- document constructors and metadata behaviour
- describe parameter handling in read/write methods
- remove trivial one-liner comments

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cb2e20dd48329b29c78540d686ee9