### PR TITLE
Improve GenerateMethodReader Javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
@@ -116,15 +116,18 @@ public class GenerateMethodReader {
     private boolean hasChainedCalls;
 
     /**
-     * Constructs a new instance of GenerateMethodReader.
-     * Initializes the required configurations, metadata handlers, and instances which are essential for code generation.
-     *
-     * @param wireType        Configuration for serialization/deserialization
-     * @param interceptor     An instance of MethodReaderInterceptorReturns
-     * @param metaDataHandler Array of meta-data handlers
-     * @param instances       Instances that dictate the structure of the generated MethodReader
+     * @param wireType                     target wire format
+     * @param interceptor                  optional interceptor for return values
+     * @param multipleNonMarshallableParamTypes if {@code Boolean#TRUE} support multiple concrete parameter types,
+     *                                          {@code Boolean#FALSE} forces a single type, {@code null} chooses automatically
+     * @param metaDataHandler              handlers for meta messages, may be {@code null}
+     * @param instances                    handler objects whose interfaces define the dispatch logic
      */
-    public GenerateMethodReader(WireType wireType, MethodReaderInterceptorReturns interceptor, Boolean multipleNonMarshallableParamTypes, Object[] metaDataHandler, Object... instances) {
+    public GenerateMethodReader(WireType wireType,
+                                MethodReaderInterceptorReturns interceptor,
+                                Boolean multipleNonMarshallableParamTypes,
+                                Object[] metaDataHandler,
+                                Object... instances) {
         this.wireType = wireType;
         this.interceptor = interceptor;
         this.multipleNonMarshallableParamTypes = multipleNonMarshallableParamTypes;
@@ -134,23 +137,17 @@ public class GenerateMethodReader {
     }
 
     /**
-     * Computes the signature of a given method.
-     * The signature comprises the return type, method name, and parameter types.
-     *
-     * @param m    The method for which the signature is to be computed
-     * @param type The type under consideration
-     * @return A string representing the method's signature
+     * Computes a unique signature for {@code m} relative to {@code type}. The
+     * result encodes return type, name and canonical parameter types to prevent
+     * duplicate handling.
      */
     private static String signature(Method m, Class<?> type) {
         return GenericReflection.getReturnType(m, type) + " " + m.getName() + " " + Arrays.toString(GenericReflection.getParameterTypes(m, type));
     }
 
     /**
-     * Checks if the given class has an "INSTANCE" field.
-     * Useful to verify if a class adheres to certain patterns or conventions.
-     *
-     * @param aClass The class to be checked
-     * @return true if the class has an "INSTANCE" field, false otherwise
+     * Checks whether {@code aClass} exposes a public static final field named {@code INSTANCE}.
+     * Many {@link LongConverter} implementations use this pattern.
      */
     static boolean hasInstance(Class<?> aClass) {
         try {
@@ -162,11 +159,9 @@ public class GenerateMethodReader {
     }
 
     /**
-     * Generates and compiles the source code of a custom {@link MethodReader} at runtime.
-     * It uses the configurations and instances provided during initialization.
-     * If there are issues during compilation, it provides detailed error messages for easier debugging.
-     *
-     * @return A new class representing the custom MethodReader
+     * Generates the reader source (if not already done) and compiles it via
+     * {@link Wires#loadFromJava(ClassLoader, String, String)}. The resulting
+     * {@link Class} object is returned.
      */
     public Class<?> createClass() {
         // If source code isn't already generated, generate it.
@@ -193,9 +188,12 @@ public class GenerateMethodReader {
     }
 
     /**
-     * Responsible for generating the source code of a {@link MethodReader} based on specified {@link #instances}.
-     * This method encapsulates the logic for building the source code dynamically, by inspecting provided interfaces,
-     * filtering ignored interfaces, and appending necessary components to the code.
+     * Main entry point for building the reader's Java source.
+     * <ol>
+     * <li>Iterates through {@link #metaDataHandler} to populate metadata dispatch.</li>
+     * <li>Iterates through {@link #instances} to populate data message dispatch.</li>
+     * <li>Assembles package, imports, fields, constructor and the read methods with switch blocks.</li>
+     * </ol>
      */
     private void generateSourceCode() {
         // Clear previously handled interfaces and method signatures for clean generation.
@@ -445,31 +443,10 @@ public class GenerateMethodReader {
     }
 
     /**
-     * This method is used to generate code for handling all method calls of a given interface.
-     * It processes the methods recursively in case of chained methods.
-     *
-     * <p>It first checks if the given interface should be chained using {@code Jvm.dontChain()} method.
-     * If not, it immediately returns without executing further. It also checks whether the interface
-     * has already been processed. If yes, it immediately returns.
-     *
-     * <p>Then it proceeds to process all non-static, non-synthetic methods declared in the given
-     * interface but not in {@code java.lang.Object}.
-     * If a method has already been processed, it's skipped.
-     *
-     * <p>It also validates that the method isn't one of those defined in {@code java.lang.Object},
-     * if it is, it's skipped.
-     *
-     * <p>If a method name has already been processed before, it throws an {@code IllegalStateException}.
-     * This is because MethodReader does not support overloaded methods.
-     *
-     * <p>Finally, it calls {@code handleMethod()} on the current method if it passed all the above checks.
-     *
-     * @param anInterface          The interface being processed.
-     * @param instanceFieldName    In the generated code, methods are executed on a field with this name.
-     * @param methodFilter         Indicates if the passed interface is marked with {@link MethodFilterOnFirstArg}. If true, only certain methods are processed.
-     * @param eventNameSwitchBlock The block of code that handles the switching of event names.
-     * @param eventIdSwitchBlock   The block of code that handles the switching of event IDs.
-     * @ blocks based on method event IDs.
+     * Recursively processes {@code anInterface} and its parents (unless listed in
+     * {@link #IGNORED_INTERFACES} or {@link Jvm#dontChain(Class)}). Each eligible
+     * method is forwarded to {@link #handleMethod(Method, Class, String, boolean, SourceCodeFormatter, SourceCodeFormatter)}.
+     * {@code instanceFieldName} names the handler field in the generated class.
      */
     private void handleInterface(Class<?> anInterface, String instanceFieldName, boolean methodFilter, SourceCodeFormatter eventNameSwitchBlock, SourceCodeFormatter eventIdSwitchBlock) {
         if (Jvm.dontChain(anInterface))
@@ -509,33 +486,14 @@ public class GenerateMethodReader {
     }
 
     /**
-     * This method generates code for handling the call of a specific method. It sets up necessary fields and structures,
-     * prepares parameters, and constructs a switch block for method calls.
-     *
-     * <p>Initially, it ensures that the method is accessible and obtains its parameter types and return type.
-     * It processes the method parameters and creates fields for storing them. It also checks if the return type of the method
-     * is chainable and updates the state accordingly.
-     *
-     * <p>If a real interceptor is returned by the method, it creates an array field to store the interceptor's arguments
-     * and also adds a static field to hold a reference to the method itself.
-     *
-     * <p>Furthermore, if the method is annotated with {@code MethodId}, it extracts the method ID from the annotation
-     * and adds a switch case for this ID to the {@code eventIdSwitchBlock}.
-     *
-     * <p>Then, it builds a case for the method in the {@code eventNameSwitchBlock}. The structure of this case varies
-     * depending on the number of parameters the method has and if it's marked with {@code MethodFilterOnFirstArg}.
-     *
-     * <p>If the method's return type is {@code DocumentContext}, it also adds code to copy the method's result to the wire
-     * and close it.
-     *
-     * <p>Finally, if the method's return type is chainable, it calls {@code handleInterface()} on it.
-     *
-     * @param m                    The method for which code is generated.
-     * @param anInterface          The interface containing the method.
-     * @param instanceFieldName    In the generated code, this method is executed on a field with this name.
-     * @param methodFilter         Indicates if the passed interface is marked with {@link MethodFilterOnFirstArg}. If true, only certain methods are processed.
-     * @param eventIdSwitchBlock   The block of code that handles the switching of event IDs.
-     * @param eventNameSwitchBlock The block of code that handles the switching of event names.
+     * Generates switch cases to dispatch {@code m}.
+     * <ol>
+     * <li>Creates fields for arguments and {@link LongConverter}s.</li>
+     * <li>Emits code to read arguments via {@link #argumentRead(Method, int, boolean, Type[])}.</li>
+     * <li>If {@code methodFilter} is true, inserts {@link MethodFilterOnFirstArg#ignoreMethodBasedOnFirstArg(String, Object)} logic.</li>
+     * <li>Invokes the method via {@link #methodCall(Method, String, String, Class)}.</li>
+     * <li>For chainable return types, recursively calls {@link #handleInterface(Class, String, boolean, SourceCodeFormatter, SourceCodeFormatter)}.</li>
+     * </ol>
      */
     private void handleMethod(Method m, Class<?> anInterface, String instanceFieldName, boolean methodFilter, SourceCodeFormatter eventNameSwitchBlock, SourceCodeFormatter eventIdSwitchBlock) {
         Jvm.setAccessible(m);
@@ -668,13 +626,8 @@ public class GenerateMethodReader {
     }
 
     /**
-     * Creates a switch block in the provided SourceCodeFormatter for a given method ID.
-     * This method facilitates the dynamic selection of methods based on their assigned IDs, allowing
-     * efficient routing and method invocation.
-     *
-     * @param methodName         The name of the method for which the switch case is generated.
-     * @param methodId           The ID assigned to the method.
-     * @param eventIdSwitchBlock Code block where the generated switch case is appended.
+     * Adds a {@code case} for {@code methodId} to {@code eventIdSwitchBlock} so that
+     * numeric identifiers map to textual method names.
      */
     private void addMethodIdSwitch(String methodName, int methodId, SourceCodeFormatter eventIdSwitchBlock) {
         // Append the switch case based on method ID
@@ -686,13 +639,10 @@ public class GenerateMethodReader {
     }
 
     /**
-     * Generates code that invokes passed method, saves method return value (in case it's a chained call)
-     * and handles {@link MethodReaderInterceptorReturns} if it's specified.
-     *
-     * @param m                 Method that is being processed.
-     * @param instanceFieldName In generated code, method is executed on field with this name.
-     * @param chainedCallPrefix Prefix for method call statement, passed in order to save method result for chaining.
-     * @return Code that performs a method call.
+     * Generates the snippet that invokes {@code m} on {@code instanceFieldName} with its deserialised
+     * arguments. A {@link GeneratingMethodReaderInterceptorReturns} may wrap the call with custom
+     * code, otherwise a standard {@link MethodReaderInterceptorReturns} is used if present.
+     * {@code chainedCallPrefix} prefixes the call when the result must be stored for chaining.
      */
     private String methodCall(Method m, String instanceFieldName, String chainedCallPrefix, @Nullable Class<?> returnType) {
         StringBuilder res = new StringBuilder();
@@ -761,19 +711,10 @@ public class GenerateMethodReader {
     }
 
     /**
-     * Generates code for reading an argument of a method from a {@link ValueIn} object.
-     * The argument's index and type, and whether it is read in a lambda function,
-     * influence the generated code. If {@link LongConversion}
-     * annotations are present on the argument, a converter field is registered.
-     *
-     * @param m              Method for which an argument is read.
-     * @param argIndex       Index of an argument to be read.
-     * @param inLambda       {@code true} if argument is read in a lambda passed to a
-     *                       {@link ValueIn#sequence(Object, BiConsumer)} call.
-     * @param parameterTypes The types of the method parameters.
-     * @return Code in the form of a String that retrieves the specified argument from {@link ValueIn} input.
-     * @see LongConversion
-     * @see ValueIn
+     * Creates the code fragment that reads the argument at {@code argIndex} from a
+     * {@link ValueIn}. Handles primitives, {@link CharSequence}, {@link Bytes} and
+     * object types. Applies {@link LongConversion} where present when the wire type
+     * supports text.
      */
     private String argumentRead(Method m, int argIndex, boolean inLambda, Type[] parameterTypes) {
         Class<?> numericConversionClass = null;
@@ -890,10 +831,18 @@ public class GenerateMethodReader {
         }
     }
 
+    /**
+     * Returns {@code true} if {@code argumentType} typically supports recycling/clearing.
+     */
     private static boolean isRecyclable(Class<?> argumentType) {
-        return argumentType.isArray() || AbstractMarshallableCfg.class.isAssignableFrom(argumentType) || Collection.class.isAssignableFrom(argumentType) || Map.class.isAssignableFrom(argumentType);
+        return argumentType.isArray() || AbstractMarshallableCfg.class.isAssignableFrom(argumentType)
+                || Collection.class.isAssignableFrom(argumentType) || Map.class.isAssignableFrom(argumentType);
     }
 
+    /**
+     * Decides whether to support multiple concrete implementations for {@code argumentType}
+     * based on {@link #multipleNonMarshallableParamTypes} and the type itself.
+     */
     private boolean multipleNonMarshallableParamTypes(Class<?> argumentType) {
         Boolean _multipleNonMarshallableParamTypes = this.multipleNonMarshallableParamTypes;
         return _multipleNonMarshallableParamTypes == null
@@ -902,19 +851,16 @@ public class GenerateMethodReader {
     }
 
     /**
-     * Checks if a real interceptor is present that returns.
-     *
-     * @return {@code true} if there's a real interceptor present, {@code false} otherwise.
+     * @return {@code true} if a non-generating {@link MethodReaderInterceptorReturns}
+     * is configured.
      */
     private boolean hasRealInterceptorReturns() {
         return interceptor != null && !(interceptor instanceof GeneratingMethodReaderInterceptorReturns);
     }
 
     /**
-     * Retrieves the package name for the generated class.
-     * The package name is determined based on the class name of the first instance.
-     *
-     * @return The package name of the generated class.
+     * Package of the generated class, derived from the first handler and
+     * {@link ReflectionUtil#generatedPackageName(String)}.
      */
     public String packageName() {
         Class<?> firstClass = instances[0].getClass();
@@ -924,21 +870,16 @@ public class GenerateMethodReader {
     }
 
     /**
-     * Gets the simple name of the generated class.
-     *
-     * @return The simple name of the generated class.
+     * @return simple name of the generated reader class.
      */
     public String generatedClassName() {
         return generatedClassName;
     }
 
     /**
-     * Constructs the generated class name using various components such as
-     * the names of instances, metadata handlers, wire type, support for interchangeable marshallable/non-marshallable
-     * ([T]rue, [F]alse or [A]uto) and potential interceptor.
-     * Special characters, such as underscores and slashes, are handled to format the class name.
-     *
-     * @return The constructed name for the generated class.
+     * Builds the unique class name from handler names, metadata handlers, wire type,
+     * interceptor configuration and {@link #multipleNonMarshallableParamTypes}.
+     * Slashes are replaced to support lambdas and inner classes.
      */
     @NotNull
     private String generatedClassName0() {
@@ -976,16 +917,8 @@ public class GenerateMethodReader {
     }
 
     /**
-     * Appends the simplified name of the instance's class to the provided StringBuilder.
-     * The method takes into account various scenarios including:
-     * - If the class is a proxy class.
-     * - If the class is enclosed within another class.
-     * - If the class is synthetic, anonymous, or local.
-     * The method aims to provide a more concise and meaningful name for the instance's class
-     * that can be used in contexts like generating a class name.
-     *
-     * @param sb The StringBuilder to which the instance name should be appended.
-     * @param i  The instance for which the class name is determined.
+     * Appends a short name for {@code i}'s class to {@code sb}. Proxy and lambda
+     * classes are handled specially so the result forms part of the generated class name.
      */
     private void appendInstanceName(StringBuilder sb, Object i) {
         Class<?> aClass = i.getClass();


### PR DESCRIPTION
## Summary
- expand constructor docs
- describe signature, hasInstance and other helper methods
- rewrite createClass and generateSourceCode docs
- streamline comments on interface and method handling

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d54a00414832980bdc0937292cad7