### PR TITLE
Improve CSVWire Javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/CSVWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/CSVWire.java
@@ -26,26 +26,34 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Represents a CSV (Comma Separated Values) based wire format.
- * It extends the generic TextWire format to specifically handle the parsing and representation
- * of data in the CSV format. This class provides functionalities for reading from a CSV
- * formatted byte source and handling the common aspects of this format like escaping, headers, etc.
+ * Text based wire format for Comma Separated Values (CSV).
+ *
+ * <p>Suitable for simple tabular data where each line represents a record and fields
+ * are delimited by commas. The first line is treated as a header row and defines the
+ * column names for subsequent rows. Nested or complex structures are not fully
+ * represented and may need to be flattened before writing to CSV.
  */
 public class CSVWire extends TextWire {
 
-    // A thread-local definition to manage stopping characters that handle escaping in CSV.
+    /**
+     * Thread local tester used when parsing CSV fields to honour escaping rules
+     * for commas within quoted text.
+     */
     private static final ThreadLocal<StopCharTester> ESCAPED_END_OF_TEXT = ThreadLocal.withInitial(
             StopCharTesters.COMMA_STOP::escaping);
 
-    // A list to manage headers in the CSV file.
+    /**
+     * Field names parsed from the first line of the input. These are used to
+     * map subsequent column values when reading records.
+     */
     private final List<String> header = new ArrayList<>();
 
     /**
-     * Constructs a new CSVWire instance from a given byte source and a flag indicating
-     * the use of 8-bit characters. Also, reads and initializes the CSV headers.
+     * Creates a wire backed by the supplied bytes and parses the first line as
+     * the header row.
      *
-     * @param bytes The byte source containing CSV data.
-     * @param use8bit A flag indicating whether to use 8-bit characters or not.
+     * @param bytes   underlying bytes containing CSV text
+     * @param use8bit {@code true} to read 8-bit characters, otherwise UTF-8
      */
     @SuppressWarnings("rawtypes")
     public CSVWire(@NotNull Bytes<?> bytes, boolean use8bit) {
@@ -59,9 +67,9 @@ public class CSVWire extends TextWire {
     }
 
     /**
-     * Constructs a new CSVWire instance from a given byte source with default character set.
+     * Creates a wire from the given bytes using UTF-8 encoding.
      *
-     * @param bytes The byte source containing CSV data.
+     * @param bytes underlying CSV data
      */
     @SuppressWarnings("rawtypes")
     public CSVWire(@NotNull Bytes<?> bytes) {
@@ -69,12 +77,12 @@ public class CSVWire extends TextWire {
     }
 
     /**
-     * Constructs a new CSVWire instance by reading data from a specified file.
-     * Uses 8-bit characters by default.
+     * Builds a {@code CSVWire} by loading the contents of the given file.
+     * Uses 8-bit parsing.
      *
-     * @param name The name of the file to read CSV data from.
-     * @return A new instance of CSVWire populated with data from the specified file.
-     * @throws IOException If any I/O error occurs while reading the file.
+     * @param name path of the CSV file
+     * @return new instance containing the file content
+     * @throws IOException if the file cannot be read
      */
     @NotNull
     public static CSVWire fromFile(String name) throws IOException {
@@ -82,10 +90,10 @@ public class CSVWire extends TextWire {
     }
 
     /**
-     * Constructs a new CSVWire instance from a provided string text.
+     * Creates a wire from the supplied text.
      *
-     * @param text The string containing CSV data.
-     * @return A new instance of CSVWire populated with data from the provided text.
+     * @param text CSV data in string form
+     * @return new instance containing the text
      */
     @NotNull
     public static CSVWire from(@NotNull String text) {
@@ -93,10 +101,8 @@ public class CSVWire extends TextWire {
     }
 
     /**
-     * Retrieves and resets the CSV escaping mechanism that dictates
-     * when to stop during text extraction.
-     *
-     * @return An instance of StopCharTester adjusted for CSV escaping rules.
+     * Returns a thread local tester configured for CSV fields and resets its
+     * state before use.
      */
     @NotNull
     static StopCharTester getEscapingCSVEndOfText() {
@@ -108,16 +114,28 @@ public class CSVWire extends TextWire {
 
     @NotNull
     @Override
+    /**
+     * Factory for {@link CSVValueOut} instances used when writing values.
+     */
+    @NotNull
+    @Override
     protected CSVValueOut createValueOut() {
         return new CSVValueOut();
     }
 
+    /**
+     * Factory for {@link CSVValueIn} instances used when reading values.
+     */
     @NotNull
     @Override
     protected TextValueIn createValueIn() {
         return new CSVValueIn();
     }
 
+    /**
+     * Reads the next column value into {@code sb} assuming the wire is
+     * positioned at the start of a field.
+     */
     @Override
     @NotNull
     public StringBuilder readField(@NotNull StringBuilder sb) {
@@ -126,9 +144,8 @@ public class CSVWire extends TextWire {
     }
 
     /**
-     * Consumes padding and whitespace at the beginning of the data source. This method is
-     * essential to handle any comments (lines starting with '#') and whitespace before
-     * the actual data starts in the CSV content.
+     * Consumes leading spaces and comment lines (prefixed with {@code #}) so
+     * the reader is positioned at the start of the header or first record.
      */
     public void consumePaddingStart() {
         for (; ; ) {
@@ -152,6 +169,10 @@ public class CSVWire extends TextWire {
         }
     }
 
+    /**
+     * Skips whitespace at the current position. Newlines and commas are not
+     * consumed here.
+     */
     @Override
     public void consumePadding() {
         for (; ; ) {
@@ -164,17 +185,28 @@ public class CSVWire extends TextWire {
         }
     }
 
+    /**
+     * In CSV the {@code commas} argument is ignored; this method delegates to
+     * {@link #consumePadding()}.
+     */
     @Override
     public void consumePadding(int commas) {
         consumePadding();
     }
 
+    /**
+     * Keys are not used when reading CSV so this simply returns {@link #valueIn}.
+     */
     @NotNull
     @Override
     public ValueIn read(@NotNull WireKey key) {
         return valueIn;
     }
 
+    /**
+     * Reads the next header name into {@code name} and returns the
+     * corresponding {@link ValueIn} for the value.
+     */
     @NotNull
     @Override
     public ValueIn read(@NotNull StringBuilder name) {
@@ -183,6 +215,9 @@ public class CSVWire extends TextWire {
         return valueIn;
     }
 
+    /**
+     * Clears {@code s} as inline comments are not expected in CSV.
+     */
     @NotNull
     @Override
     public Wire readComment(@NotNull StringBuilder s) {
@@ -191,13 +226,15 @@ public class CSVWire extends TextWire {
     }
 
     /**
-     * Represents the value output functionality specific to the CSV format.
-     * It extends the YamlValueOut class to handle specific behaviors associated with
-     * writing values in CSV. This includes certain restrictions, such as not supporting
-     * type literals and serializable objects in CSV format.
-     *
-         */
+     * {@link ValueOut} implementation for CSV. Complex types are not supported
+     * and will throw {@link UnsupportedOperationException}.
+     */
     class CSVValueOut extends YamlValueOut {
+        /**
+         * CSV has no concept of type literals.
+         *
+         * @throws UnsupportedOperationException always
+         */
         @NotNull
         @Override
         public CSVWire typeLiteral(@Nullable CharSequence type) {
@@ -206,6 +243,11 @@ public class CSVWire extends TextWire {
             throw new UnsupportedOperationException("Type literals not supported in CSV, cannot write " + type);
         }
 
+        /**
+         * Writing arbitrary serializable objects is not supported in CSV.
+         *
+         * @throws UnsupportedOperationException always
+         */
         @NotNull
         @Override
         public CSVWire marshallable(@NotNull Serializable object) {
@@ -214,18 +256,24 @@ public class CSVWire extends TextWire {
     }
 
     /**
-     * Represents the value input functionality specific to the CSV format.
-     * It extends the TextValueIn class to handle specific behaviors associated with
-     * reading values from CSV. This includes handling CSV specific escape sequences and delimiters.
+     * {@link ValueIn} implementation for CSV that understands quoting and
+     * escaping rules for comma separated text.
      */
     class CSVValueIn extends TextValueIn {
 
+        /**
+         * Determines whether more data are available after skipping leading
+         * padding and comments.
+         */
         @Override
         public boolean hasNext() {
             consumePaddingStart();
             return bytes.readRemaining() > 0;
         }
 
+        /**
+         * Reads a CSV field into {@code a}, handling quoted values and escaping.
+         */
         @Override
         @Nullable <T extends Appendable & CharSequence> T textTo0(@NotNull T a) {
             consumePadding();
@@ -287,6 +335,10 @@ public class CSVWire extends TextWire {
             return a;
         }
 
+        /**
+         * Calculates the remaining characters for the current record by scanning
+         * until the next line ending.
+         */
         @Override
         protected long readLengthMarshallable() {
             long start = bytes.readPosition();
@@ -307,6 +359,10 @@ public class CSVWire extends TextWire {
             }
         }
 
+        /**
+         * Returns {@code true} if another field is present on the current line and
+         * consumes a trailing comma.
+         */
         @Override
         public boolean hasNextSequenceItem() {
             consumePadding();
@@ -318,6 +374,9 @@ public class CSVWire extends TextWire {
             return ch > 0 && ch != ']';
         }
 
+        /**
+         * Reads a marshallable object from the current record.
+         */
         @Override
         public boolean marshallable(@NotNull ReadMarshallable object) throws InvalidMarshallableException {
             if (isNull())


### PR DESCRIPTION
## Summary
- enhance the class-level description of `CSVWire`
- document constructor behaviour and static factories
- clarify constant and field roles
- add Javadoc for parsing helpers and padding consumers
- describe behaviour of value in/out classes and their methods

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cb2ffd4cc83298c09a076133b806b