### PR TITLE
Improve javadoc in NanoDurationLongConverter

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/NanoDurationLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/NanoDurationLongConverter.java
@@ -26,9 +26,9 @@ import java.time.Duration;
 public class NanoDurationLongConverter implements LongConverter {
 
     /**
-     * Parses the provided {@link CharSequence} into a duration and returns the equivalent duration in nanoseconds.
+     * Parse a duration in ISO-8601 format and return the equivalent value in nanoseconds.
      *
-     * @param text the {@link CharSequence} to parse
+     * @param text The character sequence representing a duration in ISO-8601 format (e.g., "PT20.345S") to be parsed into total nanoseconds.
      * @return the parsed duration as a long value in nanoseconds
      */
     @Override
@@ -38,9 +38,9 @@ public class NanoDurationLongConverter implements LongConverter {
     }
 
     /**
-     * Converts a duration represented in nanoseconds to a {@link Duration} object.
+     * Convert a number of nanoseconds to a {@link Duration}.
      *
-     * @param value the duration as a long value in nanoseconds
+     * @param value The duration expressed as a total number of nanoseconds.
      * @return a {@link Duration} representing the same duration
      */
     private Duration duration(long value) {
@@ -49,10 +49,10 @@ public class NanoDurationLongConverter implements LongConverter {
     }
 
     /**
-     * Appends a {@link Duration} representation of the provided long value (in nanoseconds) to the provided {@link StringBuilder}.
+     * Append the ISO-8601 form of the given duration to the supplied {@link StringBuilder}.
      *
-     * @param text the {@link StringBuilder} to append to
-     * @param value the duration as a long value in nanoseconds
+     * @param text The {@link StringBuilder} to which the ISO-8601 string representation of the duration {@code value} will be appended.
+     * @param value The duration, expressed as a total number of nanoseconds, to be formatted and appended.
      */
     @Override
     public void append(StringBuilder text, long value) {
@@ -60,10 +60,10 @@ public class NanoDurationLongConverter implements LongConverter {
     }
 
     /**
-     * Appends a {@link Duration} representation of the provided long value (in nanoseconds) to the provided {@link Bytes}.
+     * Append the ISO-8601 form of the given duration to the supplied {@link Bytes}.
      *
-     * @param bytes the {@link Bytes} object to append to
-     * @param value the duration as a long value in nanoseconds
+     * @param bytes The {@link net.openhft.chronicle.bytes.Bytes} instance to which the ISO-8601 string representation of the duration {@code value} will be appended.
+     * @param value The duration, expressed as a total number of nanoseconds, to be formatted and appended.
      */
     @Override
     public void append(Bytes<?> bytes, long value) {


### PR DESCRIPTION
## Summary
- clarify parameter descriptions for `parse`, `duration`, and `append` methods in `NanoDurationLongConverter`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d5ca892148329b7c124fd04698641