### PR TITLE
Improve Javadoc for parser and source context

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/MarshallableParser.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableParser.java
@@ -18,20 +18,21 @@ package net.openhft.chronicle.wire;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * This is the {@code MarshallableParser} functional interface.
- * It provides a contract for parsing methods that convert a given {@link ValueIn} into an instance of type {@code T}.
- * Designed to be used in scenarios where marshalling is required to transform input values into desired data types.
+ * Functional interface describing a strategy for deserialising data.
+ * <p>
+ * Implementations convert a {@link ValueIn} representation to an object of type {@code T}.
+ * This allows custom logic to be supplied wherever a {@code ValueIn} needs to be turned into a concrete object.
  *
- * @param <T> the type of the object that will be produced after parsing the input value.
+ * @param <T> the type produced after parsing the input value
  */
 @FunctionalInterface
 public interface MarshallableParser<T> {
 
     /**
-     * Parses the provided {@code ValueIn} into an instance of type {@code T}.
+     * Create an instance of {@code T} from the supplied wire representation.
      *
-     * @param valueIn the input value to be parsed.
-     * @return the parsed instance of type {@code T}.
+     * @param valueIn the {@link ValueIn} holding the serialised form
+     * @return non-null instance of {@code T} deserialised from {@code valueIn}
      */
     @NotNull
     T parse(ValueIn valueIn);

--- a/src/main/java/net/openhft/chronicle/wire/SourceContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/SourceContext.java
@@ -18,29 +18,26 @@ package net.openhft.chronicle.wire;
 import net.openhft.chronicle.core.io.IORuntimeException;
 
 /**
- * This is the SourceContext interface.
- * It defines methods to interact with the underlying source context, particularly in terms of accessing its source ID
- * and the last read index. Implementations of this interface are expected to handle source contexts which could be used
- * in various scenarios like I/O operations, data streaming, or context management.
+ * Interface for accessing metadata about the origin of a message.
+ * <p>
+ * It exposes the source identifier and position of the current document.
+ * A {@link DocumentContext} may implement this interface to provide
+ * traceability of a message to its queue index and source ID.
  */
 public interface SourceContext {
 
     /**
-     * Retrieves the source ID associated with this context.
-     * A unique identifier that represents the source from which data or operations might be fetched or to which data
-     * might be written. If a valid source ID has not been established or isn't available, it defaults to returning -1.
+     * The identifier of the source from which the message originated.
      *
-     * @return The unique identifier for this source context, or -1 if not available.
+     * @return unique identifier for this context, or {@code -1} if not available or not applicable
      */
     int sourceId();
 
     /**
-     * Obtains the index of the last read operation from this source context.
-     * This is particularly useful to track the reading progress and can act as a checkpoint or reference point.
-     * Note: This method is specifically intended for read contexts and might not be relevant for other context types.
+     * Index of the current document or message within its source.
      *
-     * @return The index corresponding to the last read operation.
-     * @throws IORuntimeException if any issue arises while fetching the index.
+     * @return index of the current entry, for example the queue index
+     * @throws IORuntimeException if the index cannot be determined
      */
     long index() throws IORuntimeException;
 }


### PR DESCRIPTION
## Summary
- clarify SourceContext description and methods
- expand MarshallableParser overview and method docs

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d7662a71c8329b9c03c00fe31305d