### PR TITLE
Improve method reader and filter javadocs

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
@@ -40,15 +40,23 @@ import static net.openhft.chronicle.core.util.GenericReflection.*;
 import static net.openhft.chronicle.wire.GenerateMethodWriter.isSynthetic;
 
 /**
- * Responsible for code generation and its runtime compilation of custom {@link MethodReader}s.
- * The class dynamically generates Java source code based on the provided configurations and compiles them at runtime.
- * It offers the flexibility to create custom MethodReaders tailored to specific needs without manual coding.
+ * Responsible for code generation and runtime compilation of custom {@link MethodReader}s.
+ * The class dynamically generates Java source code based on the provided configurations and compiles it on the fly.
+ * Generated readers extend {@link AbstractGeneratedMethodReader} for faster dispatch than reflection and are used
+ * internally by {@link VanillaMethodReaderBuilder}.
  */
 public class GenerateMethodReader {
 
-    // Configuration flag for dumping the generated code.
+    /**
+     * System property ({@code dumpCode}) flag. If {@code true}, the generated Java source
+     * code for the method reader will be printed to {@code System.out}.
+     */
     private static final boolean DUMP_CODE = Jvm.getBoolean("dumpCode");
-    // Set of interfaces that are not meant to be processed.
+    /**
+     * A {@link Set} of common Chronicle Wire and Java interfaces (e.g. {@link Marshallable},
+     * {@link DocumentContext}) that should be ignored when searching for methods to generate
+     * reader logic for. This avoids creating readers for utility or infrastructure methods.
+     */
     private static final Set<Class<?>> IGNORED_INTERFACES = new LinkedHashSet<>();
 
     static {

--- a/src/main/java/net/openhft/chronicle/wire/MethodFilterOnFirstArg.java
+++ b/src/main/java/net/openhft/chronicle/wire/MethodFilterOnFirstArg.java
@@ -16,26 +16,21 @@
 package net.openhft.chronicle.wire;
 
 /**
- * Represents a functional interface that provides a mechanism to filter methods based on their
- * first argument. This interface is designed for multi-argument method calls, allowing the user
- * to decide, based on the first argument, whether to ignore the rest of the method's arguments
- * and the method itself.
- * <p>
- * Implementors of this interface can define custom logic to determine if a specific method
- * should be ignored based on its first argument. This can be especially useful in scenarios
- * where performance is crucial, and not every method needs to be processed.
+ * Functional interface for filtering method invocations by examining the first argument.
+ * Implementors decide, based on that argument, whether the rest of the call should be ignored.
+ * This can save processing time when not every event needs to be handled.
  *
- * @param <T> the type of the first argument that the method receives
+ * @param <T> type of the first argument
  */
 @FunctionalInterface
 public interface MethodFilterOnFirstArg<T> {
     /**
-     * Determines whether a method should be ignored based on its name and its first argument.
+     * Determines whether a method should be ignored based on its name and first argument.
      *
-     * @param methodName The name of the method being evaluated.
-     * @param firstArg   The first argument passed to the method.
-     *
-     * @return true if the method should be ignored, otherwise false.
+     * @param methodName the name of the method being evaluated
+     * @param firstArg   the first argument passed to the method
+     * @return {@code true} if the call should be skipped entirely because {@code firstArg}
+     * meets certain criteria, {@code false} to process the method normally
      */
     boolean ignoreMethodBasedOnFirstArg(String methodName, T firstArg);
 }


### PR DESCRIPTION
## Summary
- clarify the `MethodFilterOnFirstArg` contract
- document the `GenerateMethodReader` class and constants

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d547bf83c83299d5bff8554031460