### PR TITLE
Clarify BaseEvent javadocs

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/BaseEvent.java
+++ b/src/main/java/net/openhft/chronicle/wire/BaseEvent.java
@@ -5,56 +5,52 @@
 package net.openhft.chronicle.wire;
 
 /**
- * This interface represents a timed event, providing methods to manage and access the time associated with the event.
- * It is typically used for events that have a specific timestamp, such as those generated externally and captured by the system.
+ * Represents a timed event and extends {@link Marshallable} so that the event can
+ * be serialised or de-serialised.
  * <p>
- * The event time is generally represented in nanoseconds. However, this can be adjusted if needed through the system property 'service.time.unit'.
+ * Typically used for events generated outside the system that carry a timestamp.
+ * The time unit defaults to nanoseconds but can be overridden globally with the
+ * {@code service.time.unit} system property.
  *
- * @param <E> The type of the implementing event class
+ * @param <E> type of the implementing event
  */
 public interface BaseEvent<E extends BaseEvent<E>> extends Marshallable {
     /**
-     * Returns the time at which the event which triggered this was generated (e.g. the time
-     * an event generated externally to the system first entered the system).
-     * <p>
-     * By default, the time is represented in nanoseconds. System property 'service.time.unit'
-     * can be changed in order to represent time in different units.
+     * Returns the timestamp of when the event occurred or was generated.
+     * The unit is controlled by the system-wide service time unit, defaulting to
+     * nanoseconds (see {@link ServicesTimestampLongConverter}).
      *
-     * @return the time at which the event which triggered this was generated.
+     * @return the event time in the configured unit
      */
     long eventTime();
 
     /**
-     * Sets the time at which the event which triggered this was generated (e.g. the time
-     * an event generated externally to the system first entered the system).
-     * <p>
-     * By default, the time is represented in nanoseconds. System property 'service.time.unit'
-     * can be changed in order to represent time in different units.
+     * Assigns the timestamp for this event.
      *
-     * @param eventTime The timestamp to set for the event, in the configured time unit.
-     * @return The current instance of the implementing class.
-     * @throws UnsupportedOperationException if the method is not overridden.
+     * @param eventTime the time to store, expressed in the service time unit
+     *                  (see {@link ServicesTimestampLongConverter}).
+     * @return this event instance for chaining
+     * @throws UnsupportedOperationException if not overridden to store the value
      */
     default E eventTime(final long eventTime) {
         throw new UnsupportedOperationException();
     }
 
     /**
-     * Sets the time at which the event which triggered this was generated (e.g. the time
-     * an event generated externally to the system first entered the system) to the
-     * current time.
-     * <p>
-     * By default, the time is represented in nanoseconds. System property 'service.time.unit'
-     * can be changed in order to represent time in different units.
+     * Convenience method that sets {@link #eventTime(long)} to the current time
+     * via {@link ServicesTimestampLongConverter#currentTime()}.
      *
-     * @return this
+     * @return this event instance
      */
     default E eventTimeNow() {
         return eventTime(ServicesTimestampLongConverter.currentTime());
     }
 
     /**
-     * Updates event's time with the current time if it hasn't been set.
+     * Sets the event time to the current time via {@link #eventTimeNow()} if the
+     * existing {@link #eventTime()} is not positive.
+     *
+     * @return this event instance
      */
     @SuppressWarnings("unchecked")
     default E updateEvent() {


### PR DESCRIPTION
## Summary
- tidy up BaseEvent class level docs and mention `Marshallable`
- clarify time units in `eventTime()` and `eventTime(long)`
- simplify `eventTimeNow()` docs
- detail behaviour of `updateEvent()`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d71e5bcac832998948a10af0adfc7