### PR TITLE
Improve AbstractEventCfg Javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AbstractEventCfg.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractEventCfg.java
@@ -29,51 +29,84 @@ import org.jetbrains.annotations.NotNull;
 @SuppressWarnings("unchecked")
 public class AbstractEventCfg<E extends AbstractEventCfg<E>> extends AbstractMarshallableCfg implements Event<E> {
 
-    // The unique identifier for the event
+    // The unique identifier for the event (defaults to an empty string)
     private String eventId = "";
 
-    // The timestamp indicating the time of the event
+    // The timestamp of the event, typically in nanoseconds since epoch.
+    // Converted via ServicesTimestampLongConverter when read from or
+    // written to a textual wire format.
     @LongConversion(ServicesTimestampLongConverter.class)
     private long eventTime;
 
-    // The service ID associated with the event
+    // The service ID associated with the event.
+    // Used for routing or identifying the source or target service.
+    // Defaults to an empty string.
     private String serviceId = "";
 
     @NotNull
     @Override
     // to be removed in x.25
+    /**
+     * Returns the unique identifier for this event.
+     *
+     * @return the current event ID
+     */
     public String eventId() {
         return eventId;
     }
 
     @Override
     // to be removed in x.25
+    /**
+     * Sets a new identifier for this event.
+     *
+     * @param eventId the unique identifier to assign; must not be null
+     * @return this instance for chaining
+     */
     public E eventId(@NotNull CharSequence eventId) {
         this.eventId = eventId.toString();
         return (E) this;
     }
 
     @Override
+    /**
+     * Returns the timestamp associated with this event.
+     *
+     * @return the event time in the unit defined by
+     *         {@link ServicesTimestampLongConverter}
+     */
     public long eventTime() {
         return eventTime;
     }
 
     @Override
+    /**
+     * Sets the timestamp for this event.
+     *
+     * @param eventTime the new timestamp, typically in nanoseconds
+     * @return this instance for chaining
+     */
     public E eventTime(long eventTime) {
         this.eventTime = eventTime;
         return (E) this;
     }
 
     @Override
+    /**
+     * Updates the event time with the current system time.
+     *
+     * @return this instance for chaining
+     */
     public E eventTimeNow() {
         return this.eventTime(ServicesTimestampLongConverter.currentTime());
     }
 
     /**
-     * This method retrieves the service ID associated with the event, used for event routing.
-     * It returns the ID of the destination event.
+     * Retrieves the service identifier associated with this event. This ID can
+     * be used to route the event to a specific service or to identify the
+     * service that originated it.
      *
-     * @return The current service ID of this object
+     * @return the current service ID
      */
     @NotNull
     public String serviceId() {
@@ -81,11 +114,10 @@ public class AbstractEventCfg<E extends AbstractEventCfg<E>> extends AbstractMar
     }
 
     /**
-     * This method sets the provided service ID to the instance variable.
-     * It returns the current instance, allowing chained method calls.
+     * Associates the given service identifier with this event.
      *
-     * @param serviceId The new service ID to be set
-     * @return The current instance of AbstractEventCfg class
+     * @param serviceId the service ID to set; may be empty if not applicable
+     * @return this instance for chaining
      */
     public E serviceId(String serviceId) {
         this.serviceId = serviceId;
@@ -93,10 +125,11 @@ public class AbstractEventCfg<E extends AbstractEventCfg<E>> extends AbstractMar
     }
 
     /**
-     * This method checks if the event is routed to a specific destination service.
+     * Checks if this event is intended for the given destination service.
      *
-     * @param destServiceId The destination service ID to check against
-     * @return true if the event is routed to the specified service, false otherwise
+     * @param destServiceId the destination service ID to check
+     * @return {@code true} if {@link #serviceId()} is null, empty or matches
+     *         {@code destServiceId}
      */
     public boolean routedTo(String destServiceId) {
         return this.serviceId == null || this.serviceId().isEmpty() || this.serviceId().equals(destServiceId);


### PR DESCRIPTION
## Summary
- document defaults for `eventId` and `serviceId`
- expand `eventTime` description and add timestamp notes
- add details to service id methods
- add javadoc for event id and time methods

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d71fd15288329a5ec51b6038f116e