### PR TITLE
Improve parselet Javadocs

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/FieldNumberParselet.java
+++ b/src/main/java/net/openhft/chronicle/wire/FieldNumberParselet.java
@@ -18,17 +18,22 @@ package net.openhft.chronicle.wire;
 import net.openhft.chronicle.core.io.InvalidMarshallableException;
 
 /**
- * Represents a parselet to process field numbers in a wire format.
- * Implementations should provide logic to read data based on the field number from a wire input source.
+ * Parses fields identified by a numeric ID.
+ * This is primarily used with binary wire formats where fields can be
+ * identified by numeric IDs instead of string names, for compactness and
+ * efficiency. It is typically registered with a {@link WireParser}
+ * (e.g., {@link VanillaWireParser}) as a fallback or for specific
+ * field numbers.
  */
 public interface FieldNumberParselet {
 
     /**
-     * Reads and processes data corresponding to the given field number (methodId) from the wire input.
+     * Invoked when a numeric field ID is parsed.
      *
-     * @param methodId The field number or methodId that denotes which data to read.
-     * @param wire     The wire input source from which the data is read.
-     * @throws InvalidMarshallableException If there's an error in reading or processing the data.
+     * @param methodId the numeric field ID read from the binary wire
+     * @param wire     the {@link WireIn} from which the value should be read;
+     *                 use {@code wire.getValueIn()} to access and deserialise the value
+     * @throws InvalidMarshallableException if the value cannot be processed
      */
     void readOne(long methodId, WireIn wire) throws InvalidMarshallableException;
 }

--- a/src/main/java/net/openhft/chronicle/wire/WireParselet.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireParselet.java
@@ -18,20 +18,20 @@ package net.openhft.chronicle.wire;
 import net.openhft.chronicle.core.io.InvalidMarshallableException;
 
 /**
- * Represents a functional interface that can process wire input based on a given
- * character sequence key and a value input. The `WireParselet` can be seen as a
- * specific action or handler for a particular key found in the wire input.
+ * Functional interface invoked when a field name is parsed.
+ * It is typically registered with a {@link WireParser} to define how to
+ * deserialise the value associated with a specific field name.
  */
 @FunctionalInterface
 public interface WireParselet {
 
     /**
-     * Consumes and processes a wire input based on a given character sequence
-     * and a value input.
+     * Invoked with the field name and corresponding value.
      *
-     * @param s The character sequence (usually representing a key) from the wire input.
-     * @param in The value associated with the key in the wire input.
-     * @throws InvalidMarshallableException If there's an issue with processing the data.
+     * @param s   the field name that matched this parselet
+     * @param in  the {@link ValueIn} positioned at the value for {@code s}. Use it to
+     *            deserialise the value
+     * @throws InvalidMarshallableException if the value cannot be processed
      */
     void accept(CharSequence s, ValueIn in) throws InvalidMarshallableException;
 }


### PR DESCRIPTION
## Summary
- clarify how WireParselet integrates with WireParser
- explain numeric ID handling for FieldNumberParselet

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d7b634f60832990efbbc09b39603f