### PR TITLE
Improve WireParser Javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/WireParser.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireParser.java
@@ -24,20 +24,34 @@ import org.jetbrains.annotations.NotNull;
 import java.util.function.Consumer;
 
 /**
- * Defines the interface for parsing arbitrary field-value data from wire input.
+ * Defines a contract for parsing field-value data from a {@link WireIn} stream.
+ * A {@code WireParser} typically maintains a set of {@link WireParselet} or
+ * {@link FieldNumberParselet} instances, each responsible for a particular
+ * field name or number encountered in the input. It orchestrates reading the
+ * field identifiers and dispatches to the relevant parselet to deserialise the
+ * value. As a {@link java.util.function.Consumer}{@code <WireIn>} it can
+ * process a whole document or a sequence of events within a wire.
  */
 public interface WireParser extends Consumer<WireIn> {
 
     /**
-     * A predefined parselet that skips all readable bytes in the wire.
+     * A predefined {@link FieldNumberParselet} that, when invoked, consumes and
+     * discards all remaining readable bytes in the current value or document
+     * context of the {@link WireIn}. This is often used as a default handler for
+     * unknown or uninteresting field numbers.
      */
     FieldNumberParselet SKIP_READABLE_BYTES = WireParser::skipReadable;
 
     /**
-     * Creates a new WireParser with a default consumer.
+     * Creates a new {@code WireParser} with a default consumer.
      *
-     * @param defaultConsumer The default consumer that handles the wire data when no specific handler is provided.
-     * @return A new WireParser instance.
+     * @param defaultConsumer the {@link WireParselet} to invoke when a field name
+     *                        read from the wire does not match any registered
+     *                        named parselets. This typically handles unknown
+     *                        fields or logs warnings.
+     * @return a new {@link VanillaWireParser} configured with the given default
+     *         consumer and {@link #SKIP_READABLE_BYTES} for unknown field
+     *         numbers.
      */
     @NotNull
     static WireParser wireParser(WireParselet defaultConsumer) {
@@ -45,11 +59,15 @@ public interface WireParser extends Consumer<WireIn> {
     }
 
     /**
-     * Creates a new WireParser with a default consumer and a custom field number parselet.
+     * Creates a new {@code WireParser} with a default consumer and a custom
+     * field number parselet.
      *
-     * @param defaultConsumer     The default consumer to handle the wire data when no specific handler is provided.
-     * @param fieldNumberParselet Custom field number parselet to handle field numbers in the wire data.
-     * @return A new WireParser instance.
+     * @param defaultConsumer     the {@link WireParselet} for unhandled named
+     *                             fields.
+     * @param fieldNumberParselet the {@link FieldNumberParselet} to invoke when
+     *                             a field number read from a binary wire does not
+     *                             match any registered numbered parselets.
+     * @return a new {@link VanillaWireParser} instance.
      */
     @NotNull
     static WireParser wireParser(@NotNull WireParselet defaultConsumer,
@@ -58,10 +76,14 @@ public interface WireParser extends Consumer<WireIn> {
     }
 
     /**
-     * Skips all readable bytes in the wire.
+     * Skips all readable bytes in the provided wire.
      *
-     * @param ignoreMethodId The method ID to ignore. (Currently unused in the method's logic)
-     * @param wire           The wire input source.
+     * @param ignoreMethodId the method id or field number that triggered this
+     *                       skip action. It is often unused by the skip logic
+     *                       itself but provided for context.
+     * @param wire           the {@link WireIn} whose current value's readable
+     *                       bytes should be skipped. This advances the read
+     *                       position to the end of the current value or context.
      */
     static void skipReadable(long ignoreMethodId, WireIn wire) {
         Bytes<?> bytes = wire.bytes();
@@ -69,27 +91,38 @@ public interface WireParser extends Consumer<WireIn> {
     }
 
     /**
-     * Retrieves the default consumer of this parser.
+     * Retrieves the {@link WireParselet} used when a field name encountered in
+     * the input does not match any explicitly registered parselet.
      *
-     * @return The default consumer.
+     * @return the default consumer for unmatched field names.
      */
     WireParselet getDefaultConsumer();
 
     /**
-     * Parses a single field-value data from the provided wire input.
+     * Parses a single field-value pair from the given {@link WireIn}. The method
+     * reads the field identifier (name or number) and dispatches to the
+     * appropriate registered {@link WireParselet} or
+     * {@link FieldNumberParselet} to deserialise the value. If no matching
+     * parselet is found the {@link #getDefaultConsumer()} or its numbered
+     * counterpart is used.
      *
-     * @param wireIn The wire input source.
-     * @throws InvocationTargetRuntimeException When there's a failure invoking the target action for a field.
-     * @throws InvalidMarshallableException     When the wire data cannot be marshaled into the desired format.
+     * @param wireIn the wire input source
+     * @throws InvocationTargetRuntimeException if invoking the target action
+     *                                          fails
+     * @throws InvalidMarshallableException     if the value cannot be
+     *                                          deserialised
      */
-    void parseOne(@NotNull WireIn wireIn) throws InvocationTargetRuntimeException, InvalidMarshallableException;
+    void parseOne(@NotNull WireIn wireIn)
+            throws InvocationTargetRuntimeException, InvalidMarshallableException;
 
     /**
-     * Default implementation for the Consumer's accept method. This method
-     * reads and processes data from the wire input, invoking the appropriate
-     * parselets for handling the data.
+     * Processes an entire document or event from {@code wireIn}. The default
+     * implementation repeatedly calls {@link #parseOne(WireIn)} until all fields
+     * within the current event or document have been consumed. Event boundaries
+     * are handled using {@link WireIn#startEvent()} and
+     * {@link WireIn#endEvent()}.
      *
-     * @param wireIn The wire input source.
+     * @param wireIn the wire input source
      */
     @Override
     default void accept(@NotNull WireIn wireIn) {
@@ -110,21 +143,24 @@ public interface WireParser extends Consumer<WireIn> {
     }
 
     /**
-     * Searches for a {@link WireParselet} associated with a given name.
+     * Searches for the {@link WireParselet} associated with the given field
+     * name.
      *
-     * @param name The name to search the associated {@link WireParselet} for.
-     * @return The found {@link WireParselet}, or {@code null} if not found.
+     * @param name the field name whose parselet is to be retrieved
+     * @return the matching {@link WireParselet}, or {@code null} if none exists
      */
     WireParselet lookup(CharSequence name);
 
     /**
-     * Attempts to register a new {@link WireParselet} for a given key. If a parselet
-     * is already registered with the same key, a warning is emitted and the new
-     * registration is ignored.
+     * Attempts to register a new {@link WireParselet} for the supplied key. If a
+     * parselet is already registered for that key a warning is emitted and the
+     * new registration is ignored.
      *
-     * @param key            The key to associate the parselet with.
-     * @param valueInConsumer The parselet to register.
-     * @return This instance for method chaining.
+     * @param key            the {@link WireKey} (providing both name and code)
+     *                       to associate with the parselet
+     * @param valueInConsumer the {@link WireParselet} to register for the key
+     * @return this {@code WireParser} instance, cast to {@link VanillaWireParser},
+     *         for fluent configuration
      */
     @NotNull
     default VanillaWireParser registerOnce(WireKey key, WireParselet valueInConsumer) {
@@ -138,11 +174,15 @@ public interface WireParser extends Consumer<WireIn> {
     }
 
     /**
-     * Registers a new {@link WireParselet} for a given key.
+     * Registers a {@link WireParselet} to handle fields matching the supplied
+     * {@link WireKey}. This typically registers the parselet for both the key's
+     * name and its code. If a parselet is already registered for the name this
+     * may overwrite it or log a warning, depending on the implementation (see
+     * {@link #registerOnce}).
      *
-     * @param key            The key to associate the parselet with.
-     * @param valueInConsumer The parselet to register.
-     * @return This instance for method chaining.
+     * @param key            the key to associate with the parselet
+     * @param valueInConsumer the parselet to register
+     * @return this instance for method chaining
      */
     @NotNull
     default VanillaWireParser register(WireKey key, WireParselet valueInConsumer) {
@@ -150,11 +190,13 @@ public interface WireParser extends Consumer<WireIn> {
     }
 
     /**
-     * Registers a new {@link WireParselet} for a given key name.
+     * Registers a {@link WireParselet} to handle fields matching the provided
+     * {@code keyName}. This typically also registers the parselet for a code
+     * derived from {@code keyName.hashCode()}.
      *
-     * @param keyName        The name of the key to associate the parselet with.
-     * @param valueInConsumer The parselet to register.
-     * @return This instance for method chaining.
+     * @param keyName        the name of the key to associate with the parselet
+     * @param valueInConsumer the parselet to register
+     * @return this instance for method chaining
      */
     @NotNull
     VanillaWireParser register(String keyName, WireParselet valueInConsumer);


### PR DESCRIPTION
## Summary
- expand the class description and explain how `WireParser` works
- document `SKIP_READABLE_BYTES` and all factory methods
- clarify behaviour of `skipReadable`, `parseOne`, and `accept`
- document registration and lookup helpers

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d7b289ca08329be98b83d0e2d96e9