### PR TITLE
Improve inline docs for demo config files

### DIFF
--- a/demo/java17setup.sh
+++ b/demo/java17setup.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+# Sets up the environment for running demos that rely on Java 17 features.
+# These options expose internal JDK modules so the examples compile and run.
 #
 # Copyright 2016-2025 chronicle.software
 #
@@ -16,8 +18,10 @@
 # limitations under the License.
 #
 
+# Extra JVM arguments needed when building with Java 17
 export MAVEN_OPTS="--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED --add-exports=java.base/sun.nio.ch=ALL-UNNAMED \
                    --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
                    --add-opens=jdk.compiler/com.sun.tools.javac=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
                    --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
                    --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED"
+

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -35,6 +35,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <!-- Inherit common dependency versions from the Chronicle BOMs -->
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -55,6 +56,7 @@
         </dependencies>
     </dependencyManagement>
 
+    <!-- Core libraries required by the demo code -->
     <dependencies>
         <dependency>
             <groupId>net.openhft</groupId>
@@ -87,7 +89,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-
+                <!-- Allows Maven to run the examples directly -->
                 <executions>
                     <execution>
                         <id>Example1</id>

--- a/demo/src/main/resources/cfg1.yaml
+++ b/demo/src/main/resources/cfg1.yaml
@@ -1,5 +1,7 @@
+# Example configuration used by Example6
 !Data1 {
-  name: Tom,
-  age: 25,
+  name: Tom,        # Person's forename
+  age: 25,          # Age in years
   address: "21 High street, Liverpool"
 }
+

--- a/demo/src/main/resources/cfg2.yaml
+++ b/demo/src/main/resources/cfg2.yaml
@@ -1,5 +1,7 @@
+# Configuration for Example7's Data2 class
 !run.chronicle.wire.demo.Example7$Data2 {
   name: Helen,
   age: 19,
   address: "15 Royal Way, Liverpool"
 }
+

--- a/demo/system.properties
+++ b/demo/system.properties
@@ -14,12 +14,16 @@
 # limitations under the License.
 #
 
-# Tracing if resources are closed/released correctly.
+# Enables tracing if resources are closed or released correctly
 jvm.resource.tracing=true
+# Suppresses warnings about auto-closeable resources
 disable.resource.warning=true
-# for profiling
+# For profiling runs disable JVM safepoint polls (default true)
 jvm.safepoint.enabled=false
+# Use version 2 of wire generation (default true)
 wire.generate.v2=false
-# reduce logging of the announcer
+# Reduce logging of the announcer component
 chronicle.announcer.disable=true
+# Print details of code that could be optimised
 report.unoptimised=true
+

--- a/marshallingperf/pom.xml
+++ b/marshallingperf/pom.xml
@@ -35,6 +35,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <!-- Import BOMs so dependency versions remain consistent across projects -->
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -55,6 +56,7 @@
         </dependencies>
     </dependencyManagement>
 
+    <!-- Libraries used by the performance benchmarks -->
     <dependencies>
         <dependency>
             <groupId>net.openhft</groupId>
@@ -97,6 +99,7 @@
         </plugins>
     </build>
 
+    <!-- Optional profiles to test alternative versions or run the benchmarks -->
     <profiles>
         <profile>
             <id>latest</id>
@@ -121,6 +124,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
+                        <!-- Runs the micro-benchmarks during the test phase -->
 
                         <configuration>
                             <systemProperties>

--- a/marshallingperf/system.properties
+++ b/marshallingperf/system.properties
@@ -14,11 +14,14 @@
 # limitations under the License.
 #
 
-# Tracing if resources are closed/released correctly.
+# Enables tracing if resources are closed or released correctly
 jvm.resource.tracing=false
-# for profiling
+# For profiling runs disable JVM safepoint polls (default true)
 jvm.safepoint.enabled=false
+# Use version 2 of wire generation (default true)
 wire.generate.v2=false
-# reduce logging of the announcer
+# Reduce logging of the announcer component
 chronicle.announcer.disable=true
+# Print details of code that could be optimised
 report.unoptimised=true
+


### PR DESCRIPTION
## Summary
- document how demo & benchmark POMs use BOMs
- explain exec-maven-plugin and benchmarking profiles
- clarify purpose of `java17setup.sh`
- document system properties for demos and performance benchmarks
- annotate YAML config examples

## Testing
- `mvn -q verify` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683d80fb38b48329a4793cebdc4c855f