### PR TITLE
Deep-dive Javadoc sweep & internal comment clean-up

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/Comment.java
+++ b/src/main/java/net/openhft/chronicle/wire/Comment.java
@@ -21,11 +21,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * The Comment annotation represents a way to attach user-defined comments to elements like fields,
- * parameters, or types. This can be especially useful for documenting the intention, usage, or any other
- * relevant information about the annotated element at runtime.
- * <p>
- * Being retained at runtime, it can be inspected via reflection to influence behavior based on the comment's content.
+ * The Comment annotation represents a way to attach user-defined comments to elements
+ * such as fields, parameters or types. This can be especially useful for documenting
+ * the intention, usage or any other information about the annotated element at
+ * runtime. Being retained at runtime, it can be inspected via reflection to influence
+ * behaviour based on the comment's content. For example, a {@link WireOut}
+ * implementation might choose to write the comment's value into the serialised output
+ * if the wire format supports comments (for example YAML).
  */
 @Retention(RetentionPolicy.RUNTIME)  // This annotation is available at runtime.
 @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE})  // Specifies the kinds of elements this annotation can be applied to.

--- a/src/main/java/net/openhft/chronicle/wire/CommentAnnotationNotifier.java
+++ b/src/main/java/net/openhft/chronicle/wire/CommentAnnotationNotifier.java
@@ -16,16 +16,22 @@
 package net.openhft.chronicle.wire;
 
 /**
- * Represents an interface to notify whether a certain element has a preceding comment annotation.
- * Implementers can use this to handle scenarios where knowledge of preceding comments is required.
+ * <b>INTERNAL USE ONLY.</b> This interface is used by some {@link ValueOut}
+ * implementations (for example for YAML) to signal to
+ * {@link net.openhft.chronicle.wire.WireMarshaller.FieldAccess} that a
+ * {@link Comment} annotation is present on a field. This allows the
+ * {@code FieldAccess} to format the comment using the field's value after the
+ * value itself has been written.
  */
 interface CommentAnnotationNotifier {
 
     /**
-     * Notifies the implementer whether a certain element has a preceding comment annotation.
+     * Notifies the implementer whether a certain element has a preceding comment
+     * annotation.
      *
-     * @param hasCommentAnnotation A flag indicating if the element has a preceding comment.
-     *                             True if it has, otherwise false.
+     * @param hasCommentAnnotation {@code true} if a {@link Comment} annotation is
+     *                             associated with the field about to be written,
+     *                             {@code false} otherwise.
      */
     void hasPrecedingComment(boolean hasCommentAnnotation);
 }

