### PR TITLE
Improve TextMethodWriterInvocationHandler javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/TextMethodWriterInvocationHandler.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextMethodWriterInvocationHandler.java
@@ -29,36 +29,44 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
- * This class represents an invocation handler specifically for text method writers. It extends the
- * AbstractMethodWriterInvocationHandler to implement method call behavior for text-based method writers.
- * It mainly converts method calls to textual data using the provided MarshallableOut.
+ * A {@link MethodWriterInvocationHandler} that serialises method calls to a
+ * text-based {@link MarshallableOut} such as YAML or JSON. Each invocation
+ * is wrapped in a {@link WriteDocumentContext} and numeric arguments annotated
+ * with {@link LongConversion} are rendered via the associated
+ * {@link LongConverter}.
  */
 public class TextMethodWriterInvocationHandler extends AbstractMethodWriterInvocationHandler {
+    /** Supplier for the target {@link MarshallableOut}. */
     @NotNull
     private final Supplier<MarshallableOut> marshallableOutSupplier;
+    /** Caches argument converters keyed by {@link Method}. */
     private final Map<Method, Consumer<Object[]>> visitorConverter = new LinkedHashMap<>();
 
     /**
-     * Constructor initializing the handler with a MarshallableOut instance.
+     * Creates a handler bound to the supplied interface and target.
      *
-     * @param tClass           The class for which this invocation handler is being used.
-     * @param marshallableOut  The MarshallableOut instance used for data serialization.
+     * @param tClass          primary interface for the method writer
+     * @param marshallableOut destination for text wire output
      */
     TextMethodWriterInvocationHandler(Class<?> tClass, @NotNull MarshallableOut marshallableOut) {
         this(tClass, () -> marshallableOut);
     }
 
     /**
-     * Constructor initializing the handler with a supplier for MarshallableOut.
+     * Creates a handler that obtains its output destination lazily.
      *
-     * @param tClass                   The class for which this invocation handler is being used.
-     * @param marshallableOutSupplier  The supplier providing instances of MarshallableOut for data serialization.
+     * @param tClass                  primary interface for the method writer
+     * @param marshallableOutSupplier supplier of the text-based output
      */
     public TextMethodWriterInvocationHandler(Class<?> tClass, @NotNull Supplier<MarshallableOut> marshallableOutSupplier) {
         super(tClass);
         this.marshallableOutSupplier = marshallableOutSupplier;
     }
 
+    /**
+     * Handles a direct {@code writingDocument()} call on the proxy before
+     * deferring to the superclass for normal method processing.
+     */
     @Override
     protected Object doInvoke(Object proxy, Method method, Object[] args) {
         if (method.getName().equals("writingDocument") && method.getParameterCount() == 0) {
@@ -68,6 +76,10 @@ public class TextMethodWriterInvocationHandler extends AbstractMethodWriterInvoc
         return super.doInvoke(proxy, method, args);
     }
 
+    /**
+     * Converts arguments if needed and writes the method call to the underlying
+     * text wire within a {@link WriteDocumentContext}.
+     */
     @Override
     protected void handleInvoke(Method method, Object[] args) {
         visitorConverter.computeIfAbsent(method, this::buildConverter)
@@ -87,14 +99,17 @@ public class TextMethodWriterInvocationHandler extends AbstractMethodWriterInvoc
         }
     }
 
+    /** Shared no-op argument converter. */
     static final Consumer<Object[]> NOOP_CONSUMER = Jvm.uncheckedCast(Mocker.ignored(Consumer.class));
 
     /**
-     * Builds a converter for method parameters based on the annotations present on the method.
-     * It supports long and int conversions based on annotations like @LongConversion and @IntConversion.
+     * Builds or retrieves a converter for the first parameter of {@code method}.
+     * If it has a {@link LongConversion} annotation (or one annotated with it),
+     * numbers are wrapped in {@link RawText} using the stated
+     * {@link LongConverter}.
      *
-     * @param method  The method for which the converter is being built.
-     * @return A Consumer that takes in an Object array and performs conversions on it.
+     * @param method source of parameter annotations
+     * @return argument consumer for that method
      */
     private Consumer<Object[]> buildConverter(Method method) {
         Annotation[][] parameterAnnotations = method.getParameterAnnotations();
@@ -118,16 +133,14 @@ public class TextMethodWriterInvocationHandler extends AbstractMethodWriterInvoc
     }
 
     /**
-     * Creates a long converter based on the provided class. The converter will convert the input
-     * object to its long representation using the provided LongConverter. It primarily focuses on
-     * handling the conversion of numbers to their textual representation in the format dictated by
-     * the provided LongConverter.
+     * Creates a consumer that converts the first argument to
+     * {@link RawText} using the provided {@link LongConverter} type.
+     * The type may expose a static {@code INSTANCE} or be
+     * instantiated reflectively.
      *
-     * @param value The class representing the desired LongConverter. The class should ideally have
-     *              a public static field named "INSTANCE" which holds a pre-created instance of
-     *              the converter. If not, a new instance is created using reflection.
-     * @return A Consumer that takes in an Object array and performs the long conversion on its first element.
-     * @throws RuntimeException If there is an IllegalAccessException when accessing the "INSTANCE" field.
+     * @param value {@link LongConverter} class or annotation holding one
+     * @return argument consumer applying the conversion
+     * @throws RuntimeException if reflection fails
      */
     @NotNull
     private Consumer<Object[]> buildLongConverter(Class<?> value) {


### PR DESCRIPTION
## Summary
- clarify the purpose of `TextMethodWriterInvocationHandler`
- document constructor, fields and helper methods
- explain behaviour of `doInvoke` and `handleInvoke`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cb9e9627c832990a2601e1809370d