### PR TITLE
Improve javadoc for MethodDelegate generator

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodDelegate.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodDelegate.java
@@ -23,20 +23,38 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * This is the GenerateMethodDelegate class, extending AbstractClassGenerator with GMDMetaData.
- * The class is responsible for generating method delegates using the provided metadata.
+ * Dynamically generates a class that implements {@link MethodDelegate} and the
+ * additional interfaces supplied in {@link GMDMetaData#interfaces()}. Calls to
+ * those interfaces are forwarded to a delegate instance set via
+ * {@link MethodDelegate#delegate(Object)}.
+ * <p>
+ * The generated class allows the delegate to be swapped or wrapped at run time,
+ * providing a lightweight means of adapting behaviour. This generator extends
+ * {@link AbstractClassGenerator} and produces a typed wrapper that forwards
+ * every method invocation to the current delegate.
  */
 public class GenerateMethodDelegate extends AbstractClassGenerator<GenerateMethodDelegate.GMDMetaData> {
+    /**
+     * Creates a generator with the default metadata.
+     */
     public GenerateMethodDelegate() {
         super(new GMDMetaData());
     }
 
+    /**
+     * Ensures {@link MethodDelegate} is always included before delegating to the
+     * superclass to create or load the proxy class.
+     */
     @Override
     public synchronized <T> Class<T> acquireClass(ClassLoader classLoader) {
         metaData().interfaces().add(MethodDelegate.class);
         return super.acquireClass(classLoader);
     }
 
+    /**
+     * Creates the generic type signature in the form
+     * {@code <OUT extends Object & Interface1 & Interface2 & MethodDelegate<OUT>>}.
+     */
     @Override
     protected String generateGenericType() {
         return "OUT extends Object & " + metaData().interfaces().stream()
@@ -45,19 +63,33 @@ public class GenerateMethodDelegate extends AbstractClassGenerator<GenerateMetho
                 .collect(Collectors.joining(" & "));
     }
 
+    /**
+     * Emits the field that stores the current delegate instance.
+     */
     @Override
     protected void generateFields(SourceCodeFormatter mainCode) {
         mainCode.append("private ").append(getDelegateType()).append(" delegate;\n");
     }
 
+    /**
+     * Returns the name used for the delegate type in generated code.
+     */
     protected String getDelegateType() {
         return "OUT";
     }
 
+    /**
+     * Uses the implicit no-arg constructor; no constructors are generated.
+     */
     @Override
     protected void generateConstructors(SourceCodeFormatter mainCode) {
     }
 
+    /**
+     * Generates a concrete implementation of each method. The
+     * {@code delegate(Object)} method stores the delegate, while all other
+     * methods are handled by the superclass.
+     */
     @Override
     protected void generateMethod(Method method, SourceCodeFormatter mainCode) {
         String s = method.toString();
@@ -71,6 +103,10 @@ public class GenerateMethodDelegate extends AbstractClassGenerator<GenerateMetho
         }
     }
 
+    /**
+     * Writes the body of a delegated method. The parameters and their list are
+     * passed in so the invocation can be constructed correctly.
+     */
     @Override
     protected void generateMethod(Method method, StringBuilder params, List<String> paramList, SourceCodeFormatter mainCode) {
         if (method.getReturnType() != void.class)
@@ -80,20 +116,17 @@ public class GenerateMethodDelegate extends AbstractClassGenerator<GenerateMetho
     }
 
     /**
-     * Appends the delegate to the main code.
-     *
-     * @param mainCode The SourceCodeFormatter to append the delegate.
-     * @param method The associated method.
-     * @return Updated SourceCodeFormatter with delegate appended.
+     * Appends the expression used to access the current delegate.
      */
     protected SourceCodeFormatter getDelegate(SourceCodeFormatter mainCode, Method method) {
         return mainCode.append("this.delegate");
     }
 
     /**
-     * This is an inner static class representing metadata for GenerateMethodDelegate.
+     * Metadata for {@link GenerateMethodDelegate}. It currently mirrors
+     * {@link AbstractClassGenerator.MetaData} without extra fields.
      */
     public static class GMDMetaData extends AbstractClassGenerator.MetaData<GMDMetaData> {
-        // This class serves as a metadata container with no additional methods or attributes.
+        // Intentionally left blank
     }
 }


### PR DESCRIPTION
## Summary
- expand the class-level description for `GenerateMethodDelegate`
- document behaviour of overridden methods and helper methods

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d55b7fac0832984d4749cc15884ce