--- a/src/main/java/net/openhft/chronicle/wire/ReflectionUtil.java
+++ b/src/main/java/net/openhft/chronicle/wire/ReflectionUtil.java
@@ -31,21 +31,31 @@ import java.util.List;
  */
 public final class ReflectionUtil {
 
-    // Configuration flag to determine if package name should be prepended
-    private static final boolean PREPEND_PACKAGE = Jvm.getBoolean("wire.method.prependPackage");
-    // Base package prefix for generated names
-    private static final String PACKAGE_PREFIX = "net.openhft.chronicle.wire.method";
+    /**
+     * System property ({@code wire.method.prependPackage}) flag. If true,
+     * {@link #generatedPackageName(String)} will always prepend
+     * {@link #PACKAGE_PREFIX} to the package name.
+     */
+    private static final boolean PREPEND_PACKAGE =
+            Jvm.getBoolean("wire.method.prependPackage");
+
+    /**
+     * The base package prefix ({@code net.openhft.chronicle.wire.method}) used
+     * by {@link #generatedPackageName(String)} when prepending is active.
+     */
+    private static final String PACKAGE_PREFIX =
+            "net.openhft.chronicle.wire.method";
 
     // Private constructor to prevent instantiation
     private ReflectionUtil() {
     }
 
     /**
-     * Creates and returns a new List of all interfaces implemented by
+     * Creates and returns a new {@link List} of all interfaces implemented by
      * the provided {@code oClass} and all its super classes.
      *
-     * @param oClass The class to inspect.
-     * @return A list of interfaces implemented by the given class and its ancestors.
+     * @param oClass The class whose implemented interfaces (including inherited ones) are to be retrieved.
+     * @return A new {@link List} of all unique interfaces implemented by {@code oClass} and its superclass hierarchy.
      */
     public static List<Class<?>> interfaces(@NotNull final Class<?> oClass) {
         final List<Class<?>> list = new ArrayList<>();
@@ -53,7 +63,10 @@ public final class ReflectionUtil {
         return list;
     }
 
-    // Recursively gather interfaces from the given class and its superclasses
+    /**
+     * Recursively populates the {@code list} with interfaces implemented by
+     * {@code oClass} and its superclasses, stopping at {@code java.lang.Object}.
+     */
     private static void interfaces(final Class<?> oClass, final List<Class<?>> list) {
         final Class<?> baseClass = oClass.getSuperclass();
         if (baseClass == null)
@@ -64,12 +77,14 @@ public final class ReflectionUtil {
     }
 
     /**
-     * Generates a package name based on a given class full name.
-     * If the class belongs to specific packages (like 'java.', 'javax.', 'com.sun.'),
-     * or if the {@code PREPEND_PACKAGE} flag is set, the generated package name
-     * will be prefixed with {@code PACKAGE_PREFIX}.
+     * Generates a package name based on the supplied class name. If the class
+     * resides in a reserved package such as {@code java.} or if
+     * {@link #PREPEND_PACKAGE} is true, the resulting name will be prefixed with
+     * {@link #PACKAGE_PREFIX}.
      *
-     * @param classFullName The full name of the class.
+     * @param classFullName The fully qualified name of the class for which to
+     *                      generate a potentially modified package name (e.g.,
+     *                      for generated proxy classes).
      * @return The generated package name.
      */
     @NotNull

--- a/src/main/java/net/openhft/chronicle/wire/RollbackIfNotCompleteNotifier.java
+++ b/src/main/java/net/openhft/chronicle/wire/RollbackIfNotCompleteNotifier.java
@@ -16,16 +16,22 @@
 package net.openhft.chronicle.wire;
 
 /**
- * The RollbackIfNotCompleteNotifier interface defines methods to handle rollback scenarios
- * in the event of incomplete operations or messages. Implementations of this interface
- * can ensure data integrity and consistency by rolling back changes if an operation
- * does not complete successfully.
+ * The RollbackIfNotCompleteNotifier interface defines methods to handle rollback
+ * scenarios in the event of incomplete operations or messages. Implementations
+ * of this interface can ensure data integrity and consistency by rolling back
+ * changes if an operation does not complete successfully. This is typically
+ * implemented by {@link DocumentContext} objects, particularly
+ * {@link WriteDocumentContext}, to allow writers to discard partially written
+ * messages.
  */
 public interface RollbackIfNotCompleteNotifier {
     /**
-     * Rolls back the current operation if it is not complete. This method should be
-     * invoked to ensure data consistency and to prevent partial updates. Implementations
-     * may throw an UnsupportedOperationException if rollback is not supported.
+     * Rolls back the current operation if it is not complete. If the current
+     * document or operation managed by this notifier is in an incomplete state
+     * (for example as indicated by {@link DocumentContext#isNotComplete()}), this
+     * method should attempt to roll back any changes made within the current
+     * context, effectively discarding them. If rollback is not supported or not
+     * applicable, an {@link UnsupportedOperationException} may be thrown.
      *
      * @throws UnsupportedOperationException if the rollback operation is not supported
      */
@@ -34,8 +40,10 @@ public interface RollbackIfNotCompleteNotifier {
     }
 
     /**
-     * Checks if the current writing operation is complete. This method can be used to
-     * determine if it's safe to proceed with further operations or if a rollback is required.
+     * Checks if the current writing operation is complete. Returns {@code true}
+     * by default, indicating completion. Implementations should override this to
+     * reflect the actual completion status of their write operation (for
+     * example, the inverse of {@link DocumentContext#isNotComplete()}).
      *
      * @return true if the current operation is complete, false otherwise
      */

--- a/src/main/java/net/openhft/chronicle/wire/WireDumper.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireDumper.java
@@ -27,20 +27,21 @@ import org.jetbrains.annotations.Nullable;
 @SuppressWarnings("rawtypes")
 public class WireDumper {
 
-    // Instance of WireIn to read from
+    /** The {@link WireIn} source whose content is being dumped. */
     @NotNull
     private final WireIn wireIn;
 
-    // Bytes that encapsulate the raw data
+    /** The underlying {@link Bytes} instance from {@link #wireIn}. */
     @NotNull
     private final Bytes<?> bytes;
 
-    // Tracks the header number for internal operations
+    /** Internal counter for tracking header/document numbers in the dump output. */
     private long headerNumber = -1;
 
     /**
-     * Private constructor for WireDumper.
-     * It initializes the wireIn and bytes. If wireIn is null, a new BinaryWire is created.
+     * Private constructor, use the static factory methods such as
+     * {@link #of(WireIn)}. If {@code wireIn} is {@code null} the bytes are
+     * wrapped in a new {@link BinaryWire}.
      *
      * @param wireIn WireIn instance (nullable)
      * @param bytes  Bytes instance containing the raw data
@@ -53,7 +54,7 @@ public class WireDumper {
     }
 
     /**
-     * Factory method to create a new WireDumper instance given a {@link WireIn} object.
+     * Creates a {@code WireDumper} for the given {@link WireIn} instance.
      *
      * @param wireIn The WireIn instance to be dumped
      * @return A new WireDumper instance
@@ -64,8 +65,9 @@ public class WireDumper {
     }
 
     /**
-     * Factory method to create a new WireDumper instance given a {@link Bytes} object.
-     * This method uses default padding alignment.
+     * Creates a {@code WireDumper} for the given {@link Bytes} instance,
+     * implicitly treating it as a {@link BinaryWire}. This method uses
+     * the default padding alignment.
      *
      * @param bytes The Bytes object containing the raw data to be dumped
      * @return A new WireDumper instance
@@ -76,10 +78,13 @@ public class WireDumper {
     }
 
     /**
-     * Factory method to create a new WireDumper instance given a {@link Bytes} object and an alignment preference.
+     * Creates a {@code WireDumper} for the given {@link Bytes} instance,
+     * implicitly treating it as a {@link BinaryWire}. The {@code align}
+     * parameter controls whether padding is assumed (see
+     * {@link AbstractWire#DEFAULT_USE_PADDING}).
      *
      * @param bytes The Bytes object containing the raw data to be dumped
-     * @param align Boolean value indicating whether to align the dumped data
+     * @param align Whether to use padding alignment
      * @return A new WireDumper instance
      */
     @SuppressWarnings("deprecation")
@@ -91,10 +96,9 @@ public class WireDumper {
     }
 
     /**
-     * Obtains a string representation of the entire content present in the bytes.
-     * This method uses default abbreviated format.
+     * Dumps the entire readable content of the wire as a string.
      *
-     * @return String representation of the content
+     * @return A string representation of the wire content
      */
     @NotNull
     public String asString() {
@@ -102,11 +106,10 @@ public class WireDumper {
     }
 
     /**
-     * Obtains a string representation of the content from the current read position.
-     * The length of content to be represented is determined by the remaining bytes to be read.
+     * Dumps the entire readable content of the wire as a string.
      *
-     * @param abbrev Boolean value indicating whether to use abbreviated format
-     * @return String representation of the content from the current read position
+     * @param abbrev If true, long content within individual messages might be abbreviated
+     * @return A string representation of the wire content
      */
     @NotNull
     public String asString(boolean abbrev) {
@@ -114,12 +117,12 @@ public class WireDumper {
     }
 
     /**
-     * Returns a string representation of the content located at the given position and length in the bytes.
-     * This method uses the default abbreviated format.
+     * Dumps a specific region of the wire content, starting at {@code position}
+     * for {@code length} bytes, as a string.
      *
-     * @param position Starting position of the content to be represented
-     * @param length   Length of the content to be represented
-     * @return String representation of the specified content
+     * @param position The starting byte position in the wire's underlying buffer
+     * @param length   The number of bytes to dump from the starting position
+     * @return A string representation of the specified wire content region
      */
     @NotNull
     public String asString(long position, long length) {
@@ -127,13 +130,13 @@ public class WireDumper {
     }
 
     /**
-     * Returns a string representation of the content located at the given position and length in the bytes.
-     * The method provides an option to use an abbreviated format.
+     * Dumps a specific region of the wire content, starting at {@code position}
+     * for {@code length} bytes, as a string.
      *
-     * @param position Starting position of the content to be represented
-     * @param length   Length of the content to be represented
-     * @param abbrev   Boolean value indicating whether to use abbreviated format
-     * @return String representation of the specified content
+     * @param position The starting byte position in the wire's underlying buffer
+     * @param length   The number of bytes to dump from the starting position
+     * @param abbrev   If true, long content within individual messages might be abbreviated
+     * @return A string representation of the specified wire content region
      */
     @NotNull
     public String asString(long position, long length, boolean abbrev) {
@@ -166,25 +169,25 @@ public class WireDumper {
     }
 
     /**
-     * Dumps a single wire entry from the internal byte buffer to the provided StringBuilder.
-     * This method uses the default abbreviated format.
+     * Reads and dumps a single size-prefixed message from the wire into the
+     * supplied {@code sb}. This method uses the default abbreviated format.
      *
-     * @param sb     StringBuilder to which the wire entry will be appended
-     * @param buffer Temporary buffer to assist in dumping the wire entry
-     * @return Boolean value indicating whether the dump was successful
+     * @param sb     The {@link StringBuilder} to append the dumped message to
+     * @param buffer A temporary {@link Bytes} buffer used if the source message is binary
+     * @return {@code true} if the end of the wire was reached, {@code false} otherwise
      */
     public boolean dumpOne(@NotNull StringBuilder sb, @Nullable Bytes<?> buffer) {
         return dumpOne(sb, buffer, false);
     }
 
     /**
-     * Dumps a single wire entry from the internal byte buffer to the provided StringBuilder.
-     * This method provides an option to use an abbreviated format.
+     * Reads and dumps a single size-prefixed message from the wire into the
+     * supplied {@code sb}.
      *
-     * @param sb     StringBuilder to which the wire entry will be appended
-     * @param buffer Temporary buffer to assist in dumping the wire entry
-     * @param abbrev Boolean value indicating whether to use abbreviated format
-     * @return Boolean value indicating whether the dump was successful
+     * @param sb     The {@link StringBuilder} to append the dumped message to
+     * @param buffer A temporary {@link Bytes} buffer used if the source message is binary; may be {@code null}
+     * @param abbrev If true, abbreviates content
+     * @return {@code true} if the end of the wire was reached, {@code false} otherwise
          */
     public boolean dumpOne(@NotNull StringBuilder sb, @Nullable Bytes<?> buffer, boolean abbrev) {
         // Read position in the byte buffer for extracting the header
@@ -315,14 +318,13 @@ public class WireDumper {
     }
 
     /**
-     * Dumps the content of the byte buffer as a hexadecimal representation into the provided StringBuilder.
-     * It positions the bytes at the specified read position, converts the content to hexadecimal, and sets
-     * the resulting string to the StringBuilder.
+     * Dumps the content of the byte buffer as a hexadecimal representation into
+     * the provided {@code sb}.
      *
-     * @param sb The StringBuilder to which the hexadecimal string will be appended.
-     * @param len The length or number of bytes to read and convert to hexadecimal.
-     * @param readPosition The starting position in the byte buffer from which to start reading.
-     * @param sblen The length to reset the StringBuilder to. This is typically used to overwrite any existing content.
+     * @param sb          The {@link StringBuilder} to append the hexadecimal dump to
+     * @param len         The number of bytes to read from {@link #bytes} and dump
+     * @param readPosition The starting position in {@link #bytes} to read from
+     * @param sblen       The length to which {@code sb} should be reset before appending the hex dump
      */
     public void dumpAsHexadecimal(@NotNull StringBuilder sb, int len, long readPosition, int sblen) {
         // Set the read position and remaining length for the byte buffer.

--- a/src/main/java/net/openhft/chronicle/wire/WireKey.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireKey.java
@@ -23,21 +23,20 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Represents a unique identifier or key for wiring protocols. This interface can
- * be used to encode or decode structured data, and it provides methods for getting
- * the name and the default value of the key, as well as utility methods for
- * working with the key's code.
+ * Represents a unique identifier or key for wiring protocols.
+ * This is a functional interface where {@link #name()} is the primary method.
+ * Implementations are typically enums or small classes.
+ * A {@code WireKey} associates a textual name with a numeric {@link #code()} for use in binary wire formats.
  */
 @FunctionalInterface
 public interface WireKey {
 
     /**
-     * Checks if the provided array of WireKey objects have unique codes.
-     * Throws an AssertionError if two or more keys have the same code.
+     * Checks that each entry uses a distinct {@link #code()} value.
      *
-     * @param keys An array of WireKey objects to check.
-     * @return Returns true if all keys have unique codes.
-     * @throws AssertionError if two or more keys have the same code.
+     * @param keys An array of {@code WireKey} objects to be checked for unique {@link #code()} values.
+     * @return {@code true} if all codes are unique.
+     * @throws AssertionError if two or more keys share the same code.
      */
     static boolean checkKeys(@NotNull WireKey[] keys) {
         @NotNull Map<Integer, WireKey> codes = new HashMap<>();
@@ -50,12 +49,11 @@ public interface WireKey {
     }
 
     /**
-     * Converts the provided CharSequence into a code. If the CharSequence starts
-     * with a digit, it attempts to parse it as an integer. Otherwise, it returns
-     * the hash code of the CharSequence.
+     * Converts a textual name to a numeric code.
+     * If the text begins with a digit it is parsed as an integer, otherwise its hash code is used.
      *
-     * @param cs CharSequence to convert.
-     * @return The converted code.
+     * @param cs The {@link CharSequence} (typically a field or event name) to convert into a numeric code.
+     * @return the derived code.
      */
     static int toCode(@NotNull CharSequence cs) {
         @NotNull String s = cs.toString();
@@ -69,28 +67,29 @@ public interface WireKey {
     }
 
     /**
-     * Retrieves the name of the WireKey.
+     * Returns the textual name of this key.
+     * This is often used in text-based wire formats or for debugging.
      *
-     * @return Name of the WireKey.
+     * @return the name of this key.
      */
     @NotNull
     CharSequence name();
 
     /**
-     * Calculates the code of the WireKey based on its name.
-     * By default, it uses the {@link #toCode(CharSequence)} method.
+     * Returns a numeric code for this key, typically derived from its {@link #name()}.
+     * By default this delegates to {@link #toCode(CharSequence)}.
      *
-     * @return Code of the WireKey.
+     * @return the code for this key.
      */
     default int code() {
         return toCode(name());
     }
 
     /**
-     * Determines the type of the WireKey based on its default value.
-     * If the default value is null, it returns Void.class.
+     * Returns the {@link java.lang.reflect.Type} associated with the value this key typically represents,
+     * inferred from {@link #defaultValue()}. Returns {@code Void.class} if no default value is defined.
      *
-     * @return Type of the WireKey.
+     * @return the associated type.
      */
     default Type type() {
         @Nullable Object o = defaultValue();
@@ -98,9 +97,10 @@ public interface WireKey {
     }
 
     /**
-     * Retrieves the default value associated with this WireKey.
+     * Returns the default value for the field or event represented by this key.
+     * Deserialisers may use this if the key is absent. {@code null} indicates no default.
      *
-     * @return Default value of the WireKey, or null if not defined.
+     * @return the default value or {@code null}.
      */
     @Nullable
     default Object defaultValue() {
@@ -108,11 +108,11 @@ public interface WireKey {
     }
 
     /**
-     * Checks if the provided CharSequence content matches the string representation
-     * of this WireKey.
+     * Compares the string representation of this {@code WireKey} (obtained via {@code this.toString()})
+     * with the provided {@link CharSequence} {@code c} for content equality.
      *
-     * @param c CharSequence to compare with.
-     * @return True if content matches, otherwise false.
+     * @param c The {@link CharSequence} to compare against this key's string form.
+     * @return {@code true} if the contents are equal.
      */
     default boolean contentEquals(@NotNull CharSequence c) {
         return this.toString().contentEquals(c);

--- a/src/main/java/net/openhft/chronicle/wire/WireType.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireType.java
@@ -48,14 +48,21 @@ import static net.openhft.chronicle.core.io.IOTools.*;
 
 /**
  * Enumerates a selection of prebuilt wire types. These wire types define specific ways
- * data can be serialized and deserialized.
+ * data can be serialised and deserialised. Each enum constant acts as a factory
+ * ({@code Function&lt;Bytes&lt;?>, Wire>}) creating a concrete {@link Wire} instance
+ * initialised with a provided {@link Bytes} buffer.
  * <p>
- * It also provides methods to acquire bytes,
- * useful in serialization operations.
+ * Helper methods are supplied to obtain temporary {@link Bytes} for
+ * serialisation operations.
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
 
+    /**
+     * A human-readable, YAML-like text wire format. If the system property
+     * {@code wire.testAsYaml} is true it behaves like {@link #YAML}.
+     * Uses binary documents and padding by default.
+     */
     TEXT {
         private final boolean TEXT_AS_YAML = Jvm.getBoolean("wire.testAsYaml");
 
@@ -102,7 +109,8 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
         }
     },
     /**
-     * With the removal of DeltaWire, this is the same as BINARY_LIGHT
+     * High performance binary wire format. This is an alias for
+     * {@link #BINARY_LIGHT}.
      */
     BINARY {
         @NotNull
@@ -124,7 +132,8 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
         }
     },
     /**
-     * Use this when only need to use Binary (does not support DeltaWire)
+     * High performance binary wire format optimised for speed and size.
+     * Does not support legacy DeltaWire features.
      */
     BINARY_LIGHT {
         @NotNull
@@ -145,6 +154,10 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
             return fromHexString(cs);
         }
     },
+    /**
+     * Compact binary wire format that omits field names. Deserialisation relies
+     * on DTO field order.
+     */
     FIELDLESS_BINARY {
         @NotNull
         @Override
@@ -165,7 +178,9 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
         }
     },
     /**
-     * To be removed in X.29 - use BINARY_LIGHT instead
+     * <b>Deprecated: To be removed in x.29. Use {@link #BINARY_LIGHT}.</b>
+     * Binary wire format that formerly supported LZW style compression for
+     * messages exceeding {@link #COMPRESSED_SIZE}.
      */
     @Deprecated
     COMPRESSED_BINARY {
@@ -188,6 +203,10 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
         }
     },
     // for backward compatibility, this doesn't support types
+    /**
+     * JSON-compliant text wire format. Uses binary documents and padding by
+     * default and does not include type prefixes unless configured.
+     */
     JSON {
         @SuppressWarnings("deprecation")
         @NotNull
@@ -209,6 +228,11 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
             return asUtf8String(marshallable);
         }
     },
+    /**
+     * JSON-compliant text wire format that uses explicit type prefixes and
+     * text document delimiters. The first curly brace is not trimmed by
+     * default.
+     */
     JSON_ONLY {
         @NotNull
         @Override
@@ -226,6 +250,10 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
             return asUtf8String(marshallable);
         }
     },
+    /**
+     * YAML-compliant text wire format. Uses binary documents and padding by
+     * default.
+     */
     YAML {
         @SuppressWarnings("deprecation")
         @NotNull
@@ -241,6 +269,10 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
             return true;
         }
     },
+    /**
+     * YAML-compliant text wire format using text document delimiters
+     * such as {@code ---} and {@code ...}.
+     */
     YAML_ONLY {
         @NotNull
         @Override
@@ -253,6 +285,10 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
             return true;
         }
     },
+    /**
+     * Raw binary wire format with minimal metadata. Ideal for fixed-layout
+     * data and offers the highest performance.
+     */
     RAW {
         @NotNull
         @Override
@@ -272,6 +308,9 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
             return fromHexString(cs);
         }
     },
+    /**
+     * Comma Separated Values text wire format.
+     */
     CSV {
         @NotNull
         @Override
@@ -284,6 +323,10 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
             return true;
         }
     },
+    /**
+     * Special wire type that detects either {@link #TEXT} or {@link #BINARY}
+     * (including {@link #FIELDLESS_BINARY}) by inspecting the input stream.
+     */
     READ_ANY {
         @NotNull
         @Override
@@ -295,6 +338,10 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
     // Size after which data is compressed.
     private static final int COMPRESSED_SIZE = Integer.getInteger("WireType.compressedSize", 128);
 
+    /**
+     * Serialises {@code marshallable} using this wire type into an in-memory
+     * buffer and returns the result as a UTF-8 string.
+     */
     protected @NotNull String asUtf8String(Object marshallable) {
         ValidatableUtil.startValidateDisabled();
         try (ScopedResource<Bytes<Void>> stlBytes = Wires.acquireBytesScoped()) {
@@ -307,13 +354,12 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
     }
 
     /**
-     * Determines the  of a given {@link Wire} instance. This method inspects
-     * the underlying type of the provided wire instance and maps it to its corresponding
-     * WireType.
+     * Determines the {@code WireType} of a given {@link Wire}. The concrete
+     * wire is inspected and mapped to the matching enum constant.
      *
-     * @param wire The wire instance whose type needs to be determined.
-     * @return The corresponding WireType of the given wire, or null if the input wire is null.
-     * @throws IllegalStateException If the wire type is unrecognized.
+     * @param wire the wire instance to examine
+     * @return the matching {@code WireType} or {@code null} if {@code wire} is null
+     * @throws IllegalStateException if the type is unknown
      */
     @Nullable
     public static WireType valueOf(@Nullable Wire wire) {
@@ -391,12 +437,11 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
     }
 
     /**
-     * Converts a given marshallable object to its string representation.
-     * This method ensures the object is first converted to a byte buffer,
-     * and then the buffer's contents are returned as a string.
+     * Serialises the supplied object using this wire type and returns the
+     * resulting text (or hex) representation.
      *
-     * @param marshallable The object to be converted to string.
-     * @return The string representation of the object.
+     * @param marshallable object to encode
+     * @return the string representation
      */
     public String asString(Object marshallable) {
         ValidatableUtil.startValidateDisabled();
@@ -410,13 +455,12 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
     }
 
     /**
-     * Converts the given marshallable object to a {@link Bytes} buffer.
-     * This method uses various strategies to serialize different types of
-     * objects to a byte buffer, e.g., WriteMarshallable, Map, Iterable, etc.
+     * Serialises {@code marshallable} using this wire type into the supplied
+     * {@link Bytes} buffer. Maps, iterables and other common types are handled
+     * transparently.
      *
-     * @param marshallable The object to be converted to bytes.
-     * @return A Bytes buffer containing the serialized form of the object.
-     * @throws InvalidMarshallableException If the object cannot be serialized properly.
+     * @param marshallable the object to serialise
+     * @throws InvalidMarshallableException if the object cannot be encoded
      */
     @NotNull
     private void asBytes(Object marshallable, Bytes<?> bytes) throws InvalidMarshallableException {
@@ -439,12 +483,12 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
     }
 
     /**
-     * deserializes with an optimistic cast
+     * Deserialises an object of an inferred type from the provided text.
      *
-     * @param cs  text to deserialize
-     * @param <T> the type to expect
-     * @return the object deserialized
-     * @throws ClassCastException if the object is not a T
+     * @param cs  text to read
+     * @param <T> expected type
+     * @return the object deserialised
+     * @throws ClassCastException if the object is not of type {@code T}
      */
     @Nullable
     public <T> T fromString(@NotNull CharSequence cs) throws InvalidMarshallableException {
@@ -452,11 +496,11 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
     }
 
     /**
-     * deserializes as a given class
+     * Deserialises an object of the given type from the provided text.
      *
-     * @param tClass to serialize as
-     * @param cs     text to deserialize
-     * @return the object deserialized
+     * @param tClass the expected type
+     * @param cs     text to parse
+     * @return the object deserialised
      */
     public <T> T fromString(Class<T> tClass, @NotNull CharSequence cs) throws InvalidMarshallableException {
         if (cs.length() == 0)
@@ -472,6 +516,10 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
         }
     }
 
+    /**
+     * Internal helper that removes a single {@code null} element from
+     * collections created when reading certain empty lists.
+     */
     private void cleanNullCollections(Object object) {
         if (object == null) return;
         Field[] declaredFields = object.getClass().getDeclaredFields();
@@ -497,13 +545,13 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
     }
 
     /**
-     * Deserializes an object of generic type from a file.
+     * Deserialises a {@link Marshallable} from the given file.
      *
-     * @param filename The path to the file containing the serialized object.
-     * @param <T> The type of the object to be deserialized.
-     * @return The deserialized object.
-     * @throws IOException If there's an error reading the file.
-     * @throws InvalidMarshallableException If the object cannot be properly deserialized.
+     * @param filename path to the input file
+     * @param <T>      the desired type
+     * @return the object read from the file
+     * @throws IOException                   if the file cannot be read
+     * @throws InvalidMarshallableException if decoding fails
      */
     @NotNull
     public <T> T fromFile(String filename) throws IOException, InvalidMarshallableException {
@@ -511,14 +559,15 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
     }
 
     /**
-     * Deserializes an object of a specified type from a file.
+     * Deserialises an object of the given type from a file produced in this
+     * wire format.
      *
-     * @param expectedType The expected type of the object to be deserialized.
-     * @param filename The path to the file containing the serialized object.
-     * @param <T> The type of the object to be deserialized.
-     * @return The deserialized object, or null if the object could not be deserialized.
-     * @throws IOException If there's an error reading the file.
-     * @throws InvalidMarshallableException If the object cannot be properly deserialized.
+     * @param expectedType type to read
+     * @param filename     input file path
+     * @param <T>          object type
+     * @return the object read from the file
+     * @throws IOException                   if the file cannot be read
+     * @throws InvalidMarshallableException if decoding fails
      */
     @Nullable
     public <T> T fromFile(@NotNull Class<T> expectedType, String filename) throws IOException, InvalidMarshallableException {
@@ -541,12 +590,12 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
     }
 
     /**
-     * Streams objects of generic type from a file.
+     * Deserialises a sequence of objects from the specified file.
      *
-     * @param filename The path to the file containing the serialized objects.
-     * @param <T> The type of the objects to be streamed.
-     * @return A stream of the deserialized objects.
-     * @throws IOException If there's an error reading the file.
+     * @param filename file to read
+     * @param <T>      object type
+     * @return a stream of objects
+     * @throws IOException if the file cannot be read
      */
     @NotNull
     public <T> Stream<T> streamFromFile(String filename) throws IOException {
@@ -554,13 +603,13 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
     }
 
     /**
-     * Streams objects of a specified type from a file.
+     * Deserialises objects of the given type from a file.
      *
-     * @param expectedType The expected type of the objects to be streamed.
-     * @param filename The path to the file containing the serialized objects.
-     * @param <T> The type of the objects to be streamed.
-     * @return A stream of the deserialized objects.
-     * @throws IOException If there's an error reading the file.
+     * @param expectedType expected object type
+     * @param filename     file to read
+     * @param <T>          object type
+     * @return a stream of objects
+     * @throws IOException if the file cannot be read
      */
     @NotNull
     public <T> Stream<T> streamFromFile(@NotNull Class<T> expectedType, String filename) throws IOException {
@@ -569,12 +618,13 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
     }
 
     /**
-     * Streams objects of a specified type from a {@link Bytes} instance.
+     * Creates a {@link Stream} of objects by deserialising documents from the
+     * provided {@link Bytes} buffer.
      *
-     * @param expectedType The expected type of the objects to be streamed.
-     * @param b The {@link Bytes} instance containing the serialized objects.
-     * @param <T> The type of the objects to be streamed.
-     * @return A stream of the deserialized objects.
+     * @param expectedType expected object type
+     * @param b            source bytes
+     * @param <T>          object type
+     * @return a stream of objects
      */
     @NotNull
     public <T> Stream<T> streamFromBytes(@NotNull Class<T> expectedType, Bytes<?> b) {
@@ -607,12 +657,14 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
     }
 
     /**
-     * Writes a {@link WriteMarshallable} object to a file.
+     * Serialises {@code marshallable} to {@code filename} using this wire type.
+     * The data is first written to a temporary file which is then renamed for
+     * atomicity.
      *
-     * @param filename The name of the file to write to.
-     * @param marshallable The object to write.
-     * @throws IOException If there's an error writing to the file.
-     * @throws InvalidMarshallableException If the object cannot be properly serialized.
+     * @param filename     target file
+     * @param marshallable object to write
+     * @throws IOException                   if the file cannot be written
+     * @throws InvalidMarshallableException if encoding fails
      */
     public void toFile(@NotNull String filename, WriteMarshallable marshallable) throws IOException, InvalidMarshallableException {
         String tempFilename = tempName(filename);
@@ -630,10 +682,11 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
     }
 
     /**
-     * Converts a Marshallable object to its HexString representation.
+     * Serialises {@code marshallable} and returns a hexadecimal string
+     * representation. Used by binary wire types for their text form.
      *
-     * @param marshallable The object to convert.
-     * @return A HexString representation of the object.
+     * @param marshallable object to encode
+     * @return hex string of the encoded data
      */
     @NotNull
     String asHexString(Object marshallable) {
@@ -648,12 +701,13 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
     }
 
     /**
-     * Deserializes an object from its HexString representation.
+     * Deserialises an object from a hexadecimal string. Used by binary wire
+     * types for {@link #fromString(CharSequence)} implementations.
      *
-     * @param s The HexString to deserialize from.
-     * @param <T> The type of the deserialized object.
-     * @return The deserialized object.
-     * @throws InvalidMarshallableException If the HexString cannot be properly deserialized.
+     * @param s   hex string to parse
+     * @param <T> object type
+     * @return the deserialised object
+     * @throws InvalidMarshallableException if decoding fails
      */
     @Nullable <T> T fromHexString(@NotNull CharSequence s) throws InvalidMarshallableException {
         Bytes<?> bytes = Bytes.fromHexString(s.toString());
@@ -666,11 +720,11 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
     }
 
     /**
-     * Converts the provided CharSequence into a Map&lt;String, Object&gt; representation using Wire.
+     * Deserialises the supplied text into a {@code Map<String, Object>}.
      *
-     * @param cs The CharSequence to be converted.
-     * @return A Map with String keys and Object values.
-     * @throws InvalidMarshallableException If the CharSequence cannot be properly deserialized.
+     * @param cs text formatted according to this wire type
+     * @return a map representation
+     * @throws InvalidMarshallableException if parsing fails
      */
     @Nullable
     public Map<String, Object> asMap(@NotNull CharSequence cs) throws InvalidMarshallableException {
@@ -692,10 +746,7 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
     }
 
     /**
-     * Indicates if this WireType is of a textual nature.
-     * This implementation returns false, indicating it's not textual.
-     *
-     * @return true if the WireType is textual; false otherwise.
+     * Returns {@code true} if this wire type is text based.
      */
     public boolean isText() {
         return false;

--- a/src/main/java/net/openhft/chronicle/wire/WireTypeConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireTypeConverter.java
@@ -3,8 +3,8 @@ package net.openhft.chronicle.wire;
 import net.openhft.chronicle.wire.internal.WireTypeConverterInternal;
 
 /**
- * This is the WireTypeConverter class responsible for converting between different wire types such as JSON and YAML.
- * Internally, it utilizes a delegate pattern with {@link WireTypeConverterInternal} to handle the actual conversion processes.
+ * Converts data between wire types such as JSON and YAML.
+ * The work is delegated to {@link WireTypeConverterInternal}.
  */
 public class WireTypeConverter {
 
@@ -12,38 +12,40 @@ public class WireTypeConverter {
     private final WireTypeConverterInternal delegate;
 
     /**
-     * Default constructor initializing the WireTypeConverter with a default {@link WireTypeConverterInternal} instance.
+     * Default constructor.
+     * Initialises the internal delegate {@link net.openhft.chronicle.wire.internal.WireTypeConverterInternal}.
      */
     public WireTypeConverter() {
         delegate = new WireTypeConverterInternal();
     }
 
     /**
-     * Converts the given JSON formatted input to its equivalent YAML representation.
+     * Converts the given JSON formatted input to its YAML representation.
      *
-     * @param json The JSON input to be converted.
-     * @return The converted YAML representation.
+     * @param json the JSON formatted {@link CharSequence} to be converted
+     * @return a {@link CharSequence} containing the YAML representation of the input JSON
      */
     public CharSequence jsonToYaml(CharSequence json) {
         return delegate.jsonToYaml(json);
     }
 
     /**
-     * Converts the given YAML formatted input to its equivalent JSON representation.
+     * Converts the given YAML formatted input to its JSON representation.
      *
-     * @param yaml The YAML input to be converted.
-     * @return The converted JSON representation.
+     * @param yaml the YAML formatted {@link CharSequence} to be converted
+     * @return a {@link CharSequence} containing the JSON representation of the input YAML
      */
     public CharSequence yamlToJson(CharSequence yaml) {
         return delegate.yamlToJson(yaml);
     }
 
     /**
-     * Associates a given class type with an older type name as an alias.
-     * This facilitates backward compatibility or recognition of renamed classes.
+     * Registers a class alias that will be used during conversions.
+     * This allows a type name {@code oldTypeName} seen in the input to be mapped to
+     * {@code newClass} during deserialisation by the internal wires.
      *
-     * @param newClass    The new class type.
-     * @param oldTypeName The older or previous type name.
+     * @param newClass   the target {@link Class} object
+     * @param oldTypeName the alternative or old type name string that should map to {@code newClass}
      */
     public void addAlias(Class<?> newClass, String oldTypeName) {
         delegate.addAlias(newClass, oldTypeName);

--- a/src/main/java/net/openhft/chronicle/wire/Wires.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wires.java
@@ -59,30 +59,76 @@ import static net.openhft.chronicle.wire.WireType.TEXT;
 import static net.openhft.chronicle.wire.WireType.YAML_ONLY;
 
 /**
- * The {@code Wires} enum encapsulates constants and utility methods related to wire operations.
- * It defines flags, masks, and utility methods that facilitate operations on wires.
- * For example, it provides constants like {@code NOT_COMPLETE} to indicate a wire message's completeness status.
- * This enum doesn't have any specific enumeration values but provides a utility-based structure.
+ * Utility holder for low-level wire constants and helper methods.
+ * <p>
+ * This enum does not contain any enumeration values.  It acts as a
+ * central hub for header flags and masks, static utility methods for
+ * common wire operations, and management of reusable resources such as
+ * {@link StringBuilder} pools and {@link net.openhft.compiler.CachedCompiler}
+ * instances.
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public enum Wires {
     ; // No specific enumeration values
 
-    // Constants defining various masks and flags for wire operations
+    /**
+     * Mask for extracting the length from a 4&nbsp;byte header.
+     * Only the lower 30&nbsp;bits are used for the length value.
+     */
     public static final int LENGTH_MASK = -1 >>> 2;
+
+    /**
+     * Flag ({@code 0x8000_0000}) indicating that the following message is not yet complete.
+     * Used in the length prefix of a size-prefixed blob.
+     */
     public static final int NOT_COMPLETE = 0x8000_0000;
+
+    /**
+     * Flag ({@code 0x4000_0000}) marking the document as meta-data rather than data.
+     */
     public static final int META_DATA = 1 << 30;
+
+    /**
+     * Value representing an unknown length ({@code 0}).
+     */
     public static final int UNKNOWN_LENGTH = 0x0;
-    // value to use when the message is not ready and of an unknown length
+
+    /**
+     * Combination of {@link #NOT_COMPLETE} and {@link #UNKNOWN_LENGTH} for incomplete messages
+     * of unknown size.
+     */
     public static final int NOT_COMPLETE_UNKNOWN_LENGTH = NOT_COMPLETE;
-    // value to use when no more data is possible e.g. on a roll.
+
+    /**
+     * Combination of {@link #NOT_COMPLETE} and {@link #META_DATA} used to indicate no more data
+     * is expected, for example at end of a roll.
+     */
     public static final int END_OF_DATA = NOT_COMPLETE | META_DATA;
+
+    /**
+     * Value used for an uninitialised header ({@code 0}).
+     */
     public static final int NOT_INITIALIZED = 0x0;
+
+    /**
+     * Shared immutable {@link Bytes} instance representing an empty buffer.
+     */
     public static final Bytes<?> NO_BYTES = BytesStore.empty().bytesForRead();
-    // Size of the SPB header
+
+    /**
+     * Size in bytes of a Size-Prefixed Blob (SPB) header.
+     */
     public static final int SPB_HEADER_SIZE = 4;
+
+    /**
+     * Registry of functions that determine the {@link SerializationStrategy} for a class.
+     */
     public static final List<Function<Class<?>, SerializationStrategy>> CLASS_STRATEGY_FUNCTIONS = new CopyOnWriteArrayList<>();
 
+    /**
+     * Cache mapping classes to their {@link SerializationStrategy}.
+     * Strategies are resolved via {@link #CLASS_STRATEGY_FUNCTIONS}.
+     */
     static final ClassLocal<SerializationStrategy> CLASS_STRATEGY = ClassLocal.withInitial(c -> {
         for (@NotNull Function<Class<?>, SerializationStrategy> func : CLASS_STRATEGY_FUNCTIONS) {
             final SerializationStrategy strategy = func.apply(c);
@@ -92,10 +138,15 @@ public enum Wires {
         return ANY_OBJECT;
     });
 
-    // Class local storage for field information lookup based on class
+    /**
+     * Cache of {@link FieldInfoPair} describing marshallable fields for each class.
+     */
     static final ClassLocal<FieldInfoPair> FIELD_INFOS = ClassLocal.withInitial(FieldInfo::lookupClass);
 
-    // Function to produce Marshallable objects based on a given class type
+    /**
+     * Provides a function that can create proxy {@link Marshallable} implementations
+     * for tuple-like interfaces.
+     */
     static final ClassLocal<Function<String, Marshallable>> MARSHALLABLE_FUNCTION = ClassLocal.withInitial(tClass -> {
         Class[] interfaces = {Marshallable.class, tClass};
         if (tClass == Marshallable.class)
@@ -110,21 +161,51 @@ public enum Wires {
             throw new IllegalStateException(e);
         }
     });
+    /**
+     * Thread-local pool of {@link StringBuilder} instances to reduce allocations.
+     */
     static final ScopedResourcePool<StringBuilder> STRING_BUILDER_SCOPED_RESOURCE_POOL = StringBuilderPool.createThreadLocal();
-    // Thread local storage for BinaryWire instances
+
+    /**
+     * Thread-local {@link BinaryWire} used for temporary read or write operations.
+     */
     static final ThreadLocal<BinaryWire> WIRE_TL = ThreadLocal.withInitial(() -> new BinaryWire(Bytes.allocateElasticOnHeap()));
-    // Flag to determine if code dump is enabled
+
+    /**
+     * Flag derived from the {@code dumpCodeToTarget} system property or {@link Jvm#isDebug()}.
+     * When true, generated Java source is written to the build target directory.
+     */
     static final boolean DUMP_CODE_TO_TARGET = Jvm.getBoolean("dumpCodeToTarget", Jvm.isDebug());
-    // Constants related to thread identifiers
+
+    /**
+     * Mask for embedding a thread identifier within a header.
+     */
     private static final int TID_MASK = 0b00111111_11111111_11111111_11111111;
+
+    /**
+     * Inverse of {@link #TID_MASK} for removing a masked thread identifier.
+     */
     private static final int INVERSE_TID_MASK = ~TID_MASK;
-    // Flag to enable tuple generation
+
+    /**
+     * Flag indicating whether tuple generation is permitted via the
+     * {@code wire.generate.tuples} system property.
+     */
     public static boolean GENERATE_TUPLES = Jvm.getBoolean("wire.generate.tuples");
-    // Flags to assist with state management and logging
+
+    /**
+     * Used to ensure an untyped bytes warning is logged only once.
+     */
     static volatile boolean warnedUntypedBytesOnce = false;
-    // Thread local storage for string builders
+
+    /**
+     * Legacy thread-local {@link StringBuilder}. Prefer {@link #STRING_BUILDER_SCOPED_RESOURCE_POOL}.
+     */
     static ThreadLocal<StringBuilder> sb = ThreadLocal.withInitial(StringBuilder::new);
-    // Compiler cache for dynamic code generation
+
+    /**
+     * Shared {@link net.openhft.compiler.CachedCompiler} for dynamic class generation.
+     */
     static CachedCompiler CACHED_COMPILER = null;
 
     /**
@@ -190,60 +271,58 @@ public enum Wires {
     }
 
     /**
-     * This decodes some Bytes where the first 4-bytes is the length.  e.g. Wire.writeDocument wrote
-     * it. <a href="https://github.com/OpenHFT/RFC/tree/master/Size-Prefixed-Blob">Size Prefixed
-     * Blob</a>
+     * Dumps a sequence of size-prefixed binary messages as a human readable
+     * string.  The first four bytes of each message contain the length and
+     * status flags.  See the <a href="https://github.com/OpenHFT/RFC/tree/master/Size-Prefixed-Blob">Size Prefixed Blob</a>
+     * specification.
      *
-     * @param bytes to decode
-     * @return as String
+     * @param bytes the bytes containing the size-prefixed data
+     * @return the dump in text form
      */
     public static String fromSizePrefixedBlobs(@NotNull Bytes<?> bytes) {
         return WireDumper.of(bytes).asString();
     }
 
     /**
-     * Converts the provided bytes, which represent aligned size-prefixed blobs,
-     * into a readable string format.
+     * Dumps aligned size-prefixed blobs.  Alignment means each record may have
+     * padding between messages.
      *
-     * @param bytes the bytes representing aligned size-prefixed blobs
-     * @return the readable string representation of the blobs
+     * @param bytes the bytes containing the aligned blobs
+     * @return textual dump of the messages
      */
     public static String fromAlignedSizePrefixedBlobs(@NotNull Bytes<?> bytes) {
         return WireDumper.of(bytes, true).asString();
     }
 
     /**
-     * Converts the provided bytes, representing size-prefixed blobs,
-     * into a readable string format with the option to abbreviate.
+     * Dumps size-prefixed blobs with optional abbreviation of long content.
      *
-     * @param bytes   the bytes representing size-prefixed blobs
-     * @param abbrev  if {@code true}, the output string will be abbreviated
-     * @return the readable string representation of the blobs
+     * @param bytes  the bytes containing the messages
+     * @param abbrev if {@code true} long fields are abbreviated
+     * @return textual dump of the blobs
      */
     public static String fromSizePrefixedBlobs(@NotNull Bytes<?> bytes, boolean abbrev) {
         return WireDumper.of(bytes).asString(abbrev);
     }
 
     /**
-     * Converts the provided bytes, representing size-prefixed blobs,
-     * into a readable string format from the specified position.
+     * Dumps size-prefixed blobs starting at a given position.
      *
-     * @param bytes    the bytes representing size-prefixed blobs
-     * @param position the position in bytes from which the conversion starts
-     * @return the readable string representation of the blobs from the specified position
+     * @param bytes    the bytes containing the messages
+     * @param position the offset in {@code bytes} to begin dumping
+     * @return textual dump of the remaining messages
      */
     public static String fromSizePrefixedBlobs(@NotNull Bytes<?> bytes, long position) {
         return fromSizePrefixedBlobs(bytes, position, false);
     }
 
     /**
-     * Converts the provided bytes, representing size-prefixed blobs,
-     * into a readable string format from a specified position and with the option to pad.
+     * Dumps size-prefixed blobs from a given position with optional padding.
      *
-     * @param bytes    the bytes representing size-prefixed blobs
-     * @param position the position in bytes from which the conversion starts
-     * @param padding  if {@code true}, the output string will have padding
-     * @return the readable string representation of the blobs from the specified position
+     * @param bytes    the bytes containing the messages
+     * @param position start position in {@code bytes}
+     * @param padding  whether message boundaries are padded
+     * @return textual dump of the blobs
      */
     public static String fromSizePrefixedBlobs(@NotNull Bytes<?> bytes, long position, boolean padding) {
         final long limit = bytes.readLimit();
@@ -253,25 +332,24 @@ public enum Wires {
     }
 
     /**
-     * Converts the provided bytes, which represent size-prefixed blobs,
-     * into a readable string format with options for padding and abbreviation.
+     * Dumps size-prefixed blobs with control over padding and abbreviation.
      *
-     * @param bytes   the bytes representing size-prefixed blobs
-     * @param padding if {@code true}, the output string will have padding
-     * @param abbrev  if {@code true}, the output string will be abbreviated
-     * @return the readable string representation of the blobs
+     * @param bytes   the bytes containing the messages
+     * @param padding whether message boundaries are padded
+     * @param abbrev  whether long content should be abbreviated
+     * @return textual dump of the blobs
      */
     public static String fromSizePrefixedBlobs(@NotNull Bytes<?> bytes, boolean padding, boolean abbrev) {
         return WireDumper.of(bytes, padding).asString(abbrev);
     }
 
     /**
-     * Converts the contents of the provided {@code DocumentContext}
-     * which represent size-prefixed blobs into a readable string format.
-     * The method supports handling of both TextWire and BinaryWire types.
+     * Dumps the current document of the supplied {@link DocumentContext} as a
+     * sequence of size-prefixed blobs.  Both {@link TextWire} and
+     * {@link BinaryWire} contexts are supported.
      *
-     * @param dc the {@code DocumentContext} holding the wire data
-     * @return the readable string representation of the blobs
+     * @param dc the document context whose content should be dumped
+     * @return textual dump of the blobs
      */
     public static String fromSizePrefixedBlobs(@NotNull DocumentContext dc) {
         Wire wire = dc.wire();
@@ -337,29 +415,33 @@ public enum Wires {
     }
 
     /**
-     * Converts the contents of the provided {@code WireIn}
-     * which represent size-prefixed blobs into a readable string format.
+     * Dumps the messages from a {@link WireIn} as a human readable string.
      *
-     * @param wireIn the {@code WireIn} instance holding the wire data
-     * @return the readable string representation of the blobs
+     * @param wireIn the input wire
+     * @return textual dump of the blobs
      */
     public static String fromSizePrefixedBlobs(@NotNull WireIn wireIn) {
         return fromSizePrefixedBlobs(wireIn, false);
     }
 
     /**
-     * Converts the contents of the provided {@code WireIn}
-     * which represent size-prefixed blobs into a readable string format,
-     * with the option to abbreviate the output.
+     * Dumps the messages from a {@link WireIn} with optional abbreviation.
      *
-     * @param wireIn the {@code WireIn} instance holding the wire data
-     * @param abbrev  if {@code true}, the output string will be abbreviated
-     * @return the readable string representation of the blobs
+     * @param wireIn the input wire
+     * @param abbrev whether long content should be abbreviated
+     * @return textual dump of the blobs
      */
     public static String fromSizePrefixedBlobs(@NotNull WireIn wireIn, boolean abbrev) {
         return WireDumper.of(wireIn).asString(abbrev);
     }
 
+    /**
+     * Converts the contents of {@code wireIn} to a text (YAML-like) representation.
+     *
+     * @param wireIn the source wire
+     * @param output buffer to receive the text
+     * @return {@code output} containing the textual form
+     */
     @NotNull
     public static CharSequence asText(@NotNull WireIn wireIn, Bytes<?> output) {
         ValidatableUtil.startValidateDisabled();
@@ -380,6 +462,9 @@ public enum Wires {
         return new JSONWire(bytes).useTypes(true).trimFirstCurly(false).useTextDocuments();
     }
 
+    /**
+     * Copies the contents of {@code wireIn} into {@code output} using a binary wire.
+     */
     public static Bytes<?> asBinary(@NotNull WireIn wireIn, Bytes<?> output) throws InvalidMarshallableException {
         return asType(wireIn, BinaryWire::new, output);
     }
@@ -402,6 +487,9 @@ public enum Wires {
         }
     }
 
+    /**
+     * Converts {@code wireIn} to JSON and writes the result into {@code output}.
+     */
     public static Bytes<?> asJson(@NotNull WireIn wireIn, Bytes<?> output) throws InvalidMarshallableException {
         return asType(wireIn, Wires::newJsonWire, output);
     }
@@ -416,97 +504,78 @@ public enum Wires {
         return new TextWire(bytes).addTimeStamps(true);
     }
 
+    /**
+     * Obtains a {@link StringBuilder} from the thread-local pool wrapped in a
+     * {@link ScopedResource} so it is automatically returned when the scope is closed.
+     */
     public static ScopedResource<StringBuilder> acquireStringBuilderScoped() {
         return STRING_BUILDER_SCOPED_RESOURCE_POOL.get();
     }
 
     /**
-     * Extracts the length from the given length value.
-     *
-     * @param len the encoded length
-     * @return the decoded length
+     * Extracts the pure length from a 4&nbsp;byte header value, removing
+     * flags such as {@link #NOT_COMPLETE} and {@link #META_DATA}.
      */
     public static int lengthOf(int len) {
         return len & LENGTH_MASK;
     }
 
     /**
-     * Checks if the given header is ready (complete and not zero).
-     *
-     * @param header the input header
-     * @return true if the header is ready, false otherwise
+     * Returns {@code true} if the header denotes a complete document.
      */
     public static boolean isReady(int header) {
         return (header & NOT_COMPLETE) == 0 && header != 0;
     }
 
     /**
-     * Checks if the given header is not complete or zero.
-     *
-     * @param header the input header
-     * @return true if the header is not complete or zero, false otherwise
+     * Returns {@code true} if the header indicates an incomplete document or zero length.
      */
     public static boolean isNotComplete(int header) {
         return (header & NOT_COMPLETE) != 0 || header == 0;
     }
 
     /**
-     * Checks if the given header represents ready data (neither meta-data nor incomplete) and is not zero.
-     *
-     * @param header the input header
-     * @return true if the header represents ready data, false otherwise
+     * Tests whether a header represents completed data (not meta-data) and is non-zero.
      */
     public static boolean isReadyData(int header) {
         return ((header & (META_DATA | NOT_COMPLETE)) == 0) && (header != 0);
     }
 
     /**
-     * Checks if the given length represents data and not meta-data.
-     *
-     * @param len the encoded length
-     * @return true if the length represents data, false otherwise
+     * Returns {@code true} if the header denotes data rather than meta-data.
      */
     public static boolean isData(int len) {
         return (len & META_DATA) == 0;
     }
 
     /**
-     * Checks if the given length represents ready meta-data.
-     *
-     * @param len the encoded length
-     * @return true if the length represents ready meta-data, false otherwise
+     * Returns {@code true} if the header is marked as meta-data and the document is complete.
      */
     public static boolean isReadyMetaData(int len) {
         return (len & (META_DATA | NOT_COMPLETE)) == META_DATA;
     }
 
     /**
-     * Checks if the given length represents a known length (neither unknown nor meta-data).
-     *
-     * @param len the encoded length
-     * @return true if the length is known, false otherwise
+     * Returns {@code true} if the header has a definite length value.
      */
     public static boolean isKnownLength(int len) {
         return (len & (META_DATA | LENGTH_MASK)) != UNKNOWN_LENGTH;
     }
 
     /**
-     * Checks if the given length is not initialized.
-     *
-     * @param len the encoded length
-     * @return true if the length is not initialized, false otherwise
+     * Returns {@code true} if the header has not been initialised.
      */
     public static boolean isNotInitialized(int len) {
         return len == NOT_INITIALIZED;
     }
 
     /**
-     * Converts a long value to an int, ensuring it falls within the 30-bit range.
+     * Converts {@code l} to a 30&nbsp;bit unsigned int.
      *
-     * @param l     the input long value
-     * @param error the error message template in case of an out-of-range value
-     * @return the converted int value
-     * @throws IllegalStateException if the value is out of the 30-bit range
+     * @param l     the value to convert
+     * @param error error message used if {@code l} is outside {@code 0}..{@link #LENGTH_MASK}
+     * @return {@code l} as an int
+     * @throws IllegalStateException if {@code l} is out of range
      */
     public static int toIntU30(long l, @NotNull String error) {
         if (l < 0 || l > LENGTH_MASK)
@@ -515,11 +584,12 @@ public enum Wires {
     }
 
     /**
-     * Acquires a lock on the given BytesStore at the specified position.
+     * Attempts to claim a 4&nbsp;byte header by atomically swapping
+     * {@link #NOT_INITIALIZED} with {@link #NOT_COMPLETE}.
      *
-     * @param store    the byte store to lock
-     * @param position the position at which to lock
-     * @return true if the lock was successfully acquired, false otherwise
+     * @param store    bytes containing the header
+     * @param position offset of the header
+     * @return {@code true} if the lock was acquired
      */
     public static boolean acquireLock(@NotNull BytesStore<?, ?> store, long position) {
         return store.compareAndSwapInt(position, NOT_INITIALIZED, NOT_COMPLETE);
@@ -587,11 +657,20 @@ public enum Wires {
         return bytes;
     }
 
+    /**
+     * Provides a pooled {@link Bytes} instance wrapped in a {@link ScopedResource}.
+     *
+     * @return the scoped bytes
+     */
     @NotNull
     public static ScopedResource<Bytes<Void>> acquireBytesScoped() {
         return WireInternal.BYTES_SCOPED_THREAD_LOCAL.get();
     }
 
+    /**
+     * Obtains a pooled {@link BinaryWire} wrapped in a {@link ScopedResource}
+     * for temporary serialisation tasks.
+     */
     public static ScopedResource<Wire> acquireBinaryWireScoped() {
         return WireInternal.BINARY_WIRE_SCOPED_TL.get();
     }
@@ -800,10 +879,7 @@ public enum Wires {
     }
 
     /**
-     * Checks if a given integer represents the end of file marker.
-     *
-     * @param num Integer to check
-     * @return true if the integer represents end of file, false otherwise
+     * Returns {@code true} if the supplied header value denotes end of data.
      */
     public static boolean isEndOfFile(int num) {
         return num == END_OF_DATA;
@@ -1249,12 +1325,8 @@ public enum Wires {
     }
 
     /**
-     * Creates a BinaryWire for reading with the given input, position, and length.
-     *
-     * @param in        The input bytes.
-     * @param position  The starting position.
-     * @param length    The length of data to read.
-     * @return A BinaryWire configured for reading.
+     * Provides a thread-local {@link BinaryWire} configured to read from the supplied
+     * byte store.  The returned wire shares the underlying bytes; no copy is made.
      */
     @NotNull
     public static BinaryWire binaryWireForRead(Bytes<?> in, long position, long length) {
@@ -1266,12 +1338,8 @@ public enum Wires {
     }
 
     /**
-     * Creates a BinaryWire for writing with the given input, position, and length.
-     *
-     * @param in        The input bytes.
-     * @param position  The starting position.
-     * @param length    The length of data to write.
-     * @return A BinaryWire configured for writing.
+     * Provides a thread-local {@link BinaryWire} configured for writing to the supplied
+     * byte store.  The returned wire views the given bytes without copying.
      */
     @NotNull
     public static BinaryWire binaryWireForWrite(Bytes<?> in, long position, long length) {
@@ -1283,15 +1351,9 @@ public enum Wires {
     }
 
     /**
-     * Loads a Java class from the given source code string using the specified class loader.
-     * If a cached compiler is not initialized, it initializes one either with default settings
-     * or specific directories if they exist and `DUMP_CODE_TO_TARGET` is true.
-     *
-     * @param classLoader The class loader to use for loading the class.
-     * @param className   The name of the class to be loaded.
-     * @param code        The Java source code for the class.
-     * @return The loaded class.
-     * @throws ClassNotFoundException If the class could not be found or loaded.
+     * Dynamically compiles and loads a class from its source code.
+     * The {@link #CACHED_COMPILER} is created lazily and may write generated
+     * files to the build directory when {@link #DUMP_CODE_TO_TARGET} is set.
      */
     static synchronized Class<?> loadFromJava(ClassLoader classLoader, String className, String code) throws ClassNotFoundException {
         if (CACHED_COMPILER == null) {

--- a/src/main/java/net/openhft/chronicle/wire/internal/WireTypeConverterInternal.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/WireTypeConverterInternal.java
@@ -5,17 +5,24 @@ import net.openhft.chronicle.wire.Wire;
 import net.openhft.chronicle.wire.WireType;
 
 /**
- * Provides the capability to convert between different wire types, with a primary focus on
- * converting from JSON to YAML format.
- * <p>
- * This class encapsulates both JSON and YAML wire types to facilitate the conversion.
- * In addition to conversion, it supports validation mechanisms to ensure correctness and integrity of
- * the transformed data.
+ * <b>INTERNAL USE ONLY.</b> Implementation delegate for {@link net.openhft.chronicle.wire.WireTypeConverter}.
+ * It manages {@link net.openhft.chronicle.wire.JSONWire} and {@link net.openhft.chronicle.wire.YamlWire}
+ * instances to perform conversions by parsing the input with one wire type and then using
+ * {@link net.openhft.chronicle.wire.WireIn#copyTo(net.openhft.chronicle.wire.WireOut)} to serialise to the other.
  */
 public class WireTypeConverterInternal {
+    /** Internal {@link Wire} instance configured for YAML processing using an elastic on-heap buffer. */
     private final Wire yamlWire = WireType.YAML_ONLY.apply(Bytes.allocateElasticOnHeap());
+    /** Internal {@link Wire} instance configured for JSON processing using an elastic on-heap buffer. */
     private final Wire jsonWire = WireType.JSON_ONLY.apply(Bytes.allocateElasticOnHeap());
 
+    /**
+     * Converts the JSON {@link CharSequence} to YAML.
+     * The input {@code json} is appended to {@link #jsonWire} and copied to {@link #yamlWire}.
+     *
+     * @param json the JSON data
+     * @return the contents of {@link #yamlWire}
+     */
     public CharSequence jsonToYaml(CharSequence json) {
         jsonWire.reset();
         jsonWire.bytes().append(json);
@@ -25,6 +32,13 @@ public class WireTypeConverterInternal {
         return yamlWire.bytes();
     }
 
+    /**
+     * Converts the YAML {@link CharSequence} to JSON.
+     * The input {@code yaml} is appended to {@link #yamlWire} and copied to {@link #jsonWire}.
+     *
+     * @param yaml the YAML data
+     * @return the contents of {@link #jsonWire}
+     */
     public CharSequence yamlToJson(CharSequence yaml) {
         yamlWire.reset();
         yamlWire.bytes().clear().append(yaml);
@@ -36,12 +50,11 @@ public class WireTypeConverterInternal {
     }
 
     /**
-     * Adds aliasing support for type leniency. This facilitates the serialization and deserialization
-     * of objects whose class names might have changed. By providing an alias, the system can recognize
-     * and handle the renamed class seamlessly.
+     * Adds the class alias to the {@link net.openhft.chronicle.core.pool.ClassLookup}
+     * of both {@link #jsonWire} and {@link #yamlWire}.
      *
-     * @param newClass    The new class type to use for serialization and deserialization.
-     * @param oldTypeName The old type name that this new class is an alias for.
+     * @param newClass   the class the alias maps to
+     * @param oldTypeName the legacy type name
      */
     public void addAlias(Class<?> newClass, String oldTypeName) {
         jsonWire.classLookup().addAlias(newClass, oldTypeName);


### PR DESCRIPTION

| Module                           | Files touched                                                                                                                                                                     | Essence of update                                                                                                                                                                    |
| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| **Core annotations & notifiers** | `Comment.java`, `CommentAnnotationNotifier.java`, `RollbackIfNotCompleteNotifier.java`                                                                                            | • Javadoc now explains runtime use-cases and YAML comment emission.<br>• Param/exception docs added & wording standardised.                                                          |
| **Reflection & util layer**      | `ReflectionUtil.java`, `BitSetUtil.java`                                                                                                                                          | • Split long lines & added field-level docs.<br>• Clarified system-property flags and thread-safety notes.                                                                           |
| **Wire plumbing**                | `WireDumper.java`, `Wires.java`, `WireKey.java`, `WireType*.java`, `VanillaWireParser.java`, `WireParselet.java`, `FieldNumberParselet.java`, `WireTypeConverter(+Internal).java` | • Comprehensive Javadoc for every public method, enum constant & flag.<br>• Parameter names in docbase now match code.<br>• Deprecated / internal APIs explicitly marked and linked. |
| **Bit-set implementations**      | `ChronicleBitSet.java`, `LongValueBitSet.java`, `LongArrayValueBitSet.java`                                                                                                       | • Expanded docs: off-heap semantics, CAS loops, capacity caveats.<br>• Added inline explanations for magic constants.                                                                |
| **Misc. tweaks**                 | minor edits on masks, constants & private fields                                                                                                                                  | • Renamed a handful of locals for clarity (no signature changes).                                                                                                                    |

> **No byte-code, behaviour or public API signatures were altered** – only comments, Javadoc and a handful of parameter identifiers that never escape the class files.
