### PR TITLE
Improve benchmark Javadoc

### DIFF
--- a/marshallingperf/src/main/java/run/chronicle/wire/perf/BytesInBytesMarshallableMain.java
+++ b/marshallingperf/src/main/java/run/chronicle/wire/perf/BytesInBytesMarshallableMain.java
@@ -17,8 +17,26 @@ write: 50/90 97/99 99.7/99.9 99.97/99.99 99.997/99.999 99.9997/99.9999 - worst w
 read: 50/90 97/99 99.7/99.9 99.97/99.99 99.997/99.999 99.9997/99.9999 - worst was 0.145 / 0.151  0.163 / 0.223  0.309 / 0.566  0.630 / 15.5  19.3 / 28.5  28.7 / 31.6 - 70.9
 write: 50/90 97/99 99.7/99.9 99.97/99.99 99.997/99.999 99.9997/99.9999 - worst was 0.079 / 0.082  0.090 / 0.122  0.177 / 0.309  0.427 / 1.108  15.8 / 22.5  28.6 / 28.9 - 53.4
 */
+
+/**
+ * Benchmarks the performance of {@link BytesInBinaryMarshallable} where each field
+ * is stored as a block of bytes. Eight byte sequences are written to and read from
+ * a direct {@link Bytes} buffer.
+ *
+ * <p>Latency for each read and write operation is recorded in a {@link Histogram}.
+ * After a warm up phase the results are printed as histograms.</p>
+ */
 public class BytesInBytesMarshallableMain {
 
+    /**
+     * Runs the benchmark.
+     *
+     * <p>The first twenty thousand iterations act as a warm up. Subsequent
+     * iterations record the time to write and then read the test object.
+     * Latency results are printed as histograms.</p>
+     *
+     * @param args Command line arguments (not used).
+     */
     public static void main(String... args) {
 
         Histogram readHist = new Histogram();
@@ -29,6 +47,7 @@ public class BytesInBytesMarshallableMain {
         WithBytes n2 = new WithBytes();
         Bytes<?> bytes = Bytes.allocateElasticDirect(128);
 
+        // Negative iterations warm up the JIT to stabilise timings
         for (int i = -20_000; i < 100_000_000; i++) {
             bytes.clear();
             long start = System.nanoTime();
@@ -39,11 +58,13 @@ public class BytesInBytesMarshallableMain {
             n2.readMarshallable(bytes);
             end = System.nanoTime();
             readHist.sample(end - start);
+            // Start timing after the warm up phase
             if (i == 0) {
                 readHist.reset();
                 writeHist.reset();
             }
             if (i >= -1000)
+                // Allow other threads a chance to run during the warm up
                 Thread.yield();
         }
 
@@ -51,14 +72,24 @@ public class BytesInBytesMarshallableMain {
         histoOut("write", BytesInBytesMarshallableMain.class, writeHist);
     }
 
+    /**
+     * Prints the histogram in a human readable form and emits the same data for
+     * TeamCity builds.
+     */
     static void histoOut(String msg, Class<?> clazz, Histogram histo) {
         System.out.println(msg + ": " + histo.toLongMicrosFormat());
         TeamCityHelper.histo(clazz.getSimpleName() + "." + msg, histo, System.out);
     }
 
+    /**
+     * Test object containing eight {@link Bytes} fields used for the benchmark.
+     */
     static class WithBytes extends BytesInBinaryMarshallable {
         Bytes<?> a, b, c, d, e, f, g, h;
 
+        /**
+         * Creates an instance with empty byte fields allocated for reading.
+         */
         public WithBytes() {
             a = Bytes.elasticHeapByteBuffer(64);
             b = Bytes.elasticHeapByteBuffer(64);
@@ -70,6 +101,9 @@ public class BytesInBytesMarshallableMain {
             h = Bytes.allocateElasticDirect(64);
         }
 
+        /**
+         * Creates an instance populated with string data converted to {@link Bytes}.
+         */
         public WithBytes(String a, String b, String c, String d, String e, String f, String g, String h) {
             this.a = Bytes.fromDirect(a);
             this.b = Bytes.fromDirect(b);

--- a/marshallingperf/src/main/java/run/chronicle/wire/perf/JSONWireMarshallableMain.java
+++ b/marshallingperf/src/main/java/run/chronicle/wire/perf/JSONWireMarshallableMain.java
@@ -11,8 +11,22 @@ import net.openhft.chronicle.wire.*;
 
 import static run.chronicle.wire.perf.BytesInBytesMarshallableMain.histoOut;
 
+/**
+ * Benchmarks the performance of marshalling and unmarshalling objects using
+ * {@link JSONWire}. The {@link Example} class exercises several primitive and
+ * string fields.
+ */
 public class JSONWireMarshallableMain {
 
+    /**
+     * Executes the JSON wire benchmark.
+     *
+     * <p>Iterations with a negative index warm the JVM. After warm up the
+     * program measures the time to write and read an {@link Example} instance.
+     * Results are printed as latency histograms.</p>
+     *
+     * @param args Command line arguments (not used).
+     */
     public static void main(String... args) {
 
         Histogram readHist = new Histogram();
@@ -24,6 +38,7 @@ public class JSONWireMarshallableMain {
         Wire wire = WireType.JSON.apply(Bytes.allocateElasticDirect(128));
 
         try (AffinityLock lock = AffinityLock.acquireLock()) {
+            // Warm up with negative iterations then record timings
             for (int i = -100_000; i < 50_000_000; i++) {
                 wire.clear();
                 long start = System.nanoTime();
@@ -50,6 +65,9 @@ public class JSONWireMarshallableMain {
         histoOut("write", JSONWireMarshallableMain.class, writeHist);
     }
 
+    /**
+     * Simple data holder used to exercise JSON serialisation of various field types.
+     */
     static class Example extends SelfDescribingMarshallable {
         int smallInt = 0;
         long longInt = 0;
@@ -57,6 +75,9 @@ public class JSONWireMarshallableMain {
         boolean flag = false;
         String text;
 
+        /**
+         * Creates an example populated with provided values.
+         */
         Example(int smallInt, long longInt, double price, boolean flag, String text) {
             this.smallInt = smallInt;
             this.longInt = longInt;
@@ -65,6 +86,9 @@ public class JSONWireMarshallableMain {
             this.text = text;
         }
 
+        /**
+         * Creates an empty instance for reading into.
+         */
         public Example() {
         }
 

--- a/marshallingperf/src/main/java/run/chronicle/wire/perf/MessageHistoryBytesMarshallableMain.java
+++ b/marshallingperf/src/main/java/run/chronicle/wire/perf/MessageHistoryBytesMarshallableMain.java
@@ -6,6 +6,11 @@ import net.openhft.chronicle.wire.VanillaMessageHistory;
 
 import static run.chronicle.wire.perf.BytesInBytesMarshallableMain.histoOut;
 
+/**
+ * Benchmarks the performance of serialising and deserialising
+ * {@link net.openhft.chronicle.wire.VanillaMessageHistory} objects using their
+ * compact binary form.
+ */
 /*
 .2.21.ea207
 read: 50/90 97/99 99.7/99.9 99.97/99.99 99.997/99.999 99.9997/99.9999 - worst was 0.020 / 0.030  0.031 / 0.031  0.040 / 0.040  0.050 / 0.060  0.080 / 0.150  2.476 / 4.15 - 30.5
@@ -14,6 +19,14 @@ write: 50/90 97/99 99.7/99.9 99.97/99.99 99.997/99.999 99.9997/99.9999 - worst w
 */
 public class MessageHistoryBytesMarshallableMain {
 
+    /**
+     * Runs the benchmark.
+     *
+     * <p>A short warm up precedes measurement of read and write latency for a
+     * {@link SetTimeMessageHistory} instance. Results are output as histograms.</p>
+     *
+     * @param args Command line arguments (not used).
+     */
     public static void main(String... args) {
 
         Histogram readHist = new Histogram();
@@ -23,6 +36,7 @@ public class MessageHistoryBytesMarshallableMain {
         SetTimeMessageHistory n2 = new SetTimeMessageHistory();
         Bytes<?> bytes = Bytes.allocateElasticDirect(128);
 
+        // Warm up with negative iterations to allow JIT optimisation
         for (int i = -20_000; i < 100_000_000; i++) {
             bytes.clear();
             long start = System.nanoTime();
@@ -33,11 +47,13 @@ public class MessageHistoryBytesMarshallableMain {
             n2.readMarshallable(bytes);
             end = System.nanoTime();
             readHist.sample(end - start);
+            // Start timing after the warm up phase
             if (i == 0) {
                 readHist.reset();
                 writeHist.reset();
             }
             if (i >= -1000)
+                // Keep the machine responsive during warm up
                 Thread.yield();
         }
 
@@ -45,6 +61,10 @@ public class MessageHistoryBytesMarshallableMain {
         histoOut("write", MessageHistoryBytesMarshallableMain.class, writeHist);
     }
 
+    /**
+     * Creates a {@link SetTimeMessageHistory} pre-populated with two sources and
+     * four timing entries.
+     */
     static SetTimeMessageHistory createMessageHistory() {
         SetTimeMessageHistory n = new SetTimeMessageHistory();
         n.addSource(1, 0xff);
@@ -56,6 +76,9 @@ public class MessageHistoryBytesMarshallableMain {
         return n;
     }
 
+    /**
+     * MessageHistory that returns a predictable nano time increasing by 100 each call.
+     */
     static class SetTimeMessageHistory extends VanillaMessageHistory {
         long nanoTime = 120962203520000L;
 

--- a/marshallingperf/src/main/java/run/chronicle/wire/perf/MessageHistoryWireMarshallableMain.java
+++ b/marshallingperf/src/main/java/run/chronicle/wire/perf/MessageHistoryWireMarshallableMain.java
@@ -8,6 +8,11 @@ import net.openhft.chronicle.wire.WireType;
 import static run.chronicle.wire.perf.BytesInBytesMarshallableMain.histoOut;
 import static run.chronicle.wire.perf.MessageHistoryBytesMarshallableMain.createMessageHistory;
 
+/**
+ * Benchmarks the performance of serialising and deserialising
+ * {@link net.openhft.chronicle.wire.VanillaMessageHistory} using the standard
+ * {@link net.openhft.chronicle.wire.WireMarshaller} mechanism (field by field).
+ */
 /*
 .2.21.ea207
 read: 50/90 97/99 99.7/99.9 99.97/99.99 99.997/99.999 99.9997/99.9999 - worst was 0.120 / 0.130  0.131 / 0.140  0.150 / 0.230  0.251 / 0.281  1.134 / 4.22  5.53 / 9.84 - 29.5
@@ -16,6 +21,15 @@ write: 50/90 97/99 99.7/99.9 99.97/99.99 99.997/99.999 99.9997/99.9999 - worst w
 */
 public class MessageHistoryWireMarshallableMain {
 
+    /**
+     * Runs the benchmark using the wire marshaller.
+     *
+     * <p>After a warm up phase the latency of writing and reading a
+     * {@link MessageHistoryBytesMarshallableMain.SetTimeMessageHistory} is recorded.
+     * Histograms are printed at the end.</p>
+     *
+     * @param args Command line arguments (not used).
+     */
     public static void main(String... args) {
 
         Histogram readHist = new Histogram();
@@ -26,6 +40,7 @@ public class MessageHistoryWireMarshallableMain {
         Bytes<?> bytes = Bytes.allocateElasticDirect(128);
         Wire bw = WireType.BINARY.apply(bytes);
 
+        // Warm up then measure read and write latency
         for (int i = -20_000; i < 100_000_000; i++) {
             bytes.clear();
             long start = System.nanoTime();
@@ -36,6 +51,7 @@ public class MessageHistoryWireMarshallableMain {
             n2.readMarshallable(bw);
             end = System.nanoTime();
             readHist.sample(end - start);
+            // Reset histograms once warm up completes
             if (i == 0) {
                 readHist.reset();
                 writeHist.reset();

--- a/marshallingperf/src/main/java/run/chronicle/wire/perf/PrimitivesInBytesMarshallableMain.java
+++ b/marshallingperf/src/main/java/run/chronicle/wire/perf/PrimitivesInBytesMarshallableMain.java
@@ -9,8 +9,20 @@ import net.openhft.chronicle.wire.BytesInBinaryMarshallable;
 
 import static run.chronicle.wire.perf.BytesInBytesMarshallableMain.histoOut;
 
+/**
+ * Benchmarks the performance of serialising and deserialising an object
+ * containing primitive fields using {@link net.openhft.chronicle.bytes.BytesMarshallable}.
+ */
 public class PrimitivesInBytesMarshallableMain {
 
+    /**
+     * Executes the primitive field benchmark.
+     *
+     * <p>A warm up is followed by measured iterations. Latency for each
+     * serialisation and deserialisation is stored in histograms.</p>
+     *
+     * @param args Command line arguments (not used).
+     */
     public static void main(String... args) {
 
         Histogram readHist = new Histogram();
@@ -21,6 +33,7 @@ public class PrimitivesInBytesMarshallableMain {
         WithPrimitives n2 = new WithPrimitives();
         Bytes<?> bytes = Bytes.elasticByteBuffer(256);
 
+        // Use negative iterations for warm up
         for (int i = -20_000; i < 100_000_000; i++) {
             bytes.clear();
             long start = System.nanoTime();
@@ -31,6 +44,7 @@ public class PrimitivesInBytesMarshallableMain {
             n2.readMarshallable(bytes);
             end = System.nanoTime();
             readHist.sample(end - start);
+            // Reset histograms after warming up
             if (i == 0) {
                 readHist.reset();
                 writeHist.reset();
@@ -43,6 +57,9 @@ public class PrimitivesInBytesMarshallableMain {
         histoOut("write", PrimitivesInBytesMarshallableMain.class, writeHist);
     }
 
+    /**
+     * Object containing various primitive fields used for the benchmark.
+     */
     static class WithPrimitives extends BytesInBinaryMarshallable {
         boolean a;
         byte b;
@@ -53,6 +70,9 @@ public class PrimitivesInBytesMarshallableMain {
         long g;
         double h;
 
+        /**
+         * Constructs an empty instance for reading into.
+         */
         public WithPrimitives() {
         }
 

--- a/marshallingperf/src/main/java/run/chronicle/wire/perf/StringsInBytesMarshallableMain.java
+++ b/marshallingperf/src/main/java/run/chronicle/wire/perf/StringsInBytesMarshallableMain.java
@@ -8,6 +8,10 @@ import net.openhft.chronicle.core.util.Histogram;
 import net.openhft.chronicle.wire.BytesInBinaryMarshallable;
 
 import static run.chronicle.wire.perf.BytesInBytesMarshallableMain.histoOut;
+/**
+ * Benchmarks the performance of serialising and deserialising an object
+ * containing string fields using {@link net.openhft.chronicle.bytes.BytesMarshallable}.
+ */
 
 /*
 .2.21ea74
@@ -21,6 +25,14 @@ write: 50/90 97/99 99.7/99.9 99.97/99.99 99.997/99.999 99.9997/99.9999 - worst w
 
 public class StringsInBytesMarshallableMain {
 
+    /**
+     * Runs the string field benchmark.
+     *
+     * <p>Negative iterations act as warm up before timings are captured.
+     * Histograms of read and write latency are printed.</p>
+     *
+     * @param args Command line arguments (not used).
+     */
     public static void main(String... args) {
 
         Histogram readHist = new Histogram();
@@ -31,6 +43,7 @@ public class StringsInBytesMarshallableMain {
         WithStrings n2 = new WithStrings();
         Bytes<?> bytes = Bytes.allocateElasticDirect(128);
 
+        // Warm up then measure serialisation costs
         for (int i = -20_000; i < 100_000_000; i++) {
             bytes.clear();
             long start = System.nanoTime();
@@ -41,6 +54,7 @@ public class StringsInBytesMarshallableMain {
             n2.readMarshallable(bytes);
             end = System.nanoTime();
             readHist.sample(end - start);
+            // Begin measurements once warm up completes
             if (i == 0) {
                 readHist.reset();
                 writeHist.reset();
@@ -53,12 +67,21 @@ public class StringsInBytesMarshallableMain {
         histoOut("write", StringsInBytesMarshallableMain.class, writeHist);
     }
 
+    /**
+     * Simple object holding eight strings for the benchmark.
+     */
     static class WithStrings extends BytesInBinaryMarshallable {
         String a, b, c, d, e, f, g, h;
 
+        /**
+         * Default constructor used when reading from bytes.
+         */
         public WithStrings() {
         }
 
+        /**
+         * Creates an instance populated with the provided strings.
+         */
         public WithStrings(String a, String b, String c, String d, String e, String f, String g, String h) {
             this.a = a;
             this.b = b;


### PR DESCRIPTION
## Summary
- add class Javadoc explaining each performance test
- document main methods and helper classes
- add inline comments about warm up and timing loops

## Testing
- `mvn -q verify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d8137ed548329992505ad34e08a2f