### PR TITLE
Improve MessageHistory Javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/MessageHistory.java
+++ b/src/main/java/net/openhft/chronicle/wire/MessageHistory.java
@@ -19,15 +19,17 @@ import net.openhft.chronicle.bytes.MethodReader;
 import net.openhft.chronicle.core.annotation.UsedViaReflection;
 
 /**
- * This is the {@code MessageHistory} interface, which extends {@link Marshallable}.
- * It provides functionalities related to managing the history of messages.
+ * Records the path a message takes as it moves through components.
+ * Each processing step may append its source identifier and timestamp,
+ * allowing tracing and latency analysis in distributed systems.
  */
 public interface MessageHistory extends Marshallable {
 
     /**
-     * Returns the {@code MessageHistory} to update it or read it.
+     * Retrieves the thread-local {@code MessageHistory} instance for the
+     * message being processed.
      *
-     * @return the MessageHistory for the current Excerpt.
+     * @return the history associated with the current excerpt.
      */
     static MessageHistory get() {
         return VanillaMessageHistory.getThreadLocal();
@@ -36,27 +38,36 @@ public interface MessageHistory extends Marshallable {
     /**
      * You only need to call this if you wish to override its behaviour.
      *
-     * @param md to change to the default implementation for this thread. Null to clear the thread local
-     *           and force withInitial to be called again
+     * @param md the history instance to use for this thread, or {@code null}
+     *           to clear the thread local so {@link #get()} will create a new
+     *           default instance
      */
     static void set(MessageHistory md) {
         VanillaMessageHistory.setThreadLocal(md);
     }
 
     /**
-     * Clears the {@code MessageHistory} for the current thread.
+     * Effectively calls {@code set(null)} removing the current thread-local
+     * history.
      */
     static void clear() {
         VanillaMessageHistory.setThreadLocal(null);
     }
 
     /**
-     * Sets an empty history the {@code MessageHistory} for the current thread.
+     * Sets the current thread-local history to a new empty
+     * {@link VanillaMessageHistory}.
      */
     static void emptyHistory() {
         VanillaMessageHistory.setThreadLocal(new VanillaMessageHistory());
     }
 
+    /**
+     * Writes the current thread's history to the given document if the
+     * document is empty.
+     *
+     * @param dc the {@link DocumentContext} to write the history to
+     */
     @UsedViaReflection
     static void writeHistory(DocumentContext dc) {
         if (((WriteDocumentContext) dc).isEmpty()) { // only add to the start of a message. i.e. for chained calls.
@@ -65,85 +76,85 @@ public interface MessageHistory extends Marshallable {
     }
 
     // needed by NoMessageHistory in Queue
+    /**
+     * Default implementation for recording history into the supplied
+     * {@link DocumentContext}. It writes an event named
+     * {@link net.openhft.chronicle.bytes.MethodReader#HISTORY} with this history
+     * as the value.
+     *
+     * @param dc the document to append the history to
+     */
     default void doWriteHistory(DocumentContext dc) {
         dc.wire().writeEventName(MethodReader.HISTORY).marshallable(get());
     }
 
     /**
-     * Returns the number of timings contained in this {@code MessageHistory}.
+     * Returns the count of timing entries recorded in this history.
      *
-     * @return the number of timings contained in this {@code MessageHistory}.
+     * @return the number of timings
      */
     int timings();
 
     /**
-     * Returns a timing at a position specified by the input {@code n}.
-     *
-     * @return a timing at a position specified by the input {@code n}.
+     * @param n zero-based index of the timing entry to read
+     * @return the timestamp recorded at index {@code n}
      */
     long timing(int n);
 
     /**
-     * Returns the number of sources contained in this {@code MessageHistory}.
+     * Returns the count of source entries recorded in this history.
      *
-     * @return the number of sources contained in this {@code MessageHistory}.
+     * @return the number of sources
      */
     int sources();
 
     /**
-     * Returns the source id at a position specified by the input {@code n}.
-     *
-     * @return the source id at a position specified by the input {@code n}.
+     * @param n zero-based index of the source entry
+     * @return the identifier of the source recorded at index {@code n}
      */
     int sourceId(int n);
 
     /**
-     * Returns {@code true} if the source ids contained in this
-     * {@code MessageHistory} end with the provided {@code sourceIds}.
-     *
-     * @return {@code true} if the source ids contained in this
-     * {@code MessageHistory} end with the provided {@code sourceIds}.
+     * @param sourceIds sequence of IDs to check against the end of this history
+     * @return {@code true} if the IDs match the end of the stored list
      */
     boolean sourceIdsEndsWith(int[] sourceIds);
 
     /**
-     * Returns the index of the source at a position specified by the
-     * input {@code n}.
-     *
-     * @return the index of the source at a position specified by the
-     * input {@code n}.
+     * @param n zero-based index of the source entry
+     * @return the index within the source component recorded at index {@code n}
      */
     long sourceIndex(int n);
 
     /**
-     * Clears all data contained in this {@code MessageHistory}
+     * Clears all recorded source and timing entries.
      */
     @Override
     void reset();
 
     /**
-     * Resets the {@code MessageHistory} with the provided {@code sourceId}
-     * and {@code sourceIndex} as a starting point.
+     * Clears existing entries and initialises this history with a single source
+     * and the current time.
+     *
+     * @param sourceId    identifier of the initial source component
+     * @param sourceIndex index within that source
      */
     void reset(int sourceId, long sourceIndex);
 
     /**
-     * Returns the last source id contained in this {@code MessageHistory}.
-     *
-     * @return the last source id contained in this {@code MessageHistory}.
+     * Returns the ID of the most recently added source or {@code -1} if none.
      */
     int lastSourceId();
 
     /**
-     * Returns the last source index contained in this {@code MessageHistory}.
-     *
-     * @return the last source index contained in this {@code MessageHistory}.
+     * Returns the index of the most recently added source or {@code -1} if none.
      */
     long lastSourceIndex();
 
     /**
-     * @return {@code true} if the message history has not been written using
-     * {@link Marshallable#writeMarshallable(net.openhft.chronicle.wire.WireOut)}
+     * Indicates if new entries were added since the last write or reset.
+     *
+     * @return {@code true} if the history has unwritten changes
      */
     boolean isDirty();
 }


### PR DESCRIPTION
## Summary
- expand the class description for `MessageHistory`
- clarify behaviour of static helpers
- explain history write operations
- document behaviour of accessors and mutators

## Testing
- `mvn -q verify` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683d72273e288329939784195731c4e6