### PR TITLE
Improve javadoc for WireTypeConverter

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/WireTypeConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireTypeConverter.java
@@ -3,8 +3,8 @@ package net.openhft.chronicle.wire;
 import net.openhft.chronicle.wire.internal.WireTypeConverterInternal;
 
 /**
- * This is the WireTypeConverter class responsible for converting between different wire types such as JSON and YAML.
- * Internally, it utilizes a delegate pattern with {@link WireTypeConverterInternal} to handle the actual conversion processes.
+ * Converts data between wire types such as JSON and YAML.
+ * The work is delegated to {@link WireTypeConverterInternal}.
  */
 public class WireTypeConverter {
 
@@ -12,38 +12,40 @@ public class WireTypeConverter {
     private final WireTypeConverterInternal delegate;
 
     /**
-     * Default constructor initializing the WireTypeConverter with a default {@link WireTypeConverterInternal} instance.
+     * Default constructor.
+     * Initialises the internal delegate {@link net.openhft.chronicle.wire.internal.WireTypeConverterInternal}.
      */
     public WireTypeConverter() {
         delegate = new WireTypeConverterInternal();
     }
 
     /**
-     * Converts the given JSON formatted input to its equivalent YAML representation.
+     * Converts the given JSON formatted input to its YAML representation.
      *
-     * @param json The JSON input to be converted.
-     * @return The converted YAML representation.
+     * @param json the JSON formatted {@link CharSequence} to be converted
+     * @return a {@link CharSequence} containing the YAML representation of the input JSON
      */
     public CharSequence jsonToYaml(CharSequence json) {
         return delegate.jsonToYaml(json);
     }
 
     /**
-     * Converts the given YAML formatted input to its equivalent JSON representation.
+     * Converts the given YAML formatted input to its JSON representation.
      *
-     * @param yaml The YAML input to be converted.
-     * @return The converted JSON representation.
+     * @param yaml the YAML formatted {@link CharSequence} to be converted
+     * @return a {@link CharSequence} containing the JSON representation of the input YAML
      */
     public CharSequence yamlToJson(CharSequence yaml) {
         return delegate.yamlToJson(yaml);
     }
 
     /**
-     * Associates a given class type with an older type name as an alias.
-     * This facilitates backward compatibility or recognition of renamed classes.
+     * Registers a class alias that will be used during conversions.
+     * This allows a type name {@code oldTypeName} seen in the input to be mapped to
+     * {@code newClass} during deserialisation by the internal wires.
      *
-     * @param newClass    The new class type.
-     * @param oldTypeName The older or previous type name.
+     * @param newClass   the target {@link Class} object
+     * @param oldTypeName the alternative or old type name string that should map to {@code newClass}
      */
     public void addAlias(Class<?> newClass, String oldTypeName) {
         delegate.addAlias(newClass, oldTypeName);

--- a/src/main/java/net/openhft/chronicle/wire/internal/WireTypeConverterInternal.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/WireTypeConverterInternal.java
@@ -5,17 +5,24 @@ import net.openhft.chronicle.wire.Wire;
 import net.openhft.chronicle.wire.WireType;
 
 /**
- * Provides the capability to convert between different wire types, with a primary focus on
- * converting from JSON to YAML format.
- * <p>
- * This class encapsulates both JSON and YAML wire types to facilitate the conversion.
- * In addition to conversion, it supports validation mechanisms to ensure correctness and integrity of
- * the transformed data.
+ * <b>INTERNAL USE ONLY.</b> Implementation delegate for {@link net.openhft.chronicle.wire.WireTypeConverter}.
+ * It manages {@link net.openhft.chronicle.wire.JSONWire} and {@link net.openhft.chronicle.wire.YamlWire}
+ * instances to perform conversions by parsing the input with one wire type and then using
+ * {@link net.openhft.chronicle.wire.WireIn#copyTo(net.openhft.chronicle.wire.WireOut)} to serialise to the other.
  */
 public class WireTypeConverterInternal {
+    /** Internal {@link Wire} instance configured for YAML processing using an elastic on-heap buffer. */
     private final Wire yamlWire = WireType.YAML_ONLY.apply(Bytes.allocateElasticOnHeap());
+    /** Internal {@link Wire} instance configured for JSON processing using an elastic on-heap buffer. */
     private final Wire jsonWire = WireType.JSON_ONLY.apply(Bytes.allocateElasticOnHeap());
 
+    /**
+     * Converts the JSON {@link CharSequence} to YAML.
+     * The input {@code json} is appended to {@link #jsonWire} and copied to {@link #yamlWire}.
+     *
+     * @param json the JSON data
+     * @return the contents of {@link #yamlWire}
+     */
     public CharSequence jsonToYaml(CharSequence json) {
         jsonWire.reset();
         jsonWire.bytes().append(json);
@@ -25,6 +32,13 @@ public class WireTypeConverterInternal {
         return yamlWire.bytes();
     }
 
+    /**
+     * Converts the YAML {@link CharSequence} to JSON.
+     * The input {@code yaml} is appended to {@link #yamlWire} and copied to {@link #jsonWire}.
+     *
+     * @param yaml the YAML data
+     * @return the contents of {@link #jsonWire}
+     */
     public CharSequence yamlToJson(CharSequence yaml) {
         yamlWire.reset();
         yamlWire.bytes().clear().append(yaml);
@@ -36,12 +50,11 @@ public class WireTypeConverterInternal {
     }
 
     /**
-     * Adds aliasing support for type leniency. This facilitates the serialization and deserialization
-     * of objects whose class names might have changed. By providing an alias, the system can recognize
-     * and handle the renamed class seamlessly.
+     * Adds the class alias to the {@link net.openhft.chronicle.core.pool.ClassLookup}
+     * of both {@link #jsonWire} and {@link #yamlWire}.
      *
-     * @param newClass    The new class type to use for serialization and deserialization.
-     * @param oldTypeName The old type name that this new class is an alias for.
+     * @param newClass   the class the alias maps to
+     * @param oldTypeName the legacy type name
      */
     public void addAlias(Class<?> newClass, String oldTypeName) {
         jsonWire.classLookup().addAlias(newClass, oldTypeName);


### PR DESCRIPTION
## Summary
- clarify class-level and method-level Javadoc in `WireTypeConverter`
- document the internal behaviour of `WireTypeConverterInternal`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d73cf2b88832992dc3d28eda71206