### PR TITLE
Improve Wires javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/Wires.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wires.java
@@ -59,30 +59,76 @@ import static net.openhft.chronicle.wire.WireType.TEXT;
 import static net.openhft.chronicle.wire.WireType.YAML_ONLY;
 
 /**
- * The {@code Wires} enum encapsulates constants and utility methods related to wire operations.
- * It defines flags, masks, and utility methods that facilitate operations on wires.
- * For example, it provides constants like {@code NOT_COMPLETE} to indicate a wire message's completeness status.
- * This enum doesn't have any specific enumeration values but provides a utility-based structure.
+ * Utility holder for low-level wire constants and helper methods.
+ * <p>
+ * This enum does not contain any enumeration values.  It acts as a
+ * central hub for header flags and masks, static utility methods for
+ * common wire operations, and management of reusable resources such as
+ * {@link StringBuilder} pools and {@link net.openhft.compiler.CachedCompiler}
+ * instances.
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public enum Wires {
     ; // No specific enumeration values
 
-    // Constants defining various masks and flags for wire operations
+    /**
+     * Mask for extracting the length from a 4&nbsp;byte header.
+     * Only the lower 30&nbsp;bits are used for the length value.
+     */
     public static final int LENGTH_MASK = -1 >>> 2;
+
+    /**
+     * Flag ({@code 0x8000_0000}) indicating that the following message is not yet complete.
+     * Used in the length prefix of a size-prefixed blob.
+     */
     public static final int NOT_COMPLETE = 0x8000_0000;
+
+    /**
+     * Flag ({@code 0x4000_0000}) marking the document as meta-data rather than data.
+     */
     public static final int META_DATA = 1 << 30;
+
+    /**
+     * Value representing an unknown length ({@code 0}).
+     */
     public static final int UNKNOWN_LENGTH = 0x0;
-    // value to use when the message is not ready and of an unknown length
+
+    /**
+     * Combination of {@link #NOT_COMPLETE} and {@link #UNKNOWN_LENGTH} for incomplete messages
+     * of unknown size.
+     */
     public static final int NOT_COMPLETE_UNKNOWN_LENGTH = NOT_COMPLETE;
-    // value to use when no more data is possible e.g. on a roll.
+
+    /**
+     * Combination of {@link #NOT_COMPLETE} and {@link #META_DATA} used to indicate no more data
+     * is expected, for example at end of a roll.
+     */
     public static final int END_OF_DATA = NOT_COMPLETE | META_DATA;
+
+    /**
+     * Value used for an uninitialised header ({@code 0}).
+     */
     public static final int NOT_INITIALIZED = 0x0;
+
+    /**
+     * Shared immutable {@link Bytes} instance representing an empty buffer.
+     */
     public static final Bytes<?> NO_BYTES = BytesStore.empty().bytesForRead();
-    // Size of the SPB header
+
+    /**
+     * Size in bytes of a Size-Prefixed Blob (SPB) header.
+     */
     public static final int SPB_HEADER_SIZE = 4;
+
+    /**
+     * Registry of functions that determine the {@link SerializationStrategy} for a class.
+     */
     public static final List<Function<Class<?>, SerializationStrategy>> CLASS_STRATEGY_FUNCTIONS = new CopyOnWriteArrayList<>();
 
