### PR TITLE
Improve path classifier and history interface javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/MessagePathClassifier.java
+++ b/src/main/java/net/openhft/chronicle/wire/MessagePathClassifier.java
@@ -26,31 +26,40 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
- * The {@code MessagePathClassifier} class is responsible for classifying message paths based on their histories.
- * This classifier allows messages to be grouped or identified based on patterns of their source IDs. It provides
- * mechanisms to associate a path ID with certain patterns of source IDs and to retrieve the appropriate path ID
- * for a given message history.
+ * Classifies message paths based on the history of each message.
  * <p>
- * This class also implements {@link IntSupplier}, allowing the direct fetching of path ID for the current
- * {@link MessageHistory}.
+ * In systems where messages may traverse several hops, known routes can be
+ * registered as patterns of source IDs. Each pattern is linked to a {@code pathId}
+ * which can later be used for metrics, monitoring or routing decisions. The
+ * longest matching pattern wins.
+ * <p>
+ * Implements {@link IntSupplier} so the current thread's
+ * {@link MessageHistory} can be classified directly via {@link #getAsInt()}.
  */
 public class MessagePathClassifier implements IntSupplier {
 
-    // Patterns of source IDs for classification.
+    /**
+     * Patterns of source IDs for classification. A message history matches a
+     * pattern when its source IDs end with the sequence.
+     */
     private final List<int[]> sourcePattern = new ArrayList<>();
 
-    // Path IDs corresponding to the patterns.
+    /**
+     * Path IDs corresponding to the patterns. Index {@code i} relates to
+     * {@code sourcePattern.get(i)}.
+     */
     private final List<Integer> pathIds = new ArrayList<>();
 
     /**
-     * Registers a path ID for message histories ending with a specific sequence of source IDs.
-     * <p>
-     * This method enables the user to define how the classifier should categorize certain patterns
-     * of message history.
+     * Registers a path ID for message histories that end with the supplied
+     * sequence of source IDs.
      *
-     * @param pathId  A unique identifier for the message path.
-     * @param sources An ordered array of source IDs representing a pattern in the message history.
-     * @return The current instance of the  for chaining.
+     * @param pathId  the identifier to associate with this pattern
+     * @param sources the sequence of source IDs that must appear at the end of
+     *                a message history
+     * @return this classifier for chaining
+     * @throws IllegalArgumentException if the same sequence is registered with a
+     *                                  different {@code pathId}
      */
     public MessagePathClassifier addPathForSourcesEnding(int pathId, int... sources) {
         OptionalInt duplicate = IntStream.range(0, sourcePattern.size())
@@ -68,16 +77,23 @@ public class MessagePathClassifier implements IntSupplier {
         return this;
     }
 
+    /**
+     * Returns the path ID for the current thread's {@link MessageHistory}.
+     */
     @Override
     public int getAsInt() {
         return pathFor(MessageHistory.get());
     }
 
     /**
-     * Determines the path ID for a specific {@link MessageHistory}.
+     * Determines the {@code pathId} for the supplied history.
+     * <p>
+     * All registered patterns are checked and the longest matching suffix is
+     * selected.
      *
-     * @param messageHistory The message history to classify.
-     * @return The classified path ID for the given message history.
+     * @param messageHistory the history to classify
+     * @return the matching path ID
+     * @throws IllegalStateException if none of the patterns apply
      */
     public int pathFor(MessageHistory messageHistory) {
         Integer pathId = null;
@@ -97,6 +113,9 @@ public class MessagePathClassifier implements IntSupplier {
         return pathId;
     }
 
+    /**
+     * Returns a readable representation of the classifier state.
+     */
     @Override
     public String toString() {
         return "MessagePathClassifier{" +

--- a/src/main/java/net/openhft/chronicle/wire/utils/RecordHistory.java
+++ b/src/main/java/net/openhft/chronicle/wire/utils/RecordHistory.java
@@ -1,10 +1,19 @@
 package net.openhft.chronicle.wire.utils;
 
+import net.openhft.chronicle.wire.VanillaMessageHistory;
+
 /**
- * Write a history before each message
+ * Functional interface for publishers that prepend a {@link VanillaMessageHistory}
+ * before the next message.
  *
- * @param <T> interface of messages with prepended history
+ * @param <T> the type of the publishing interface augmented with history recording
  */
 public interface RecordHistory<T> {
-    T history(net.openhft.chronicle.wire.VanillaMessageHistory history);
+    /**
+     * Records the supplied history so that it is written before the next message.
+     *
+     * @param history the history to prepend
+     * @return typically {@code this} to allow method chaining
+     */
+    T history(VanillaMessageHistory history);
 }


### PR DESCRIPTION
## Summary
- expand javadoc for `MessagePathClassifier`
- document fields and methods with additional behaviour notes
- clarify usage of `RecordHistory`

## Testing
- `mvn -q verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d72604f688329987ee824d16f6bab