### PR TITLE
Improve Javadoc for Sequence and related classes

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/RawText.java
+++ b/src/main/java/net/openhft/chronicle/wire/RawText.java
@@ -16,19 +16,23 @@
 package net.openhft.chronicle.wire;
 
 /**
- * Represents a container for raw textual data.
- * The primary purpose of this class is to encapsulate a text
- * while providing a simple structure for raw text handling.
+ * Represents a container for raw textual data. This class can be used as a
+ * method argument type in method writers (see {@link VanillaMethodWriterBuilder})
+ * to indicate that the provided {@link CharSequence} should be written to the
+ * wire with minimal or no escaping, if supported by the wire type (for example,
+ * {@link ValueOut#rawText(CharSequence)}). This is a package-private class,
+ * intended for internal use within the Chronicle Wire framework.
  */
 class RawText {
-    // The encapsulated raw textual data
+    /** The raw text content, stored as a {@link String}. */
     String text;
 
     /**
-     * Constructs a new instance of {@code RawText} initialized with
-     * the provided CharSequence.
+     * Constructs a new instance of {@code RawText} initialised with the provided
+     * {@link CharSequence}.
      *
-     * @param text The CharSequence to be encapsulated by this instance.
+     * @param text The {@link CharSequence} whose content will be stored. It is
+     *             converted to a {@link String} internally.
      */
     public RawText(CharSequence text) {
         this.text = text.toString();

--- a/src/main/java/net/openhft/chronicle/wire/Sequence.java
+++ b/src/main/java/net/openhft/chronicle/wire/Sequence.java
@@ -16,35 +16,66 @@
 package net.openhft.chronicle.wire;
 
 /**
- * This is used in Chronicle-Queue to map a position to a sequence number.
+ * Defines a contract for mapping a write position (typically in a persistent
+ * store such as Chronicle Queue) to a logical sequence number, and vice versa.
+ * This is crucial for systems that need to assign ordered sequence numbers to
+ * messages or events written at potentially non-contiguous positions.
  */
 public interface Sequence {
+    /**
+     * Returned by {@link #getSequence(long)} when a sequence number cannot be
+     * found for the given position but the operation may succeed if retried.
+     */
     long NOT_FOUND_RETRY = Long.MIN_VALUE;
+
+    /**
+     * Returned by {@link #getSequence(long)} when a sequence number cannot be
+     * found for the given position and retrying is unlikely to succeed.
+     */
     long NOT_FOUND = -1;
 
     /**
-     * gets the sequence for a writePosition
-     * <p>
-     * This method will only return a valid sequence number of the write position if the write position is the
-     * last write position in the queue. YOU CAN NOT USE THIS METHOD TO LOOK UP RANDOM SEQUENCES FOR ANY WRITE POSITION.
-     * NOT_FOUND_RETRY will be return if a sequence number can not be found  ( so retry )
-     * or NOT_FOUND if you should not retry
+     * Gets the sequence number for the supplied write position. This method is
+     * typically used with the last write position and may not be suitable for
+     * arbitrary positions.
      *
-     * @param forWritePosition the last write position, expected to be the end of queue
-     * @return NOT_FOUND_RETRY if the sequence for this write position can not be found (you can retry), or
-     * NOT_FOUND if it can't be found and there is no point in retrying
+     * @param forWritePosition The write position (for example an excerpt's
+     *                         starting offset) for which the sequence number is
+     *                         requested. This is usually the most recently
+     *                         written position.
+     * @return The sequence number for {@code forWritePosition}, or
+     *         {@link #NOT_FOUND_RETRY} if the lookup should be retried, or
+     *         {@link #NOT_FOUND} if the position does not map to a sequence
+     *         number.
      */
     long getSequence(long forWritePosition);
 
     /**
-     * sets the sequence number for a writePosition
+     * Sets the sequence number for the given write position.
      *
-     * @param sequence the sequence number
-     * @param position the write position
+     * @param sequence The sequence number to associate with the position.
+     * @param position The write position for which the sequence number should be
+     *                 recorded.
      */
     void setSequence(long sequence, long position);
 
+    /**
+     * Combines a {@code headerNumber} (such as a cycle count) and a
+     * {@code sequence} within that header into a single index value.
+     *
+     * @param headerNumber The higher-order part of the index, for example a
+     *                     cycle number.
+     * @param sequence The lower-order sequence number within the header.
+     * @return A combined index representing the header and sequence.
+     */
     long toIndex(long headerNumber, long sequence);
 
+    /**
+     * Extracts the lower-order sequence number from an index previously created
+     * by {@link #toIndex(long, long)}.
+     *
+     * @param index The combined index.
+     * @return The sequence number extracted from the index.
+     */
     long toSequenceNumber(long index);
 }

--- a/src/main/java/net/openhft/chronicle/wire/UnexpectedFieldHandlingException.java
+++ b/src/main/java/net/openhft/chronicle/wire/UnexpectedFieldHandlingException.java
@@ -27,7 +27,8 @@ public class UnexpectedFieldHandlingException extends RuntimeException {
     /**
      * Constructs a new UnexpectedFieldHandlingException with the provided underlying cause.
      *
-     * @param cause The root cause of this exception, typically originating from
+     * @param cause The root cause of this exception, often an exception thrown
+     *              from within an implementation of
      *              {@link ReadMarshallable#unexpectedField(Object, ValueIn)}.
      */
     public UnexpectedFieldHandlingException(Throwable cause) {


### PR DESCRIPTION
## Summary
- clarify constructor javadoc for `UnexpectedFieldHandlingException`
- expand usage details for package-private `RawText`
- detail behaviour of constants and methods in `Sequence`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d76c869fc8329982e4bc94b2a338a