### PR TITLE
Improve CharSequenceObjectMap documentation

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/CharSequenceObjectMap.java
+++ b/src/main/java/net/openhft/chronicle/wire/CharSequenceObjectMap.java
@@ -19,28 +19,46 @@ import net.openhft.chronicle.core.Maths;
 import net.openhft.chronicle.core.util.StringUtils;
 
 /**
- * This class provides a simple hash map implementation optimized for {@link CharSequence} keys and generic values.
- * The main advantage of this implementation is that it's tailored for CharSequence inputs, allowing for a more
- * memory-efficient and performant solution in specific use-cases.
+ * Simple hash map implementation optimised for {@link CharSequence} keys.
+ * It uses open addressing with linear probing and stores key strings directly.
+ * Not intended as a general-purpose replacement for {@link java.util.HashMap},
+ * but can be beneficial in performance-sensitive components where lookups on
+ * {@link CharSequence} instances are frequent.  This implementation is not
+ * thread-safe.
  *
- * @param <T> the type of values to be stored in the map.
+ * @param <T> type of values stored in the map
  */
 public class CharSequenceObjectMap<T> {
 
-    // Constants used in the hash function for improved distribution.
+    /**
+     * Multiplier used in {@link #hashFor(CharSequence)} to improve hash code distribution.
+     */
     private static final int K0 = 0x6d0f27bd;
+    /**
+     * Second multiplier used in {@link #hashFor(CharSequence)} for better distribution.
+     */
     @SuppressWarnings("unused")
     private static final int M0 = 0x5bc80bad;
 
-    // Arrays to store the keys and corresponding values.
+    /**
+     * Array storing the string representations of the keys.
+     * {@code null} entries indicate empty slots.
+     */
     final String[] keys;
+    /**
+     * Array storing the values associated with the keys at the same index.
+     */
     final T[] values;
-    final int mask;  // The mask used for wrapping hash values within the bounds.
+    /**
+     * Mask used for mapping hash codes to array indices. Equal to the array length minus one.
+     */
+    final int mask;
 
     /**
-     * Constructs an empty map with the specified initial capacity.
+     * Creates a map with an initial table size that is the next power of two
+     * greater than or equal to {@code capacity} with a minimum of sixteen.
      *
-     * @param capacity the initial capacity of the map.
+     * @param capacity desired initial capacity before rounding
      */
     @SuppressWarnings("unchecked")
     public CharSequenceObjectMap(int capacity) {
@@ -51,12 +69,12 @@ public class CharSequenceObjectMap<T> {
     }
 
     /**
-     * Associates the specified value with the specified key (name) in this map.
-     * If the map previously contained a mapping for the key, the old value is replaced.
+     * Store a value against a key. The key's {@code toString()} value is stored
+     * if it is not already present, replacing any existing mapping.
      *
-     * @param name key with which the specified value is to be associated.
-     * @param t    value to be associated with the specified key.
-     * @throws IllegalStateException if the map is full.
+     * @param name the key
+     * @param t    value to store
+     * @throws IllegalStateException if no empty slot can be found after probing
      */
     public void put(CharSequence name, T t) {
         int h = hashFor(name);
@@ -72,12 +90,12 @@ public class CharSequenceObjectMap<T> {
     }
 
     /**
-     * Returns the value to which the specified key (cs) is mapped,
-     * or {@code null} if this map contains no mapping for the key.
+     * Retrieve the value associated with a key.
      *
-     * @param cs the key whose associated value is to be returned.
-     * @return the value to which the specified key is mapped, or {@code null} if this map contains no mapping for the key.
-     * @throws IllegalStateException if the map is full.
+     * @param cs the key to search for
+     * @return the mapped value, or {@code null} if the key is absent or the map is
+     *         full and the key cannot be located
+     * @throws IllegalStateException if probing finds no empty slot
      */
     public T get(CharSequence cs) {
         int h = hashFor(cs);
@@ -92,11 +110,10 @@ public class CharSequenceObjectMap<T> {
     }
 
     /**
-     * Generates a hash code for the given CharSequence using a custom hash function.
-     * This custom function is designed to produce well-distributed hash codes for CharSequence inputs.
+     * Compute a hash code for a {@link CharSequence} using the internal multipliers.
      *
-     * @param name the CharSequence for which the hash code is to be calculated.
-     * @return the calculated hash code.
+     * @param name the {@link CharSequence} to hash
+     * @return an int masked to the current table size
      */
     private int hashFor(CharSequence name) {
         long h = name.length();


### PR DESCRIPTION
## Summary
- clarify CharSequenceObjectMap behaviour and purpose
- document fields used in hashing and storage
- refine Javadoc for constructor and methods

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d76dd48f88329a68c56203e0b911a