### PR TITLE
Improve javadoc for checker and utils

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/HeadNumberChecker.java
+++ b/src/main/java/net/openhft/chronicle/wire/HeadNumberChecker.java
@@ -21,6 +21,9 @@ package net.openhft.chronicle.wire;
  * This interface provides a contract for checking a given header number and its position.
  * Typically, implementations of this interface will contain logic to determine whether
  * the provided header number, in the context of its position are a valid combination.
+ * <p>
+ * Used by {@link AbstractWire} to validate header numbers, for example, to ensure sequence
+ * numbers are contiguous or monotonically increasing when reading from a queue.
  */
 @FunctionalInterface
 public interface HeadNumberChecker {
@@ -28,9 +31,11 @@ public interface HeadNumberChecker {
     /**
      * Checks whether the provided header number meets a certain condition in the context of its position.
      *
-     * @param headerNumber The header number to be checked.
-     * @param position The position or context associated with the header number.
-     * @return {@code true} if the header number is valid; {@code false} otherwise.
+     * @param headerNumber The header number read from the wire.
+     * @param position     The byte position in the wire where this header number was encountered.
+     *                      This can be used for context or logging.
+     * @return {@code true} if the header number is considered valid according to the implementation's
+     * logic, {@code false} otherwise (which might lead to an error or retry).
      */
     boolean checkHeaderNumber(long headerNumber, long position);
 }

--- a/src/main/java/net/openhft/chronicle/wire/TriConsumer.java
+++ b/src/main/java/net/openhft/chronicle/wire/TriConsumer.java
@@ -22,7 +22,8 @@ import java.util.Objects;
 
 /**
  * Represents an operation that accepts three input arguments and returns no result.
- * This is a three-arity specialization of {@code Consumer}.
+ * This is a three-arity specialization of {@code Consumer} and functions much
+ * like {@link java.util.function.BiConsumer} but with an additional argument.
  * Unlike most other functional interfaces, {@code TriConsumer} is expected to operate
  * via side effects. This interface is useful in scenarios where lambda expressions
  * or method references would benefit from custom manipulations of three separate arguments.
@@ -37,9 +38,9 @@ public interface TriConsumer<T, U, V> {
     /**
      * Performs this operation on the given arguments.
      *
-     * @param t the first input argument
-     * @param u the second input argument
-     * @param v the third input argument
+     * @param t The first input argument.
+     * @param u The second input argument.
+     * @param v The third input argument.
      * @throws InvalidMarshallableException if there are issues with marshalling
      *                                      during the accept operation.
      */
@@ -52,9 +53,9 @@ public interface TriConsumer<T, U, V> {
      * composed operation.  If performing this operation throws an exception,
      * the {@code after} operation will not be performed.
      *
-     * @param after the operation to perform after this operation
-     * @return a composed {@code TriConsumer} that performs in sequence this
-     * operation followed by the {@code after} operation
+     * @param after The {@code TriConsumer} to execute after this one completes.
+     * @return A new composed {@code TriConsumer} that performs this operation
+     * followed by the {@code after} operation
      * @throws NullPointerException if {@code after} is null
      */
     @NotNull

--- a/src/main/java/net/openhft/chronicle/wire/utils/MethodReaderStatus.java
+++ b/src/main/java/net/openhft/chronicle/wire/utils/MethodReaderStatus.java
@@ -16,9 +16,30 @@
 
 package net.openhft.chronicle.wire.utils;
 
+/**
+ * Enumerates the possible outcomes of a single read attempt by a
+ * {@link net.openhft.chronicle.bytes.MethodReader}, particularly for
+ * generated readers such as {@link net.openhft.chronicle.wire.AbstractGeneratedMethodReader}.
+ */
 public enum MethodReaderStatus {
+    /**
+     * Indicates that no message or event was found or processed in the current
+     * read attempt (for example end of document or no data available).
+     */
     EMPTY,
+    /**
+     * Indicates that a {@link net.openhft.chronicle.wire.MessageHistory} event
+     * was read and processed.
+     */
     HISTORY,
+    /**
+     * Indicates that a known method or event was successfully read,
+     * deserialized and dispatched to a handler.
+     */
     KNOWN,
+    /**
+     * Indicates that an unknown method or event was encountered. The default
+     * parselet may have skipped it or an error might have been logged.
+     */
     UNKNOWN
 }


### PR DESCRIPTION
## Summary
- clarify HeadNumberChecker javadoc and parameters
- document MethodReaderStatus enum and values
- refine TriConsumer javadoc and parameter docs

## Testing
- `mvn -q verify` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d76919b348329946ec67bbe144b6a