### PR TITLE
Improve Javadoc for timestamp and duration converters

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/MicroDurationLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/MicroDurationLongConverter.java
@@ -28,7 +28,9 @@ public class MicroDurationLongConverter implements LongConverter {
     /**
      * Parses the provided {@link CharSequence} into a duration and returns the equivalent duration in microseconds.
      *
-     * @param text the {@link CharSequence} to parse
+     * @param text The character sequence representing a duration in ISO-8601
+     *             format (e.g., "PT20.345S") to be parsed into total
+     *             microseconds.
      * @return the parsed duration as a long value in microseconds
      */
     @Override
@@ -40,7 +42,7 @@ public class MicroDurationLongConverter implements LongConverter {
     /**
      * Converts a duration represented in microseconds to a {@link Duration} object.
      *
-     * @param value the duration as a long value in microseconds
+     * @param value The duration expressed as a total number of microseconds
      * @return a {@link Duration} representing the same duration
      */
     private Duration duration(long value) {
@@ -51,8 +53,11 @@ public class MicroDurationLongConverter implements LongConverter {
     /**
      * Appends a {@link Duration} representation of the provided long value (in microseconds) to the provided {@link StringBuilder}.
      *
-     * @param text the {@link StringBuilder} to append to
-     * @param value the duration as a long value in microseconds
+     * @param text  The {@link StringBuilder} to which the ISO-8601 string
+     *              representation of the duration {@code value} will be
+     *              appended.
+     * @param value The duration, expressed as a total number of microseconds,
+     *              to be formatted and appended
      */
     @Override
     public void append(StringBuilder text, long value) {
@@ -62,8 +67,11 @@ public class MicroDurationLongConverter implements LongConverter {
     /**
      * Appends a {@link Duration} representation of the provided long value (in microseconds) to the provided {@link Bytes}.
      *
-     * @param bytes the {@link Bytes} object to append to
-     * @param value the duration as a long value in microseconds
+     * @param bytes The {@link net.openhft.chronicle.bytes.Bytes} instance to
+     *              which the ISO-8601 string representation of the duration
+     *              {@code value} will be appended
+     * @param value The duration, expressed as a total number of microseconds,
+     *              to be formatted and appended
      */
     @Override
     public void append(Bytes<?> bytes, long value) {

--- a/src/main/java/net/openhft/chronicle/wire/MicroTimestampLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/MicroTimestampLongConverter.java
@@ -59,7 +59,9 @@ public class MicroTimestampLongConverter extends AbstractTimestampLongConverter 
     /**
      * Constructs a new {@code MicroTimestampLongConverter} with the specified zone ID.
      *
-     * @param zoneId the zone ID to be used for the conversion of long values
+     * @param zoneId The string representation of the ZoneId (e.g., "UTC", "Europe/London")
+     *               to be used for formatting date-time strings. This converter
+     *               handles timestamps with microsecond precision.
      */
     public MicroTimestampLongConverter(String zoneId) {
         super(zoneId, TimeUnit.MICROSECONDS);

--- a/src/main/java/net/openhft/chronicle/wire/MilliTimestampLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/MilliTimestampLongConverter.java
@@ -45,7 +45,9 @@ public class MilliTimestampLongConverter extends AbstractTimestampLongConverter 
     /**
      * Constructs a new {@code MilliTimestampLongConverter} with the specified zone ID.
      *
-     * @param zoneId the zone ID to be used for the conversion of long values
+     * @param zoneId The string representation of the ZoneId (e.g., "UTC", "Europe/London")
+     *               to be used for formatting date-time strings. This converter
+     *               handles timestamps with millisecond precision.
      */
     public MilliTimestampLongConverter(String zoneId) {
         super(zoneId, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
## Summary
- refine the zoneId parameter docs for timestamp converters
- clarify parameter docs for `MicroDurationLongConverter`

## Testing
- `mvn -q verify` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d5c779cec832990fd3df77ff0e6e5