### PR TITLE
Improve MethodDelegate Javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/MethodDelegate.java
+++ b/src/main/java/net/openhft/chronicle/wire/MethodDelegate.java
@@ -18,11 +18,18 @@ package net.openhft.chronicle.wire;
 
 /**
  * Represents an interface that provides a mechanism for method delegation.
- * Implementors of this interface can set a delegate to which method invocations are
- * forwarded. By using this interface, users can achieve behavior modification,
- * augmentation, or decoration of method calls by setting appropriate delegates.
- *
- * @param <OUT> The type of the delegate to which method calls will be forwarded.
+ * Implementors may set a delegate to which method invocations are forwarded,
+ * allowing behaviour to be modified, augmented or decorated.
+ * <p>
+ * Typically, an instance implementing {@code MethodDelegate} and another target
+ * interface (for example {@code MyService}) is generated dynamically (see
+ * {@link GenerateMethodDelegate}). When methods of {@code MyService} are called
+ * on the generated instance, they are forwarded to the {@code delegate} object
+ * set via the {@link #delegate(Object)} method, provided that the delegate also
+ * implements {@code MyService}.
+ * <p>
+ * The type parameter {@code <OUT>} specifies the type of the delegate object to
+ * which methods will be forwarded.
  */
 public interface MethodDelegate<OUT> {
 
@@ -30,9 +37,13 @@ public interface MethodDelegate<OUT> {
      * Sets the delegate to which method invocations will be forwarded.
      * <p>
      * This mechanism allows the delegation of method calls to an alternate implementation,
-     * enabling behaviors like logging, mocking, or additional processing.
+     * enabling behaviours such as logging, mocking or additional processing. The provided
+     * {@code delegate} should typically implement the same business interface(s) as the
+     * proxy that implements this {@code MethodDelegate} interface so that calls can be
+     * successfully forwarded.
      *
-     * @param delegate The object that will receive the delegated method calls.
+     * @param delegate The target object of type {@code OUT} that will receive the
+     *                 forwarded method calls.
      */
     void delegate(OUT delegate);
 }


### PR DESCRIPTION
## Summary
- clarify how MethodDelegate delegates calls to a target object
- document the generic `OUT` type in the interface javadoc
- explain expectations for objects passed to `delegate(OUT delegate)`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d55a50f50832996f274210621dceb