### PR TITLE
Improve Javadoc for MethodWriterValidationException

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/MethodWriterValidationException.java
+++ b/src/main/java/net/openhft/chronicle/wire/MethodWriterValidationException.java
@@ -17,10 +17,14 @@
 package net.openhft.chronicle.wire;
 
 /**
- * The {@code MethodWriterValidationException} is a specialized exception class that indicates a failure
- * in generating a {@link MethodWriter}. This exception type prevents falling back to the default proxy
- * implementation. It is typically thrown when there are invalid conditions or configurations related to
- * {@link MethodWriter} creation.
+ * Exception thrown when a generated {@link MethodWriter} cannot be created.
+ *
+ * <p>Generated writers are typically faster and richer than reflection based
+ * proxies. When the generator configuration fails validation this exception is
+ * thrown so the system does not fall back to the proxy implementation.
+ *
+ * @see GenerateMethodWriter
+ * @see VanillaMethodWriterBuilder
  */
 public class MethodWriterValidationException extends IllegalArgumentException {
     private static final long serialVersionUID = 0L;
@@ -28,7 +32,7 @@ public class MethodWriterValidationException extends IllegalArgumentException {
     /**
      * Constructs a new {@code MethodWriterValidationException} with the specified detail message.
      *
-     * @param s the detail message explaining the reason for the exception.
+     * @param s the detail message explaining the validation failure
      */
     public MethodWriterValidationException(String s) {
         super(s);


### PR DESCRIPTION
## Summary
- clarify behaviour of `MethodWriterValidationException`
- document constructor parameter

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cbb6ad70c8329a90f97748ad7c4f1