+    /**
+     * Cache mapping classes to their {@link SerializationStrategy}.
+     * Strategies are resolved via {@link #CLASS_STRATEGY_FUNCTIONS}.
+     */
     static final ClassLocal<SerializationStrategy> CLASS_STRATEGY = ClassLocal.withInitial(c -> {
         for (@NotNull Function<Class<?>, SerializationStrategy> func : CLASS_STRATEGY_FUNCTIONS) {
             final SerializationStrategy strategy = func.apply(c);
@@ -92,10 +138,15 @@ public enum Wires {
         return ANY_OBJECT;
     });
 
-    // Class local storage for field information lookup based on class
+    /**
+     * Cache of {@link FieldInfoPair} describing marshallable fields for each class.
+     */
     static final ClassLocal<FieldInfoPair> FIELD_INFOS = ClassLocal.withInitial(FieldInfo::lookupClass);
 
-    // Function to produce Marshallable objects based on a given class type
+    /**
+     * Provides a function that can create proxy {@link Marshallable} implementations
+     * for tuple-like interfaces.
+     */
     static final ClassLocal<Function<String, Marshallable>> MARSHALLABLE_FUNCTION = ClassLocal.withInitial(tClass -> {
         Class[] interfaces = {Marshallable.class, tClass};
         if (tClass == Marshallable.class)
@@ -110,21 +161,51 @@ public enum Wires {
             throw new IllegalStateException(e);
         }
     });
+    /**
+     * Thread-local pool of {@link StringBuilder} instances to reduce allocations.
+     */
     static final ScopedResourcePool<StringBuilder> STRING_BUILDER_SCOPED_RESOURCE_POOL = StringBuilderPool.createThreadLocal();
-    // Thread local storage for BinaryWire instances
+
+    /**
+     * Thread-local {@link BinaryWire} used for temporary read or write operations.
+     */
     static final ThreadLocal<BinaryWire> WIRE_TL = ThreadLocal.withInitial(() -> new BinaryWire(Bytes.allocateElasticOnHeap()));
-    // Flag to determine if code dump is enabled
+
+    /**
+     * Flag derived from the {@code dumpCodeToTarget} system property or {@link Jvm#isDebug()}.
+     * When true, generated Java source is written to the build target directory.
+     */
     static final boolean DUMP_CODE_TO_TARGET = Jvm.getBoolean("dumpCodeToTarget", Jvm.isDebug());
-    // Constants related to thread identifiers
+
+    /**
+     * Mask for embedding a thread identifier within a header.
+     */
     private static final int TID_MASK = 0b00111111_11111111_11111111_11111111;
+
+    /**
+     * Inverse of {@link #TID_MASK} for removing a masked thread identifier.
+     */
     private static final int INVERSE_TID_MASK = ~TID_MASK;
-    // Flag to enable tuple generation
+
+    /**
+     * Flag indicating whether tuple generation is permitted via the
+     * {@code wire.generate.tuples} system property.
+     */
     public static boolean GENERATE_TUPLES = Jvm.getBoolean("wire.generate.tuples");
-    // Flags to assist with state management and logging
+
+    /**
+     * Used to ensure an untyped bytes warning is logged only once.
+     */
     static volatile boolean warnedUntypedBytesOnce = false;
-    // Thread local storage for string builders
+
+    /**
+     * Legacy thread-local {@link StringBuilder}. Prefer {@link #STRING_BUILDER_SCOPED_RESOURCE_POOL}.
+     */
     static ThreadLocal<StringBuilder> sb = ThreadLocal.withInitial(StringBuilder::new);
-    // Compiler cache for dynamic code generation
+
+    /**
+     * Shared {@link net.openhft.compiler.CachedCompiler} for dynamic class generation.
+     */
     static CachedCompiler CACHED_COMPILER = null;
 
     /**
@@ -190,60 +271,58 @@ public enum Wires {
     }
 
     /**
-     * This decodes some Bytes where the first 4-bytes is the length.  e.g. Wire.writeDocument wrote
-     * it. <a href="https://github.com/OpenHFT/RFC/tree/master/Size-Prefixed-Blob">Size Prefixed
-     * Blob</a>
+     * Dumps a sequence of size-prefixed binary messages as a human readable
+     * string.  The first four bytes of each message contain the length and
+     * status flags.  See the <a href="https://github.com/OpenHFT/RFC/tree/master/Size-Prefixed-Blob">Size Prefixed Blob</a>
+     * specification.
      *
-     * @param bytes to decode
-     * @return as String
+     * @param bytes the bytes containing the size-prefixed data
+     * @return the dump in text form
      */
     public static String fromSizePrefixedBlobs(@NotNull Bytes<?> bytes) {
         return WireDumper.of(bytes).asString();
     }
 
     /**
-     * Converts the provided bytes, which represent aligned size-prefixed blobs,
-     * into a readable string format.
+     * Dumps aligned size-prefixed blobs.  Alignment means each record may have
+     * padding between messages.
      *
-     * @param bytes the bytes representing aligned size-prefixed blobs
-     * @return the readable string representation of the blobs
+     * @param bytes the bytes containing the aligned blobs
+     * @return textual dump of the messages
      */
     public static String fromAlignedSizePrefixedBlobs(@NotNull Bytes<?> bytes) {
         return WireDumper.of(bytes, true).asString();
     }
 
     /**
-     * Converts the provided bytes, representing size-prefixed blobs,
-     * into a readable string format with the option to abbreviate.
+     * Dumps size-prefixed blobs with optional abbreviation of long content.
      *
-     * @param bytes   the bytes representing size-prefixed blobs
-     * @param abbrev  if {@code true}, the output string will be abbreviated
-     * @return the readable string representation of the blobs
+     * @param bytes  the bytes containing the messages
+     * @param abbrev if {@code true} long fields are abbreviated
+     * @return textual dump of the blobs
      */
     public static String fromSizePrefixedBlobs(@NotNull Bytes<?> bytes, boolean abbrev) {
         return WireDumper.of(bytes).asString(abbrev);
     }
 
     /**
-     * Converts the provided bytes, representing size-prefixed blobs,
-     * into a readable string format from the specified position.
+     * Dumps size-prefixed blobs starting at a given position.
      *
-     * @param bytes    the bytes representing size-prefixed blobs
-     * @param position the position in bytes from which the conversion starts
-     * @return the readable string representation of the blobs from the specified position
+     * @param bytes    the bytes containing the messages
+     * @param position the offset in {@code bytes} to begin dumping
+     * @return textual dump of the remaining messages
      */
     public static String fromSizePrefixedBlobs(@NotNull Bytes<?> bytes, long position) {
         return fromSizePrefixedBlobs(bytes, position, false);
     }
 
     /**
-     * Converts the provided bytes, representing size-prefixed blobs,
-     * into a readable string format from a specified position and with the option to pad.
+     * Dumps size-prefixed blobs from a given position with optional padding.
      *
-     * @param bytes    the bytes representing size-prefixed blobs
-     * @param position the position in bytes from which the conversion starts
-     * @param padding  if {@code true}, the output string will have padding
-     * @return the readable string representation of the blobs from the specified position
+     * @param bytes    the bytes containing the messages
+     * @param position start position in {@code bytes}
+     * @param padding  whether message boundaries are padded
+     * @return textual dump of the blobs
      */
     public static String fromSizePrefixedBlobs(@NotNull Bytes<?> bytes, long position, boolean padding) {
         final long limit = bytes.readLimit();
@@ -253,25 +332,24 @@ public enum Wires {
     }
 
     /**
-     * Converts the provided bytes, which represent size-prefixed blobs,
-     * into a readable string format with options for padding and abbreviation.
+     * Dumps size-prefixed blobs with control over padding and abbreviation.
      *
-     * @param bytes   the bytes representing size-prefixed blobs
-     * @param padding if {@code true}, the output string will have padding
-     * @param abbrev  if {@code true}, the output string will be abbreviated
-     * @return the readable string representation of the blobs
+     * @param bytes   the bytes containing the messages
+     * @param padding whether message boundaries are padded
+     * @param abbrev  whether long content should be abbreviated
+     * @return textual dump of the blobs
      */
     public static String fromSizePrefixedBlobs(@NotNull Bytes<?> bytes, boolean padding, boolean abbrev) {
         return WireDumper.of(bytes, padding).asString(abbrev);
     }
 
     /**
-     * Converts the contents of the provided {@code DocumentContext}
-     * which represent size-prefixed blobs into a readable string format.
-     * The method supports handling of both TextWire and BinaryWire types.
+     * Dumps the current document of the supplied {@link DocumentContext} as a
+     * sequence of size-prefixed blobs.  Both {@link TextWire} and
+     * {@link BinaryWire} contexts are supported.
      *
-     * @param dc the {@code DocumentContext} holding the wire data
-     * @return the readable string representation of the blobs
+     * @param dc the document context whose content should be dumped
+     * @return textual dump of the blobs
      */
     public static String fromSizePrefixedBlobs(@NotNull DocumentContext dc) {
         Wire wire = dc.wire();
@@ -337,29 +415,33 @@ public enum Wires {
     }
 
     /**
-     * Converts the contents of the provided {@code WireIn}
-     * which represent size-prefixed blobs into a readable string format.
+     * Dumps the messages from a {@link WireIn} as a human readable string.
      *
-     * @param wireIn the {@code WireIn} instance holding the wire data
-     * @return the readable string representation of the blobs
+     * @param wireIn the input wire
+     * @return textual dump of the blobs
      */
     public static String fromSizePrefixedBlobs(@NotNull WireIn wireIn) {
         return fromSizePrefixedBlobs(wireIn, false);
     }
 
     /**
-     * Converts the contents of the provided {@code WireIn}
-     * which represent size-prefixed blobs into a readable string format,
-     * with the option to abbreviate the output.
+     * Dumps the messages from a {@link WireIn} with optional abbreviation.
      *
-     * @param wireIn the {@code WireIn} instance holding the wire data
-     * @param abbrev  if {@code true}, the output string will be abbreviated
-     * @return the readable string representation of the blobs
+     * @param wireIn the input wire
+     * @param abbrev whether long content should be abbreviated
+     * @return textual dump of the blobs
      */
     public static String fromSizePrefixedBlobs(@NotNull WireIn wireIn, boolean abbrev) {
         return WireDumper.of(wireIn).asString(abbrev);
     }
 
+    /**
+     * Converts the contents of {@code wireIn} to a text (YAML-like) representation.
+     *
+     * @param wireIn the source wire
+     * @param output buffer to receive the text
+     * @return {@code output} containing the textual form
+     */
     @NotNull
     public static CharSequence asText(@NotNull WireIn wireIn, Bytes<?> output) {
         ValidatableUtil.startValidateDisabled();
@@ -380,6 +462,9 @@ public enum Wires {
         return new JSONWire(bytes).useTypes(true).trimFirstCurly(false).useTextDocuments();
     }
 
+    /**
+     * Copies the contents of {@code wireIn} into {@code output} using a binary wire.
+     */
     public static Bytes<?> asBinary(@NotNull WireIn wireIn, Bytes<?> output) throws InvalidMarshallableException {
         return asType(wireIn, BinaryWire::new, output);
     }
@@ -402,6 +487,9 @@ public enum Wires {
         }
     }
 
+    /**
+     * Converts {@code wireIn} to JSON and writes the result into {@code output}.
+     */
     public static Bytes<?> asJson(@NotNull WireIn wireIn, Bytes<?> output) throws InvalidMarshallableException {
         return asType(wireIn, Wires::newJsonWire, output);
     }
@@ -416,97 +504,78 @@ public enum Wires {
         return new TextWire(bytes).addTimeStamps(true);
     }
 
+    /**
+     * Obtains a {@link StringBuilder} from the thread-local pool wrapped in a
+     * {@link ScopedResource} so it is automatically returned when the scope is closed.
+     */
     public static ScopedResource<StringBuilder> acquireStringBuilderScoped() {
         return STRING_BUILDER_SCOPED_RESOURCE_POOL.get();
     }
 
     /**
-     * Extracts the length from the given length value.
-     *
-     * @param len the encoded length
-     * @return the decoded length
+     * Extracts the pure length from a 4&nbsp;byte header value, removing
+     * flags such as {@link #NOT_COMPLETE} and {@link #META_DATA}.
      */
     public static int lengthOf(int len) {
         return len & LENGTH_MASK;
     }
 
     /**
-     * Checks if the given header is ready (complete and not zero).
-     *
-     * @param header the input header
-     * @return true if the header is ready, false otherwise
+     * Returns {@code true} if the header denotes a complete document.
      */
     public static boolean isReady(int header) {
         return (header & NOT_COMPLETE) == 0 && header != 0;
     }
 
     /**
-     * Checks if the given header is not complete or zero.
-     *
-     * @param header the input header
-     * @return true if the header is not complete or zero, false otherwise
+     * Returns {@code true} if the header indicates an incomplete document or zero length.
      */
     public static boolean isNotComplete(int header) {
         return (header & NOT_COMPLETE) != 0 || header == 0;
     }
 
     /**
-     * Checks if the given header represents ready data (neither meta-data nor incomplete) and is not zero.
-     *
-     * @param header the input header
-     * @return true if the header represents ready data, false otherwise
+     * Tests whether a header represents completed data (not meta-data) and is non-zero.
      */
     public static boolean isReadyData(int header) {
         return ((header & (META_DATA | NOT_COMPLETE)) == 0) && (header != 0);
     }
 
     /**
-     * Checks if the given length represents data and not meta-data.
-     *
-     * @param len the encoded length
-     * @return true if the length represents data, false otherwise
+     * Returns {@code true} if the header denotes data rather than meta-data.
      */
     public static boolean isData(int len) {
         return (len & META_DATA) == 0;
     }
 
     /**
-     * Checks if the given length represents ready meta-data.
-     *
-     * @param len the encoded length
-     * @return true if the length represents ready meta-data, false otherwise
+     * Returns {@code true} if the header is marked as meta-data and the document is complete.
      */
     public static boolean isReadyMetaData(int len) {
         return (len & (META_DATA | NOT_COMPLETE)) == META_DATA;
     }
 
     /**
-     * Checks if the given length represents a known length (neither unknown nor meta-data).
-     *
-     * @param len the encoded length
-     * @return true if the length is known, false otherwise
+     * Returns {@code true} if the header has a definite length value.
      */
     public static boolean isKnownLength(int len) {
         return (len & (META_DATA | LENGTH_MASK)) != UNKNOWN_LENGTH;
     }
 
     /**
-     * Checks if the given length is not initialized.
-     *
-     * @param len the encoded length
-     * @return true if the length is not initialized, false otherwise
+     * Returns {@code true} if the header has not been initialised.
      */
     public static boolean isNotInitialized(int len) {
         return len == NOT_INITIALIZED;
     }
 
     /**
-     * Converts a long value to an int, ensuring it falls within the 30-bit range.
+     * Converts {@code l} to a 30&nbsp;bit unsigned int.
      *
-     * @param l     the input long value
-     * @param error the error message template in case of an out-of-range value
-     * @return the converted int value
-     * @throws IllegalStateException if the value is out of the 30-bit range
+     * @param l     the value to convert
+     * @param error error message used if {@code l} is outside {@code 0}..{@link #LENGTH_MASK}
+     * @return {@code l} as an int
+     * @throws IllegalStateException if {@code l} is out of range
      */
     public static int toIntU30(long l, @NotNull String error) {
         if (l < 0 || l > LENGTH_MASK)
@@ -515,11 +584,12 @@ public enum Wires {
     }
 
     /**
-     * Acquires a lock on the given BytesStore at the specified position.
+     * Attempts to claim a 4&nbsp;byte header by atomically swapping
+     * {@link #NOT_INITIALIZED} with {@link #NOT_COMPLETE}.
      *
-     * @param store    the byte store to lock
-     * @param position the position at which to lock
-     * @return true if the lock was successfully acquired, false otherwise
+     * @param store    bytes containing the header
+     * @param position offset of the header
+     * @return {@code true} if the lock was acquired
      */
     public static boolean acquireLock(@NotNull BytesStore<?, ?> store, long position) {
         return store.compareAndSwapInt(position, NOT_INITIALIZED, NOT_COMPLETE);
@@ -587,11 +657,20 @@ public enum Wires {
         return bytes;
     }
 
+    /**
+     * Provides a pooled {@link Bytes} instance wrapped in a {@link ScopedResource}.
+     *
+     * @return the scoped bytes
+     */
     @NotNull
     public static ScopedResource<Bytes<Void>> acquireBytesScoped() {
         return WireInternal.BYTES_SCOPED_THREAD_LOCAL.get();
     }
 
+    /**
+     * Obtains a pooled {@link BinaryWire} wrapped in a {@link ScopedResource}
+     * for temporary serialisation tasks.
+     */
     public static ScopedResource<Wire> acquireBinaryWireScoped() {
         return WireInternal.BINARY_WIRE_SCOPED_TL.get();
     }
@@ -800,10 +879,7 @@ public enum Wires {
     }
 
     /**
-     * Checks if a given integer represents the end of file marker.
-     *
-     * @param num Integer to check
-     * @return true if the integer represents end of file, false otherwise
+     * Returns {@code true} if the supplied header value denotes end of data.
      */
     public static boolean isEndOfFile(int num) {
         return num == END_OF_DATA;
@@ -1249,12 +1325,8 @@ public enum Wires {
     }
 
     /**
-     * Creates a BinaryWire for reading with the given input, position, and length.
-     *
-     * @param in        The input bytes.
-     * @param position  The starting position.
-     * @param length    The length of data to read.
-     * @return A BinaryWire configured for reading.
+     * Provides a thread-local {@link BinaryWire} configured to read from the supplied
+     * byte store.  The returned wire shares the underlying bytes; no copy is made.
      */
     @NotNull
     public static BinaryWire binaryWireForRead(Bytes<?> in, long position, long length) {
@@ -1266,12 +1338,8 @@ public enum Wires {
     }
 
     /**
-     * Creates a BinaryWire for writing with the given input, position, and length.
-     *
-     * @param in        The input bytes.
-     * @param position  The starting position.
-     * @param length    The length of data to write.
-     * @return A BinaryWire configured for writing.
+     * Provides a thread-local {@link BinaryWire} configured for writing to the supplied
+     * byte store.  The returned wire views the given bytes without copying.
      */
     @NotNull
     public static BinaryWire binaryWireForWrite(Bytes<?> in, long position, long length) {
@@ -1283,15 +1351,9 @@ public enum Wires {
     }
 
     /**
-     * Loads a Java class from the given source code string using the specified class loader.
-     * If a cached compiler is not initialized, it initializes one either with default settings
-     * or specific directories if they exist and `DUMP_CODE_TO_TARGET` is true.
-     *
-     * @param classLoader The class loader to use for loading the class.
-     * @param className   The name of the class to be loaded.
-     * @param code        The Java source code for the class.
-     * @return The loaded class.
-     * @throws ClassNotFoundException If the class could not be found or loaded.
+     * Dynamically compiles and loads a class from its source code.
+     * The {@link #CACHED_COMPILER} is created lazily and may write generated
+     * files to the build directory when {@link #DUMP_CODE_TO_TARGET} is set.
      */
     static synchronized Class<?> loadFromJava(ClassLoader classLoader, String className, String code) throws ClassNotFoundException {
         if (CACHED_COMPILER == null) {


### PR DESCRIPTION
## Summary
- expand `Wires` overview
- document constants and caches in detail
- clarify behaviour of `fromSizePrefixedBlobs` variants
- document wire conversion helpers and thread‑local resources
- add explanations for header flag utilities and helper methods

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d734a74d88329898fdc6ebb55bbf3