### PR TITLE
Adv/25 wire parsers

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/BitSetUtil.java
+++ b/src/main/java/net/openhft/chronicle/wire/BitSetUtil.java
@@ -22,24 +22,30 @@ import java.util.BitSet;
 
 /**
  * Utility class to access and manipulate the internals of the {@link BitSet} class.
+ *
  * This class provides methods to directly interact with the underlying word storage
- * and related metadata of a BitSet. It leverages reflection to access private fields
- * and therefore, should be used with caution.
+ * and related metadata of a BitSet. It leverages reflection to access private fields.
+ * <b>This class relies on reflection of private fields of {@link java.util.BitSet}
+ * and may break with different Java versions or JDK implementations. Use with extreme
+ * caution and only when direct access to {@code BitSet} internals is absolutely necessary.</b>
  */
 final class BitSetUtil {
 
-    // Reflective field reference to the 'words' field in BitSet
+    /** Private static final {@link Field} reference for the 'words' field within
+     * {@link java.util.BitSet}. Initialised reflectively and made accessible. */
     private static final Field wordsField;
-    // Reflective field reference to the 'wordsInUse' field in BitSet
+    /** Private static final {@link Field} reference for the 'wordsInUse' field within
+     * {@link java.util.BitSet}. Initialised reflectively and made accessible. */
     private static final Field wordsInUse;
-    // Reflective field reference to the 'sizeIsSticky' field in BitSet
+    /** Private static final {@link Field} reference for the 'sizeIsSticky' field within
+     * {@link java.util.BitSet}. Initialised reflectively and made accessible. */
     private static final Field sizeIsSticky;
 
     // Private constructor to prevent instantiation of utility class
     private BitSetUtil() {
     }
 
-    // Static block to initialize reflective fields
+    // Static block to initialise reflective fields
     static {
         try {
             wordsField = BitSet.class.getDeclaredField("words");
@@ -58,9 +64,10 @@ final class BitSetUtil {
     /**
      * Retrieves the word from a {@link BitSet} at the given index.
      *
-     * @param bs    The target BitSet.
-     * @param index The index of the word to retrieve.
-     * @return The word (as a long value) at the given index in the BitSet.
+     * @param bs    The {@link java.util.BitSet} instance from which to retrieve the word.
+     * @param index The zero-based index of the internal {@code long} word to retrieve.
+     * @return The {@code long} value of the word at the specified {@code index}.
+     * @throws RuntimeException wrapping {@link IllegalAccessException} if reflective access fails.
      */
     static long getWord(BitSet bs, int index) {
         try {
@@ -73,11 +80,14 @@ final class BitSetUtil {
     }
 
     /**
-     * Sets the underlying words of a {@link BitSet} and updates related metadata.
+     * Directly sets the internal 'words' array of the {@code using} {@link java.util.BitSet}
+     * to the provided {@code words} array. Also updates the 'wordsInUse' field to
+     * {@code words.length} and 'sizeIsSticky' to {@code false} to reflect the change.
      *
-     * @param using The BitSet to modify.
-     * @param words The new words to set in the BitSet.
-     * @return The modified BitSet.
+     * @param using  The {@link java.util.BitSet} instance to modify.
+     * @param words  The new {@code long[]} array to set as the internal bit storage.
+     * @return The modified {@code using} {@link java.util.BitSet} instance.
+     * @throws RuntimeException wrapping {@link IllegalAccessException} if reflective access fails.
      */
     static BitSet set(final BitSet using, final long[] words) {
         try {

--- a/src/main/java/net/openhft/chronicle/wire/ChronicleBitSet.java
+++ b/src/main/java/net/openhft/chronicle/wire/ChronicleBitSet.java
@@ -25,6 +25,7 @@ import net.openhft.chronicle.core.io.Closeable;
  * {@link LongValueBitSet} and {@link LongArrayValueBitSet}.
  */
 public interface ChronicleBitSet extends Marshallable, Closeable {
+
     /** The number of bits in a {@code long} word (64). */
     long BITS_PER_WORD = Long.BYTES * 8L;
 
@@ -104,6 +105,17 @@ public interface ChronicleBitSet extends Marshallable, Closeable {
     /**
      * Finds the index of the next set bit between {@code fromIndex} and
      * {@code toIndex} inclusive.
+     *
+     * <p>To iterate over the {@code true} bits in a {@code ChronicleBitSet},
+     * use the following loop:
+     *
+     * <pre> {@code
+     * for (int i = bs.nextSetBit(0); i >= 0; i = bs.nextSetBit(i+1,to)) {
+     *     // operate on index i here
+     *     if (i == Integer.MAX_VALUE) {
+     *         break; // or (i+1) would overflow
+     *     }
+     * }}</pre>
      *
      * @param fromIndex zero-based index to begin searching (inclusive)
      * @param toIndex   maximum index to examine (inclusive)

--- a/src/main/java/net/openhft/chronicle/wire/ChronicleBitSet.java
+++ b/src/main/java/net/openhft/chronicle/wire/ChronicleBitSet.java
@@ -18,31 +18,38 @@ package net.openhft.chronicle.wire;
 
 import net.openhft.chronicle.core.io.Closeable;
 
+/**
+ * Interface for a bit set that is both {@link Marshallable} and
+ * {@link Closeable}. Implementations may store state off-heap so that bits can
+ * be persisted or shared between processes. Examples include
+ * {@link LongValueBitSet} and {@link LongArrayValueBitSet}.
+ */
 public interface ChronicleBitSet extends Marshallable, Closeable {
+    /** The number of bits in a {@code long} word (64). */
     long BITS_PER_WORD = Long.BYTES * 8L;
 
     /**
-     * Returns the number of bits of space actually in use by this {@code ChronicleBitSet} to represent bit values.
-     * The maximum element in the set is the size - 1st element.
+     * Returns the number of addressable bits in this set. The highest valid bit
+     * index is {@code size() - 1}.
      *
-     * @return the number of bits currently in this bit set
+     * @return the current capacity of this bit set
      */
     int size();
 
     /**
-     * Sets the bit at the specified index to {@code true}.
+     * Sets the bit at the given zero-based index.
      *
-     * @param bitIndex a bit index
-     * @throws IndexOutOfBoundsException if the specified index is negative
+     * @param bitIndex index of the bit to set
+     * @throws IndexOutOfBoundsException if {@code bitIndex < 0}
      */
     void set(int bitIndex);
 
     /**
-     * Sets the bit at the specified index to the specified value.
+     * Sets the bit at the given index to the provided value.
      *
-     * @param bitIndex a bit index
-     * @param value    a boolean value to set
-     * @throws IndexOutOfBoundsException if the specified index is negative
+     * @param bitIndex zero-based index of the bit to modify
+     * @param value    the value to store at that index
+     * @throws IndexOutOfBoundsException if {@code bitIndex < 0}
      */
     default void set(int bitIndex, boolean value) {
         if (value)
@@ -51,16 +58,24 @@ public interface ChronicleBitSet extends Marshallable, Closeable {
             clear(bitIndex);
     }
 
+    /**
+     * Sets every bit in the range {@code [fromIndex, toIndex)} to
+     * {@code true}.
+     *
+     * @param fromIndex index of the first bit to set, zero-based
+     * @param toIndex   index after the last bit to set
+     * @throws IndexOutOfBoundsException if an index is negative or the range
+     *                                   is invalid
+     */
     void set(int fromIndex, int toIndex);
 
     /**
-     * Sets the bits from the specified {@code fromIndex} (inclusive) to the specified {@code toIndex} (exclusive) to the specified value.
+     * Sets each bit in the range {@code [fromIndex, toIndex)} to the given value.
      *
-     * @param fromIndex index of the first bit to be set
-     * @param toIndex   index after the last bit to be set
-     * @param value     value to set the selected bits to
-     * @throws IndexOutOfBoundsException if {@code fromIndex} is negative, or {@code toIndex} is negative,
-     *                                   or {@code fromIndex} is larger than {@code toIndex}
+     * @param fromIndex zero-based index of the first bit to modify
+     * @param toIndex   index after the last bit to modify
+     * @param value     value to store in the selected range
+     * @throws IndexOutOfBoundsException if an index is negative or the range is invalid
      */
     default void set(int fromIndex, int toIndex, boolean value) {
         if (value)
@@ -70,45 +85,40 @@ public interface ChronicleBitSet extends Marshallable, Closeable {
     }
 
     /**
-     * Returns the value of the bit with the specified index. The value is {@code true} if the bit with the index {@code bitIndex} is currently set in
-     * this {@code ChronicleBitSet}; otherwise, the result is {@code false}.
+     * Returns the value of the bit at the given zero-based index.
      *
-     * @param bitIndex the bit index
-     * @return the value of the bit with the specified index
-     * @throws IndexOutOfBoundsException if the specified index is negative
+     * @param bitIndex index of the bit to query
+     * @return {@code true} if the bit is set
+     * @throws IndexOutOfBoundsException if {@code bitIndex < 0}
      */
     boolean get(int bitIndex);
 
     /**
-     * Sets the bit specified by the index to {@code false}.
+     * Clears the bit at the given zero-based index.
      *
-     * @param bitIndex the index of the bit to be cleared
-     * @throws IndexOutOfBoundsException if the specified index is negative
+     * @param bitIndex index of the bit to clear
+     * @throws IndexOutOfBoundsException if {@code bitIndex < 0}
      */
     void clear(int bitIndex);
 
     /**
-     * Returns the index of the first bit that is set to {@code true} that occurs on or after the specified starting index. If no such bit exists then
-     * {@code -1} is returned.
+     * Finds the index of the next set bit between {@code fromIndex} and
+     * {@code toIndex} inclusive.
      *
-     * <p>To iterate over the {@code true} bits in a {@code ChronicleBitSet},
-     * use the following loop:
-     *
-     * <pre> {@code
-     * for (int i = bs.nextSetBit(0); i >= 0; i = bs.nextSetBit(i+1,to)) {
-     *     // operate on index i here
-     *     if (i == Integer.MAX_VALUE) {
-     *         break; // or (i+1) would overflow
-     *     }
-     * }}</pre>
-     *
-     * @param fromIndex the index to start checking from (inclusive)
-     * @param toIndex   (inclusive) returns -1 if a bit is not found before this value
-     * @return the index of the next set bit, or {@code -1} if there is no such bit
-     * @throws IndexOutOfBoundsException if the specified index is negative
+     * @param fromIndex zero-based index to begin searching (inclusive)
+     * @param toIndex   maximum index to examine (inclusive)
+     * @return index of the next set bit or {@code -1} if none is found
+     * @throws IndexOutOfBoundsException if an index is negative
      */
     int nextSetBit(int fromIndex, int toIndex);
 
+    /**
+     * Finds the next set bit at or after {@code fromIndex}.
+     *
+     * @param fromIndex zero-based index to begin searching
+     * @return index of the next set bit or {@code -1} if none is found
+     * @throws IndexOutOfBoundsException if {@code fromIndex < 0}
+     */
     int nextSetBit(int fromIndex);
 
     /**
@@ -140,32 +150,114 @@ public interface ChronicleBitSet extends Marshallable, Closeable {
         return 0;
     }
 
+    /**
+     * Counts the number of bits set to {@code true}.
+     *
+     * @return number of set bits
+     */
     int cardinality();
 
+    /**
+     * Returns the index of the next clear bit at or after {@code index}.
+     *
+     * @param index zero-based starting position
+     * @return index of the next clear bit or {@code -1} if none is found
+     * @throws IndexOutOfBoundsException if {@code index < 0}
+     */
     int nextClearBit(int index);
 
+    /**
+     * Flips the state of the bit at {@code index}.
+     *
+     * @param index zero-based index of the bit to flip
+     * @throws IndexOutOfBoundsException if {@code index < 0}
+     */
     void flip(int index);
 
+    /**
+     * Toggles all bits in the range {@code [fromIndex, toIndex)}.
+     *
+     * @param fromIndex zero-based start of the range
+     * @param toIndex   end of the range (exclusive)
+     * @throws IndexOutOfBoundsException if the range is invalid
+     */
     void flip(int fromIndex, int toIndex);
 
+    /**
+     * Clears all bits in the range {@code [fromIndex, toIndex)}.
+     *
+     * @param fromIndex zero-based start of the range
+     * @param toIndex   end of the range (exclusive)
+     * @throws IndexOutOfBoundsException if the range is invalid
+     */
     void clear(int fromIndex, int toIndex);
 
+    /**
+     * Returns the number of {@code long} words currently used to hold the bits.
+     * Trailing zero words are not counted.
+     *
+     * @return number of words in use
+     */
     int getWordsInUse();
 
+    /**
+     * Fetches the word at {@code wordIndex} from the internal representation.
+     *
+     * @param wordIndex zero-based index of the word
+     * @return the word value or {@code 0} if out of range
+     */
     long getWord(int wordIndex);
 
+    /**
+     * Sets the word at {@code wordIndex} to {@code bits}. Implementations may
+     * extend the storage to accommodate the index.
+     *
+     * @param wordIndex zero-based index of the word to modify
+     * @param bits      the 64 bits to store
+     */
     void setWord(int wordIndex, long bits);
 
+    /**
+     * Clears the bits that are set in the given set from this set.
+     *
+     * @param bitSet bit set defining the bits to clear
+     */
     void andNot(ChronicleBitSet bitSet);
 
+    /**
+     * Performs a logical AND with the given set.
+     *
+     * @param bitSet other bit set
+     */
     void and(ChronicleBitSet bitSet);
 
+    /**
+     * Performs a logical XOR with the given set.
+     *
+     * @param bitSet other bit set
+     */
     void xor(ChronicleBitSet bitSet);
 
+    /**
+     * Performs a logical OR with the given set.
+     *
+     * @param bitSet other bit set
+     */
     void or(ChronicleBitSet bitSet);
 
+    /**
+     * Checks whether any bit is set in both this set and {@code bitSet}.
+     *
+     * @param bitSet other bit set
+     * @return {@code true} if the sets share a common set bit
+     */
     boolean intersects(ChronicleBitSet bitSet);
 
+    /**
+     * Copies all bits from {@code bitSet} into this set.
+     *
+     * @param bitSet source bit set
+     */
     void copyFrom(ChronicleBitSet bitSet);
 
 //    ChronicleBitSet get(int rangeStart, int rangeEnd);

--- a/src/main/java/net/openhft/chronicle/wire/FieldNumberParselet.java
+++ b/src/main/java/net/openhft/chronicle/wire/FieldNumberParselet.java
@@ -18,17 +18,22 @@ package net.openhft.chronicle.wire;
 import net.openhft.chronicle.core.io.InvalidMarshallableException;
 
 /**
- * Represents a parselet to process field numbers in a wire format.
- * Implementations should provide logic to read data based on the field number from a wire input source.
+ * Parses fields identified by a numeric ID.
+ * This is primarily used with binary wire formats where fields can be
+ * identified by numeric IDs instead of string names, for compactness and
+ * efficiency. It is typically registered with a {@link WireParser}
+ * (e.g., {@link VanillaWireParser}) as a fallback or for specific
+ * field numbers.
  */
 public interface FieldNumberParselet {
 
     /**
-     * Reads and processes data corresponding to the given field number (methodId) from the wire input.
+     * Invoked when a numeric field ID is parsed.
      *
-     * @param methodId The field number or methodId that denotes which data to read.
-     * @param wire     The wire input source from which the data is read.
-     * @throws InvalidMarshallableException If there's an error in reading or processing the data.
+     * @param methodId the numeric field ID read from the binary wire
+     * @param wire     the {@link WireIn} from which the value should be read;
+     *                 use {@code wire.getValueIn()} to access and deserialise the value
+     * @throws InvalidMarshallableException if the value cannot be processed
      */
     void readOne(long methodId, WireIn wire) throws InvalidMarshallableException;
 }

--- a/src/main/java/net/openhft/chronicle/wire/LongArrayValueBitSet.java
+++ b/src/main/java/net/openhft/chronicle/wire/LongArrayValueBitSet.java
@@ -129,15 +129,22 @@ public class LongArrayValueBitSet extends AbstractCloseable implements Marshalla
     }
 
     /**
-     * Number of words currently used as reported by {@link LongArrayValues#getUsed()}.
+     * Retrieves the number of words that are currently in use by this bit set.
+     * This indicates the number of long values that are currently utilized to represent bits in the bit set.
+     *
+     * @return The number of words in use, converted to an integer.
      */
     public int getWordsInUse() {
         return Math.toIntExact(words.getUsed());
     }
 
     /**
-     * Atomically update the word at {@code wordIndex} using {@code function}.
-     * The function receives the current value and {@code param} and returns the new value.
+     * Sets a specific word in this bit set using a provided function and parameter.
+     * This method is lock-free and uses CAS operations to safely update the word value.
+     *
+     * @param wordIndex The index of the word to set.
+     * @param param     The parameter to pass to the function.
+     * @param function  The function to compute the new word value based on the old value and the provided parameter.
      */
     public void set(int wordIndex, long param, LongFunction function) {
         throwExceptionIfClosed();
@@ -156,7 +163,9 @@ public class LongArrayValueBitSet extends AbstractCloseable implements Marshalla
     }
 
     /**
-     * Lazily create a {@link Pauser} for CAS retry loops.
+     * Retrieves or initializes the internal {@code Pauser}, which is used to manage pauses during lock-free operations.
+     *
+     * @return The {@code Pauser} instance associated with this object.
      */
     private Pauser pauser() {
         if (this.pauser == null)
@@ -179,7 +188,10 @@ public class LongArrayValueBitSet extends AbstractCloseable implements Marshalla
     }
 
     /**
-     * Serialise the currently used words into a little‑endian byte array.
+     * Converts the bits in this bit set to a byte array.
+     * This allows the bit set to be easily serialized or transferred.
+     *
+     * @return A byte array containing all the bits in this bit set.
      */
     public byte[] toByteArray() {
         throwExceptionIfClosed();
@@ -925,12 +937,17 @@ public class LongArrayValueBitSet extends AbstractCloseable implements Marshalla
     }
 
     /**
-     * Simple long-to-long function used by CAS helpers.
+     * Represents a functional interface for a long-to-long function.
+     * This can be useful for operations that require transforming or manipulating long values.
      */
     @FunctionalInterface
     interface LongFunction {
         /**
-         * Compute a new value from {@code oldValue} and {@code param}.
+         * Applies the function on the given long values.
+         *
+         * @param oldValue The old value.
+         * @param param The parameter value.
+         * @return The result of applying the function.
          */
         long apply(long oldValue, long param);
     }

--- a/src/main/java/net/openhft/chronicle/wire/LongArrayValueBitSet.java
+++ b/src/main/java/net/openhft/chronicle/wire/LongArrayValueBitSet.java
@@ -33,27 +33,29 @@ import java.util.stream.StreamSupport;
 import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
 
 /**
- * This {@code ChronicleBitSet} is intended to be shared between processes. To minimize locking constraints, it is implemented as a lock-free solution
- * without support for resizing.
+ * A {@link ChronicleBitSet} backed by a {@link net.openhft.chronicle.core.values.LongArrayValues}.
+ * The backing array can reside off-heap, allowing multiple processes to share the same state.
+ * All updates rely on compare‑and‑swap operations and therefore do not require explicit locks.
+ * <b>Note:</b> the capacity is fixed when the instance is created and cannot later be expanded.
  */
 @SuppressWarnings("this-escape")
 public class LongArrayValueBitSet extends AbstractCloseable implements Marshallable, ChronicleBitSet {
 
-    /* Used to shift left or right for a partial word mask */
+    /** Internal constant used when masking partial words. */
     private static final long WORD_MASK = ~0L;
 
-    // Pauser object used for managing concurrent access (assuming based on its name, actual use needs context)
+    /** Lazily created {@link Pauser} used during CAS spin loops. */
     private transient Pauser pauser;
 
     /**
-     * The internal field corresponding to the serialField "bits".
+     * Holds the 64-bit words representing the bits. Each index is one word in the
+     * underlying {@link LongArrayValues} instance.
      */
     private LongArrayValues words;
 
     /**
-     * Constructs a new {@code LongArrayValueBitSet} with the given maximum number of bits.
-     *
-     * @param maxNumberOfBits Maximum number of bits that the bit set can handle.
+     * Create a bit set capable of holding {@code maxNumberOfBits} bits.
+     * The backing {@link BinaryLongArrayReference} is sized once during construction.
      */
     public LongArrayValueBitSet(final long maxNumberOfBits) {
         words = new BinaryLongArrayReference((maxNumberOfBits + BITS_PER_WORD - 1) / BITS_PER_WORD);
@@ -61,10 +63,9 @@ public class LongArrayValueBitSet extends AbstractCloseable implements Marshalla
     }
 
     /**
-     * Constructs a new {@code LongArrayValueBitSet} with the given maximum number of bits and initializes it with the given {@code Wire}.
-     *
-     * @param maxNumberOfBits Maximum number of bits that the bit set can handle.
-     * @param w               The {@code Wire} object to be used for initialization.
+     * Create a bit set of {@code maxNumberOfBits} bits and immediately marshal its state
+     * to and from the provided {@link Wire}. The {@link #words} field is initialised using
+     * a {@link BinaryLongArrayReference} before marshalling occurs.
      */
     public LongArrayValueBitSet(final long maxNumberOfBits, Wire w) {
         this(maxNumberOfBits);
@@ -73,11 +74,9 @@ public class LongArrayValueBitSet extends AbstractCloseable implements Marshalla
     }
 
     /**
-     * Calculates the word index in the internal storage corresponding to a given bit index.
+     * Locate the word containing {@code bitIndex}.
      *
-     * @param bitIndex The bit index for which to find the word index.
-     * @return The word index containing the given bit index.
-     * @throws IndexOutOfBoundsException if the provided bitIndex is negative.
+     * @throws IndexOutOfBoundsException if {@code bitIndex} is negative
      */
     private static int wordIndex(int bitIndex) {
         if (bitIndex < 0)
@@ -87,17 +86,14 @@ public class LongArrayValueBitSet extends AbstractCloseable implements Marshalla
     }
 
     /**
-     * Constructs and returns a new {@code BitSet} using the bits from the provided byte array.
-     *
-     * @param bytes The byte array to be used for constructing the {@code BitSet}.
-     * @return A new {@code BitSet} containing all bits from the given byte array.
+     * Utility method matching {@link BitSet#valueOf(byte[])} for convenience.
      */
     public static BitSet valueOf(byte[] bytes) {
         return BitSet.valueOf(ByteBuffer.wrap(bytes));
     }
 
     /**
-     * Checks that fromIndex ... toIndex is a valid range of bit indices.
+     * Validate that {@code fromIndex}..{@code toIndex} forms a non‑empty range.
      */
     private static void checkRange(int fromIndex, int toIndex) {
         if (fromIndex < 0)
@@ -109,11 +105,18 @@ public class LongArrayValueBitSet extends AbstractCloseable implements Marshalla
                     " > toIndex: " + toIndex);
     }
 
+    /**
+     * Return the value of the word at {@code wordIndex} or zero if beyond {@link #getWordsInUse()}.
+     */
     @Override
     public long getWord(int wordIndex) {
         return wordIndex < getWordsInUse() ? words.getValueAt(wordIndex) : 0;
     }
 
+    /**
+     * Store {@code bits} at the given {@code wordIndex}. The backing {@link LongArrayValues}
+     * is expanded to the index if needed.
+     */
     @Override
     public void setWord(int wordIndex, long bits) {
         expandTo(wordIndex);
@@ -126,22 +129,15 @@ public class LongArrayValueBitSet extends AbstractCloseable implements Marshalla
     }
 
     /**
-     * Retrieves the number of words that are currently in use by this bit set.
-     * This indicates the number of long values that are currently utilized to represent bits in the bit set.
-     *
-     * @return The number of words in use, converted to an integer.
+     * Number of words currently used as reported by {@link LongArrayValues#getUsed()}.
      */
     public int getWordsInUse() {
         return Math.toIntExact(words.getUsed());
     }
 
     /**
-     * Sets a specific word in this bit set using a provided function and parameter.
-     * This method is lock-free and uses CAS operations to safely update the word value.
-     *
-     * @param wordIndex The index of the word to set.
-     * @param param     The parameter to pass to the function.
-     * @param function  The function to compute the new word value based on the old value and the provided parameter.
+     * Atomically update the word at {@code wordIndex} using {@code function}.
+     * The function receives the current value and {@code param} and returns the new value.
      */
     public void set(int wordIndex, long param, LongFunction function) {
         throwExceptionIfClosed();
@@ -160,9 +156,7 @@ public class LongArrayValueBitSet extends AbstractCloseable implements Marshalla
     }
 
     /**
-     * Retrieves or initializes the internal {@code Pauser}, which is used to manage pauses during lock-free operations.
-     *
-     * @return The {@code Pauser} instance associated with this object.
+     * Lazily create a {@link Pauser} for CAS retry loops.
      */
     private Pauser pauser() {
         if (this.pauser == null)
@@ -171,11 +165,8 @@ public class LongArrayValueBitSet extends AbstractCloseable implements Marshalla
     }
 
     /**
-     * Sets a new value for a given word in this bit set.
-     * This method is lock-free and uses CAS operations to safely set the new word value.
-     *
-     * @param word     The {@code LongValue} instance representing the word to set.
-     * @param newValue The new value to set for the word.
+     * Atomically set an external {@link LongValue} to {@code newValue}.
+     * This helper does not access {@link #words}; it is provided for convenience.
      */
     public void set(LongValue word, long newValue) {
         throwExceptionIfClosed();
@@ -188,10 +179,7 @@ public class LongArrayValueBitSet extends AbstractCloseable implements Marshalla
     }
 
     /**
-     * Converts the bits in this bit set to a byte array.
-     * This allows the bit set to be easily serialized or transferred.
-     *
-     * @return A byte array containing all the bits in this bit set.
+     * Serialise the currently used words into a little‑endian byte array.
      */
     public byte[] toByteArray() {
         throwExceptionIfClosed();
@@ -207,9 +195,8 @@ public class LongArrayValueBitSet extends AbstractCloseable implements Marshalla
     }
 
     /**
-     * Ensures that the ChronicleBitSet can accommodate a given wordIndex.
-     *
-     * @param wordIndex the index to be accommodated.
+     * Ensure the backing store can address {@code wordIndex}. Throws if the requested index
+     * exceeds the initial capacity.
      */
     private void expandTo(int wordIndex) {
         int wordsRequired = wordIndex + 1;
@@ -938,17 +925,12 @@ public class LongArrayValueBitSet extends AbstractCloseable implements Marshalla
     }
 
     /**
-     * Represents a functional interface for a long-to-long function.
-     * This can be useful for operations that require transforming or manipulating long values.
+     * Simple long-to-long function used by CAS helpers.
      */
     @FunctionalInterface
     interface LongFunction {
         /**
-         * Applies the function on the given long values.
-         *
-         * @param oldValue The old value.
-         * @param param The parameter value.
-         * @return The result of applying the function.
+         * Compute a new value from {@code oldValue} and {@code param}.
          */
         long apply(long oldValue, long param);
     }

--- a/src/main/java/net/openhft/chronicle/wire/LongValueBitSet.java
+++ b/src/main/java/net/openhft/chronicle/wire/LongValueBitSet.java
@@ -32,47 +32,60 @@ import java.util.stream.StreamSupport;
 import static net.openhft.chronicle.core.io.Closeable.closeQuietly;
 
 /**
- * This is the LongValueBitSet class extending AbstractCloseable.
- * This class represents a BitSet designed to be shared across processes without requiring locks.
- * It has been implemented as a lock-free solution and does not support resizing.
+ * A {@link ChronicleBitSet} implementation backed by an array of
+ * {@link net.openhft.chronicle.core.values.LongValue}s. The backing
+ * words may reside in off-heap memory so the bit set can be shared
+ * between processes. Operations are performed using compare-and-swap
+ * loops rather than explicit locks.
+ * <b>Note:</b> the capacity is fixed on construction and cannot be
+ * expanded later.
  */
 @SuppressWarnings("this-escape")
 public class LongValueBitSet extends AbstractCloseable implements Marshallable, ChronicleBitSet {
 
-    // Mask used for operations on partial words.
+    /**
+     * Internal constant with all bits set ({@code 0xFFFF_FFFF_FFFF_FFFFL}) used
+     * when masking partial words.
+     */
     private static final long WORD_MASK = ~0L;
 
-    // Provides a pausing strategy for contention management.
+    /**
+     * Transient {@link Pauser} used to back off in CAS loops. Lazily
+     * initialised on first use.
+     */
     private transient Pauser pauser;
 
     /**
-     * The internal field corresponding to the serialField "bits".
+     * The array of {@link LongValue} words storing the bits for this set.
+     * Each entry is a 64‑bit word that may be shared across processes.
      */
     private LongValue[] words;
 
     /**
-     * Constructor that initializes a LongValueBitSet with a maximum number of bits provided as an integer.
+     * Creates a bit set sized for {@code maxNumberOfBits} bits.
+     * The backing array is allocated but not bound to any {@link Wire}.
      *
-     * @param maxNumberOfBits The maximum number of bits this BitSet can accommodate.
+     * @param maxNumberOfBits maximum number of bits this set can hold
      */
     public LongValueBitSet(final int maxNumberOfBits) {
         this((long) maxNumberOfBits);
     }
 
     /**
-     * Constructor that initializes a LongValueBitSet with a maximum number of bits provided as an integer and associates it with a Wire.
+     * Creates a bit set sized for {@code maxNumberOfBits} bits and immediately
+     * binds the backing array to the supplied {@link Wire} for serialisation.
      *
-     * @param maxNumberOfBits The maximum number of bits this BitSet can accommodate.
-     * @param w The Wire associated with this BitSet.
+     * @param maxNumberOfBits maximum number of bits this set can hold
+     * @param w               wire used to marshal the initial state
      */
     public LongValueBitSet(final int maxNumberOfBits, Wire w) {
         this((long) maxNumberOfBits, w);
     }
 
     /**
-     * Constructor that initializes a LongValueBitSet with a maximum number of bits provided as a long.
+     * Creates a bit set sized for {@code maxNumberOfBits} bits.
      *
-     * @param maxNumberOfBits The maximum number of bits this BitSet can accommodate.
+     * @param maxNumberOfBits maximum number of bits this set can hold
      */
     public LongValueBitSet(final long maxNumberOfBits) {
         int size = (int) ((maxNumberOfBits + BITS_PER_WORD - 1) / BITS_PER_WORD);
@@ -81,10 +94,11 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Constructor that initializes a LongValueBitSet with a maximum number of bits provided as a long and associates it with a Wire.
+     * Creates a bit set sized for {@code maxNumberOfBits} bits and binds its
+     * storage to a {@link Wire} for marshalling.
      *
-     * @param maxNumberOfBits The maximum number of bits this BitSet can accommodate.
-     * @param w The Wire associated with this BitSet.
+     * @param maxNumberOfBits maximum number of bits this set can hold
+     * @param w               wire used to marshal the initial state
      */
     public LongValueBitSet(final long maxNumberOfBits, Wire w) {
         this(maxNumberOfBits);
@@ -130,11 +144,20 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
                     " > toIndex: " + toIndex);
     }
 
+    /**
+     * Returns the raw word at {@code wordIndex}. If the index is beyond the
+     * backing array the value {@code 0} is returned.
+     */
     @Override
     public long getWord(int wordIndex) {
         return wordIndex < words.length ? words[wordIndex].getValue() : 0;
     }
 
+    /**
+     * Sets the raw word at {@code wordIndex} to {@code bits}. The array is
+     * not expanded; {@link #expandTo(int)} will throw if the index is beyond the
+     * configured capacity.
+     */
     @Override
     public void setWord(int wordIndex, long bits) {
         expandTo(wordIndex);
@@ -147,21 +170,18 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Fetches the number of words currently in use in this BitSet.
-     *
-     * @return The number of words in use.
+     * Returns the number of {@link LongValue} words available in the backing
+     * array. This is the fixed capacity rather than a logical size.
      */
     public int getWordsInUse() {
         return words.length;
     }
 
     /**
-     * Atomically sets the value of a LongValue object based on a provided function and parameter.
-     * It uses a pausing strategy to deal with contention.
-     *
-     * @param word The LongValue object whose value needs to be set.
-     * @param param The parameter to pass to the function.
-     * @param function A function that takes the old value of the word and the provided parameter to produce a new value.
+     * Atomically updates {@code word} using a compare‑and‑swap loop. The
+     * {@code function} computes a new value from the current one and
+     * {@code param}. The {@link #pauser()} is used between failed CAS
+     * attempts to reduce contention.
      */
     public void set(LongValue word, long param, LongFunction function) {
         throwExceptionIfClosed();
@@ -178,10 +198,8 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Fetches the Pauser object for this bit set.
-     * If the Pauser object is not yet initialized, it initializes it to a busy pauser.
-     *
-     * @return The Pauser object associated with this bit set.
+     * Returns the {@link Pauser} used for CAS backoff, creating it on first
+     * use. The default strategy is {@link Pauser#busy()}.
      */
     private Pauser pauser() {
         if (this.pauser == null)
@@ -190,11 +208,8 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Atomically sets the value of a LongValue object to a new value.
-     * It uses a pausing strategy to handle contention during the set operation.
-     *
-     * @param word The LongValue object whose value needs to be set.
-     * @param newValue The new value to be set.
+     * Atomically sets {@code word} to {@code newValue}. A CAS loop is used
+     * with {@link #pauser()} invoked between attempts when contention occurs.
      */
     public void set(LongValue word, long newValue) {
         throwExceptionIfClosed();
@@ -207,10 +222,8 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Converts the bit set to a byte array representation.
-     * It serializes the bits into bytes in little-endian order.
-     *
-     * @return A byte array containing all the bits set in this bit set.
+     * Returns a little‑endian byte array representing this set. Each word
+     * is written in sequence.
      */
     public byte[] toByteArray() {
         throwExceptionIfClosed();
@@ -231,10 +244,9 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Ensures that the current bit set can accommodate a specified word index.
-     * Throws an UnsupportedOperationException if the bit set cannot be expanded.
-     *
-     * @param wordIndex The word index that needs to be accommodated.
+     * Verifies that {@code wordIndex} is within the fixed capacity. This
+     * implementation never resizes and will throw
+     * {@link UnsupportedOperationException} if expansion would be required.
      */
     private void expandTo(int wordIndex) {
         int wordsRequired = wordIndex + 1;
@@ -246,10 +258,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Flips the bit at the specified index, toggling it from its current value.
-     * If the bit is currently set to 0, it will become 1, and vice versa.
-     *
-     * @param bitIndex The index of the bit to flip.
+     * Atomically toggles the bit at {@code bitIndex}.
      */
     public void flip(int bitIndex) {
         throwExceptionIfClosed();
@@ -263,33 +272,21 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Applies the bitwise XOR operation between the provided word and parameter.
-     * The result of this operation toggles the bits where they differ.
-     *
-     * @param word The LongValue object representing the word.
-     * @param param The parameter against which XOR operation needs to be performed.
+     * Atomically performs {@code word ^= param}.
      */
     private void caret(LongValue word, long param) {
         set(word, param, (x, y) -> x ^ y);
     }
 
     /**
-     * Applies the bitwise AND operation between the provided word and parameter.
-     * The result of this operation retains the bits that are set in both the word and the parameter.
-     *
-     * @param word The LongValue object representing the word.
-     * @param param The parameter against which AND operation needs to be performed.
+     * Atomically performs {@code word &= param}.
      */
     private void and(LongValue word, final long param) {
         set(word, param, (x, y) -> x & y);
     }
 
     /**
-     * Flips a range of bits, toggling them from their current value.
-     * If a bit within the range is currently set to 0, it will become 1, and vice versa.
-     *
-     * @param fromIndex Index of the first bit to flip (inclusive).
-     * @param toIndex Index of the last bit to flip (exclusive).
+     * Atomically flips bits in the range [{@code fromIndex}, {@code toIndex}).
      */
     public void flip(int fromIndex, int toIndex) {
         throwExceptionIfClosed();
@@ -326,9 +323,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Sets the bit at the specified index to {@code true}.
-     *
-     * @param bitIndex The index of the bit to be set to {@code true}.
+     * Atomically sets the bit at {@code bitIndex}.
      */
     public void set(int bitIndex) {
         // Check if the BitSet is closed, if so, throws an exception
@@ -346,11 +341,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Performs a bitwise OR operation on the given word and parameter.
-     * This method is particularly used to set a specific bit to {@code true} within a word.
-     *
-     * @param word The word on which the operation will be performed.
-     * @param param The parameter value used in the OR operation.
+     * Atomically performs {@code word |= param}.
      */
     private void pipe(LongValue word, long param) {
         // Set the desired bit by using the OR operation
@@ -358,11 +349,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Sets the bit at the specified index to the specified value.
-     * If the value is {@code true}, the bit is set to 1, otherwise it is set to 0.
-     *
-     * @param bitIndex The index of the bit to be modified.
-     * @param value The new value for the specified bit.
+     * Sets the bit at {@code bitIndex} to {@code value}.
      */
     public void set(int bitIndex, boolean value) {
         throwExceptionIfClosed();
@@ -374,7 +361,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Sets the bits from the specified {@code fromIndex} (inclusive) to the specified {@code toIndex} (exclusive) to {@code true}.
+     * Atomically sets all bits in the range [{@code fromIndex}, {@code toIndex}) to {@code true}.
      */
     public void set(int fromIndex, int toIndex) {
         throwExceptionIfClosed();
@@ -411,13 +398,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Sets the bits from the specified {@code fromIndex} (inclusive) to the specified {@code toIndex} (exclusive) to the specified value.
-     *
-     * @param fromIndex index of the first bit to be set
-     * @param toIndex   index after the last bit to be set
-     * @param value     value to set the selected bits to
-     * @throws IndexOutOfBoundsException if {@code fromIndex} is negative, or {@code toIndex} is negative, or {@code fromIndex} is larger than {@code
-     *                                   toIndex}
+     * Atomically sets all bits in the range to {@code value}.
      */
     public void set(int fromIndex, int toIndex, boolean value) {
         throwExceptionIfClosed();
@@ -429,7 +410,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Sets the bit specified by the index to {@code false}.
+     * Clears the bit at {@code bitIndex}.
      */
     public void clear(int bitIndex) {
         throwExceptionIfClosed();
@@ -445,7 +426,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Sets the bits from the specified {@code fromIndex} (inclusive) to the specified {@code toIndex} (exclusive) to {@code false}.
+     * Clears all bits in the range [{@code fromIndex}, {@code toIndex}).
      */
     public void clear(int fromIndex, int toIndex) {
         throwExceptionIfClosed();
@@ -490,7 +471,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Sets all of the bits in this ChronicleBitSet to {@code false}.
+     * Clears every bit in the set.
      */
     public void clear() {
         throwExceptionIfClosed();
@@ -501,11 +482,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Returns the value of the bit with the specified index. The value is {@code true} if the bit with the index {@code bitIndex}
-     * is currently set in this {@code ChronicleBitSet}; otherwise, the result is {@code false}.
-     *
-     * @param bitIndex the index of the bit to check
-     * @return true if the bit at the specified index is set, false otherwise
+     * Returns {@code true} if the bit at {@code bitIndex} is set.
      */
     public boolean get(int bitIndex) {
         throwExceptionIfClosed();
@@ -519,11 +496,8 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Returns the index of the first bit that is set to {@code true} that occurs on or after the specified starting index.
-     * If no such bit exists then {@code -1} is returned.
-     *
-     * @param fromIndex the index to start checking from
-     * @return the index of the next set bit, or -1 if no such bit is found
+     * Returns the index of the next set bit on or after {@code fromIndex}.
+     * Uses volatile reads for cross-process visibility.
      */
     public int nextSetBit(int fromIndex) {
         throwExceptionIfClosed();
@@ -556,12 +530,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Returns the index of the first bit that is set to {@code true} that occurs on or after the specified starting index but before the toIndex.
-     * If no such bit exists then {@code -1} is returned.
-     *
-     * @param fromIndex the index to start checking from
-     * @param toIndex the index to stop checking (exclusive)
-     * @return the index of the next set bit within the specified range, or -1 if no such bit is found
+     * Variant of {@link #nextSetBit(int)} that stops searching at {@code toIndex}.
      */
     public int nextSetBit(int fromIndex, int toIndex) {
         throwExceptionIfClosed();
@@ -595,10 +564,8 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Returns the index of the first bit that is set to {@code false} that occurs on or after the specified starting index.
-     *
-     * @param fromIndex the index to start checking from
-     * @return the index of the next unset bit, or the total length if all bits are set
+     * Returns the index of the next clear bit on or after {@code fromIndex}.
+     * Uses volatile reads for visibility.
      */
     public int nextClearBit(int fromIndex) {
         throwExceptionIfClosed();
@@ -634,13 +601,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * This method searches for the closest bit set to {@code true} from the specified starting index moving backwards.
-     * If the bit at the specified starting index is set to {@code true}, it will return the index itself.
-     * If no such bit exists before the given index, or if {@code -1} is the specified index, then {@code -1} is returned.
-     *
-     * @param fromIndex The starting index to begin the search. The search moves towards the index 0 from this point.
-     * @return The index of the nearest set bit (with value {@code true}) before the specified starting index, or {@code -1} if none exists.
-     * @throws IndexOutOfBoundsException if {@code fromIndex} is less than {@code -1}
+     * Scans backwards for the previous set bit starting from {@code fromIndex}.
      */
     public int previousSetBit(int fromIndex) {
         throwExceptionIfClosed();
@@ -669,13 +630,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * This method searches for the closest bit set to {@code false} from the specified starting index moving backwards.
-     * If the bit at the specified starting index is set to {@code false}, it will return the index itself.
-     * If no such unset bit exists before the given index, or if {@code -1} is the specified index, then {@code -1} is returned.
-     *
-     * @param fromIndex The starting index to begin the search. The search moves towards the index 0 from this point.
-     * @return The index of the nearest unset bit (with value {@code false}) before the specified starting index, or {@code -1} if none exists.
-     * @throws IndexOutOfBoundsException if {@code fromIndex} is less than {@code -1}
+     * Scans backwards for the previous clear bit starting from {@code fromIndex}.
      */
     public int previousClearBit(int fromIndex) {
         throwExceptionIfClosed();
@@ -732,9 +687,8 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Calculates and returns the number of bits set to {@code true} in this {@code ChronicleBitSet}.
-     *
-     * @return The number of bits currently set to {@code true}.
+     * Counts the bits set to {@code true}. Each word is read
+     * with {@link LongValue#getVolatileValue()} for visibility.
      */
     public int cardinality() {
         throwExceptionIfClosed();
@@ -884,9 +838,8 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Computes the hash code for this {@code ChronicleBitSet}. The hash code is calculated based on the bit values that are set.
-     *
-     * @return The computed hash code.
+     * Computes a hash code from the values of all words. A load fence is used
+     * before reading them.
      */
     public int hashCode() {
         long h = 1234;
@@ -898,26 +851,15 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Retrieves the number of bits that are actually being used by this {@code ChronicleBitSet} to represent bit values.
-     * Essentially, this is the highest set bit plus one.
-     *
-     * @return The number of bits of space in use.
+     * Returns the maximum number of bits represented by this set.
      */
     public int size() {
         return Math.toIntExact(words.length * BITS_PER_WORD);
     }
 
     /**
-     * Compares this {@code ChronicleBitSet} object against the specified object. The result is {@code true} if and only if:
-     * <ul>
-     *     <li>The provided object is not {@code null}.
-     *     <li>The provided object is an instance of {@code ChronicleBitSet}.
-     *     <li>Both {@code ChronicleBitSet} objects have the exact same set of bits set to {@code true}.
-     * </ul>
-     * In essence, for every non-negative {@code int} index {@code k}, the bits of both {@code ChronicleBitSet} objects at index {@code k} should be identical.
-     *
-     * @param obj The object to compare with.
-     * @return {@code true} if the objects are the same; {@code false} otherwise.
+     * Returns {@code true} if {@code obj} is a {@link ChronicleBitSet} with the
+     * same word values. A load fence is issued before comparison.
      */
     public boolean equals(Object obj) {
         throwExceptionIfClosed();
@@ -970,8 +912,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Returns a stream of indices for which this {@code ChronicleBitSet} contains a bit in the set state. The indices are returned in order, from lowest to
-     * highest. The size of the stream is the number of bits in the set state, equal to the value returned by the {@link #cardinality()} method.
+     * Streams the set bit indices in ascending order.
      */
     public IntStream stream() {
         throwExceptionIfClosed();
@@ -1009,6 +950,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
                 false);
     }
 
+    /** Serialises the backing words to {@code wire}. */
     @Override
     public void writeMarshallable(@NotNull final WireOut wire) {
         wire.write("numberOfLongValues").int32(words.length);
@@ -1020,6 +962,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
         }
     }
 
+    /** Deserialises the backing words from {@code wire}. */
     @Override
     public void readMarshallable(@NotNull final WireIn wire) throws IORuntimeException {
         singleThreadedCheckDisabled(true);
@@ -1034,6 +977,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
         }
     }
 
+    /** Copies the contents of {@code bitSet} into this instance. */
     @Override
     public void copyFrom(ChronicleBitSet bitSet) {
         OS.memory().loadFence();
@@ -1048,28 +992,14 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
     }
 
     /**
-     * Represents a function that accepts two long values (an old value and a parameter) and produces a long result.
-     * This is the {@code long}-consuming and {@code long}-producing primitive specialization for
-     * {@link java.util.function.Function}.
-     *
-     * <p>For example, this interface can be used to represent functions like addition:
-     * <pre>
-     * {@code
-     * LongFunction add = (oldValue, param) -> oldValue + param;
-     * long result = add.apply(2L, 3L);  // result will be 5
-     * }
-     * </pre>
-     *
-         */
+     * Function used for atomic updates on a {@code long} value. It accepts the
+     * current value and a parameter and returns the new value.
+     */
     @FunctionalInterface
     interface LongFunction {
 
         /**
-         * Applies this function to the given arguments.
-         *
-         * @param oldValue The old long value.
-         * @param param The long parameter.
-         * @return The function result.
+         * Applies the function to {@code oldValue} and {@code param}.
          */
         long apply(long oldValue, long param);
     }

--- a/src/main/java/net/openhft/chronicle/wire/VanillaWireParser.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaWireParser.java
@@ -78,7 +78,7 @@ public class VanillaWireParser implements WireParser {
     private long lastStart = 0;
 
     /**
-     * Creates a parser using the supplied handlers.
+     * Constructs a new VanillaWireParser with the specified default consumer and field number parselet.
      *
      * @param defaultConsumer      consumer for unregistered named fields. Must not be {@code null}.
      * @param fieldNumberParselet  handler for unregistered numeric ids. Must not be {@code null}.
@@ -220,7 +220,9 @@ public class VanillaWireParser implements WireParser {
     }
 
     /**
-     * Internal helper that stores the mapping in both the named and numbered maps.
+     * Registers a WireParselet with a given keyName and code.
+     * The keyName is stored in the namedConsumer map and the code
+     * with its corresponding keyName in the numberedConsumer map.
      *
      * @param keyName         textual name of the field
      * @param code            numeric id of the field

--- a/src/main/java/net/openhft/chronicle/wire/VanillaWireParser.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaWireParser.java
@@ -28,42 +28,60 @@ import java.util.Map;
 import java.util.TreeMap;
 
 /**
- * Provides an implementation of the WireParser interface, parsing wire inputs using both named and numbered
- * parselets to associate specific actions with events or field names.
- * <p>
- * This parser uses a default consumer to handle unmatched entries and a field number parselet for numbered fields.
+ * Provides an implementation of {@link WireParser} that maps field names or ids to
+ * {@link WireParselet}s. Named parselets are looked up via {@link #namedConsumer} and
+ * numbered fields via {@link #numberedConsumer}. A {@link #defaultConsumer} handles
+ * fields that are not explicitly registered and {@link #fieldNumberParselet} deals with
+ * unmapped numeric identifiers.
  */
 public class VanillaWireParser implements WireParser {
 
-    // Map of field names to their associated parselets, sorted by CharSequence order.
+    /**
+     * {@link TreeMap} of field names to parselets. {@link CharSequenceComparator#INSTANCE}
+     * provides stable ordering and lookup semantics.
+     */
     private final Map<CharSequence, WireParselet> namedConsumer = new TreeMap<>(CharSequenceComparator.INSTANCE);
 
-    // Map of field numbers to their associated parselets.
+    /**
+     * {@link HashMap} of numeric field ids to the original name and parselet.
+     */
     private final Map<Integer, Map.Entry<String, WireParselet>> numberedConsumer = new HashMap<>();
 
-    // The default consumer to handle unmatched entries.
+    /**
+     * Invoked when a field name is not present in {@link #namedConsumer}.
+     */
     private final WireParselet defaultConsumer;
 
-    // Used for building strings for parsing.
+    /**
+     * Reusable buffer for reading textual field names.
+     */
     private final StringBuilder sb = new StringBuilder(128);
 
-    // Holds the name of the last event that was parsed.
+    /**
+     * Caches the most recently parsed field name.
+     */
     private final StringBuilder lastEventName = new StringBuilder(128);
 
-    // Handles numbered fields.
+    /**
+     * Called when a numeric field id is not mapped in {@link #numberedConsumer}.
+     */
     private FieldNumberParselet fieldNumberParselet;
 
-    // Holds the last parslet that was used.
+    /**
+     * Cache of the parselet associated with {@link #lastEventName}.
+     */
     private WireParselet lastParslet = null;
 
-    // Indicates the position in the wire input of the last parsed event.
+    /**
+     * Start position of the last parsed event for debugging purposes.
+     */
     private long lastStart = 0;
 
     /**
-     * Constructs a new VanillaWireParser with the specified default consumer and field number parselet.
+     * Creates a parser using the supplied handlers.
      *
-     * @param defaultConsumer The default consumer to handle unmatched entries.
-     * @param fieldNumberParselet The field number parselet for handling numbered fields.
+     * @param defaultConsumer      consumer for unregistered named fields. Must not be {@code null}.
+     * @param fieldNumberParselet  handler for unregistered numeric ids. Must not be {@code null}.
      */
     public VanillaWireParser(@NotNull WireParselet defaultConsumer,
                              @NotNull FieldNumberParselet fieldNumberParselet) {
@@ -75,10 +93,8 @@ public class VanillaWireParser implements WireParser {
     }
 
     /**
-     * Peeks at the next code or byte in the wire input without moving the read position.
-     *
-     * @param wireIn The wire input to peek into.
-     * @return The next unsigned byte as an integer.
+     * Returns the next byte in {@code wireIn} without altering its read position.
+     * The value is returned as an unsigned int.
      */
     private int peekCode(@NotNull WireIn wireIn) {
         return wireIn.bytes().peekUnsignedByte();
@@ -90,12 +106,16 @@ public class VanillaWireParser implements WireParser {
     }
 
     /**
-     * Parses a single input from the wire. Determines if the input should be parsed as binary or not.
-     * Throws specific exceptions in the case of invocation issues or invalid marshallable data.
+     * Reads one field from {@code wireIn}. Binary fields (identified by
+     * {@link BinaryWireCode#FIELD_NUMBER}) are handled by
+     * {@link #parseOneBinary(WireIn)}. Otherwise the field name is read into
+     * {@link #sb} and the matching parselet located via {@link #namedConsumer}.
+     * If no match is found, {@link #getDefaultConsumer()} is used. The chosen
+     * parselet and name are cached for the next call.
      *
-     * @param wireIn The wire input to parse.
-     * @throws InvocationTargetRuntimeException if an invocation error occurs during parsing.
-     * @throws InvalidMarshallableException if invalid marshallable data is encountered during parsing.
+     * @param wireIn the source of the field
+     * @throws InvocationTargetRuntimeException if a parselet throws a checked exception
+     * @throws InvalidMarshallableException     if the wire data is malformed
      */
     public void parseOne(@NotNull WireIn wireIn) throws InvocationTargetRuntimeException, InvalidMarshallableException {
         long start = wireIn.bytes().readPosition();
@@ -135,11 +155,11 @@ public class VanillaWireParser implements WireParser {
     }
 
     /**
-     * Handles the scenario where an attempt to read a method name results in an empty value.
-     * Logs a warning about the situation and the contents leading up to this.
+     * Called when {@link ValueIn#text()} returns an empty name. Emits a warning
+     * with the surrounding bytes to aid debugging.
      *
-     * @param wireIn The wire input being parsed.
-     * @param start  The position in the wire input at which the method started.
+     * @param wireIn source of the bytes
+     * @param start  position at which the field began
      */
     private void parseOneEmpty(@NotNull WireIn wireIn, long start) {
         // Log a warning message indicating a potential misplaced method.
@@ -152,11 +172,12 @@ public class VanillaWireParser implements WireParser {
     }
 
     /**
-     * Parses binary data from the wire based on a method ID. If the ID is not mapped, the
-     * field number parselet is used to continue the parsing process.
+     * Handles binary wires that encode the field by numeric id. The id is read
+     * as a stop-bit long. If a parselet is registered for that id it is invoked;
+     * otherwise {@link #fieldNumberParselet} is called.
      *
-     * @param wireIn The wire input containing binary data.
-     * @throws InvalidMarshallableException if invalid marshallable data is encountered.
+     * @param wireIn binary wire to read from
+     * @throws InvalidMarshallableException if the wire contains malformed data
      */
     private void parseOneBinary(@NotNull WireIn wireIn) throws InvalidMarshallableException {
         long methodId = wireIn.readEventNumber();
@@ -174,6 +195,10 @@ public class VanillaWireParser implements WireParser {
         fieldNumberParselet.readOne(methodId, wireIn);
     }
 
+    /**
+     * Registers {@code valueInConsumer} for both the text and numeric forms of
+     * {@code key}.
+     */
     @NotNull
     @Override
     public VanillaWireParser register(@NotNull WireKey key, WireParselet valueInConsumer) {
@@ -181,12 +206,12 @@ public class VanillaWireParser implements WireParser {
     }
 
     /**
-     * Registers a WireParselet with a keyName. This method calculates the hashcode
-     * of the keyName and delegates to the private register method.
+     * Registers {@code valueInConsumer} to handle the field named {@code keyName}.
+     * Also associates it with {@code keyName.hashCode()} for binary ids.
      *
-     * @param keyName         The name of the key to register.
-     * @param valueInConsumer The WireParselet associated with the keyName.
-     * @return Returns the current instance of VanillaWireParser for method chaining.
+     * @param keyName         textual field name
+     * @param valueInConsumer parselet invoked for this field
+     * @return this parser instance
      */
     @NotNull
     public VanillaWireParser register(String keyName, WireParselet valueInConsumer) {
@@ -195,14 +220,12 @@ public class VanillaWireParser implements WireParser {
     }
 
     /**
-     * Registers a WireParselet with a given keyName and code.
-     * The keyName is stored in the namedConsumer map and the code
-     * with its corresponding keyName in the numberedConsumer map.
+     * Internal helper that stores the mapping in both the named and numbered maps.
      *
-     * @param keyName         The name of the key to register.
-     * @param code            The code associated with the keyName.
-     * @param valueInConsumer The WireParselet associated with the keyName.
-     * @return Returns the current instance of VanillaWireParser for method chaining.
+     * @param keyName         textual name of the field
+     * @param code            numeric id of the field
+     * @param valueInConsumer parselet invoked for this field
+     * @return this parser instance
      */
     private VanillaWireParser register(String keyName, int code, WireParselet valueInConsumer) {
         // Store the WireParselet in the namedConsumer map using the keyName.
@@ -213,6 +236,9 @@ public class VanillaWireParser implements WireParser {
         return this;
     }
 
+    /**
+     * Returns the parselet registered for {@code name} or {@code null} if none.
+     */
     @Override
     public WireParselet lookup(CharSequence name) {
         return namedConsumer.get(name);

--- a/src/main/java/net/openhft/chronicle/wire/WireParselet.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireParselet.java
@@ -18,20 +18,20 @@ package net.openhft.chronicle.wire;
 import net.openhft.chronicle.core.io.InvalidMarshallableException;
 
 /**
- * Represents a functional interface that can process wire input based on a given
- * character sequence key and a value input. The `WireParselet` can be seen as a
- * specific action or handler for a particular key found in the wire input.
+ * Functional interface invoked when a field name is parsed.
+ * It is typically registered with a {@link WireParser} to define how to
+ * deserialise the value associated with a specific field name.
  */
 @FunctionalInterface
 public interface WireParselet {
 
     /**
-     * Consumes and processes a wire input based on a given character sequence
-     * and a value input.
+     * Invoked with the field name and corresponding value.
      *
-     * @param s The character sequence (usually representing a key) from the wire input.
-     * @param in The value associated with the key in the wire input.
-     * @throws InvalidMarshallableException If there's an issue with processing the data.
+     * @param s   the field name that matched this parselet
+     * @param in  the {@link ValueIn} positioned at the value for {@code s}. Use it to
+     *            deserialise the value
+     * @throws InvalidMarshallableException if the value cannot be processed
      */
     void accept(CharSequence s, ValueIn in) throws InvalidMarshallableException;
 }

--- a/src/main/java/net/openhft/chronicle/wire/WireParser.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireParser.java
@@ -24,20 +24,34 @@ import org.jetbrains.annotations.NotNull;
 import java.util.function.Consumer;
 
 /**
- * Defines the interface for parsing arbitrary field-value data from wire input.
+ * Defines a contract for parsing field-value data from a {@link WireIn} stream.
+ * A {@code WireParser} typically maintains a set of {@link WireParselet} or
+ * {@link FieldNumberParselet} instances, each responsible for a particular
+ * field name or number encountered in the input. It orchestrates reading the
+ * field identifiers and dispatches to the relevant parselet to deserialise the
+ * value. As a {@link java.util.function.Consumer}{@code <WireIn>} it can
+ * process a whole document or a sequence of events within a wire.
  */
 public interface WireParser extends Consumer<WireIn> {
 
     /**
-     * A predefined parselet that skips all readable bytes in the wire.
+     * A predefined {@link FieldNumberParselet} that, when invoked, consumes and
+     * discards all remaining readable bytes in the current value or document
+     * context of the {@link WireIn}. This is often used as a default handler for
+     * unknown or uninteresting field numbers.
      */
     FieldNumberParselet SKIP_READABLE_BYTES = WireParser::skipReadable;
 
     /**
-     * Creates a new WireParser with a default consumer.
+     * Creates a new {@code WireParser} with a default consumer.
      *
-     * @param defaultConsumer The default consumer that handles the wire data when no specific handler is provided.
-     * @return A new WireParser instance.
+     * @param defaultConsumer the {@link WireParselet} to invoke when a field name
+     *                        read from the wire does not match any registered
+     *                        named parselets. This typically handles unknown
+     *                        fields or logs warnings.
+     * @return a new {@link VanillaWireParser} configured with the given default
+     *         consumer and {@link #SKIP_READABLE_BYTES} for unknown field
+     *         numbers.
      */
     @NotNull
     static WireParser wireParser(WireParselet defaultConsumer) {
@@ -45,11 +59,15 @@ public interface WireParser extends Consumer<WireIn> {
     }
 
     /**
-     * Creates a new WireParser with a default consumer and a custom field number parselet.
+     * Creates a new {@code WireParser} with a default consumer and a custom
+     * field number parselet.
      *
-     * @param defaultConsumer     The default consumer to handle the wire data when no specific handler is provided.
-     * @param fieldNumberParselet Custom field number parselet to handle field numbers in the wire data.
-     * @return A new WireParser instance.
+     * @param defaultConsumer     the {@link WireParselet} for unhandled named
+     *                             fields.
+     * @param fieldNumberParselet the {@link FieldNumberParselet} to invoke when
+     *                             a field number read from a binary wire does not
+     *                             match any registered numbered parselets.
+     * @return a new {@link VanillaWireParser} instance.
      */
     @NotNull
     static WireParser wireParser(@NotNull WireParselet defaultConsumer,
@@ -58,10 +76,14 @@ public interface WireParser extends Consumer<WireIn> {
     }
 
     /**
-     * Skips all readable bytes in the wire.
+     * Skips all readable bytes in the provided wire.
      *
-     * @param ignoreMethodId The method ID to ignore. (Currently unused in the method's logic)
-     * @param wire           The wire input source.
+     * @param ignoreMethodId the method id or field number that triggered this
+     *                       skip action. It is often unused by the skip logic
+     *                       itself but provided for context.
+     * @param wire           the {@link WireIn} whose current value's readable
+     *                       bytes should be skipped. This advances the read
+     *                       position to the end of the current value or context.
      */
     static void skipReadable(long ignoreMethodId, WireIn wire) {
         Bytes<?> bytes = wire.bytes();
@@ -69,27 +91,38 @@ public interface WireParser extends Consumer<WireIn> {
     }
 
     /**
-     * Retrieves the default consumer of this parser.
+     * Retrieves the {@link WireParselet} used when a field name encountered in
+     * the input does not match any explicitly registered parselet.
      *
-     * @return The default consumer.
+     * @return the default consumer for unmatched field names.
      */
     WireParselet getDefaultConsumer();
 
     /**
-     * Parses a single field-value data from the provided wire input.
+     * Parses a single field-value pair from the given {@link WireIn}. The method
+     * reads the field identifier (name or number) and dispatches to the
+     * appropriate registered {@link WireParselet} or
+     * {@link FieldNumberParselet} to deserialise the value. If no matching
+     * parselet is found the {@link #getDefaultConsumer()} or its numbered
+     * counterpart is used.
      *
-     * @param wireIn The wire input source.
-     * @throws InvocationTargetRuntimeException When there's a failure invoking the target action for a field.
-     * @throws InvalidMarshallableException     When the wire data cannot be marshaled into the desired format.
+     * @param wireIn the wire input source
+     * @throws InvocationTargetRuntimeException if invoking the target action
+     *                                          fails
+     * @throws InvalidMarshallableException     if the value cannot be
+     *                                          deserialised
      */
-    void parseOne(@NotNull WireIn wireIn) throws InvocationTargetRuntimeException, InvalidMarshallableException;
+    void parseOne(@NotNull WireIn wireIn)
+            throws InvocationTargetRuntimeException, InvalidMarshallableException;
 
     /**
-     * Default implementation for the Consumer's accept method. This method
-     * reads and processes data from the wire input, invoking the appropriate
-     * parselets for handling the data.
+     * Processes an entire document or event from {@code wireIn}. The default
+     * implementation repeatedly calls {@link #parseOne(WireIn)} until all fields
+     * within the current event or document have been consumed. Event boundaries
+     * are handled using {@link WireIn#startEvent()} and
+     * {@link WireIn#endEvent()}.
      *
-     * @param wireIn The wire input source.
+     * @param wireIn the wire input source
      */
     @Override
     default void accept(@NotNull WireIn wireIn) {
@@ -110,21 +143,24 @@ public interface WireParser extends Consumer<WireIn> {
     }
 
     /**
-     * Searches for a {@link WireParselet} associated with a given name.
+     * Searches for the {@link WireParselet} associated with the given field
+     * name.
      *
-     * @param name The name to search the associated {@link WireParselet} for.
-     * @return The found {@link WireParselet}, or {@code null} if not found.
+     * @param name the field name whose parselet is to be retrieved
+     * @return the matching {@link WireParselet}, or {@code null} if none exists
      */
     WireParselet lookup(CharSequence name);
 
     /**
-     * Attempts to register a new {@link WireParselet} for a given key. If a parselet
-     * is already registered with the same key, a warning is emitted and the new
-     * registration is ignored.
+     * Attempts to register a new {@link WireParselet} for the supplied key. If a
+     * parselet is already registered for that key a warning is emitted and the
+     * new registration is ignored.
      *
-     * @param key            The key to associate the parselet with.
-     * @param valueInConsumer The parselet to register.
-     * @return This instance for method chaining.
+     * @param key            the {@link WireKey} (providing both name and code)
+     *                       to associate with the parselet
+     * @param valueInConsumer the {@link WireParselet} to register for the key
+     * @return this {@code WireParser} instance, cast to {@link VanillaWireParser},
+     *         for fluent configuration
      */
     @NotNull
     default VanillaWireParser registerOnce(WireKey key, WireParselet valueInConsumer) {
@@ -138,11 +174,15 @@ public interface WireParser extends Consumer<WireIn> {
     }
 
     /**
-     * Registers a new {@link WireParselet} for a given key.
+     * Registers a {@link WireParselet} to handle fields matching the supplied
+     * {@link WireKey}. This typically registers the parselet for both the key's
+     * name and its code. If a parselet is already registered for the name this
+     * may overwrite it or log a warning, depending on the implementation (see
+     * {@link #registerOnce}).
      *
-     * @param key            The key to associate the parselet with.
-     * @param valueInConsumer The parselet to register.
-     * @return This instance for method chaining.
+     * @param key            the key to associate with the parselet
+     * @param valueInConsumer the parselet to register
+     * @return this instance for method chaining
      */
     @NotNull
     default VanillaWireParser register(WireKey key, WireParselet valueInConsumer) {
@@ -150,11 +190,13 @@ public interface WireParser extends Consumer<WireIn> {
     }
 
     /**
-     * Registers a new {@link WireParselet} for a given key name.
+     * Registers a {@link WireParselet} to handle fields matching the provided
+     * {@code keyName}. This typically also registers the parselet for a code
+     * derived from {@code keyName.hashCode()}.
      *
-     * @param keyName        The name of the key to associate the parselet with.
-     * @param valueInConsumer The parselet to register.
-     * @return This instance for method chaining.
+     * @param keyName        the name of the key to associate with the parselet
+     * @param valueInConsumer the parselet to register
+     * @return this instance for method chaining
      */
     @NotNull
     VanillaWireParser register(String keyName, WireParselet valueInConsumer);

--- a/src/main/java/net/openhft/chronicle/wire/WireParser.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireParser.java
@@ -106,14 +106,11 @@ public interface WireParser extends Consumer<WireIn> {
      * parselet is found the {@link #getDefaultConsumer()} or its numbered
      * counterpart is used.
      *
-     * @param wireIn the wire input source
-     * @throws InvocationTargetRuntimeException if invoking the target action
-     *                                          fails
-     * @throws InvalidMarshallableException     if the value cannot be
-     *                                          deserialised
+     * @param wireIn The wire input source.
+     * @throws InvocationTargetRuntimeException When there's a failure invoking the target action for a field.
+     * @throws InvalidMarshallableException     When the wire data cannot be marshaled into the desired format.
      */
-    void parseOne(@NotNull WireIn wireIn)
-            throws InvocationTargetRuntimeException, InvalidMarshallableException;
+    void parseOne(@NotNull WireIn wireIn) throws InvocationTargetRuntimeException, InvalidMarshallableException;
 
     /**
      * Processes an entire document or event from {@code wireIn}. The default
@@ -143,18 +140,17 @@ public interface WireParser extends Consumer<WireIn> {
     }
 
     /**
-     * Searches for the {@link WireParselet} associated with the given field
-     * name.
+     * Searches for a {@link WireParselet} associated with a given name.
      *
-     * @param name the field name whose parselet is to be retrieved
-     * @return the matching {@link WireParselet}, or {@code null} if none exists
+     * @param name The name to search the associated {@link WireParselet} for.
+     * @return The found {@link WireParselet}, or {@code null} if not found.
      */
     WireParselet lookup(CharSequence name);
 
     /**
-     * Attempts to register a new {@link WireParselet} for the supplied key. If a
-     * parselet is already registered for that key a warning is emitted and the
-     * new registration is ignored.
+     * Attempts to register a new {@link WireParselet} for a given key. If a parselet
+     * is already registered with the same key, a warning is emitted and the new
+     * registration is ignored.
      *
      * @param key            the {@link WireKey} (providing both name and code)
      *                       to associate with the parselet


### PR DESCRIPTION

### What’s inside?

| Area                  | Files touched                                                                                      | Summary                                                                                                                                                              |
| --------------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| **BitSet internals**  | `BitSetUtil.java`                                                                                  | • Added prominent warning about reflective access<br>• Re-documented field semantics & exceptions                                                                    |
| **Public BitSet API** | `ChronicleBitSet.java`<br>`LongArrayValueBitSet.java`<br>`LongValueBitSet.java`                    | • Full Javadoc for every method & constant<br>• Clearer parameter/exception contracts<br>• Highlighted off-heap / fixed-capacity caveats                             |
| **Wire parsing SPI**  | `FieldNumberParselet.java`<br>`WireParselet.java`<br>`WireParser.java`<br>`VanillaWireParser.java` | • Re-wrote high-level docs explaining binary- vs text-field dispatch<br>• Documented default handlers & error-paths<br>• Tightened parameter names & `@return` notes |
| **Misc. constants**   | minor tweaks across files                                                                          | • `WORD_MASK`, `BITS_PER_WORD` now clarified in-line                                                                                                                 |

> **Code behaviour is unchanged** – only comments, Javadoc and variable names that do **not** leak into public byte-code were touched.
