### PR TITLE
Clarify converter docs and parameter names

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AbstractLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractLongConverter.java
@@ -61,46 +61,46 @@ public abstract class AbstractLongConverter implements LongConverter {
     /**
      * Parses the provided text using the underlying converter.
      *
-     * @param text the text to parse.
+     * @param textToParse the text to parse.
      * @return the parsed long value.
      */
     @Override
-    public long parse(CharSequence text) {
-        return converter.parse(text);
+    public long parse(CharSequence textToParse) {
+        return converter.parse(textToParse);
     }
 
     /**
      * Parses a part of the provided text using the underlying converter.
      *
-     * @param text the text to parse.
+     * @param textToParse the text to parse.
      * @param beginIndex the beginning index, inclusive.
      * @param endIndex the ending index, exclusive.
      * @return the parsed long value.
      */
     @Override
-    public long parse(CharSequence text, int beginIndex, int endIndex) {
-        return converter.parse(text, beginIndex, endIndex);
+    public long parse(CharSequence textToParse, int beginIndex, int endIndex) {
+        return converter.parse(textToParse, beginIndex, endIndex);
     }
 
     /**
      * Appends the provided long value to the provided {@code StringBuilder} text.
      *
-     * @param text the StringBuilder to append to.
-     * @param value the long value to convert and append.
+     * @param outputBuilder the StringBuilder to append to.
+     * @param numericValue the long value to convert and append.
      */
     @Override
-    public void append(StringBuilder text, long value) {
-        converter.append(text, value);
+    public void append(StringBuilder outputBuilder, long numericValue) {
+        converter.append(outputBuilder, numericValue);
     }
 
     /**
      * Appends the provided long value to the provided {@code Bytes} text.
      *
-     * @param bytes the Bytes object to append to.
-     * @param value the long value to convert and append.
+     * @param outputBytes the Bytes object to append to.
+     * @param numericValue the long value to convert and append.
      */
     @Override
-    public void append(Bytes<?> bytes, long value) {
-        converter.append(bytes, value);
+    public void append(Bytes<?> outputBytes, long numericValue) {
+        converter.append(outputBytes, numericValue);
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/AbstractTimestampLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractTimestampLongConverter.java
@@ -120,17 +120,17 @@ public abstract class AbstractTimestampLongConverter implements LongConverter {
      * The text can be an ISO date or a timestamp. If the text includes a timezone, it's used for conversion;
      * otherwise, the converter's timezone is used.
      *
-     * @param text the text to be parsed
+     * @param textToParse the text to be parsed
      * @return a long value representing the parsed timestamp
      */
     @Override
-    public long parse(CharSequence text) {
-        if (text == null || text.length() == 0)
+    public long parse(CharSequence textToParse) {
+        if (textToParse == null || textToParse.length() == 0)
             return 0;
         try {
-            if (text.length() > 4 && text.charAt(4) == '/')
-                text = text.toString().replace('/', '-');
-            final TemporalAccessor parse = formatterForParsing.parse(text);
+            if (textToParse.length() > 4 && textToParse.charAt(4) == '/')
+                textToParse = textToParse.toString().replace('/', '-');
+            final TemporalAccessor parse = formatterForParsing.parse(textToParse);
             if (parse.query(TemporalQueries.zoneId()) != null) {
                 return parseFormattedDate(ZonedDateTime.from(parse).withZoneSameInstant(UTC));
             } else {
@@ -214,22 +214,22 @@ public abstract class AbstractTimestampLongConverter implements LongConverter {
     /**
      * Appends the provided long value to the given {@code StringBuilder}. This method delegates to {@code append(Appendable, long)}.
      *
-     * @param text  the {@code StringBuilder} to append to
-     * @param value the long value to be appended
+     * @param outputBuilder  the {@code StringBuilder} to append to
+     * @param numericValue the long value to be appended
      */
     @Override
-    public void append(StringBuilder text, long value) {
-        append((Appendable) text, value);
+    public void append(StringBuilder outputBuilder, long numericValue) {
+        append((Appendable) outputBuilder, numericValue);
     }
 
     /**
      * Appends the provided long value to the given {@code Bytes}. This method delegates to {@code append(Appendable, long)}.
      *
-     * @param bytes the {@code Bytes} to append to
-     * @param value the long value to be appended
+     * @param outputBytes the {@code Bytes} to append to
+     * @param numericValue the long value to be appended
      */
     @Override
-    public void append(Bytes<?> bytes, long value) {
-        append((Appendable) bytes, value);
+    public void append(Bytes<?> outputBytes, long numericValue) {
+        append((Appendable) outputBytes, numericValue);
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/IdentifierLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/IdentifierLongConverter.java
@@ -59,15 +59,15 @@ public class IdentifierLongConverter implements LongConverter {
      * @return The parsed long identifier representation.
      */
     @Override
-    public long parse(CharSequence text) {
-        return parse(text, 0, text.length());
+    public long parse(CharSequence textToParse) {
+        return parse(textToParse, 0, textToParse.length());
     }
 
     /**
      * Parses a part of the provided {@link CharSequence} into a long identifier.
      * The parsing behavior changes depending on the difference between indices.
      *
-     * @param text the CharSequence to parse.
+     * @param textToParse the CharSequence to parse.
      * @param beginIndex the beginning index, inclusive.
      * @param endIndex the ending index, exclusive.
      * @return the parsed long identifier
@@ -75,44 +75,44 @@ public class IdentifierLongConverter implements LongConverter {
      *      outside of range accepted by the converter.
      */
     @Override
-    public long parse(CharSequence text, int beginIndex, int endIndex) {
+    public long parse(CharSequence textToParse, int beginIndex, int endIndex) {
         return (endIndex - beginIndex) <= 10
-                ? SMALL_POSITIVE.parse(text, beginIndex, endIndex)
-                : NanoTimestampLongConverter.INSTANCE.parse(text, beginIndex, endIndex);
+                ? SMALL_POSITIVE.parse(textToParse, beginIndex, endIndex)
+                : NanoTimestampLongConverter.INSTANCE.parse(textToParse, beginIndex, endIndex);
     }
 
     /**
      * Appends a long identifier to a provided {@link StringBuilder} instance.
      * The behavior changes depending on the magnitude of the identifier.
      *
-     * @param text the StringBuilder to append the identifier to
-     * @param value the long identifier
+     * @param outputBuilder the StringBuilder to append the identifier to
+     * @param numericValue the long identifier
      */
     @Override
-    public void append(StringBuilder text, long value) {
-        if (value < 0)
-            throw new IllegalArgumentException("value: " + value); // reserved
-        if (value <= MAX_SMALL_ID)
-            SMALL_POSITIVE.append(text, value);
+    public void append(StringBuilder outputBuilder, long numericValue) {
+        if (numericValue < 0)
+            throw new IllegalArgumentException("value: " + numericValue); // reserved
+        if (numericValue <= MAX_SMALL_ID)
+            SMALL_POSITIVE.append(outputBuilder, numericValue);
         else
-            NanoTimestampLongConverter.INSTANCE.append(text, value);
+            NanoTimestampLongConverter.INSTANCE.append(outputBuilder, numericValue);
     }
 
     /**
      * Appends a long identifier to a provided {@link Bytes} instance.
      * The behavior changes depending on the magnitude of the identifier.
      *
-     * @param bytes the Bytes to append the identifier to
-     * @param value the long identifier
+     * @param outputBytes the Bytes to append the identifier to
+     * @param numericValue the long identifier
      */
     @Override
-    public void append(Bytes<?> bytes, long value) {
-        if (value < 0)
-            throw new IllegalArgumentException("value: " + value); // reserved
-        if (value <= MAX_SMALL_ID)
-            SMALL_POSITIVE.append(bytes, value);
+    public void append(Bytes<?> outputBytes, long numericValue) {
+        if (numericValue < 0)
+            throw new IllegalArgumentException("value: " + numericValue); // reserved
+        if (numericValue <= MAX_SMALL_ID)
+            SMALL_POSITIVE.append(outputBytes, numericValue);
         else
-            NanoTimestampLongConverter.INSTANCE.append(bytes, value);
+            NanoTimestampLongConverter.INSTANCE.append(outputBytes, numericValue);
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/LongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/LongConverter.java
@@ -61,10 +61,10 @@ public interface LongConverter {
      * Parses the provided {@link CharSequence} and returns the parsed results as a
      * {@code long} primitive.
      *
-     * @return the parsed {@code text} as an {@code long} primitive.
+     * @return the parsed {@code textToParse} as a {@code long} primitive.
      * @throws IllegalArgumentException if the text length is outside of range accepted by a specific converter.
      */
-    long parse(CharSequence text);
+    long parse(CharSequence textToParse);
 
     /**
      * Parses a part of the provided {@link CharSequence} and returns the parsed results as a
@@ -72,37 +72,37 @@ public interface LongConverter {
      * <p>
      * The default implementation is garbage-producing and an implementing class is supposed to reimplement this method.
      *
-     * @param text character sequence containing the string representation of the value.
+     * @param textToParse character sequence containing the string representation of the value.
      * @param beginIndex the beginning index, inclusive.
      * @param endIndex the ending index, exclusive.
      *
-     * @return the parsed {@code text} as an {@code long} primitive.
+     * @return the parsed {@code textToParse} as a {@code long} primitive.
      * @throws IllegalArgumentException if any of the indices are invalid or the sub-sequence length is
      *      outside of range accepted by a specific converter.
      */
-    default long parse(CharSequence text, int beginIndex, int endIndex) {
-        return parse(text.toString().substring(beginIndex, endIndex));
+    default long parse(CharSequence textToParse, int beginIndex, int endIndex) {
+        return parse(textToParse.toString().substring(beginIndex, endIndex));
     }
 
     /**
      * Converts the given long value to a string and appends it to the provided StringBuilder.
      *
-     * @param text  The StringBuilder to which the converted value is appended.
-     * @param value The long value to convert.
+     * @param outputBuilder The StringBuilder to which the converted value is appended.
+     * @param numericValue  The long value to convert.
      */
-    void append(StringBuilder text, long value);
+    void append(StringBuilder outputBuilder, long numericValue);
 
     /**
      * Converts the given long value to a string and appends it to the provided Bytes object.
      *
-     * @param bytes The Bytes object to which the converted value is appended.
-     * @param value The long value to convert.
+     * @param outputBytes The Bytes object to which the converted value is appended.
+     * @param numericValue The long value to convert.
      */
-    default void append(Bytes<?> bytes, long value) {
+    default void append(Bytes<?> outputBytes, long numericValue) {
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
             final StringBuilder sb = stlSb.get();
-            append(sb, value);
-            bytes.append(sb);
+            append(sb, numericValue);
+            outputBytes.append(sb);
         }
     }
 
@@ -150,24 +150,24 @@ public interface LongConverter {
     /**
      * Checks that the length of the provided text does not exceed the allowable maximum.
      *
-     * @param text The text to check.
+     * @param textToCheck The text to check.
      * @throws IllegalArgumentException if the text length exceeds the maximum allowable length.
      */
-    default void lengthCheck(CharSequence text) {
-        if (text.length() > maxParseLength())
-            throw new IllegalArgumentException(format("text={0} exceeds the maximum allowable length of {1}", text, maxParseLength()));
+    default void lengthCheck(CharSequence textToCheck) {
+        if (textToCheck.length() > maxParseLength())
+            throw new IllegalArgumentException(format("text={0} exceeds the maximum allowable length of {1}", textToCheck, maxParseLength()));
     }
 
     /**
      * Checks that the length of the provided text does not exceed the allowable maximum.
      *
-     * @param text The text to check.
+     * @param textToCheck The text to check.
      * @param beginIndex the beginning index, inclusive.
      * @param endIndex   the ending index, exclusive.
      * @throws IllegalArgumentException if the text length exceeds the maximum allowable length.
      */
-    default void lengthCheck(CharSequence text, int beginIndex, int endIndex) {
-        if ((beginIndex | endIndex | (endIndex - beginIndex) | (text.length() - endIndex + beginIndex) | (maxParseLength() - endIndex + beginIndex)) < 0)
+    default void lengthCheck(CharSequence textToCheck, int beginIndex, int endIndex) {
+        if ((beginIndex | endIndex | (endIndex - beginIndex) | (textToCheck.length() - endIndex + beginIndex) | (maxParseLength() - endIndex + beginIndex)) < 0)
             throw new IllegalArgumentException(format("range [{0}, {1}) exceeds the maximum allowable length of {2}",
                     beginIndex, endIndex, maxParseLength()));
     }

--- a/src/main/java/net/openhft/chronicle/wire/MicroDurationLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/MicroDurationLongConverter.java
@@ -28,12 +28,12 @@ public class MicroDurationLongConverter implements LongConverter {
     /**
      * Parses the provided {@link CharSequence} into a duration and returns the equivalent duration in microseconds.
      *
-     * @param text the {@link CharSequence} to parse
+     * @param textToParse the {@link CharSequence} to parse
      * @return the parsed duration as a long value in microseconds
      */
     @Override
-    public long parse(CharSequence text) {
-        final Duration parse = Duration.parse(text);
+    public long parse(CharSequence textToParse) {
+        final Duration parse = Duration.parse(textToParse);
         return parse.getSeconds() * 1000_000 + parse.getNano() / 1000;
     }
 
@@ -55,8 +55,8 @@ public class MicroDurationLongConverter implements LongConverter {
      * @param value the duration as a long value in microseconds
      */
     @Override
-    public void append(StringBuilder text, long value) {
-        text.append(duration(value));
+    public void append(StringBuilder outputBuilder, long numericValue) {
+        outputBuilder.append(duration(numericValue));
     }
 
     /**
@@ -66,7 +66,7 @@ public class MicroDurationLongConverter implements LongConverter {
      * @param value the duration as a long value in microseconds
      */
     @Override
-    public void append(Bytes<?> bytes, long value) {
-        bytes.append(duration(value).toString());
+    public void append(Bytes<?> outputBytes, long numericValue) {
+        outputBytes.append(duration(numericValue).toString());
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/NanoDurationLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/NanoDurationLongConverter.java
@@ -28,12 +28,12 @@ public class NanoDurationLongConverter implements LongConverter {
     /**
      * Parses the provided {@link CharSequence} into a duration and returns the equivalent duration in nanoseconds.
      *
-     * @param text the {@link CharSequence} to parse
+     * @param textToParse the {@link CharSequence} to parse
      * @return the parsed duration as a long value in nanoseconds
      */
     @Override
-    public long parse(CharSequence text) {
-        final Duration parse = Duration.parse(text);
+    public long parse(CharSequence textToParse) {
+        final Duration parse = Duration.parse(textToParse);
         return parse.getSeconds() * 1_000_000_000L + parse.getNano();
     }
 
@@ -51,22 +51,22 @@ public class NanoDurationLongConverter implements LongConverter {
     /**
      * Appends a {@link Duration} representation of the provided long value (in nanoseconds) to the provided {@link StringBuilder}.
      *
-     * @param text the {@link StringBuilder} to append to
-     * @param value the duration as a long value in nanoseconds
+     * @param outputBuilder the {@link StringBuilder} to append to
+     * @param numericValue the duration as a long value in nanoseconds
      */
     @Override
-    public void append(StringBuilder text, long value) {
-        text.append(duration(value));
+    public void append(StringBuilder outputBuilder, long numericValue) {
+        outputBuilder.append(duration(numericValue));
     }
 
     /**
      * Appends a {@link Duration} representation of the provided long value (in nanoseconds) to the provided {@link Bytes}.
      *
-     * @param bytes the {@link Bytes} object to append to
-     * @param value the duration as a long value in nanoseconds
+     * @param outputBytes the {@link Bytes} object to append to
+     * @param numericValue the duration as a long value in nanoseconds
      */
     @Override
-    public void append(Bytes<?> bytes, long value) {
-        bytes.append(duration(value).toString());
+    public void append(Bytes<?> outputBytes, long numericValue) {
+        outputBytes.append(duration(numericValue).toString());
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/ServicesTimestampLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/ServicesTimestampLongConverter.java
@@ -118,47 +118,47 @@ public class ServicesTimestampLongConverter implements LongConverter {
 
     /**
      * Parses the provided {@link CharSequence} into a timestamp in the configured time unit.
-     * @param text The text to parse.
+     * @param textToParse The text to parse.
      * @return The parsed timestamp as a long value in the configured time unit.
      */
     @Override
-    public long parse(CharSequence text) {
-        return underlying.parse(text);
+    public long parse(CharSequence textToParse) {
+        return underlying.parse(textToParse);
     }
 
     /**
      * Parses a part of the provided {@link CharSequence} using the underlying converter.
      *
-     * @param text the text to parse.
+     * @param textToParse the text to parse.
      * @param beginIndex the beginning index, inclusive.
      * @param endIndex the ending index, exclusive.
      * @return the parsed timestamp as a long value in the configured time unit.
      */
     @Override
-    public long parse(CharSequence text, int beginIndex, int endIndex) {
-        return underlying.parse(text, beginIndex, endIndex);
+    public long parse(CharSequence textToParse, int beginIndex, int endIndex) {
+        return underlying.parse(textToParse, beginIndex, endIndex);
     }
 
     /**
      * Appends a representation of the provided long timestamp (in the system-configured time unit) to the provided {@link StringBuilder}.
      *
-     * @param text  The StringBuilder to which the timestamp representation will be appended.
-     * @param value The timestamp as a long value in the system-configured time unit.
+     * @param outputBuilder  The StringBuilder to which the timestamp representation will be appended.
+     * @param numericValue The timestamp as a long value in the system-configured time unit.
      */
     @Override
-    public void append(StringBuilder text, long value) {
-        underlying.append(text, value);
+    public void append(StringBuilder outputBuilder, long numericValue) {
+        underlying.append(outputBuilder, numericValue);
     }
 
     /**
      * Appends a representation of the provided long timestamp (in the system-configured time unit) to the provided {@link Bytes}.
      *
-     * @param bytes The Bytes object to which the timestamp representation will be appended.
-     * @param value The timestamp as a long value in the system-configured time unit.
+     * @param outputBytes The Bytes object to which the timestamp representation will be appended.
+     * @param numericValue The timestamp as a long value in the system-configured time unit.
      */
     @Override
-    public void append(Bytes<?> bytes, long value) {
-        underlying.append(bytes, value);
+    public void append(Bytes<?> outputBytes, long numericValue) {
+        underlying.append(outputBytes, numericValue);
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/WordsLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/WordsLongConverter.java
@@ -83,13 +83,13 @@ public class WordsLongConverter implements LongConverter {
     /**
      * Parses the provided text to produce a long value.
      *
-     * @param text The sequence of words to parse.
+     * @param textToParse The sequence of words to parse.
      * @return The long value corresponding to the given word sequence.
      * @throws IllegalArgumentException If a word in the sequence is not recognized.
      */
     @Override
-    public long parse(CharSequence text) {
-        String[] split = NON_LETTER.split(text.toString().trim(), 0);
+    public long parse(CharSequence textToParse) {
+        String[] split = NON_LETTER.split(textToParse.toString().trim(), 0);
         long value = 0;
         int shift = 0;
         for (String s : split) {
@@ -105,34 +105,34 @@ public class WordsLongConverter implements LongConverter {
     /**
      * Appends the word representation of the given long value to the provided StringBuilder.
      *
-     * @param text The StringBuilder to append to.
-     * @param value The long value to be converted and appended.
+     * @param outputBuilder The StringBuilder to append to.
+     * @param numericValue The long value to be converted and appended.
      */
     @Override
-    public void append(StringBuilder text, long value) {
+    public void append(StringBuilder outputBuilder, long numericValue) {
         String asep = "";
         do {
-            text.append(asep);
-            text.append(WORDS[(int) (value & 2047)]);
-            value >>>= 11;
+            outputBuilder.append(asep);
+            outputBuilder.append(WORDS[(int) (numericValue & 2047)]);
+            numericValue >>>= 11;
             asep = this.sep;
-        } while (value > 0);
+        } while (numericValue > 0);
     }
 
     /**
      * Appends the word representation of the given long value to the provided Bytes object.
      *
-     * @param bytes The Bytes object to append to.
-     * @param value The long value to be converted and appended.
+     * @param outputBytes The Bytes object to append to.
+     * @param numericValue The long value to be converted and appended.
      */
     @Override
-    public void append(Bytes<?> bytes, long value) {
+    public void append(Bytes<?> outputBytes, long numericValue) {
         String asep = "";
         do {
-            bytes.append(asep);
-            bytes.append(WORDS[(int) (value & 2047)]);
-            value >>>= 11;
+            outputBytes.append(asep);
+            outputBytes.append(WORDS[(int) (numericValue & 2047)]);
+            numericValue >>>= 11;
             asep = this.sep;
-        } while (value > 0);
+        } while (numericValue > 0);
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/converter/Base16.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/Base16.java
@@ -25,16 +25,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation for fields or parameters to indicate that the annotated long value
- * represents a string of 0 to 16 characters encoded in Base16.
- * <p>
- * This allows for consistent, self-descriptive annotations in fields or parameters,
- * guiding developers and API users about the intended format of the long value.
- * <p>
- * The Base16 format is often used for representing binary data in an ASCII string format,
- * and this annotation helps in ensuring that the long value adheres to this representation.
+ * Indicates that the associated {@code long} value is encoded as hexadecimal (Base16)
+ * text when written to or read from a textual wire format.
+ * Applying this annotation selects the {@link PowerOfTwoLongConverter} for the
+ * conversion process.
  *
+ * @see LongConversion
  * @see PowerOfTwoLongConverter
+ * @see LongConverter
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.PARAMETER})

--- a/src/main/java/net/openhft/chronicle/wire/converter/Base64.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/Base64.java
@@ -25,21 +25,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation to indicate that a given field or parameter, represented as a long value,
- * should be treated as a string containing 0 to 10 characters in Base64 format.
- * <p>
- * When this annotation is applied to a field or parameter, it provides a hint about the expected format
- * and representation of the data, allowing for potential encoding and decoding operations based on Base64.
- * <p>
- * The provided {@link #INSTANCE} is a default converter that can be used for operations relevant to the Base64 format.
- * <b>Example:</b>
- * <pre>
- * {@code @Base64}
- * private long encodedData;
- * </pre>
+ * Indicates that the associated {@code long} value is encoded using standard Base64
+ * when persisted in textual wire formats. The {@link PowerOfTwoLongConverter}
+ * performs the actual conversion.
  *
- * @see LongConverter
+ * @see LongConversion
  * @see PowerOfTwoLongConverter
+ * @see LongConverter
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.PARAMETER})

--- a/src/main/java/net/openhft/chronicle/wire/converter/Base85.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/Base85.java
@@ -26,25 +26,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation to indicate that a given field or parameter, represented as a long value,
- * should be treated as a string containing 0 to 10 characters in Base85 format.
- * <p>
- * Base85, also known as Ascii85, is a binary-to-ASCII encoding scheme optimized for
- * encoding binary data in a compact ASCII string format. It's particularly useful for
- * transporting binary data over text-based protocols where binary formats are not supported.
- * <p>
- * When this annotation is applied to a field or parameter, it provides a hint about the expected format
- * and representation of the data, allowing for potential encoding and decoding operations based on Base85.
- * <p>
- * The provided {@link #INSTANCE} is a default converter that can be used for operations relevant to the Base85 format.
- * <b>Example:</b>
- * <pre>
- * {@code @Base85}
- * private long encodedData;
- * </pre>
+ * Indicates that the associated {@code long} value uses Base85 (Ascii85) text when
+ * serialised or parsed in textual wire formats. The conversion logic is implemented
+ * by {@link Base85LongConverter}.
  *
- * @see LongConverter
+ * @see LongConversion
  * @see Base85LongConverter
+ * @see LongConverter
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.PARAMETER})

--- a/src/main/java/net/openhft/chronicle/wire/converter/Id.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/Id.java
@@ -26,14 +26,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation used to signify that the annotated field or parameter represents an identifier,
- * specifically as a Nanosecond resolution timestamp from epoch.
- * <p>
- * This annotation could be used in scenarios where the system wants to generate
- * unique identifiers based on the precise timestamp at which they are created.
- * <p>
- * The INSTANCE field is a singleton instance of the IdentifierLongConverter class,
- * which is used to perform the conversion between long values and the nanosecond timestamp.
+ * Indicates that the associated {@code long} value should be rendered as a compact
+ * identifier-like string. The default implementation uses
+ * {@link IdentifierLongConverter} which falls back to a timestamp when the
+ * value cannot be expressed as a short identifier.
+ *
+ * @see LongConversion
+ * @see IdentifierLongConverter
+ * @see LongConverter
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.PARAMETER})

--- a/src/main/java/net/openhft/chronicle/wire/converter/NanoTime.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/NanoTime.java
@@ -26,28 +26,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation to indicate that a given field or parameter, represented as a long value,
- * should be treated as a timestamp with nanosecond resolution, based from the epoch.
- * <p>
- * The epoch, typically referred to as "UNIX epoch," is the point in time when time starts,
- * and is represented as "1970-01-01 00:00:00 UTC". A value annotated with {@code NanoTime}
- * counts the number of nanoseconds since the epoch. For instance, a value of 1,000,000,000
- * would indicate 1 second past the epoch.
- * <p>
- * When this annotation is applied to a field or parameter, it provides a hint about the
- * expected format and representation of the data, allowing for potential encoding, decoding,
- * and date-time operations based on nanosecond resolution timestamps.
- * <p>
- * The provided {@link #INSTANCE} is a default converter specifically crafted for
- * operations relevant to the nanosecond timestamp format.
- * <b>Example:</b>
- * <pre>
- * {@code @NanoTime}
- * private long timestamp;
- * </pre>
+ * Indicates that the associated {@code long} value represents epoch nanoseconds.
+ * Chronicle Wire will use {@link NanoTimestampLongConverter} to render the value
+ * as a human-readable timestamp and to parse such strings back to a long.
  *
- * @see LongConverter
+ * @see LongConversion
  * @see NanoTimestampLongConverter
+ * @see LongConverter
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.PARAMETER})

--- a/src/main/java/net/openhft/chronicle/wire/converter/PowerOfTwoLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/PowerOfTwoLongConverter.java
@@ -80,22 +80,22 @@ public class PowerOfTwoLongConverter implements LongConverter {
     /**
      * Parses a sequence of characters into a long value.
      *
-     * @param text the character sequence to parse.
+     * @param textToParse the character sequence to parse.
      * @return the parsed long value.
      * @throws IllegalArgumentException if the character sequence contains unexpected characters or its length
      *      exceeds the maximum allowable length.
      */
     @Override
-    public long parse(CharSequence text) {
-        lengthCheck(text);
+    public long parse(CharSequence textToParse) {
+        lengthCheck(textToParse);
 
-        return parse0(text, 0, text.length());
+        return parse0(textToParse, 0, textToParse.length());
     }
 
     /**
      * Parses a part of a sequence of characters into a long value.
      *
-     * @param text the character sequence to parse.
+     * @param textToParse the character sequence to parse.
      * @param beginIndex the beginning index, inclusive.
      * @param endIndex the ending index, exclusive.
      * @return the parsed long value.
@@ -103,20 +103,20 @@ public class PowerOfTwoLongConverter implements LongConverter {
      *      the indices are invalid or the sub-sequence length exceeds the maximum allowable length.
      */
     @Override
-    public long parse(CharSequence text, int beginIndex, int endIndex) {
-        lengthCheck(text, beginIndex, endIndex);
+    public long parse(CharSequence textToParse, int beginIndex, int endIndex) {
+        lengthCheck(textToParse, beginIndex, endIndex);
 
-        return parse0(text, beginIndex, endIndex);
+        return parse0(textToParse, beginIndex, endIndex);
     }
 
-    private long parse0(CharSequence text, int beginIndex, int endIndex) {
+    private long parse0(CharSequence textToParse, int beginIndex, int endIndex) {
         long v = 0;
         for (int i = beginIndex; i < endIndex; i++) {
-            final char ch = text.charAt(i);
+            final char ch = textToParse.charAt(i);
 
             // Check for characters outside of the encoding range or not present in the encoding map.
             if (ch >= encode.length || encode[ch] < 0)
-                throw new IllegalArgumentException("Unexpected character '" + ch + "' in \"" + text + "\"");
+                throw new IllegalArgumentException("Unexpected character '" + ch + "' in \"" + textToParse + "\"");
 
             // Convert the character into its corresponding long value.
             v = (v << shift) + encode[ch];
@@ -127,46 +127,46 @@ public class PowerOfTwoLongConverter implements LongConverter {
     /**
      * Appends a long value to a StringBuilder.
      *
-     * @param text the StringBuilder to append to
-     * @param value the long value to append
+     * @param outputBuilder the StringBuilder to append to
+     * @param numericValue the long value to append
      */
     @Override
-    public void append(StringBuilder text, long value) {
-        int start = text.length();
-        while (value != 0) {
-            int val = (int) (value & mask); // Isolate bits for the current value.
-            text.append(decode[val]);
-            value >>>= shift; // Right-shift to move to the next value.
+    public void append(StringBuilder outputBuilder, long numericValue) {
+        int start = outputBuilder.length();
+        while (numericValue != 0) {
+            int val = (int) (numericValue & mask); // Isolate bits for the current value.
+            outputBuilder.append(decode[val]);
+            numericValue >>>= shift; // Right-shift to move to the next value.
         }
 
-        StringUtils.reverse(text, start); // Reverse the result since it's constructed backward.
+        StringUtils.reverse(outputBuilder, start); // Reverse the result since it's constructed backward.
 
-        if (text.length() > start + maxParseLength()) {
+        if (outputBuilder.length() > start + maxParseLength()) {
             Jvm.warn().on(getClass(), "truncated because the value was too large");
-            text.setLength(start + maxParseLength());
+            outputBuilder.setLength(start + maxParseLength());
         }
     }
 
     /**
      * Appends a long value to a Bytes object.
      *
-     * @param text the Bytes object to append to
-     * @param value the long value to append
+     * @param outputBytes the Bytes object to append to
+     * @param numericValue the long value to append
      */
     @Override
-    public void append(Bytes<?> text, long value) {
-        int start = text.length();
-        while (value != 0) {
-            int val = (int) (value & mask);
-            text.append(decode[val]);
-            value >>>= shift;
+    public void append(Bytes<?> outputBytes, long numericValue) {
+        int start = outputBytes.length();
+        while (numericValue != 0) {
+            int val = (int) (numericValue & mask);
+            outputBytes.append(decode[val]);
+            numericValue >>>= shift;
         }
 
-        BytesUtil.reverse(text, start); // Reverse the result for bytes.
+        BytesUtil.reverse(outputBytes, start); // Reverse the result for bytes.
 
-        if (text.length() > start + maxParseLength()) {
+        if (outputBytes.length() > start + maxParseLength()) {
             Jvm.warn().on(getClass(), "truncated because the value was too large");
-            text.readLimit((long) start + maxParseLength());
+            outputBytes.readLimit((long) start + maxParseLength());
         }
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/converter/ShortText.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/ShortText.java
@@ -26,25 +26,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation to indicate that a given field or parameter, represented as a long value,
- * should be treated as a string containing 0 to 10 characters in Base85 format. This truncated leading spaces, but preserves leading zero c.f. {@link Base85}
- * <p>
- * Base85, also known as Ascii85, is a binary-to-ASCII encoding scheme that provides
- * an efficient way to encode binary data for transport over text-based protocols.
- * <p>
- * When this annotation is applied to a field or parameter, it provides a hint about the expected format
- * and representation of the data, allowing for potential encoding and decoding operations based on Base85.
- * <p>
- * The provided {@link #INSTANCE} is a default converter that can be used for operations relevant to the Base85 format.
- * <b>Usage Example:</b>
- * <pre>
- * {@code @ShortText}
- * private long encodedText;
- * </pre>
+ * Marks a {@code long} field or parameter that uses the compact "short text" Base85
+ * representation. Leading spaces are discarded but leading zero is retained.
+ * The {@link ShortTextLongConverter} performs the conversion.
  *
- * @see LongConverter
- * @see Base85
+ * @see LongConversion
  * @see ShortTextLongConverter
+ * @see Base85
+ * @see LongConverter
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.PARAMETER})

--- a/src/main/java/net/openhft/chronicle/wire/converter/SizeLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/SizeLongConverter.java
@@ -46,13 +46,13 @@ public class SizeLongConverter implements LongConverter {
      *                               a valid long number or if the text is empty.
      */
     @Override
-    public long parse(CharSequence text) throws NumberFormatException {
-        int length = text.length();
+    public long parse(CharSequence textToParse) throws NumberFormatException {
+        int length = textToParse.length();
         if (length < 1)
             throw new NumberFormatException("Empty string");
 
         int shift;
-        switch (text.charAt(length - 1)) {
+        switch (textToParse.charAt(length - 1)) {
             case 't':
             case 'T':
                 shift = 40;
@@ -75,11 +75,11 @@ public class SizeLongConverter implements LongConverter {
         }
         if (shift != 0) {
             if (length < 2)
-                throw new NumberFormatException("No number for prefix '" + text + "'");
-            text = text.subSequence(0, length - 1);
+                throw new NumberFormatException("No number for prefix '" + textToParse + "'");
+            textToParse = textToParse.subSequence(0, length - 1);
         }
 
-        return Long.parseLong(text.toString()) << shift;
+        return Long.parseLong(textToParse.toString()) << shift;
     }
 
     /**
@@ -88,23 +88,23 @@ public class SizeLongConverter implements LongConverter {
      * (kilo, mega, giga, tera, respectively). If the value does not match
      * one of these categories, it is converted to a string without a suffix.
      *
-     * @param text  The {@link StringBuilder} to which the converted value
+     * @param outputBuilder  The {@link StringBuilder} to which the converted value
      *              and suffix are appended.
-     * @param value The long value to be converted.
+     * @param numericValue The long value to be converted.
      */
     @Override
-    public void append(StringBuilder text, long value) {
-        if (value == 0)
-            text.append('0');
-        else if (value >> 40 << 40 == value)
-            text.append(value >> 40).append('T');
-        else if (value >> 30 << 30 == value)
-            text.append(value >> 30).append('G');
-        else if (value >> 20 << 20 == value)
-            text.append(value >> 20).append('M');
-        else if (value >> 10 << 10 == value)
-            text.append(value >> 10).append('K');
+    public void append(StringBuilder outputBuilder, long numericValue) {
+        if (numericValue == 0)
+            outputBuilder.append('0');
+        else if (numericValue >> 40 << 40 == numericValue)
+            outputBuilder.append(numericValue >> 40).append('T');
+        else if (numericValue >> 30 << 30 == numericValue)
+            outputBuilder.append(numericValue >> 30).append('G');
+        else if (numericValue >> 20 << 20 == numericValue)
+            outputBuilder.append(numericValue >> 20).append('M');
+        else if (numericValue >> 10 << 10 == numericValue)
+            outputBuilder.append(numericValue >> 10).append('K');
         else
-            text.append(value);
+            outputBuilder.append(numericValue);
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/converter/SymbolsLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/SymbolsLongConverter.java
@@ -71,22 +71,22 @@ public class SymbolsLongConverter implements LongConverter {
     /**
      * Parses a sequence of characters into a long value.
      *
-     * @param text the character sequence to parse.
+     * @param textToParse the character sequence to parse.
      * @return the parsed long value.
      * @throws IllegalArgumentException if the character sequence contains unexpected characters or
      *      its length exceeds the maximum allowable length.
      */
     @Override
-    public long parse(CharSequence text) {
-        lengthCheck(text);
+    public long parse(CharSequence textToParse) {
+        lengthCheck(textToParse);
 
-        return parse0(text, 0, text.length());
+        return parse0(textToParse, 0, textToParse.length());
     }
 
     /**
      * Parses a part of a sequence of characters into a long value.
      *
-     * @param text the character sequence to parse.
+     * @param textToParse the character sequence to parse.
      * @param beginIndex the beginning index, inclusive.
      * @param endIndex the ending index, exclusive.
      * @return the parsed long value.
@@ -94,20 +94,20 @@ public class SymbolsLongConverter implements LongConverter {
      *      indices are invalid or the sub-sequence length exceeds the maximum allowable length.
      */
     @Override
-    public long parse(CharSequence text, int beginIndex, int endIndex) {
-        lengthCheck(text, beginIndex, endIndex);
+    public long parse(CharSequence textToParse, int beginIndex, int endIndex) {
+        lengthCheck(textToParse, beginIndex, endIndex);
 
-        return parse0(text, beginIndex, endIndex);
+        return parse0(textToParse, beginIndex, endIndex);
     }
 
-    private long parse0(CharSequence text, int beginIndex, int endIndex) {
+    private long parse0(CharSequence textToParse, int beginIndex, int endIndex) {
         long v = 0;
         for (int i = beginIndex; i < endIndex; i++) {
-            final char ch = text.charAt(i);
+            final char ch = textToParse.charAt(i);
 
             // Check for characters outside of the encoding range or not present in the encoding map.
             if (ch >= encode.length || encode[ch] < 0)
-                throw new IllegalArgumentException("Unexpected character '" + ch + "' in \"" + text + "\"");
+                throw new IllegalArgumentException("Unexpected character '" + ch + "' in \"" + textToParse + "\"");
 
             // Convert the character into its corresponding long value.
             v = v * factor + encode[ch];
@@ -118,62 +118,62 @@ public class SymbolsLongConverter implements LongConverter {
     /**
      * Appends a long value to a StringBuilder.
      *
-     * @param text the StringBuilder to append to
-     * @param value the long value to append
+     * @param outputBuilder the StringBuilder to append to
+     * @param numericValue the long value to append
      */
     @Override
-    public void append(StringBuilder text, long value) {
-        final int start = text.length();
+    public void append(StringBuilder outputBuilder, long numericValue) {
+        final int start = outputBuilder.length();
 
         // Handle negative values by converting them using unsigned operations.
-        if (value < 0) {
-            int v = (int) Long.remainderUnsigned(value, factor);
-            value = Long.divideUnsigned(value, factor);
-            text.append(decode[v]);
+        if (numericValue < 0) {
+            int v = (int) Long.remainderUnsigned(numericValue, factor);
+            numericValue = Long.divideUnsigned(numericValue, factor);
+            outputBuilder.append(decode[v]);
         }
 
-        while (value != 0) {
-            int v = (int) (value % factor);
-            value /= factor;
-            text.append(decode[v]);
+        while (numericValue != 0) {
+            int v = (int) (numericValue % factor);
+            numericValue /= factor;
+            outputBuilder.append(decode[v]);
         }
 
-        StringUtils.reverse(text, start); // Reverse the result since it's constructed backward.
+        StringUtils.reverse(outputBuilder, start); // Reverse the result since it's constructed backward.
 
-        if (text.length() > start + maxParseLength()) {
+        if (outputBuilder.length() > start + maxParseLength()) {
             Jvm.warn().on(getClass(), "truncated because the value was too large");
-            text.setLength(start + maxParseLength());
+            outputBuilder.setLength(start + maxParseLength());
         }
     }
 
     /**
      * Appends a long value to a Bytes object.
      *
-     * @param text the Bytes object to append to
-     * @param value the long value to append
+     * @param outputBytes the Bytes object to append to
+     * @param numericValue the long value to append
      */
     @Override
-    public void append(Bytes<?> text, long value) {
-        final int start = text.length();
+    public void append(Bytes<?> outputBytes, long numericValue) {
+        final int start = outputBytes.length();
 
         // Handle negative values in bytes format.
-        if (value < 0) {
-            int v = (int) Long.remainderUnsigned(value, factor);
-            value = Long.divideUnsigned(value, factor);
-            text.append(decode[v]);
+        if (numericValue < 0) {
+            int v = (int) Long.remainderUnsigned(numericValue, factor);
+            numericValue = Long.divideUnsigned(numericValue, factor);
+            outputBytes.append(decode[v]);
         }
 
-        while (value != 0) {
-            int v = (int) (value % factor);
-            value /= factor;
-            text.append(decode[v]);
+        while (numericValue != 0) {
+            int v = (int) (numericValue % factor);
+            numericValue /= factor;
+            outputBytes.append(decode[v]);
         }
 
-        BytesUtil.reverse(text, start); // Reverse the result for bytes.
+        BytesUtil.reverse(outputBytes, start); // Reverse the result for bytes.
 
-        if (text.length() > start + maxParseLength()) {
+        if (outputBytes.length() > start + maxParseLength()) {
             Jvm.warn().on(getClass(), "truncated because the value was too large");
-            text.readLimit((long) start + maxParseLength());
+            outputBytes.readLimit((long) start + maxParseLength());
         }
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/converter/Words.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/Words.java
@@ -26,12 +26,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotates fields or parameters to signify that the long value represents a string consisting
- * of 0 to 6 words using a base 2048 encoding. This is mainly utilized for converting between
- * long representations and word sequences for better human readability.
- * <p>
- * The actual conversion between long values and words is handled by the {@link WordsLongConverter} class.
+ * Indicates that the associated {@code long} value should be written and read as
+ * a sequence of words. This human-friendly representation uses
+ * {@link WordsLongConverter} for the actual mapping.
  *
+ * @see LongConversion
  * @see WordsLongConverter
  * @see LongConverter
  */


### PR DESCRIPTION
## Summary
- document converters and annotations in the `converter` package
- rename method parameters for clarity in `LongConverter` and implementations
- align docs with new parameter names

## Testing
- `mvn -q verify` *(fails: `mvn` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683d5e106d388329b6eaacbc3e76031a