### PR TITLE
Improve Javadoc for long conversion

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/LongConversion.java
+++ b/src/main/java/net/openhft/chronicle/wire/LongConversion.java
@@ -33,6 +33,7 @@ import java.lang.annotation.Target;
  * @Retention(RetentionPolicy.RUNTIME)
  * @Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
  * public @interface MyHexFormat {
+ *    LongConverter INSTANCE = new MyHexFormatConverter("0123456789ABCDEF");
  * }
  * }</pre>
  *
@@ -43,10 +44,14 @@ import java.lang.annotation.Target;
 public @interface LongConversion {
 
     /**
-     * Specifies the {@link LongConverter} class that provides the logic for
-     * converting the value to and from text.
+     * Returns the class responsible for converting the long value or an annotation with an INSTANCE of one.
+     *<p>
+     * The {@link LongConverter} class to be used for conversion.
+     * The class specified should either have a static final field named INSTANCE,
+     * or a constructor that takes a single string parameter for initialization.
      *
-     * @return the {@link LongConverter} implementation class
+     * @return The implementing class which either contains a static final field named `INSTANCE`
+     *         or provides a constructor that takes a string for initialization.
      */
-    Class<? extends LongConverter> value();
+    Class<?> value();
 }

--- a/src/main/java/net/openhft/chronicle/wire/LongConversion.java
+++ b/src/main/java/net/openhft/chronicle/wire/LongConversion.java
@@ -19,13 +19,22 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 /**
- * Annotation to specify the conversion strategy for a `long` value.
- * <p>
- * This annotation can be applied to fields, parameters, or other annotations to define
- * a custom conversion strategy using a specific {@link LongConverter} implementation.
- * The referenced converter annotation should either have a static final instance named
- * `INSTANCE` or should be a {@link LongConverter}
+ * Meta-annotation used to associate a concrete {@link LongConverter}
+ * implementation with another annotation. Custom marker annotations (for
+ * example {@code @Hexadecimal} or {@code @Base64}) can declare which converter
+ * should be applied when serialising or deserialising {@code long} fields or
+ * parameters.
+ *
+ * <p>Example:</p>
+ * <pre>{@code
+ * @LongConversion(HexadecimalLongConverter.class)
+ * @Retention(RetentionPolicy.RUNTIME)
+ * @Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+ * public @interface MyHexFormat {
+ * }
+ * }</pre>
  *
  * @see LongConverter
  */
@@ -34,14 +43,10 @@ import java.lang.annotation.Target;
 public @interface LongConversion {
 
     /**
-     * Returns the class responsible for converting the long value or an annotation with an INSTANCE of one.
-     *<p>
-     * The {@link LongConverter} class to be used for conversion.
-     * The class specified should either have a static final field named INSTANCE,
-     * or a constructor that takes a single string parameter for initialization.
+     * Specifies the {@link LongConverter} class that provides the logic for
+     * converting the value to and from text.
      *
-     * @return The implementing class which either contains a static final field named `INSTANCE`
-     *         or provides a constructor that takes a string for initialization.
+     * @return the {@link LongConverter} implementation class
      */
-    Class<?> value();
+    Class<? extends LongConverter> value();
 }

