### PR TITLE
Improve ReflectionUtil and WireDumper Javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/ReflectionUtil.java
+++ b/src/main/java/net/openhft/chronicle/wire/ReflectionUtil.java
@@ -31,21 +31,31 @@ import java.util.List;
  */
 public final class ReflectionUtil {
 
-    // Configuration flag to determine if package name should be prepended
-    private static final boolean PREPEND_PACKAGE = Jvm.getBoolean("wire.method.prependPackage");
-    // Base package prefix for generated names
-    private static final String PACKAGE_PREFIX = "net.openhft.chronicle.wire.method";
+    /**
+     * System property ({@code wire.method.prependPackage}) flag. If true,
+     * {@link #generatedPackageName(String)} will always prepend
+     * {@link #PACKAGE_PREFIX} to the package name.
+     */
+    private static final boolean PREPEND_PACKAGE =
+            Jvm.getBoolean("wire.method.prependPackage");
+
+    /**
+     * The base package prefix ({@code net.openhft.chronicle.wire.method}) used
+     * by {@link #generatedPackageName(String)} when prepending is active.
+     */
+    private static final String PACKAGE_PREFIX =
+            "net.openhft.chronicle.wire.method";
 
     // Private constructor to prevent instantiation
     private ReflectionUtil() {
     }
 
     /**
-     * Creates and returns a new List of all interfaces implemented by
+     * Creates and returns a new {@link List} of all interfaces implemented by
      * the provided {@code oClass} and all its super classes.
      *
-     * @param oClass The class to inspect.
-     * @return A list of interfaces implemented by the given class and its ancestors.
+     * @param oClass The class whose implemented interfaces (including inherited ones) are to be retrieved.
+     * @return A new {@link List} of all unique interfaces implemented by {@code oClass} and its superclass hierarchy.
      */
     public static List<Class<?>> interfaces(@NotNull final Class<?> oClass) {
         final List<Class<?>> list = new ArrayList<>();
@@ -53,7 +63,10 @@ public final class ReflectionUtil {
         return list;
     }
 
-    // Recursively gather interfaces from the given class and its superclasses
+    /**
+     * Recursively populates the {@code list} with interfaces implemented by
+     * {@code oClass} and its superclasses, stopping at {@code java.lang.Object}.
+     */
     private static void interfaces(final Class<?> oClass, final List<Class<?>> list) {
         final Class<?> baseClass = oClass.getSuperclass();
         if (baseClass == null)
@@ -64,12 +77,14 @@ public final class ReflectionUtil {
     }
 
     /**
-     * Generates a package name based on a given class full name.
-     * If the class belongs to specific packages (like 'java.', 'javax.', 'com.sun.'),
-     * or if the {@code PREPEND_PACKAGE} flag is set, the generated package name
-     * will be prefixed with {@code PACKAGE_PREFIX}.
+     * Generates a package name based on the supplied class name. If the class
+     * resides in a reserved package such as {@code java.} or if
+     * {@link #PREPEND_PACKAGE} is true, the resulting name will be prefixed with
+     * {@link #PACKAGE_PREFIX}.
      *
-     * @param classFullName The full name of the class.
+     * @param classFullName The fully qualified name of the class for which to
+     *                      generate a potentially modified package name (e.g.,
+     *                      for generated proxy classes).
      * @return The generated package name.
      */
     @NotNull

--- a/src/main/java/net/openhft/chronicle/wire/WireDumper.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireDumper.java
@@ -27,20 +27,21 @@ import org.jetbrains.annotations.Nullable;
 @SuppressWarnings("rawtypes")
 public class WireDumper {
 
-    // Instance of WireIn to read from
+    /** The {@link WireIn} source whose content is being dumped. */
     @NotNull
     private final WireIn wireIn;
 
-    // Bytes that encapsulate the raw data
+    /** The underlying {@link Bytes} instance from {@link #wireIn}. */
     @NotNull
     private final Bytes<?> bytes;
 
-    // Tracks the header number for internal operations
+    /** Internal counter for tracking header/document numbers in the dump output. */
     private long headerNumber = -1;
 
     /**
-     * Private constructor for WireDumper.
-     * It initializes the wireIn and bytes. If wireIn is null, a new BinaryWire is created.
+     * Private constructor, use the static factory methods such as
+     * {@link #of(WireIn)}. If {@code wireIn} is {@code null} the bytes are
+     * wrapped in a new {@link BinaryWire}.
      *
      * @param wireIn WireIn instance (nullable)
      * @param bytes  Bytes instance containing the raw data
@@ -53,7 +54,7 @@ public class WireDumper {
     }
 
     /**
-     * Factory method to create a new WireDumper instance given a {@link WireIn} object.
+     * Creates a {@code WireDumper} for the given {@link WireIn} instance.
      *
      * @param wireIn The WireIn instance to be dumped
      * @return A new WireDumper instance
@@ -64,8 +65,9 @@ public class WireDumper {
     }
 
     /**
-     * Factory method to create a new WireDumper instance given a {@link Bytes} object.
-     * This method uses default padding alignment.
+     * Creates a {@code WireDumper} for the given {@link Bytes} instance,
+     * implicitly treating it as a {@link BinaryWire}. This method uses
+     * the default padding alignment.
      *
      * @param bytes The Bytes object containing the raw data to be dumped
      * @return A new WireDumper instance
@@ -76,10 +78,13 @@ public class WireDumper {
     }
 
     /**
-     * Factory method to create a new WireDumper instance given a {@link Bytes} object and an alignment preference.
+     * Creates a {@code WireDumper} for the given {@link Bytes} instance,
+     * implicitly treating it as a {@link BinaryWire}. The {@code align}
+     * parameter controls whether padding is assumed (see
+     * {@link AbstractWire#DEFAULT_USE_PADDING}).
      *
      * @param bytes The Bytes object containing the raw data to be dumped
-     * @param align Boolean value indicating whether to align the dumped data
+     * @param align Whether to use padding alignment
      * @return A new WireDumper instance
      */
     @SuppressWarnings("deprecation")
@@ -91,10 +96,9 @@ public class WireDumper {
     }
 
     /**
-     * Obtains a string representation of the entire content present in the bytes.
-     * This method uses default abbreviated format.
+     * Dumps the entire readable content of the wire as a string.
      *
-     * @return String representation of the content
+     * @return A string representation of the wire content
      */
     @NotNull
     public String asString() {
@@ -102,11 +106,10 @@ public class WireDumper {
     }
 
     /**
-     * Obtains a string representation of the content from the current read position.
-     * The length of content to be represented is determined by the remaining bytes to be read.
+     * Dumps the entire readable content of the wire as a string.
      *
-     * @param abbrev Boolean value indicating whether to use abbreviated format
-     * @return String representation of the content from the current read position
+     * @param abbrev If true, long content within individual messages might be abbreviated
+     * @return A string representation of the wire content
      */
     @NotNull
     public String asString(boolean abbrev) {
@@ -114,12 +117,12 @@ public class WireDumper {
     }
 
     /**
-     * Returns a string representation of the content located at the given position and length in the bytes.
-     * This method uses the default abbreviated format.
+     * Dumps a specific region of the wire content, starting at {@code position}
+     * for {@code length} bytes, as a string.
      *
-     * @param position Starting position of the content to be represented
-     * @param length   Length of the content to be represented
-     * @return String representation of the specified content
+     * @param position The starting byte position in the wire's underlying buffer
+     * @param length   The number of bytes to dump from the starting position
+     * @return A string representation of the specified wire content region
      */
     @NotNull
     public String asString(long position, long length) {
@@ -127,13 +130,13 @@ public class WireDumper {
     }
 
     /**
-     * Returns a string representation of the content located at the given position and length in the bytes.
-     * The method provides an option to use an abbreviated format.
+     * Dumps a specific region of the wire content, starting at {@code position}
+     * for {@code length} bytes, as a string.
      *
-     * @param position Starting position of the content to be represented
-     * @param length   Length of the content to be represented
-     * @param abbrev   Boolean value indicating whether to use abbreviated format
-     * @return String representation of the specified content
+     * @param position The starting byte position in the wire's underlying buffer
+     * @param length   The number of bytes to dump from the starting position
+     * @param abbrev   If true, long content within individual messages might be abbreviated
+     * @return A string representation of the specified wire content region
      */
     @NotNull
     public String asString(long position, long length, boolean abbrev) {
@@ -166,25 +169,25 @@ public class WireDumper {
     }
 
     /**
-     * Dumps a single wire entry from the internal byte buffer to the provided StringBuilder.
-     * This method uses the default abbreviated format.
+     * Reads and dumps a single size-prefixed message from the wire into the
+     * supplied {@code sb}. This method uses the default abbreviated format.
      *
-     * @param sb     StringBuilder to which the wire entry will be appended
-     * @param buffer Temporary buffer to assist in dumping the wire entry
-     * @return Boolean value indicating whether the dump was successful
+     * @param sb     The {@link StringBuilder} to append the dumped message to
+     * @param buffer A temporary {@link Bytes} buffer used if the source message is binary
+     * @return {@code true} if the end of the wire was reached, {@code false} otherwise
      */
     public boolean dumpOne(@NotNull StringBuilder sb, @Nullable Bytes<?> buffer) {
         return dumpOne(sb, buffer, false);
     }
 
     /**
-     * Dumps a single wire entry from the internal byte buffer to the provided StringBuilder.
-     * This method provides an option to use an abbreviated format.
+     * Reads and dumps a single size-prefixed message from the wire into the
+     * supplied {@code sb}.
      *
-     * @param sb     StringBuilder to which the wire entry will be appended
-     * @param buffer Temporary buffer to assist in dumping the wire entry
-     * @param abbrev Boolean value indicating whether to use abbreviated format
-     * @return Boolean value indicating whether the dump was successful
+     * @param sb     The {@link StringBuilder} to append the dumped message to
+     * @param buffer A temporary {@link Bytes} buffer used if the source message is binary; may be {@code null}
+     * @param abbrev If true, abbreviates content
+     * @return {@code true} if the end of the wire was reached, {@code false} otherwise
          */
     public boolean dumpOne(@NotNull StringBuilder sb, @Nullable Bytes<?> buffer, boolean abbrev) {
         // Read position in the byte buffer for extracting the header
@@ -315,14 +318,13 @@ public class WireDumper {
     }
 
     /**
-     * Dumps the content of the byte buffer as a hexadecimal representation into the provided StringBuilder.
-     * It positions the bytes at the specified read position, converts the content to hexadecimal, and sets
-     * the resulting string to the StringBuilder.
+     * Dumps the content of the byte buffer as a hexadecimal representation into
+     * the provided {@code sb}.
      *
-     * @param sb The StringBuilder to which the hexadecimal string will be appended.
-     * @param len The length or number of bytes to read and convert to hexadecimal.
-     * @param readPosition The starting position in the byte buffer from which to start reading.
-     * @param sblen The length to reset the StringBuilder to. This is typically used to overwrite any existing content.
+     * @param sb          The {@link StringBuilder} to append the hexadecimal dump to
+     * @param len         The number of bytes to read from {@link #bytes} and dump
+     * @param readPosition The starting position in {@link #bytes} to read from
+     * @param sblen       The length to which {@code sb} should be reset before appending the hex dump
      */
     public void dumpAsHexadecimal(@NotNull StringBuilder sb, int len, long readPosition, int sblen) {
         // Set the read position and remaining length for the byte buffer.


### PR DESCRIPTION
## Summary
- clarify configuration constants in `ReflectionUtil`
- expand `interfaces` and `generatedPackageName` Javadoc
- document fields and factory methods in `WireDumper`
- add details for the various dumping methods

## Testing
- `mvn -q verify` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683d73e5b3d8832995b2d6bb9aac0b69