### PR TITLE
Update response header to use -1 for indicating no content length

### DIFF
--- a/src/test/java/net/openhft/chronicle/wire/MarshallableOutBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MarshallableOutBuilderTest.java
@@ -200,7 +200,8 @@ public class MarshallableOutBuilderTest extends net.openhft.chronicle.wire.WireT
                 queue.add(bytes.toHexString());
             else
                 queue.add(bytes.toString());
-            xchg.sendResponseHeaders(202, 0);
+            // use -1 to indicate not response as 0 allows an arbitrary length
+            xchg.sendResponseHeaders(202, -1);
         }
     }
 


### PR DESCRIPTION
We need no response, not an arbitrarily long response.

responseLength – 

if > 0, specifies a fixed response body length and that exact number of bytes must be written to the stream acquired from getResponseCode() 

**If == 0,** then chunked encoding is used, and an arbitrary number of bytes may be written. 

**If <= -1**, then no response body length is specified and no response body may be written.