### PR TITLE
Improve converter javadoc and parameter names

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AbstractLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractLongConverter.java
@@ -29,23 +29,24 @@ public abstract class AbstractLongConverter implements LongConverter {
     protected final LongConverter converter;
 
     /**
-     * Constructs an {@code AbstractLongConverter} using a given set of characters.
-     * Internally, it uses the LongConverter's forSymbols method to create an instance of LongConverter with the provided characters.
+     * Constructs an {@code AbstractLongConverter} using a given set of symbols.
+     * Internally, it delegates to {@link LongConverter#forSymbols(String)} to build
+     * a converter suited to the supplied symbols.
      *
-     * @param chars set of characters to use for conversion.
+     * @param symbolSet the characters that define the encoding scheme
      */
-    protected AbstractLongConverter(String chars) {
-        this(LongConverter.forSymbols(chars));
+    protected AbstractLongConverter(String symbolSet) {
+        this(LongConverter.forSymbols(symbolSet));
     }
 
     /**
-     * Constructs an {@code AbstractLongConverter} with a specified converter.
-     * This constructor allows subclasses to provide a custom implementation of LongConverter.
+     * Constructs an {@code AbstractLongConverter} with a specific converter.
+     * This constructor allows subclasses to supply their own implementation.
      *
-     * @param converter the underlying {@link LongConverter} to be used for conversions.
+     * @param underlyingConverter the {@link LongConverter} that performs the work
      */
-    protected AbstractLongConverter(LongConverter converter) {
-        this.converter = converter;
+    protected AbstractLongConverter(LongConverter underlyingConverter) {
+        this.converter = underlyingConverter;
     }
 
     /**
@@ -61,46 +62,46 @@ public abstract class AbstractLongConverter implements LongConverter {
     /**
      * Parses the provided text using the underlying converter.
      *
-     * @param text the text to parse.
-     * @return the parsed long value.
+     * @param textToParse the text to parse
+     * @return the parsed long value
      */
     @Override
-    public long parse(CharSequence text) {
-        return converter.parse(text);
+    public long parse(CharSequence textToParse) {
+        return converter.parse(textToParse);
     }
 
     /**
      * Parses a part of the provided text using the underlying converter.
      *
-     * @param text the text to parse.
-     * @param beginIndex the beginning index, inclusive.
-     * @param endIndex the ending index, exclusive.
+     * @param textToParse the text to parse
+     * @param beginIndex  the beginning index, inclusive
+     * @param endIndex    the ending index, exclusive
      * @return the parsed long value.
      */
     @Override
-    public long parse(CharSequence text, int beginIndex, int endIndex) {
-        return converter.parse(text, beginIndex, endIndex);
+    public long parse(CharSequence textToParse, int beginIndex, int endIndex) {
+        return converter.parse(textToParse, beginIndex, endIndex);
     }
 
     /**
-     * Appends the provided long value to the provided {@code StringBuilder} text.
+     * Appends the provided long value to the destination builder.
      *
-     * @param text the StringBuilder to append to.
-     * @param value the long value to convert and append.
+     * @param destinationBuilder the builder receiving the formatted value
+     * @param numericValue the long value to convert and append
      */
     @Override
-    public void append(StringBuilder text, long value) {
-        converter.append(text, value);
+    public void append(StringBuilder destinationBuilder, long numericValue) {
+        converter.append(destinationBuilder, numericValue);
     }
 
     /**
-     * Appends the provided long value to the provided {@code Bytes} text.
+     * Appends the provided long value to the destination {@code Bytes}.
      *
-     * @param bytes the Bytes object to append to.
-     * @param value the long value to convert and append.
+     * @param destination the Bytes to append to
+     * @param numericValue the long value to convert and append
      */
     @Override
-    public void append(Bytes<?> bytes, long value) {
-        converter.append(bytes, value);
+    public void append(Bytes<?> destination, long numericValue) {
+        converter.append(destination, numericValue);
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/LongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/LongConverter.java
@@ -61,10 +61,10 @@ public interface LongConverter {
      * Parses the provided {@link CharSequence} and returns the parsed results as a
      * {@code long} primitive.
      *
-     * @return the parsed {@code text} as an {@code long} primitive.
+     * @return the parsed {@code textToParse} as a {@code long} value
      * @throws IllegalArgumentException if the text length is outside of range accepted by a specific converter.
      */
-    long parse(CharSequence text);
+    long parse(CharSequence textToParse);
 
     /**
      * Parses a part of the provided {@link CharSequence} and returns the parsed results as a
@@ -72,69 +72,69 @@ public interface LongConverter {
      * <p>
      * The default implementation is garbage-producing and an implementing class is supposed to reimplement this method.
      *
-     * @param text character sequence containing the string representation of the value.
+     * @param textToParse character sequence containing the string representation of the value
      * @param beginIndex the beginning index, inclusive.
      * @param endIndex the ending index, exclusive.
      *
-     * @return the parsed {@code text} as an {@code long} primitive.
+     * @return the parsed {@code textToParse} as a {@code long} value
      * @throws IllegalArgumentException if any of the indices are invalid or the sub-sequence length is
      *      outside of range accepted by a specific converter.
      */
-    default long parse(CharSequence text, int beginIndex, int endIndex) {
-        return parse(text.toString().substring(beginIndex, endIndex));
+    default long parse(CharSequence textToParse, int beginIndex, int endIndex) {
+        return parse(textToParse.toString().substring(beginIndex, endIndex));
     }
 
     /**
      * Converts the given long value to a string and appends it to the provided StringBuilder.
      *
-     * @param text  The StringBuilder to which the converted value is appended.
-     * @param value The long value to convert.
+     * @param destinationBuilder the builder to append to
+     * @param numericValue the long value to convert
      */
-    void append(StringBuilder text, long value);
+    void append(StringBuilder destinationBuilder, long numericValue);
 
     /**
      * Converts the given long value to a string and appends it to the provided Bytes object.
      *
-     * @param bytes The Bytes object to which the converted value is appended.
-     * @param value The long value to convert.
+     * @param destination the Bytes object to append to
+     * @param numericValue the long value to convert
      */
-    default void append(Bytes<?> bytes, long value) {
+    default void append(Bytes<?> destination, long numericValue) {
         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
             final StringBuilder sb = stlSb.get();
-            append(sb, value);
-            bytes.append(sb);
+            append(sb, numericValue);
+            destination.append(sb);
         }
     }
 
     /**
      * Converts the given long value to a string.
      *
-     * @param value The long value to convert.
+     * @param numericValue the long value to convert
      * @return The string representation of the value.
      */
-    default String asString(long value) {
-        return asText(value).toString();
+    default String asString(long numericValue) {
+        return asText(numericValue).toString();
     }
 
     /**
      * Converts the provided integer value to a CharSequence representation.
      *
-     * @param value The integer value to convert.
+     * @param numericValue the integer value to convert
      * @return The CharSequence representation of the value.
      */
-    default CharSequence asText(int value) {
-        return asText(value & 0xFFFF_FFFFL);
+    default CharSequence asText(int numericValue) {
+        return asText(numericValue & 0xFFFF_FFFFL);
     }
 
     /**
      * Converts the provided long value to a CharSequence representation.
      *
-     * @param value The long value to convert.
+     * @param numericValue the long value to convert
      * @return The CharSequence representation of the value.
      */
-    default CharSequence asText(long value) {
+    default CharSequence asText(long numericValue) {
         StringBuilder sb = new StringBuilder();
-        append(sb, value);
+        append(sb, numericValue);
         return sb;
     }
 
@@ -150,24 +150,24 @@ public interface LongConverter {
     /**
      * Checks that the length of the provided text does not exceed the allowable maximum.
      *
-     * @param text The text to check.
+     * @param textToCheck The text to check
      * @throws IllegalArgumentException if the text length exceeds the maximum allowable length.
      */
-    default void lengthCheck(CharSequence text) {
-        if (text.length() > maxParseLength())
-            throw new IllegalArgumentException(format("text={0} exceeds the maximum allowable length of {1}", text, maxParseLength()));
+    default void lengthCheck(CharSequence textToCheck) {
+        if (textToCheck.length() > maxParseLength())
+            throw new IllegalArgumentException(format("text={0} exceeds the maximum allowable length of {1}", textToCheck, maxParseLength()));
     }
 
     /**
      * Checks that the length of the provided text does not exceed the allowable maximum.
      *
-     * @param text The text to check.
+     * @param textToCheck The text to check
      * @param beginIndex the beginning index, inclusive.
      * @param endIndex   the ending index, exclusive.
      * @throws IllegalArgumentException if the text length exceeds the maximum allowable length.
      */
-    default void lengthCheck(CharSequence text, int beginIndex, int endIndex) {
-        if ((beginIndex | endIndex | (endIndex - beginIndex) | (text.length() - endIndex + beginIndex) | (maxParseLength() - endIndex + beginIndex)) < 0)
+    default void lengthCheck(CharSequence textToCheck, int beginIndex, int endIndex) {
+        if ((beginIndex | endIndex | (endIndex - beginIndex) | (textToCheck.length() - endIndex + beginIndex) | (maxParseLength() - endIndex + beginIndex)) < 0)
             throw new IllegalArgumentException(format("range [{0}, {1}) exceeds the maximum allowable length of {2}",
                     beginIndex, endIndex, maxParseLength()));
     }

--- a/src/main/java/net/openhft/chronicle/wire/converter/PowerOfTwoLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/PowerOfTwoLongConverter.java
@@ -80,33 +80,33 @@ public class PowerOfTwoLongConverter implements LongConverter {
     /**
      * Parses a sequence of characters into a long value.
      *
-     * @param text the character sequence to parse.
+     * @param textToParse the character sequence to parse
      * @return the parsed long value.
      * @throws IllegalArgumentException if the character sequence contains unexpected characters or its length
      *      exceeds the maximum allowable length.
      */
     @Override
-    public long parse(CharSequence text) {
-        lengthCheck(text);
+    public long parse(CharSequence textToParse) {
+        lengthCheck(textToParse);
 
-        return parse0(text, 0, text.length());
+        return parse0(textToParse, 0, textToParse.length());
     }
 
     /**
      * Parses a part of a sequence of characters into a long value.
      *
-     * @param text the character sequence to parse.
-     * @param beginIndex the beginning index, inclusive.
-     * @param endIndex the ending index, exclusive.
+     * @param textToParse the character sequence to parse
+     * @param beginIndex  the beginning index, inclusive
+     * @param endIndex    the ending index, exclusive
      * @return the parsed long value.
      * @throws IllegalArgumentException if the character sequence contains unexpected character, or if any of
      *      the indices are invalid or the sub-sequence length exceeds the maximum allowable length.
      */
     @Override
-    public long parse(CharSequence text, int beginIndex, int endIndex) {
-        lengthCheck(text, beginIndex, endIndex);
+    public long parse(CharSequence textToParse, int beginIndex, int endIndex) {
+        lengthCheck(textToParse, beginIndex, endIndex);
 
-        return parse0(text, beginIndex, endIndex);
+        return parse0(textToParse, beginIndex, endIndex);
     }
 
     private long parse0(CharSequence text, int beginIndex, int endIndex) {
@@ -127,46 +127,46 @@ public class PowerOfTwoLongConverter implements LongConverter {
     /**
      * Appends a long value to a StringBuilder.
      *
-     * @param text the StringBuilder to append to
-     * @param value the long value to append
+     * @param destinationBuilder the StringBuilder to append to
+     * @param numericValue the long value to append
      */
     @Override
-    public void append(StringBuilder text, long value) {
-        int start = text.length();
-        while (value != 0) {
-            int val = (int) (value & mask); // Isolate bits for the current value.
-            text.append(decode[val]);
-            value >>>= shift; // Right-shift to move to the next value.
+    public void append(StringBuilder destinationBuilder, long numericValue) {
+        int start = destinationBuilder.length();
+        while (numericValue != 0) {
+            int val = (int) (numericValue & mask); // Isolate bits for the current value.
+            destinationBuilder.append(decode[val]);
+            numericValue >>>= shift; // Right-shift to move to the next value.
         }
 
-        StringUtils.reverse(text, start); // Reverse the result since it's constructed backward.
+        StringUtils.reverse(destinationBuilder, start); // Reverse the result since it's constructed backward.
 
-        if (text.length() > start + maxParseLength()) {
+        if (destinationBuilder.length() > start + maxParseLength()) {
             Jvm.warn().on(getClass(), "truncated because the value was too large");
-            text.setLength(start + maxParseLength());
+            destinationBuilder.setLength(start + maxParseLength());
         }
     }
 
     /**
      * Appends a long value to a Bytes object.
      *
-     * @param text the Bytes object to append to
-     * @param value the long value to append
+     * @param destination the Bytes object to append to
+     * @param numericValue the long value to append
      */
     @Override
-    public void append(Bytes<?> text, long value) {
-        int start = text.length();
-        while (value != 0) {
-            int val = (int) (value & mask);
-            text.append(decode[val]);
-            value >>>= shift;
+    public void append(Bytes<?> destination, long numericValue) {
+        int start = destination.length();
+        while (numericValue != 0) {
+            int val = (int) (numericValue & mask);
+            destination.append(decode[val]);
+            numericValue >>>= shift;
         }
 
-        BytesUtil.reverse(text, start); // Reverse the result for bytes.
+        BytesUtil.reverse(destination, start); // Reverse the result for bytes.
 
-        if (text.length() > start + maxParseLength()) {
+        if (destination.length() > start + maxParseLength()) {
             Jvm.warn().on(getClass(), "truncated because the value was too large");
-            text.readLimit((long) start + maxParseLength());
+            destination.readLimit((long) start + maxParseLength());
         }
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/converter/SymbolsLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/SymbolsLongConverter.java
@@ -71,33 +71,33 @@ public class SymbolsLongConverter implements LongConverter {
     /**
      * Parses a sequence of characters into a long value.
      *
-     * @param text the character sequence to parse.
+     * @param textToParse the character sequence to parse
      * @return the parsed long value.
      * @throws IllegalArgumentException if the character sequence contains unexpected characters or
      *      its length exceeds the maximum allowable length.
      */
     @Override
-    public long parse(CharSequence text) {
-        lengthCheck(text);
+    public long parse(CharSequence textToParse) {
+        lengthCheck(textToParse);
 
-        return parse0(text, 0, text.length());
+        return parse0(textToParse, 0, textToParse.length());
     }
 
     /**
      * Parses a part of a sequence of characters into a long value.
      *
-     * @param text the character sequence to parse.
-     * @param beginIndex the beginning index, inclusive.
-     * @param endIndex the ending index, exclusive.
+     * @param textToParse the character sequence to parse
+     * @param beginIndex  the beginning index, inclusive
+     * @param endIndex    the ending index, exclusive
      * @return the parsed long value.
      * @throws IllegalArgumentException if the character sequence contains unexpected characters, or if any of the
      *      indices are invalid or the sub-sequence length exceeds the maximum allowable length.
      */
     @Override
-    public long parse(CharSequence text, int beginIndex, int endIndex) {
-        lengthCheck(text, beginIndex, endIndex);
+    public long parse(CharSequence textToParse, int beginIndex, int endIndex) {
+        lengthCheck(textToParse, beginIndex, endIndex);
 
-        return parse0(text, beginIndex, endIndex);
+        return parse0(textToParse, beginIndex, endIndex);
     }
 
     private long parse0(CharSequence text, int beginIndex, int endIndex) {
@@ -118,62 +118,62 @@ public class SymbolsLongConverter implements LongConverter {
     /**
      * Appends a long value to a StringBuilder.
      *
-     * @param text the StringBuilder to append to
-     * @param value the long value to append
+     * @param destinationBuilder the StringBuilder to append to
+     * @param numericValue the long value to append
      */
     @Override
-    public void append(StringBuilder text, long value) {
-        final int start = text.length();
+    public void append(StringBuilder destinationBuilder, long numericValue) {
+        final int start = destinationBuilder.length();
 
         // Handle negative values by converting them using unsigned operations.
-        if (value < 0) {
-            int v = (int) Long.remainderUnsigned(value, factor);
-            value = Long.divideUnsigned(value, factor);
-            text.append(decode[v]);
+        if (numericValue < 0) {
+            int v = (int) Long.remainderUnsigned(numericValue, factor);
+            numericValue = Long.divideUnsigned(numericValue, factor);
+            destinationBuilder.append(decode[v]);
         }
 
-        while (value != 0) {
-            int v = (int) (value % factor);
-            value /= factor;
-            text.append(decode[v]);
+        while (numericValue != 0) {
+            int v = (int) (numericValue % factor);
+            numericValue /= factor;
+            destinationBuilder.append(decode[v]);
         }
 
-        StringUtils.reverse(text, start); // Reverse the result since it's constructed backward.
+        StringUtils.reverse(destinationBuilder, start); // Reverse the result since it's constructed backward.
 
-        if (text.length() > start + maxParseLength()) {
+        if (destinationBuilder.length() > start + maxParseLength()) {
             Jvm.warn().on(getClass(), "truncated because the value was too large");
-            text.setLength(start + maxParseLength());
+            destinationBuilder.setLength(start + maxParseLength());
         }
     }
 
     /**
      * Appends a long value to a Bytes object.
      *
-     * @param text the Bytes object to append to
-     * @param value the long value to append
+     * @param destination the Bytes object to append to
+     * @param numericValue the long value to append
      */
     @Override
-    public void append(Bytes<?> text, long value) {
-        final int start = text.length();
+    public void append(Bytes<?> destination, long numericValue) {
+        final int start = destination.length();
 
         // Handle negative values in bytes format.
-        if (value < 0) {
-            int v = (int) Long.remainderUnsigned(value, factor);
-            value = Long.divideUnsigned(value, factor);
-            text.append(decode[v]);
+        if (numericValue < 0) {
+            int v = (int) Long.remainderUnsigned(numericValue, factor);
+            numericValue = Long.divideUnsigned(numericValue, factor);
+            destination.append(decode[v]);
         }
 
-        while (value != 0) {
-            int v = (int) (value % factor);
-            value /= factor;
-            text.append(decode[v]);
+        while (numericValue != 0) {
+            int v = (int) (numericValue % factor);
+            numericValue /= factor;
+            destination.append(decode[v]);
         }
 
-        BytesUtil.reverse(text, start); // Reverse the result for bytes.
+        BytesUtil.reverse(destination, start); // Reverse the result for bytes.
 
-        if (text.length() > start + maxParseLength()) {
+        if (destination.length() > start + maxParseLength()) {
             Jvm.warn().on(getClass(), "truncated because the value was too large");
-            text.readLimit((long) start + maxParseLength());
+            destination.readLimit((long) start + maxParseLength());
         }
     }
 


### PR DESCRIPTION
## Summary
- clarify parameter names in LongConverter API and implementations
- expand Javadoc in AbstractLongConverter
- align SymbolsLongConverter and PowerOfTwoLongConverter with new API

## Testing
- `mvn -q verify` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d5fdf941083298df17f8b7a80a0c3