### PR TITLE
Improve builder javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/VanillaMethodReaderBuilder.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMethodReaderBuilder.java
@@ -32,18 +32,19 @@ import java.util.function.Predicate;
 import static net.openhft.chronicle.wire.WireParser.SKIP_READABLE_BYTES;
 
 /**
- * The {@code VanillaMethodReaderBuilder} class implements the {@link MethodReaderBuilder} interface.
- * It provides a mechanism to create a method reader for deserializing method calls from a wire input.
+ * Builder for {@link VanillaMethodReader}. Implements {@link MethodReaderBuilder} and
+ * allows configuration of default parsing behaviour, exception handling, method
+ * interception and use of generated proxies.
  */
 public class VanillaMethodReaderBuilder implements MethodReaderBuilder {
 
-    // A constant representing the configuration property to disable reader proxy code generation.
+    /** System property name to disable proxy generation. */
     public static final String DISABLE_READER_PROXY_CODEGEN = "disableReaderProxyCodegen";
 
-    // Cache for storing classes associated with their names for optimization.
+    /** Cache of generated reader classes keyed by name. */
     private static final Map<String, Class<?>> classCache = new ConcurrentHashMap<>();
 
-    // A sentinel value indicating a failed compilation attempt.
+    /** Marker stored in {@link #classCache} when generation fails. */
     private static final Class<?> COMPILE_FAILED = ClassNotFoundException.class;
 
     // The input from which method calls are read.


### PR DESCRIPTION
## Summary
- clarify `VanillaMethodReaderBuilder` overview
- document reader codegen constants

## Testing
- `javac src/main/java/net/openhft/chronicle/wire/VanillaMethodReaderBuilder.java` *(fails: unnamed classes are a preview feature)*

------
https://chatgpt.com/codex/tasks/task_e_683d541fc2e483298c3eec5a634d2f17