### PR TITLE
Improve QueryWire javadocs

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/QueryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/QueryWire.java
@@ -37,41 +37,52 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 
 /**
- * This class represents a wire format designed to decode URL query strings.
- * It extends the TextWire class and provides custom implementations for reading fields and consuming padding
- * in the context of URL query strings. Specialized value input and output handlers, namely {@code QueryValueIn}
- * and {@code QueryValueOut}, are used to manage the specific intricacies of the query string format.
+ * Parses a URL query string such as {@code "a=1&b=2"}.
+ * The bytes are treated as UTF-8 text and are not percent-decoded.
+ * Extends {@link TextWire} and supplies {@link QueryValueIn} and
+ * {@link QueryValueOut} for query specific value handling.
  */
 @SuppressWarnings("rawtypes")
 public class QueryWire extends TextWire {
 
-    // The specialized output handler for query string values.
+    /** Helper used to write query parameters. */
     final QueryValueOut valueOut = new QueryValueOut();
 
-    // The specialized input handler for query string values.
+    /** Helper used to read query parameters. */
     final QueryValueIn valueIn = new QueryValueIn();
 
     /**
-     * Constructs a new instance of {@code QueryWire} using the provided bytes.
+     * Creates a wire over the supplied bytes which must contain a query
+     * string, for example {@code "key=val&flag=true"}.
      *
-     * @param bytes The bytes that represent the query string to be processed.
+     * @param bytes buffer holding the UTF-8 query text
      */
     public QueryWire(@NotNull Bytes<?> bytes) {
         super(bytes);
     }
 
+    /**
+     * Returns a writer that formats values as query parameters.
+     */
     @NotNull
     @Override
     protected QueryValueOut createValueOut() {
         return new QueryValueOut();
     }
 
+    /**
+     * Returns a reader that parses query parameter values.
+     */
     @NotNull
     @Override
     protected TextValueIn createValueIn() {
         return new QueryValueIn();
     }
 
+    /**
+     * Reads the next field name into {@code sb} stopping at '=' or '&'.
+     * If an '&' has been consumed it is rewound.
+     */
     @Override
     @NotNull
     protected StringBuilder readField(@NotNull StringBuilder sb) {
@@ -82,6 +93,9 @@ public class QueryWire extends TextWire {
         return sb;
     }
 
+    /**
+     * Skips any leading whitespace from the current read position.
+     */
     @Override
     @ForceInline
     public void consumePadding() {
@@ -92,18 +106,30 @@ public class QueryWire extends TextWire {
         }
     }
 
+    /**
+     * Query strings do not support unnamed writes.
+     * Always throws UnsupportedOperationException.
+     */
     @NotNull
     @Override
     public ValueOut write() {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * Starts a query parameter using the supplied key.
+     * The value is written when a primitive writer is invoked.
+     */
     @NotNull
     @Override
     public ValueOut write(@NotNull WireKey key) {
         return valueOut.write(key);
     }
 
+    /**
+     * Starts a query parameter using the supplied key.
+     * The value is written when a primitive writer is invoked.
+     */
     @NotNull
     @Override
     public ValueOut write(@NotNull CharSequence name) {
@@ -134,47 +160,46 @@ public class QueryWire extends TextWire {
     }
 
     /**
-     * Reads an unsigned byte at the current position minus one.
-     *
-     * @return The unsigned byte value at the position one byte before the current read position.
+     * Reads the byte immediately before the current read position.
      */
     int rewindAndRead() {
         return bytes.readUnsignedByte(bytes.readPosition() - 1);
     }
 
+    /** Unsupported for query strings. */
     @NotNull
     @Override
     public LongValue newLongReference() {
         throw new UnsupportedOperationException();
     }
 
+    /** Unsupported for query strings. */
     @NotNull
     @Override
     public IntValue newIntReference() {
         throw new UnsupportedOperationException();
     }
 
+    /** Unsupported for query strings. */
     @NotNull
     @Override
     public BinaryLongArrayReference newLongArrayReference() {
         throw new UnsupportedOperationException();
     }
 
+    /** Unsupported for query strings. */
     @Override
     public @NotNull IntArrayValues newIntArrayReference() {
         throw new UnsupportedOperationException();
     }
 
     /**
-     * An enumeration defining testers for stopping characters when parsing fields and values
-     * in the context of URL query strings.
+     * Stop character testers used while parsing query strings.
      */
     enum QueryStopCharTesters implements StopCharTester {
 
         /**
-         * Tester for identifying stopping characters when parsing a field name in a query string.
-         * The method returns true if the character represents an '&' (delimiter) or '=' (assignment)
-         * or if the character is a negative value (end of input).
+         * Terminates a field name at '&', '=' or end of input.
          */
         QUERY_FIELD_NAME {
             @Override
@@ -184,9 +209,7 @@ public class QueryWire extends TextWire {
         },
 
         /**
-         * Tester for identifying stopping characters when parsing a value in a query string.
-         * The method returns true if the character represents an '&' (delimiter)
-         * or if the character is a negative value (end of input).
+         * Terminates a value at '&' or end of input.
          */
         QUERY_VALUE {
             @Override
@@ -197,20 +220,22 @@ public class QueryWire extends TextWire {
     }
 
     /**
-     * Represents an output handler specialized for writing values in the context of URL query strings.
-     * This class extends the {@code YamlValueOut} and provides custom implementations for
-     * appending values to the wire with appropriate separators and field assignments.
+     * {@link ValueOut} implementation for query strings.
+     * Builds fragments such as {@code &key=value}.
      */
     class QueryValueOut extends YamlValueOut {
 
-        // The separator to prepend before writing the next value.
+        /** Next separator to write. */
         @NotNull
         String sep = "";
 
-        // The field name to prepend before writing the next value.
+        /** Field name awaiting a value. */
         @Nullable
         CharSequence fieldName = null;
 
+        /**
+         * Writes the current separator and pending field name.
+         */
         @Override
         void prependSeparator() {
             bytes.appendUtf8(sep);
@@ -226,6 +251,9 @@ public class QueryWire extends TextWire {
             sep = "&";
         }
 
+        /**
+         * Writes the flag if non-null, encoding it as {@code true} or {@code false}.
+         */
         @NotNull
         @Override
         public QueryWire bool(@Nullable Boolean flag) {
@@ -237,6 +265,9 @@ public class QueryWire extends TextWire {
             return QueryWire.this;
         }
 
+        /**
+         * Writes the text value if it is not {@code null}.
+         */
         @NotNull
         @Override
         public QueryWire text(@Nullable CharSequence s) {
@@ -248,6 +279,9 @@ public class QueryWire extends TextWire {
             return QueryWire.this;
         }
 
+        /**
+         * Writes the byte value in decimal form.
+         */
         @NotNull
         @Override
         public QueryWire int8(byte i8) {
@@ -257,12 +291,16 @@ public class QueryWire extends TextWire {
             return QueryWire.this;
         }
 
+        /** Unsupported for query strings. */
         @NotNull
         @Override
         public QueryWire bytes(@Nullable BytesStore<?, ?> fromBytes) {
             throw new UnsupportedOperationException("todo");
         }
 
+        /**
+         * Writes the raw bytes as-is.
+         */
         @NotNull
         @Override
         public QueryWire rawBytes(@Nullable byte[] value) {
@@ -274,6 +312,9 @@ public class QueryWire extends TextWire {
             return QueryWire.this;
         }
 
+        /**
+         * Writes the byte array as a Base64 string.
+         */
         @NotNull
         @Override
         public QueryWire bytes(byte[] byteArray) {
@@ -284,18 +325,23 @@ public class QueryWire extends TextWire {
             return QueryWire.this;
         }
 
+        /** Unsupported for query strings. */
         @NotNull
         @Override
         public QueryWire int64array(long capacity) {
             throw new UnsupportedOperationException();
         }
 
+        /** Unsupported for query strings. */
         @NotNull
         @Override
         public QueryWire int64array(long capacity, @NotNull LongArrayValues values) {
             throw new UnsupportedOperationException();
         }
 
+        /**
+         * Writes a type prefix followed by a space.
+         */
         @NotNull
         @Override
         public QueryValueOut typePrefix(@NotNull CharSequence typeName) {
@@ -305,42 +351,49 @@ public class QueryWire extends TextWire {
             return this;
         }
 
+        /** Unsupported for query strings. */
         @NotNull
         @Override
         public QueryWire typeLiteral(@Nullable CharSequence type) {
             throw new UnsupportedOperationException();
         }
 
+        /** Unsupported for query strings. */
         @NotNull
         @Override
         public QueryWire typeLiteral(@NotNull BiConsumer<Class, Bytes<?>> typeTranslator, @NotNull Class<?> type) {
             throw new UnsupportedOperationException();
         }
 
+        /** Unsupported for query strings. */
         @NotNull
         @Override
         public QueryWire int32forBinding(int value) {
             throw new UnsupportedOperationException();
         }
 
+        /** Unsupported for query strings. */
         @NotNull
         @Override
         public QueryWire int32forBinding(int value, @NotNull IntValue intValue) {
             throw new UnsupportedOperationException();
         }
 
+        /** Unsupported for query strings. */
         @NotNull
         @Override
         public QueryWire int64forBinding(long value) {
             throw new UnsupportedOperationException();
         }
 
+        /** Unsupported for query strings. */
         @NotNull
         @Override
         public QueryWire int64forBinding(long value, @NotNull LongValue longValue) {
             throw new UnsupportedOperationException();
         }
 
+        /** Writes a sequence using comma separated values. */
         @NotNull
         @Override
         public <T> QueryWire sequence(T t, @NotNull BiConsumer<T, ValueOut> writer) {
@@ -359,6 +412,7 @@ public class QueryWire extends TextWire {
             return QueryWire.this;
         }
 
+        /** Writes a sequence with a provided class. */
         @NotNull
         @Override
         public <T, K> QueryWire sequence(T t, K kls, @NotNull TriConsumer<T, K, ValueOut> writer) throws InvalidMarshallableException {
@@ -385,6 +439,7 @@ public class QueryWire extends TextWire {
         protected void pushState() {
         }
 
+        /** Writes a marshallable object in braces. */
         @NotNull
         @Override
         public QueryWire marshallable(@NotNull WriteMarshallable object) throws InvalidMarshallableException {
@@ -403,12 +458,14 @@ public class QueryWire extends TextWire {
             return QueryWire.this;
         }
 
+        /** Unsupported for query strings. */
         @NotNull
         @Override
         public QueryWire map(@NotNull final Map map) {
             throw new UnsupportedOperationException();
         }
 
+        /** Unsupported for query strings. */
         @Override
         @NotNull
         public QueryValueOut write() {
@@ -431,11 +488,10 @@ public class QueryWire extends TextWire {
     }
 
     /**
-     * Represents an input handler specialized for reading values in the context of URL query strings.
-     * This class extends the {@code TextValueIn} and provides custom implementations for
-     * extracting text values from the wire with appropriate handling of separators and encodings.
+     * {@link ValueIn} implementation for query strings.
      */
     class QueryValueIn extends TextValueIn {
+        /** Returns the value text of the current parameter. */
         @Override
         public String text() {
             try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
@@ -443,6 +499,9 @@ public class QueryWire extends TextWire {
             }
         }
 
+        /**
+         * Reads the value text up to '&' and appends it to {@code a}.
+         */
         @Nullable
         @Override
         public StringBuilder textTo(@NotNull StringBuilder a) {
@@ -451,6 +510,9 @@ public class QueryWire extends TextWire {
             return a;
         }
 
+        /**
+         * Reads the value text up to '&' and appends it to {@code a}.
+         */
         @Nullable
         @Override
         public Bytes<?> textTo(@NotNull Bytes<?> a) {
@@ -459,6 +521,9 @@ public class QueryWire extends TextWire {
             return a;
         }
 
+        /**
+         * Passes the value text to {@code classNameConsumer} as a type name.
+         */
         @Override
         @NotNull
         public <T> WireIn typeLiteralAsText(T t, @NotNull BiConsumer<T, CharSequence> classNameConsumer) {
@@ -470,6 +535,9 @@ public class QueryWire extends TextWire {
             return wireIn();
         }
 
+        /**
+         * Returns the class for the value text using the wire's class lookup.
+         */
         @Override
         public Type typeLiteral(BiFunction<CharSequence, ClassNotFoundException, Type> unresolvedHandler) {
             try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
@@ -479,6 +547,9 @@ public class QueryWire extends TextWire {
             }
         }
 
+        /**
+         * Checks for another item in a comma separated list.
+         */
         @Override
         public boolean hasNextSequenceItem() {
             consumePadding();


### PR DESCRIPTION
## Summary
- expand behaviour docs for QueryWire value factories and write methods
- clarify boolean/text/int8 writers and how textTo reads values

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cb317a74c8329bcdf215fcfb2bf1c