### PR TITLE
Improve Javadoc on ParameterHolderSequenceWriter

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/ParameterHolderSequenceWriter.java
+++ b/src/main/java/net/openhft/chronicle/wire/ParameterHolderSequenceWriter.java
@@ -22,43 +22,41 @@ import java.lang.reflect.Method;
 import java.util.function.BiConsumer;
 
 /**
- * Represents a utility class responsible for writing sequences of method parameters into a given output format.
- * Specifically, it encapsulates the logic to serialize method parameters into a wire format or similar output stream.
- * The class is designed with the assumption that the sequence will either start from the first parameter or
- * skip the first parameter and start from the second, as dictated by the `from0` and `from1` `BiConsumer` respectively.
- * <p>
- * This was a lambda but it caused garbage
+ * Internal helper for generated method writers.
+ *
+ * <p>This class analyses a {@link Method}'s parameter types once and builds
+ * {@link BiConsumer} instances that write the arguments to a
+ * {@link ValueOut}. {@link #from0} writes all arguments while
+ * {@link #from1} skips the first. The {@link MethodId} annotation is
+ * cached in {@link #methodId} for efficient reuse.
+ *
+ * <p>This was previously implemented with a lambda which produced
+ * garbage.
+ *
+ * @implNote For internal use only and not part of the public API.
  */
 class ParameterHolderSequenceWriter {
 
-    /**
-     * Represents the parameter types of a method.
-     */
+    /** The cached parameter types of the target method. */
     @SuppressWarnings("rawtypes")
     final Class[] parameterTypes;
 
-    /**
-     * A consumer that writes the entire sequence of parameters into a given output format.
-     */
+    /** Serialises every argument to the provided {@link ValueOut}. */
     final BiConsumer<Object[], ValueOut> from0;
 
-    /**
-     * A consumer that writes the sequence of parameters into a given output format,
-     * starting from the second parameter.
-     */
+    /** Serialises arguments from index {@code 1} onwards. */
     final BiConsumer<Object[], ValueOut> from1;
 
-    /**
-     * Represents the method ID associated with the method.
-     * It's useful for identifying the method in serialized data.
-     */
+    /** MethodId value or {@code Long.MIN_VALUE} when absent. */
     final long methodId;
 
     /**
-     * Initializes the `ParameterHolderSequenceWriter` with the provided method. The method's parameters are extracted,
-     * and appropriate serialization consumers (`from0` and `from1`) are initialized based on the parameters.
+     * Creates a writer for the given method.
+     * <p>
+     * Parameter types are cached and the consumer functions are built.
+     * The {@link MethodId} value is read if present.
      *
-     * @param method The method whose parameters are to be serialized.
+     * @param method the method to analyse
      */
     @SuppressWarnings("unchecked")
     protected ParameterHolderSequenceWriter(Method method) {


### PR DESCRIPTION
## Summary
- clarify internal role of ParameterHolderSequenceWriter
- document cached MethodId and the from0/from1 consumers

## Testing
- `mvn -q verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cbb577a0c832981d21d1530da5d33