### PR TITLE
Deep-dive Javadoc sweep & internal comment clean-up

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/CharSequenceObjectMap.java
+++ b/src/main/java/net/openhft/chronicle/wire/CharSequenceObjectMap.java
@@ -30,13 +30,8 @@ import net.openhft.chronicle.core.util.StringUtils;
  */
 public class CharSequenceObjectMap<T> {
 
-    /**
-     * Multiplier used in {@link #hashFor(CharSequence)} to improve hash code distribution.
-     */
+    /** Constants used in {@link #hashFor(CharSequence)} for improved distribution. */
     private static final int K0 = 0x6d0f27bd;
-    /**
-     * Second multiplier used in {@link #hashFor(CharSequence)} for better distribution.
-     */
     @SuppressWarnings("unused")
     private static final int M0 = 0x5bc80bad;
 

--- a/src/main/java/net/openhft/chronicle/wire/CharSequenceObjectMap.java
+++ b/src/main/java/net/openhft/chronicle/wire/CharSequenceObjectMap.java
@@ -19,28 +19,46 @@ import net.openhft.chronicle.core.Maths;
 import net.openhft.chronicle.core.util.StringUtils;
 
 /**
- * This class provides a simple hash map implementation optimized for {@link CharSequence} keys and generic values.
- * The main advantage of this implementation is that it's tailored for CharSequence inputs, allowing for a more
- * memory-efficient and performant solution in specific use-cases.
+ * Simple hash map implementation optimised for {@link CharSequence} keys.
+ * It uses open addressing with linear probing and stores key strings directly.
+ * Not intended as a general-purpose replacement for {@link java.util.HashMap},
+ * but can be beneficial in performance-sensitive components where lookups on
+ * {@link CharSequence} instances are frequent.  This implementation is not
+ * thread-safe.
  *
- * @param <T> the type of values to be stored in the map.
+ * @param <T> type of values stored in the map
  */
 public class CharSequenceObjectMap<T> {
 
-    // Constants used in the hash function for improved distribution.
+    /**
+     * Multiplier used in {@link #hashFor(CharSequence)} to improve hash code distribution.
+     */
     private static final int K0 = 0x6d0f27bd;
+    /**
+     * Second multiplier used in {@link #hashFor(CharSequence)} for better distribution.
+     */
     @SuppressWarnings("unused")
     private static final int M0 = 0x5bc80bad;
 
-    // Arrays to store the keys and corresponding values.
+    /**
+     * Array storing the string representations of the keys.
+     * {@code null} entries indicate empty slots.
+     */
     final String[] keys;
+    /**
+     * Array storing the values associated with the keys at the same index.
+     */
     final T[] values;
-    final int mask;  // The mask used for wrapping hash values within the bounds.
+    /**
+     * Mask used for mapping hash codes to array indices. Equal to the array length minus one.
+     */
+    final int mask;
 
     /**
-     * Constructs an empty map with the specified initial capacity.
+     * Creates a map with an initial table size that is the next power of two
+     * greater than or equal to {@code capacity} with a minimum of sixteen.
      *
-     * @param capacity the initial capacity of the map.
+     * @param capacity desired initial capacity before rounding
      */
     @SuppressWarnings("unchecked")
     public CharSequenceObjectMap(int capacity) {
@@ -51,12 +69,12 @@ public class CharSequenceObjectMap<T> {
     }
 
     /**
-     * Associates the specified value with the specified key (name) in this map.
-     * If the map previously contained a mapping for the key, the old value is replaced.
+     * Store a value against a key. The key's {@code toString()} value is stored
+     * if it is not already present, replacing any existing mapping.
      *
-     * @param name key with which the specified value is to be associated.
-     * @param t    value to be associated with the specified key.
-     * @throws IllegalStateException if the map is full.
+     * @param name the key
+     * @param t    value to store
+     * @throws IllegalStateException if no empty slot can be found after probing
      */
     public void put(CharSequence name, T t) {
         int h = hashFor(name);
@@ -72,12 +90,12 @@ public class CharSequenceObjectMap<T> {
     }
 
     /**
-     * Returns the value to which the specified key (cs) is mapped,
-     * or {@code null} if this map contains no mapping for the key.
+     * Retrieve the value associated with a key.
      *
-     * @param cs the key whose associated value is to be returned.
-     * @return the value to which the specified key is mapped, or {@code null} if this map contains no mapping for the key.
-     * @throws IllegalStateException if the map is full.
+     * @param cs the key to search for
+     * @return the mapped value, or {@code null} if the key is absent or the map is
+     *         full and the key cannot be located
+     * @throws IllegalStateException if probing finds no empty slot
      */
     public T get(CharSequence cs) {
         int h = hashFor(cs);
@@ -92,11 +110,10 @@ public class CharSequenceObjectMap<T> {
     }
 
     /**
-     * Generates a hash code for the given CharSequence using a custom hash function.
-     * This custom function is designed to produce well-distributed hash codes for CharSequence inputs.
+     * Compute a hash code for a {@link CharSequence} using the internal multipliers.
      *
-     * @param name the CharSequence for which the hash code is to be calculated.
-     * @return the calculated hash code.
+     * @param name the {@link CharSequence} to hash
+     * @return an int masked to the current table size
      */
     private int hashFor(CharSequence name) {
         long h = name.length();

--- a/src/main/java/net/openhft/chronicle/wire/GeneratingMethodReaderInterceptorReturns.java
+++ b/src/main/java/net/openhft/chronicle/wire/GeneratingMethodReaderInterceptorReturns.java
@@ -46,12 +46,12 @@ import java.lang.reflect.Method;
  *     }
  * }</pre>
  *
- * <p>This mechanism is used by {@link GenerateMethodReader} to weave logic
- * directly into the generated class.  If the supplied code fails to compile,
- * the call falls back to {@link #intercept(Method, Object, Object[], Invocation)}
- * as it would with a reflective interceptor.
+ * <p>Please mind that if provided code fails to compile, reflexive method call will be delegated to the interceptor
+ * with {@link #intercept(Method, Object, Object[], Invocation)}, like it happens with a regular
+ * {@link MethodReaderInterceptorReturns}.
  */
 public interface GeneratingMethodReaderInterceptorReturns extends MethodReaderInterceptorReturns {
+
     /**
      * Specifies ID of this generating interceptor.<br>
      * Contract: if the code provided by generating interceptor differs from the code provided by another generating
@@ -59,23 +59,23 @@ public interface GeneratingMethodReaderInterceptorReturns extends MethodReaderIn
      * Provided ID will be used in the classname of a generated method reader to ensure re-compilation when a new
      * generator is passed.
      *
-     * @return a unique string ID for this generator implementation. This ID influences the generated class name.
+     * @return a unique string ID for this generator implementation.
      */
     String generatorId();
 
     /**
-     * @param m             the {@link Method} being intercepted
-     * @param objectName    name of the variable holding the target instance in the generated code
-     * @param argumentNames variable names of the deserialised arguments in the generated code
-     * @return Java source code to insert before the actual call, or {@code null} if nothing should be added
+     * @param m             Calling method.
+     * @param objectName    Object instance name.
+     * @param argumentNames Call argument names.
+     * @return Source code to add before the method call.
      */
     String codeBeforeCall(Method m, String objectName, String[] argumentNames);
 
     /**
-     * @param m             the {@link Method} being intercepted
-     * @param objectName    name of the variable holding the target instance in the generated code
-     * @param argumentNames variable names of the deserialised arguments in the generated code
-     * @return Java source code to insert after the actual call, or {@code null} if nothing should be added
+     * @param m             Calling method.
+     * @param objectName    Object instance name.
+     * @param argumentNames Call argument names.
+     * @return Source code to add after the method call.
      */
     String codeAfterCall(Method m, String objectName, String[] argumentNames);
 }

--- a/src/main/java/net/openhft/chronicle/wire/GeneratingMethodReaderInterceptorReturns.java
+++ b/src/main/java/net/openhft/chronicle/wire/GeneratingMethodReaderInterceptorReturns.java
@@ -21,14 +21,15 @@ import net.openhft.chronicle.bytes.MethodReaderInterceptorReturns;
 import java.lang.reflect.Method;
 
 /**
- * <p>This interface is a version of method reader interceptor that allows to change the logic of
- * {@link net.openhft.chronicle.bytes.MethodReader} without overhead provided by reflexive calls.
+ * Version of {@link MethodReaderInterceptorReturns} that lets generated
+ * readers inline custom logic without reflection overhead.
  *
  * <p>Code returned by {@link #codeBeforeCall(Method, String, String[])} and
- * {@link #codeAfterCall(Method, String, String[])} will be added before and after actual method call in the generated
- * source code of the method reader. It's possible to use original call arguments and object instance in the added code.
+ * {@link #codeAfterCall(Method, String, String[])} is inserted before and after
+ * the actual invocation in the generated reader.  The snippets may reference
+ * the deserialised argument variables and the target object instance.
  *
- * <p>Simple example that allows to skip call of method "foo" in case its second argument is null:
+ * <p>Simple example that skips the call of method "foo" when its second argument is null:
  * <pre>{@code
  *     public String codeBeforeCall(Method m, String objectName, String[] argumentNames) {
  *         if (m.getName().equals("foo"))
@@ -45,9 +46,10 @@ import java.lang.reflect.Method;
  *     }
  * }</pre>
  *
- * <p>Please mind that if provided code fails to compile, reflexive method call will be delegated to the interceptor
- * with {@link #intercept(Method, Object, Object[], Invocation)}, like it happens with a regular
- * {@link MethodReaderInterceptorReturns}.
+ * <p>This mechanism is used by {@link GenerateMethodReader} to weave logic
+ * directly into the generated class.  If the supplied code fails to compile,
+ * the call falls back to {@link #intercept(Method, Object, Object[], Invocation)}
+ * as it would with a reflective interceptor.
  */
 public interface GeneratingMethodReaderInterceptorReturns extends MethodReaderInterceptorReturns {
     /**
@@ -57,23 +59,23 @@ public interface GeneratingMethodReaderInterceptorReturns extends MethodReaderIn
      * Provided ID will be used in the classname of a generated method reader to ensure re-compilation when a new
      * generator is passed.
      *
-     * @return ID of this generator.
+     * @return a unique string ID for this generator implementation. This ID influences the generated class name.
      */
     String generatorId();
 
     /**
-     * @param m             Calling method.
-     * @param objectName    Object instance name.
-     * @param argumentNames Call argument names.
-     * @return Source code to add before the method call.
+     * @param m             the {@link Method} being intercepted
+     * @param objectName    name of the variable holding the target instance in the generated code
+     * @param argumentNames variable names of the deserialised arguments in the generated code
+     * @return Java source code to insert before the actual call, or {@code null} if nothing should be added
      */
     String codeBeforeCall(Method m, String objectName, String[] argumentNames);
 
     /**
-     * @param m             Calling method.
-     * @param objectName    Object instance name.
-     * @param argumentNames Call argument names.
-     * @return Source code to add after the method call.
+     * @param m             the {@link Method} being intercepted
+     * @param objectName    name of the variable holding the target instance in the generated code
+     * @param argumentNames variable names of the deserialised arguments in the generated code
+     * @return Java source code to insert after the actual call, or {@code null} if nothing should be added
      */
     String codeAfterCall(Method m, String objectName, String[] argumentNames);
 }

--- a/src/main/java/net/openhft/chronicle/wire/HeadNumberChecker.java
+++ b/src/main/java/net/openhft/chronicle/wire/HeadNumberChecker.java
@@ -33,7 +33,7 @@ public interface HeadNumberChecker {
      *
      * @param headerNumber The header number read from the wire.
      * @param position     The byte position in the wire where this header number was encountered.
-     *                      This can be used for context or logging.
+     *                     This can be used for context or logging.
      * @return {@code true} if the header number is considered valid according to the implementation's
      * logic, {@code false} otherwise (which might lead to an error or retry).
      */

--- a/src/main/java/net/openhft/chronicle/wire/HeadNumberChecker.java
+++ b/src/main/java/net/openhft/chronicle/wire/HeadNumberChecker.java
@@ -21,6 +21,9 @@ package net.openhft.chronicle.wire;
  * This interface provides a contract for checking a given header number and its position.
  * Typically, implementations of this interface will contain logic to determine whether
  * the provided header number, in the context of its position are a valid combination.
+ * <p>
+ * Used by {@link AbstractWire} to validate header numbers, for example, to ensure sequence
+ * numbers are contiguous or monotonically increasing when reading from a queue.
  */
 @FunctionalInterface
 public interface HeadNumberChecker {
@@ -28,9 +31,11 @@ public interface HeadNumberChecker {
     /**
      * Checks whether the provided header number meets a certain condition in the context of its position.
      *
-     * @param headerNumber The header number to be checked.
-     * @param position The position or context associated with the header number.
-     * @return {@code true} if the header number is valid; {@code false} otherwise.
+     * @param headerNumber The header number read from the wire.
+     * @param position     The byte position in the wire where this header number was encountered.
+     *                      This can be used for context or logging.
+     * @return {@code true} if the header number is considered valid according to the implementation's
+     * logic, {@code false} otherwise (which might lead to an error or retry).
      */
     boolean checkHeaderNumber(long headerNumber, long position);
 }

--- a/src/main/java/net/openhft/chronicle/wire/MarshallableParser.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableParser.java
@@ -18,20 +18,21 @@ package net.openhft.chronicle.wire;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * This is the {@code MarshallableParser} functional interface.
- * It provides a contract for parsing methods that convert a given {@link ValueIn} into an instance of type {@code T}.
- * Designed to be used in scenarios where marshalling is required to transform input values into desired data types.
+ * Functional interface describing a strategy for deserialising data.
+ * <p>
+ * Implementations convert a {@link ValueIn} representation to an object of type {@code T}.
+ * This allows custom logic to be supplied wherever a {@code ValueIn} needs to be turned into a concrete object.
  *
- * @param <T> the type of the object that will be produced after parsing the input value.
+ * @param <T> the type produced after parsing the input value
  */
 @FunctionalInterface
 public interface MarshallableParser<T> {
 
     /**
-     * Parses the provided {@code ValueIn} into an instance of type {@code T}.
+     * Create an instance of {@code T} from the supplied wire representation.
      *
-     * @param valueIn the input value to be parsed.
-     * @return the parsed instance of type {@code T}.
+     * @param valueIn the {@link ValueIn} holding the serialised form
+     * @return non-null instance of {@code T} deserialised from {@code valueIn}
      */
     @NotNull
     T parse(ValueIn valueIn);

--- a/src/main/java/net/openhft/chronicle/wire/MarshallableParser.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableParser.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.NotNull;
 public interface MarshallableParser<T> {
 
     /**
-     * Create an instance of {@code T} from the supplied wire representation.
+     * Parses the provided {@code ValueIn} into an instance of type {@code T}.
      *
      * @param valueIn the {@link ValueIn} holding the serialised form
      * @return non-null instance of {@code T} deserialised from {@code valueIn}

--- a/src/main/java/net/openhft/chronicle/wire/ObjectIntObjectConsumer.java
+++ b/src/main/java/net/openhft/chronicle/wire/ObjectIntObjectConsumer.java
@@ -16,21 +16,20 @@
 package net.openhft.chronicle.wire;
 
 /**
- * Represents a consumer that accepts two objects of types T and V, and an integer value.
- * This functional interface provides a mechanism to perform an action with three inputs,
- * combining object-object-int in the provided order. It's designed for scenarios
- * where two objects and an integer are needed for processing or computation.
+ * Functional interface representing a consumer that accepts two objects and an
+ * integer. It is useful when a lambda or method reference needs to process an
+ * object-int-object tuple in that order.
  *
- * <p>Example Usage:
+ * <p>Example usage:
  * <pre>
  *     ObjectIntObjectConsumer&lt;String, Double&gt; printer = (str, num, dbl) -&gt;
  *         System.out.println(str + " - " + num + " - " + dbl);
  *     printer.accept("Value", 5, 20.5);
  * </pre>
- * The above will print: Value - 5 - 20.5
+ * The example prints: Value - 5 - 20.5
  *
- * @param <T> The type of the first object to be consumed.
- * @param <V> The type of the second object to be consumed.
+ * @param <T> type of the first object argument
+ * @param <V> type of the second object argument
  */
 @FunctionalInterface
 public interface ObjectIntObjectConsumer<T, V> {
@@ -38,9 +37,9 @@ public interface ObjectIntObjectConsumer<T, V> {
     /**
      * Performs the operation defined by this consumer.
      *
-     * @param t The first object argument.
-     * @param u The integer argument.
-     * @param v The second object argument.
+     * @param t the first input argument of type {@code T}
+     * @param u the second input argument, an {@code int} value
+     * @param v the third input argument of type {@code V}
      */
     void accept(T t, int u, V v);
 }

--- a/src/main/java/net/openhft/chronicle/wire/RawText.java
+++ b/src/main/java/net/openhft/chronicle/wire/RawText.java
@@ -16,19 +16,23 @@
 package net.openhft.chronicle.wire;
 
 /**
- * Represents a container for raw textual data.
- * The primary purpose of this class is to encapsulate a text
- * while providing a simple structure for raw text handling.
+ * Represents a container for raw textual data. This class can be used as a
+ * method argument type in method writers (see {@link VanillaMethodWriterBuilder})
+ * to indicate that the provided {@link CharSequence} should be written to the
+ * wire with minimal or no escaping, if supported by the wire type (for example,
+ * {@link ValueOut#rawText(CharSequence)}). This is a package-private class,
+ * intended for internal use within the Chronicle Wire framework.
  */
 class RawText {
-    // The encapsulated raw textual data
+    /** The raw text content, stored as a {@link String}. */
     String text;
 
     /**
-     * Constructs a new instance of {@code RawText} initialized with
-     * the provided CharSequence.
+     * Constructs a new instance of {@code RawText} initialised with the provided
+     * {@link CharSequence}.
      *
-     * @param text The CharSequence to be encapsulated by this instance.
+     * @param text The {@link CharSequence} whose content will be stored. It is
+     *             converted to a {@link String} internally.
      */
     public RawText(CharSequence text) {
         this.text = text.toString();

--- a/src/main/java/net/openhft/chronicle/wire/Sequence.java
+++ b/src/main/java/net/openhft/chronicle/wire/Sequence.java
@@ -16,35 +16,66 @@
 package net.openhft.chronicle.wire;
 
 /**
- * This is used in Chronicle-Queue to map a position to a sequence number.
+ * Defines a contract for mapping a write position (typically in a persistent
+ * store such as Chronicle Queue) to a logical sequence number, and vice versa.
+ * This is crucial for systems that need to assign ordered sequence numbers to
+ * messages or events written at potentially non-contiguous positions.
  */
 public interface Sequence {
+    /**
+     * Returned by {@link #getSequence(long)} when a sequence number cannot be
+     * found for the given position but the operation may succeed if retried.
+     */
     long NOT_FOUND_RETRY = Long.MIN_VALUE;
+
+    /**
+     * Returned by {@link #getSequence(long)} when a sequence number cannot be
+     * found for the given position and retrying is unlikely to succeed.
+     */
     long NOT_FOUND = -1;
 
     /**
-     * gets the sequence for a writePosition
-     * <p>
-     * This method will only return a valid sequence number of the write position if the write position is the
-     * last write position in the queue. YOU CAN NOT USE THIS METHOD TO LOOK UP RANDOM SEQUENCES FOR ANY WRITE POSITION.
-     * NOT_FOUND_RETRY will be return if a sequence number can not be found  ( so retry )
-     * or NOT_FOUND if you should not retry
+     * Gets the sequence number for the supplied write position. This method is
+     * typically used with the last write position and may not be suitable for
+     * arbitrary positions.
      *
-     * @param forWritePosition the last write position, expected to be the end of queue
-     * @return NOT_FOUND_RETRY if the sequence for this write position can not be found (you can retry), or
-     * NOT_FOUND if it can't be found and there is no point in retrying
+     * @param forWritePosition The write position (for example an excerpt's
+     *                         starting offset) for which the sequence number is
+     *                         requested. This is usually the most recently
+     *                         written position.
+     * @return The sequence number for {@code forWritePosition}, or
+     *         {@link #NOT_FOUND_RETRY} if the lookup should be retried, or
+     *         {@link #NOT_FOUND} if the position does not map to a sequence
+     *         number.
      */
     long getSequence(long forWritePosition);
 
     /**
-     * sets the sequence number for a writePosition
+     * Sets the sequence number for the given write position.
      *
-     * @param sequence the sequence number
-     * @param position the write position
+     * @param sequence The sequence number to associate with the position.
+     * @param position The write position for which the sequence number should be
+     *                 recorded.
      */
     void setSequence(long sequence, long position);
 
+    /**
+     * Combines a {@code headerNumber} (such as a cycle count) and a
+     * {@code sequence} within that header into a single index value.
+     *
+     * @param headerNumber The higher-order part of the index, for example a
+     *                     cycle number.
+     * @param sequence The lower-order sequence number within the header.
+     * @return A combined index representing the header and sequence.
+     */
     long toIndex(long headerNumber, long sequence);
 
+    /**
+     * Extracts the lower-order sequence number from an index previously created
+     * by {@link #toIndex(long, long)}.
+     *
+     * @param index The combined index.
+     * @return The sequence number extracted from the index.
+     */
     long toSequenceNumber(long index);
 }

--- a/src/main/java/net/openhft/chronicle/wire/Sequence.java
+++ b/src/main/java/net/openhft/chronicle/wire/Sequence.java
@@ -35,18 +35,16 @@ public interface Sequence {
     long NOT_FOUND = -1;
 
     /**
-     * Gets the sequence number for the supplied write position. This method is
-     * typically used with the last write position and may not be suitable for
-     * arbitrary positions.
+     * gets the sequence for a writePosition
+     * <p>
+     * This method will only return a valid sequence number of the write position if the write position is the
+     * last write position in the queue. YOU CAN NOT USE THIS METHOD TO LOOK UP RANDOM SEQUENCES FOR ANY WRITE POSITION.
+     * NOT_FOUND_RETRY will be return if a sequence number can not be found  ( so retry )
+     * or NOT_FOUND if you should not retry
      *
-     * @param forWritePosition The write position (for example an excerpt's
-     *                         starting offset) for which the sequence number is
-     *                         requested. This is usually the most recently
-     *                         written position.
-     * @return The sequence number for {@code forWritePosition}, or
-     *         {@link #NOT_FOUND_RETRY} if the lookup should be retried, or
-     *         {@link #NOT_FOUND} if the position does not map to a sequence
-     *         number.
+     * @param forWritePosition the last write position, expected to be the end of queue
+     * @return NOT_FOUND_RETRY if the sequence for this write position can not be found (you can retry), or
+     * NOT_FOUND if it can't be found and there is no point in retrying
      */
     long getSequence(long forWritePosition);
 

--- a/src/main/java/net/openhft/chronicle/wire/SourceContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/SourceContext.java
@@ -27,14 +27,16 @@ import net.openhft.chronicle.core.io.IORuntimeException;
 public interface SourceContext {
 
     /**
-     * The identifier of the source from which the message originated.
+     * Retrieves the identifier of the source from which the message originated.
      *
      * @return unique identifier for this context, or {@code -1} if not available or not applicable
      */
     int sourceId();
 
     /**
-     * Index of the current document or message within its source.
+     * Obtains the index of the last read operation from this source context.
+     * This is particularly useful to track the reading progress and can act as a checkpoint or reference point.
+     * Note: This method is specifically intended for read contexts and might not be relevant for other context types.
      *
      * @return index of the current entry, for example the queue index
      * @throws IORuntimeException if the index cannot be determined

--- a/src/main/java/net/openhft/chronicle/wire/SourceContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/SourceContext.java
@@ -18,29 +18,26 @@ package net.openhft.chronicle.wire;
 import net.openhft.chronicle.core.io.IORuntimeException;
 
 /**
- * This is the SourceContext interface.
- * It defines methods to interact with the underlying source context, particularly in terms of accessing its source ID
- * and the last read index. Implementations of this interface are expected to handle source contexts which could be used
- * in various scenarios like I/O operations, data streaming, or context management.
+ * Interface for accessing metadata about the origin of a message.
+ * <p>
+ * It exposes the source identifier and position of the current document.
+ * A {@link DocumentContext} may implement this interface to provide
+ * traceability of a message to its queue index and source ID.
  */
 public interface SourceContext {
 
     /**
-     * Retrieves the source ID associated with this context.
-     * A unique identifier that represents the source from which data or operations might be fetched or to which data
-     * might be written. If a valid source ID has not been established or isn't available, it defaults to returning -1.
+     * The identifier of the source from which the message originated.
      *
-     * @return The unique identifier for this source context, or -1 if not available.
+     * @return unique identifier for this context, or {@code -1} if not available or not applicable
      */
     int sourceId();
 
     /**
-     * Obtains the index of the last read operation from this source context.
-     * This is particularly useful to track the reading progress and can act as a checkpoint or reference point.
-     * Note: This method is specifically intended for read contexts and might not be relevant for other context types.
+     * Index of the current document or message within its source.
      *
-     * @return The index corresponding to the last read operation.
-     * @throws IORuntimeException if any issue arises while fetching the index.
+     * @return index of the current entry, for example the queue index
+     * @throws IORuntimeException if the index cannot be determined
      */
     long index() throws IORuntimeException;
 }

--- a/src/main/java/net/openhft/chronicle/wire/TriConsumer.java
+++ b/src/main/java/net/openhft/chronicle/wire/TriConsumer.java
@@ -22,7 +22,8 @@ import java.util.Objects;
 
 /**
  * Represents an operation that accepts three input arguments and returns no result.
- * This is a three-arity specialization of {@code Consumer}.
+ * This is a three-arity specialization of {@code Consumer} and functions much
+ * like {@link java.util.function.BiConsumer} but with an additional argument.
  * Unlike most other functional interfaces, {@code TriConsumer} is expected to operate
  * via side effects. This interface is useful in scenarios where lambda expressions
  * or method references would benefit from custom manipulations of three separate arguments.
@@ -37,9 +38,9 @@ public interface TriConsumer<T, U, V> {
     /**
      * Performs this operation on the given arguments.
      *
-     * @param t the first input argument
-     * @param u the second input argument
-     * @param v the third input argument
+     * @param t The first input argument.
+     * @param u The second input argument.
+     * @param v The third input argument.
      * @throws InvalidMarshallableException if there are issues with marshalling
      *                                      during the accept operation.
      */
@@ -52,9 +53,9 @@ public interface TriConsumer<T, U, V> {
      * composed operation.  If performing this operation throws an exception,
      * the {@code after} operation will not be performed.
      *
-     * @param after the operation to perform after this operation
-     * @return a composed {@code TriConsumer} that performs in sequence this
-     * operation followed by the {@code after} operation
+     * @param after The {@code TriConsumer} to execute after this one completes.
+     * @return A new composed {@code TriConsumer} that performs this operation
+     * followed by the {@code after} operation
      * @throws NullPointerException if {@code after} is null
      */
     @NotNull

--- a/src/main/java/net/openhft/chronicle/wire/UnexpectedFieldHandlingException.java
+++ b/src/main/java/net/openhft/chronicle/wire/UnexpectedFieldHandlingException.java
@@ -27,7 +27,8 @@ public class UnexpectedFieldHandlingException extends RuntimeException {
     /**
      * Constructs a new UnexpectedFieldHandlingException with the provided underlying cause.
      *
-     * @param cause The root cause of this exception, typically originating from
+     * @param cause The root cause of this exception, often an exception thrown
+     *              from within an implementation of
      *              {@link ReadMarshallable#unexpectedField(Object, ValueIn)}.
      */
     public UnexpectedFieldHandlingException(Throwable cause) {

--- a/src/main/java/net/openhft/chronicle/wire/UnrecoverableTimeoutException.java
+++ b/src/main/java/net/openhft/chronicle/wire/UnrecoverableTimeoutException.java
@@ -32,7 +32,8 @@ public class UnrecoverableTimeoutException extends IllegalStateException {
      * exception as the cause.
      * The message from the underlying exception is propagated to this exception.
      *
-     * @param e The underlying exception that caused this timeout exception.
+     * @param e The underlying {@link Exception} that represents the original
+     *          timeout or related error condition.
      */
     @SuppressWarnings("this-escape")
     public UnrecoverableTimeoutException(@NotNull Exception e) {

--- a/src/main/java/net/openhft/chronicle/wire/Validate.java
+++ b/src/main/java/net/openhft/chronicle/wire/Validate.java
@@ -1,22 +1,25 @@
 package net.openhft.chronicle.wire;
 
 /**
- * This is the Validate interface.
- * Implementations of this interface are responsible for validating objects
- * based on specific criteria or conditions.
- * The purpose of the validate method is to ensure the correctness or suitability
- * of the object in question.
+ * Interface for validating objects.
+ *
+ * <p>Implementations ensure the state of an object meets its invariants or
+ * preconditions. It is often used for DTOs or configuration objects to ensure
+ * their state is consistent and valid before use or after deserialisation. See
+ * {@link net.openhft.chronicle.core.io.ValidatableUtil} for utilities related
+ * to validation.
  */
 public interface Validate {
 
     /**
-     * Validates the provided object based on specific criteria or conditions.
-     * If the object does not meet the conditions, the method might throw a
-     * runtime exception or exhibit other behavior as defined by the
-     * implementation. It is recommended for implementers to clearly document
-     * the validation rules and potential outcomes.
+     * Validates the provided object.
      *
-     * @param o The object to be validated.
+     * <p>If validation fails, this method should throw a descriptive
+     * {@link RuntimeException} such as {@link IllegalStateException} or a custom
+     * validation exception.
+     *
+     * @param o The object to be validated. Implementations will typically cast
+     *          this to their specific type.
      */
     void validate(Object o);
 }

--- a/src/main/java/net/openhft/chronicle/wire/WireSerializedLambda.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireSerializedLambda.java
@@ -26,46 +26,58 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Helper class to support the serialization of lambda expressions in Wire formats.
+ * Helper class to support the serialisation of lambda expressions in Wire formats.
  * <p>
- * This class provides functionalities to check if a class is a serializable lambda and
- * serialize it using the Wire format. It uses Java's {@link SerializedLambda} mechanism
- * to capture details about the lambda and then writes those details to a Wire format.
+ * This allows lambdas that are {@link java.io.Serializable} to be written to and read
+ * from a {@link Wire}, preserving their capturing arguments and target functional
+ * interface method. It effectively mimics Java's built-in lambda serialisation
+ * mechanism for Chronicle Wire.
  */
 @SuppressWarnings("rawtypes")
 public class WireSerializedLambda implements ReadMarshallable, ReadResolvable {
 
+    /** The class that captured the lambda. */
     private Class<?> capturingClass;
+    /** Fully qualified name of the functional interface. */
     private String functionalInterfaceClass;
+    /** Name of the functional interface method. */
     private String functionalInterfaceMethodName;
+    /** Method signature of the functional interface method. */
     private String functionalInterfaceMethodSignature;
+    /** Implementation class containing the lambda body. */
     private String implClass;
+    /** Name of the implementation method. */
     private String implMethodName;
+    /** Signature of the implementation method. */
     private String implMethodSignature;
+    /** Kind of the implementation method as defined by {@link SerializedLambda}. */
     private int implMethodKind;
+    /** Instantiated method type descriptor. */
     private String instantiatedMethodType;
+    /** List of arguments captured by the lambda. */
     @NotNull
     private List<Object> capturedArgs = new ArrayList<>();
 
     /**
-     * Determines if the provided class is a serializable lambda.
+     * Checks whether {@code clazz} represents a lambda class that also implements
+     * {@link java.io.Serializable}.
      *
-     * @param clazz The class to be checked.
-     * @return {@code true} if the class is a serializable lambda, {@code false} otherwise.
+     * @param clazz class to check
+     * @return {@code true} if {@code clazz} is a serialisable lambda
      */
     public static boolean isSerializableLambda(@NotNull Class<?> clazz) {
         return Serializable.class.isAssignableFrom(clazz) && Jvm.isLambdaClass(clazz);
     }
 
     /**
-     * Serializes the given lambda to a Wire format using the provided {@link ValueOut} instance.
+     * Writes a serialisable lambda to the supplied {@link ValueOut}.
      * <p>
-     * This method fetches the details of the lambda using the {@link SerializedLambda} mechanism
-     * and then writes these details to the provided Wire format.
+     * The lambda's {@code writeReplace} method yields a {@link SerializedLambda},
+     * which is written as a {@code WireSerializedLambda}.
      *
-     * @param <L> The type of the lambda to be serialized.
-     * @param lambda The lambda instance to be serialized.
-     * @param valueOut The {@link ValueOut} instance to which the lambda should be serialized.
+     * @param <L>      the type of the lambda expression
+     * @param lambda   the serialisable lambda instance
+     * @param valueOut target for the lambda's serialised form
      */
     public static <L> void write(@NotNull L lambda, @NotNull ValueOut valueOut) {
         try {
@@ -93,6 +105,10 @@ public class WireSerializedLambda implements ReadMarshallable, ReadResolvable {
         }
     }
 
+    /**
+     * Deserialises this {@code WireSerializedLambda} from the given wire.
+     * All fields corresponding to {@link SerializedLambda} properties are read.
+     */
     @Override
     public void readMarshallable(@NotNull WireIn wire) throws IllegalStateException {
         capturedArgs = new ArrayList<>();
@@ -113,6 +129,10 @@ public class WireSerializedLambda implements ReadMarshallable, ReadResolvable {
 
     }
 
+    /**
+     * Recreates the original lambda instance from the deserialised state.
+     * Called after all fields have been populated via {@link #readMarshallable(WireIn)}.
+     */
     @NotNull
     @Override
     public Object readResolve() {

--- a/src/main/java/net/openhft/chronicle/wire/utils/MethodReaderStatus.java
+++ b/src/main/java/net/openhft/chronicle/wire/utils/MethodReaderStatus.java
@@ -16,9 +16,30 @@
 
 package net.openhft.chronicle.wire.utils;
 
+/**
+ * Enumerates the possible outcomes of a single read attempt by a
+ * {@link net.openhft.chronicle.bytes.MethodReader}, particularly for
+ * generated readers such as {@link net.openhft.chronicle.wire.AbstractGeneratedMethodReader}.
+ */
 public enum MethodReaderStatus {
+    /**
+     * Indicates that no message or event was found or processed in the current
+     * read attempt (for example end of document or no data available).
+     */
     EMPTY,
+    /**
+     * Indicates that a {@link net.openhft.chronicle.wire.MessageHistory} event
+     * was read and processed.
+     */
     HISTORY,
+    /**
+     * Indicates that a known method or event was successfully read,
+     * deserialized and dispatched to a handler.
+     */
     KNOWN,
+    /**
+     * Indicates that an unknown method or event was encountered. The default
+     * parselet may have skipped it or an error might have been logged.
+     */
     UNKNOWN
 }


### PR DESCRIPTION
| Module                           | Files touched                                                                                                                                                                     | Essence of update                                                                                                                                                                    |
| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| **Core annotations & notifiers** | `Comment.java`, `CommentAnnotationNotifier.java`, `RollbackIfNotCompleteNotifier.java`                                                                                            | • Javadoc now explains runtime use-cases and YAML comment emission.<br>• Param/exception docs added & wording standardised.                                                          |
| **Reflection & util layer**      | `ReflectionUtil.java`, `BitSetUtil.java`                                                                                                                                          | • Split long lines & added field-level docs.<br>• Clarified system-property flags and thread-safety notes.                                                                           |
| **Wire plumbing**                | `WireDumper.java`, `Wires.java`, `WireKey.java`, `WireType*.java`, `VanillaWireParser.java`, `WireParselet.java`, `FieldNumberParselet.java`, `WireTypeConverter(+Internal).java` | • Comprehensive Javadoc for every public method, enum constant & flag.<br>• Parameter names in docbase now match code.<br>• Deprecated / internal APIs explicitly marked and linked. |
| **Bit-set implementations**      | `ChronicleBitSet.java`, `LongValueBitSet.java`, `LongArrayValueBitSet.java`                                                                                                       | • Expanded docs: off-heap semantics, CAS loops, capacity caveats.<br>• Added inline explanations for magic constants.                                                                |
| **Misc. tweaks**                 | minor edits on masks, constants & private fields                                                                                                                                  | • Renamed a handful of locals for clarity (no signature changes).                                                                                                                    |

> **No byte-code, behaviour or public API signatures were altered** – only comments, Javadoc and a handful of parameter identifiers that never escape the class files.
