### PR TITLE
Improve javadoc for binary method writer handler

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/BinaryMethodWriterInvocationHandler.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryMethodWriterInvocationHandler.java
@@ -22,31 +22,39 @@ import java.lang.reflect.Method;
 import java.util.function.Supplier;
 
 /**
- * The BinaryMethodWriterInvocationHandler handles method invocations specific to binary writing scenarios with optional metadata support.
+ * {@link MethodWriterInvocationHandler} that serialises method calls to a
+ * {@link MarshallableOut} using the binary wire format.
+ * <p>
+ * Each call is wrapped in a {@link WriteDocumentContext} which is opened and
+ * closed by this handler. Calls may be written as data or metadata documents
+ * depending on the {@link #metaData} flag.
  */
 public class BinaryMethodWriterInvocationHandler extends AbstractMethodWriterInvocationHandler {
+    /** Supplier for the target {@link MarshallableOut} used to serialise method calls. */
     @NotNull
     private final Supplier<MarshallableOut> marshallableOutSupplier;
-    private final boolean metaData;  // Flag to determine if metadata should be written.
+    /**
+     * When {@code true} each call is written as metadata rather than data.
+     */
+    private final boolean metaData;
 
     /**
-     * Constructor that initializes the handler using the given class, metadata flag and MarshallableOut.
-     * This constructor uses a constant MarshallableOut.
+     * Create a handler bound to a single {@link MarshallableOut} instance.
      *
-     * @param tClass           The class type associated with this handler.
-     * @param metaData         Flag to determine if metadata is to be written.
-     * @param marshallableOut  The MarshallableOut instance for binary writing.
+     * @param tClass          primary interface of the proxy
+     * @param metaData        whether messages are written as metadata
+     * @param marshallableOut destination for serialised calls
      */
     BinaryMethodWriterInvocationHandler(Class<?> tClass, final boolean metaData, @NotNull MarshallableOut marshallableOut) {
         this(tClass, metaData, () -> marshallableOut);
     }
 
     /**
-     * Constructor that initializes the handler using the given class, metadata flag and a supplier of MarshallableOut.
+     * Create a handler that fetches the target {@link MarshallableOut} from the given supplier.
      *
-     * @param tClass                  The class type associated with this handler.
-     * @param metaData                Flag to determine if metadata is to be written.
-     * @param marshallableOutSupplier The supplier providing instances of MarshallableOut.
+     * @param tClass                  primary interface of the proxy
+     * @param metaData                whether messages are written as metadata
+     * @param marshallableOutSupplier supplier of the destination for serialised calls
      */
     public BinaryMethodWriterInvocationHandler(Class<?> tClass, final boolean metaData, Supplier<MarshallableOut> marshallableOutSupplier) {
         super(tClass);
@@ -55,6 +63,11 @@ public class BinaryMethodWriterInvocationHandler extends AbstractMethodWriterInv
         recordHistory = marshallableOutSupplier.get().recordHistory();
     }
 
+    /**
+     * Intercepts calls on the proxy. A call to {@code writingDocument()} is handled here
+     * to expose the underlying {@link WriteDocumentContext} directly.
+     * Other calls are delegated to {@link AbstractMethodWriterInvocationHandler#doInvoke(Object, Method, Object[])}.
+     */
     @Override
     protected Object doInvoke(Object proxy, Method method, Object[] args) {
         if (method.getName().equals("writingDocument") && method.getParameterCount() == 0) {
@@ -65,14 +78,21 @@ public class BinaryMethodWriterInvocationHandler extends AbstractMethodWriterInv
     }
 
     /**
-     * Gets the current metadata setting for this handler.
+     * Returns whether this handler writes messages as metadata documents.
      *
-     * @return {@code true} if metadata is enabled, {@code false} otherwise.
+     * @return {@code true} when messages are metadata
      */
     public boolean metaData() {
         return metaData;
     }
 
+    /**
+     * Serialises the given {@code method} call with {@code args} to the configured output.
+     * Each invocation acquires a new {@link WriteDocumentContext} which is marked
+     * as data or metadata according to {@link #metaData}. If the return type of the
+     * method is an interface the document context is marked as {@code chained} so
+     * subsequent calls may share the same context.
+     */
     @Override
     protected void handleInvoke(Method method, Object[] args) {
         boolean chained = method.getReturnType().isInterface();


### PR DESCRIPTION
## Summary
- document `BinaryMethodWriterInvocationHandler`
- clarify field purpose and constructor parameters
- describe special cases in `doInvoke`
- explain metadata behaviour and chaining logic in `handleInvoke`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cb9d1f56c8329921897d9bd6e5452