### PR TITLE
Improve BitSetUtil Javadoc

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/BitSetUtil.java
+++ b/src/main/java/net/openhft/chronicle/wire/BitSetUtil.java
@@ -22,24 +22,30 @@ import java.util.BitSet;
 
 /**
  * Utility class to access and manipulate the internals of the {@link BitSet} class.
+ *
  * This class provides methods to directly interact with the underlying word storage
- * and related metadata of a BitSet. It leverages reflection to access private fields
- * and therefore, should be used with caution.
+ * and related metadata of a BitSet. It leverages reflection to access private fields.
+ * <b>This class relies on reflection of private fields of {@link java.util.BitSet}
+ * and may break with different Java versions or JDK implementations. Use with extreme
+ * caution and only when direct access to {@code BitSet} internals is absolutely necessary.</b>
  */
 final class BitSetUtil {
 
-    // Reflective field reference to the 'words' field in BitSet
+    /** Private static final {@link Field} reference for the 'words' field within
+     * {@link java.util.BitSet}. Initialised reflectively and made accessible. */
     private static final Field wordsField;
-    // Reflective field reference to the 'wordsInUse' field in BitSet
+    /** Private static final {@link Field} reference for the 'wordsInUse' field within
+     * {@link java.util.BitSet}. Initialised reflectively and made accessible. */
     private static final Field wordsInUse;
-    // Reflective field reference to the 'sizeIsSticky' field in BitSet
+    /** Private static final {@link Field} reference for the 'sizeIsSticky' field within
+     * {@link java.util.BitSet}. Initialised reflectively and made accessible. */
     private static final Field sizeIsSticky;
 
     // Private constructor to prevent instantiation of utility class
     private BitSetUtil() {
     }
 
-    // Static block to initialize reflective fields
+    // Static block to initialise reflective fields
     static {
         try {
             wordsField = BitSet.class.getDeclaredField("words");
@@ -58,9 +64,10 @@ final class BitSetUtil {
     /**
      * Retrieves the word from a {@link BitSet} at the given index.
      *
-     * @param bs    The target BitSet.
-     * @param index The index of the word to retrieve.
-     * @return The word (as a long value) at the given index in the BitSet.
+     * @param bs    The {@link java.util.BitSet} instance from which to retrieve the word.
+     * @param index The zero-based index of the internal {@code long} word to retrieve.
+     * @return The {@code long} value of the word at the specified {@code index}.
+     * @throws RuntimeException wrapping {@link IllegalAccessException} if reflective access fails.
      */
     static long getWord(BitSet bs, int index) {
         try {
@@ -73,11 +80,14 @@ final class BitSetUtil {
     }
 
     /**
-     * Sets the underlying words of a {@link BitSet} and updates related metadata.
+     * Directly sets the internal 'words' array of the {@code using} {@link java.util.BitSet}
+     * to the provided {@code words} array. Also updates the 'wordsInUse' field to
+     * {@code words.length} and 'sizeIsSticky' to {@code false} to reflect the change.
      *
-     * @param using The BitSet to modify.
-     * @param words The new words to set in the BitSet.
-     * @return The modified BitSet.
+     * @param using  The {@link java.util.BitSet} instance to modify.
+     * @param words  The new {@code long[]} array to set as the internal bit storage.
+     * @return The modified {@code using} {@link java.util.BitSet} instance.
+     * @throws RuntimeException wrapping {@link IllegalAccessException} if reflective access fails.
      */
     static BitSet set(final BitSet using, final long[] words) {
         try {


### PR DESCRIPTION
## Summary
- clarify reflection caveats in `BitSetUtil`
- document reflective fields
- expand parameter info for `getWord` and `set`

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d7bc65550832982f8bdec0e097991