--- a/src/main/java/net/openhft/chronicle/wire/LongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/LongConverter.java
@@ -25,11 +25,21 @@ import static java.lang.Math.log;
 import static java.text.MessageFormat.format;
 
 /**
- * Provides an abstraction for converting between long values and their string representations,
- * potentially based on a custom character or symbol set.
- * <p>
- * The conversion allows encoding long values into compact, human-readable strings and vice versa,
- * useful in contexts where storage efficiency or readability is a concern.
+ * Defines a contract for converting {@code long} values to and from textual
+ * representations. Implementations are typically triggered by annotations such
+ * as {@link LongConversion} to encode or decode fields using formats like
+ * hexadecimal, base64 or symbolic alphabets.
+ *
+ * <p>Example usage:</p>
+ * <pre>{@code
+ * LongConverter converter = LongConverter.forSymbols("0123456789ABCDEF");
+ * long value = converter.parse("1A");
+ * StringBuilder out = new StringBuilder();
+ * converter.append(out, value);
+ * }</pre>
+ *
+ * @see LongConversion
+ * @see AbstractLongConverter
  */
 public interface LongConverter {
 
@@ -58,13 +68,15 @@ public interface LongConverter {
     }
 
     /**
-     * Parses the provided {@link CharSequence} and returns the parsed results as a
-     * {@code long} primitive.
+     * Parses the given character sequence, which represents a long value in a
+     * specific format, into its numeric form.
      *
-     * @return the parsed {@code text} as an {@code long} primitive.
-     * @throws IllegalArgumentException if the text length is outside of range accepted by a specific converter.
+     * @param textToParse the character sequence to parse; must not be {@code null}
+     * @return the {@code long} value represented by the text
+     * @throws IllegalArgumentException if the text cannot be parsed according to
+     *         the converter's rules
      */
-    long parse(CharSequence text);
+    long parse(CharSequence textToParse);
 
     /**
      * Parses a part of the provided {@link CharSequence} and returns the parsed results as a
@@ -72,36 +84,38 @@ public interface LongConverter {
      * <p>
      * The default implementation is garbage-producing and an implementing class is supposed to reimplement this method.
      *
-     * @param text character sequence containing the string representation of the value.
-     * @param beginIndex the beginning index, inclusive.
-     * @param endIndex the ending index, exclusive.
+     * @param textToParse character sequence containing the string representation of the value
+     * @param beginIndex  the beginning index, inclusive
+     * @param endIndex    the ending index, exclusive
      *
-     * @return the parsed {@code text} as an {@code long} primitive.
-     * @throws IllegalArgumentException if any of the indices are invalid or the sub-sequence length is
-     *      outside of range accepted by a specific converter.
+     * @return the {@code long} value represented by the specified sub-sequence
+     * @throws IllegalArgumentException if any of the indices are invalid or the
+     *      sub-sequence length is outside the range accepted by a specific converter
      */
-    default long parse(CharSequence text, int beginIndex, int endIndex) {
-        return parse(text.toString().substring(beginIndex, endIndex));
+    default long parse(CharSequence textToParse, int beginIndex, int endIndex) {
+        return parse(textToParse.toString().substring(beginIndex, endIndex));
     }
 
     /**
-     * Converts the given long value to a string and appends it to the provided StringBuilder.
+     * Appends the textual form of the provided {@code long} to the given
+     * {@link StringBuilder} using the converter's formatting rules.
      *
-     * @param text  The StringBuilder to which the converted value is appended.
-     * @param value The long value to convert.
+     * @param outputBuilder the destination for the formatted value; must not be
+     *                      {@code null}
+     * @param numericValue  the value to convert and append
      */
-    void append(StringBuilder text, long value);
+    void append(StringBuilder outputBuilder, long numericValue);
 
     /**
      * Converts the given long value to a string and appends it to the provided Bytes object.
      *
-     * @param bytes The Bytes object to which the converted value is appended.
-     * @param value The long value to convert.
+     * @param bytes        the Bytes object to which the formatted value is appended
+     * @param numericValue the value to convert
      */
-    default void append(Bytes<?> bytes, long value) {
+    default void append(Bytes<?> bytes, long numericValue) {
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
             final StringBuilder sb = stlSb.get();
-            append(sb, value);
+            append(sb, numericValue);
             bytes.append(sb);
         }
     }

--- a/src/main/java/net/openhft/chronicle/wire/WireDumper.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireDumper.java
@@ -20,11 +20,11 @@ import net.openhft.chronicle.bytes.BytesUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-@SuppressWarnings("rawtypes")
 /**
  * The WireDumper class provides utility methods to obtain a human-readable dump representation of {@link WireIn} content.
  * This class can operate on different WireIn or Bytes inputs and is designed to facilitate debugging and logging.
  */
+@SuppressWarnings("rawtypes")
 public class WireDumper {
 
     // Instance of WireIn to read from

--- a/src/main/java/net/openhft/chronicle/wire/Wires.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wires.java
@@ -58,13 +58,13 @@ import static net.openhft.chronicle.wire.SerializationStrategies.*;
 import static net.openhft.chronicle.wire.WireType.TEXT;
 import static net.openhft.chronicle.wire.WireType.YAML_ONLY;
 
-@SuppressWarnings({"rawtypes", "unchecked"})
 /**
  * The {@code Wires} enum encapsulates constants and utility methods related to wire operations.
  * It defines flags, masks, and utility methods that facilitate operations on wires.
  * For example, it provides constants like {@code NOT_COMPLETE} to indicate a wire message's completeness status.
  * This enum doesn't have any specific enumeration values but provides a utility-based structure.
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public enum Wires {
     ; // No specific enumeration values
 


### PR DESCRIPTION
## Summary
- document how LongConverter is used
- show a usage example in LongConverter Javadoc
- expand parameter names in parse/append methods
- document LongConversion annotation and narrow its return type

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d5d9194648329ade4865a3088dcfc