### PR TITLE
Improve Javadoc for validation

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/UnrecoverableTimeoutException.java
+++ b/src/main/java/net/openhft/chronicle/wire/UnrecoverableTimeoutException.java
@@ -32,7 +32,8 @@ public class UnrecoverableTimeoutException extends IllegalStateException {
      * exception as the cause.
      * The message from the underlying exception is propagated to this exception.
      *
-     * @param e The underlying exception that caused this timeout exception.
+     * @param e The underlying {@link Exception} that represents the original
+     *          timeout or related error condition.
      */
     @SuppressWarnings("this-escape")
     public UnrecoverableTimeoutException(@NotNull Exception e) {

--- a/src/main/java/net/openhft/chronicle/wire/Validate.java
+++ b/src/main/java/net/openhft/chronicle/wire/Validate.java
@@ -1,22 +1,25 @@
 package net.openhft.chronicle.wire;
 
 /**
- * This is the Validate interface.
- * Implementations of this interface are responsible for validating objects
- * based on specific criteria or conditions.
- * The purpose of the validate method is to ensure the correctness or suitability
- * of the object in question.
+ * Interface for validating objects.
+ *
+ * <p>Implementations ensure the state of an object meets its invariants or
+ * preconditions. It is often used for DTOs or configuration objects to ensure
+ * their state is consistent and valid before use or after deserialisation. See
+ * {@link net.openhft.chronicle.core.io.ValidatableUtil} for utilities related
+ * to validation.
  */
 public interface Validate {
 
     /**
-     * Validates the provided object based on specific criteria or conditions.
-     * If the object does not meet the conditions, the method might throw a
-     * runtime exception or exhibit other behavior as defined by the
-     * implementation. It is recommended for implementers to clearly document
-     * the validation rules and potential outcomes.
+     * Validates the provided object.
      *
-     * @param o The object to be validated.
+     * <p>If validation fails, this method should throw a descriptive
+     * {@link RuntimeException} such as {@link IllegalStateException} or a custom
+     * validation exception.
+     *
+     * @param o The object to be validated. Implementations will typically cast
+     *          this to their specific type.
      */
     void validate(Object o);
 }


### PR DESCRIPTION
## Summary
- expand Validate interface javadoc
- clarify behaviour of validate method
- detail constructor parameter for UnrecoverableTimeoutException

## Testing
- `mvn -q verify` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d76a7a88083299ebcc35b42c8e200