### PR TITLE
Improve Javadoc for comment and rollback interfaces

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/Comment.java
+++ b/src/main/java/net/openhft/chronicle/wire/Comment.java
@@ -21,11 +21,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * The Comment annotation represents a way to attach user-defined comments to elements like fields,
- * parameters, or types. This can be especially useful for documenting the intention, usage, or any other
- * relevant information about the annotated element at runtime.
- * <p>
- * Being retained at runtime, it can be inspected via reflection to influence behavior based on the comment's content.
+ * The Comment annotation represents a way to attach user-defined comments to elements
+ * such as fields, parameters or types. This can be especially useful for documenting
+ * the intention, usage or any other information about the annotated element at
+ * runtime. Being retained at runtime, it can be inspected via reflection to influence
+ * behaviour based on the comment's content. For example, a {@link WireOut}
+ * implementation might choose to write the comment's value into the serialised output
+ * if the wire format supports comments (for example YAML).
  */
 @Retention(RetentionPolicy.RUNTIME)  // This annotation is available at runtime.
 @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE})  // Specifies the kinds of elements this annotation can be applied to.

--- a/src/main/java/net/openhft/chronicle/wire/CommentAnnotationNotifier.java
+++ b/src/main/java/net/openhft/chronicle/wire/CommentAnnotationNotifier.java
@@ -16,16 +16,22 @@
 package net.openhft.chronicle.wire;
 
 /**
- * Represents an interface to notify whether a certain element has a preceding comment annotation.
- * Implementers can use this to handle scenarios where knowledge of preceding comments is required.
+ * <b>INTERNAL USE ONLY.</b> This interface is used by some {@link ValueOut}
+ * implementations (for example for YAML) to signal to
+ * {@link net.openhft.chronicle.wire.WireMarshaller.FieldAccess} that a
+ * {@link Comment} annotation is present on a field. This allows the
+ * {@code FieldAccess} to format the comment using the field's value after the
+ * value itself has been written.
  */
 interface CommentAnnotationNotifier {
 
     /**
-     * Notifies the implementer whether a certain element has a preceding comment annotation.
+     * Notifies the implementer whether a certain element has a preceding comment
+     * annotation.
      *
-     * @param hasCommentAnnotation A flag indicating if the element has a preceding comment.
-     *                             True if it has, otherwise false.
+     * @param hasCommentAnnotation {@code true} if a {@link Comment} annotation is
+     *                             associated with the field about to be written,
+     *                             {@code false} otherwise.
      */
     void hasPrecedingComment(boolean hasCommentAnnotation);
 }

--- a/src/main/java/net/openhft/chronicle/wire/RollbackIfNotCompleteNotifier.java
+++ b/src/main/java/net/openhft/chronicle/wire/RollbackIfNotCompleteNotifier.java
@@ -16,16 +16,22 @@
 package net.openhft.chronicle.wire;
 
 /**
- * The RollbackIfNotCompleteNotifier interface defines methods to handle rollback scenarios
- * in the event of incomplete operations or messages. Implementations of this interface
- * can ensure data integrity and consistency by rolling back changes if an operation
- * does not complete successfully.
+ * The RollbackIfNotCompleteNotifier interface defines methods to handle rollback
+ * scenarios in the event of incomplete operations or messages. Implementations
+ * of this interface can ensure data integrity and consistency by rolling back
+ * changes if an operation does not complete successfully. This is typically
+ * implemented by {@link DocumentContext} objects, particularly
+ * {@link WriteDocumentContext}, to allow writers to discard partially written
+ * messages.
  */
 public interface RollbackIfNotCompleteNotifier {
     /**
-     * Rolls back the current operation if it is not complete. This method should be
-     * invoked to ensure data consistency and to prevent partial updates. Implementations
-     * may throw an UnsupportedOperationException if rollback is not supported.
+     * Rolls back the current operation if it is not complete. If the current
+     * document or operation managed by this notifier is in an incomplete state
+     * (for example as indicated by {@link DocumentContext#isNotComplete()}), this
+     * method should attempt to roll back any changes made within the current
+     * context, effectively discarding them. If rollback is not supported or not
+     * applicable, an {@link UnsupportedOperationException} may be thrown.
      *
      * @throws UnsupportedOperationException if the rollback operation is not supported
      */
@@ -34,8 +40,10 @@ public interface RollbackIfNotCompleteNotifier {
     }
 
     /**
-     * Checks if the current writing operation is complete. This method can be used to
-     * determine if it's safe to proceed with further operations or if a rollback is required.
+     * Checks if the current writing operation is complete. Returns {@code true}
+     * by default, indicating completion. Implementations should override this to
+     * reflect the actual completion status of their write operation (for
+     * example, the inverse of {@link DocumentContext#isNotComplete()}).
      *
      * @return true if the current operation is complete, false otherwise
      */


### PR DESCRIPTION
## Summary
- expand `Comment` Javadoc with example usage
- clarify internal role of `CommentAnnotationNotifier`
- detail `RollbackIfNotCompleteNotifier` and its methods

## Testing
- `mvn -q verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d73b5b7588329b59627ad4769b032