### PR TITLE
Improve YAML compliance doc and word list headers

### DIFF
--- a/YAML2SpecificationCompliance.adoc
+++ b/YAML2SpecificationCompliance.adoc
@@ -4,9 +4,18 @@
 :toc-placement: preamble
 :sectnums:
 
+== Overview
+
+Chronicle Wire implements YAML parsing primarily through `YamlWire` and `TextWire`.
+This document outlines the level of compliance with the YAML 1.2.2 specification
+and highlights any deviations. It is intended for developers who require
+interoperability information.
+
+link:https://yaml.org/spec/1.2.2/[YAML 1.2.2 specification]
+
 == YAML 1.2.2 Specification Compliance
 
-Chronicle Wire's `YAML` wire type aims to parse a significant portion of the YAML 1.2.2 specification, focusing on features commonly found in real‑world YAML documents and those necessary for robust data serialisation. While the `TEXT` wire type supports a narrower subset suitable for simple Wire object graphs, this document describes the YAML 1.2.2 features that are supported and notes how Chronicle Wire provides equivalent functionality or handles specific YAML features where behaviour differs.
+Chronicle Wire's `YAML` wire type aims to parse a significant portion of the YAML 1.2.2 specification, focusing on features commonly found in real-world YAML documents and those necessary for robust data serialisation. While the `TEXT` wire type supports a narrower subset suitable for simple Wire object graphs, this document describes the YAML 1.2.2 features that are supported and notes how Chronicle Wire provides equivalent functionality or handles specific YAML features where behaviour differs.
 
 === YAML 1.2.2 features supported in Chronicle Wire
 
@@ -29,10 +38,21 @@ NOTE: The numbers refer to the example sections in the YAML 1.2.2 specification.
 | Quoted Scalars (single `'` and double `"`) | 7.3.1, Example 2.17 | **Yes** | Escape sequences handled in double quotes.
 | Integers | 10.3.2, Example 2.19 | **Yes** | Decimal, hexadecimal `0x`, and octal `0o` numbers supported.
 | Floating-Point Numbers | 10.3.2, Example 2.20 | Partial | Standard floating-point numbers supported. Parsing of `.inf`, `-.inf`, and `.nan` limited.
-| Timestamps | 10.3.2, Example 2.22 | **Yes** | ISO‑8601 timestamps supported, can be used with `@NanoTime` or `@MillisTime`.
+| Timestamps | 10.3.2, Example 2.22 | **Yes** | ISO-8601 timestamps supported, can be used with `@NanoTime` or `@MillisTime`.
 | Unordered Sets (`!!set`) | 10.3.2, Example 2.25 | No | Deserialised as `LinkedHashMap` or `List`. Convert to a `Set` in application code if needed.
 | Ordered Mappings (`!!omap`) | 10.3.2, Example 2.26 | No | Deserialised as `LinkedHashMap` which preserves insertion order.
-| Complex Examples (`Invoice`, `LogFile`) | 2.27–2.28 | Partial | Standard structures supported; custom tags may require custom `Marshallable` implementations.
+| Complex Examples (`Invoice`, `LogFile`) | 2.27-2.28 | Partial | Standard structures supported; custom tags may require custom `Marshallable` implementations.
 |===
+
+=== Deviations
+
+* Complex mapping keys are not supported; mapping keys must be scalars.
+* `!!set` and `!!omap` are read as `LinkedHashMap` or `List`.
+* Special floating-point values such as `.inf` and `.nan` are only partially recognised.
+* Multi-line flow scalars may need quoting to parse correctly.
+
+=== Extensions
+
+Chronicle Wire does not introduce YAML extensions. Custom tags can map to application-specific classes via `Marshallable` implementations.
 
 https://github.com/OpenHFT/Chronicle-Wire[Back to Chronicle Wire project]

--- a/src/main/java/net/openhft/chronicle/wire/WordsLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/WordsLongConverter.java
@@ -23,6 +23,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * The {@code WordsLongConverter} class implements the LongConverter interface.
@@ -46,9 +48,17 @@ public class WordsLongConverter implements LongConverter {
     // Static block to load words from the 'common-words.txt' file into the WORDS array and the WORD_ID map.
     static {
         try {
-            // Load the words from a resource file.
-            String[] words = new String(IOTools.readFile(WordsLongConverter.class, "common-words.txt"), StandardCharsets.ISO_8859_1).split("\\s+");
-            WORDS = words;
+            // Load the words from the resource file, ignoring comment lines.
+            String content = new String(IOTools.readFile(WordsLongConverter.class, "common-words.txt"), StandardCharsets.ISO_8859_1);
+            String[] lines = content.split("\\R");
+            List<String> list = new ArrayList<>();
+            for (String line : lines) {
+                String t = line.trim();
+                if (t.isEmpty() || t.startsWith("#"))
+                    continue;
+                list.add(t);
+            }
+            WORDS = list.toArray(new String[0]);
 
             // Populate the WORD_ID map.
             for (int i = 0; i < WORDS.length; i++) {

--- a/src/main/java/net/openhft/chronicle/wire/internal/package-info.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/package-info.java
@@ -15,18 +15,12 @@
  */
 
 /**
- * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.
- * Internal classes shall <em>never</em> be used directly.
+ * Provides internal utility classes and implementation details for the Chronicle Wire library.
  * <p>
- *  Specifically, the following actions (including, but not limited to) are not allowed
- *  on internal classes and packages:
- *  <ul>
- *      <li>Casting to</li>
- *      <li>Reflection of any kind</li>
- *      <li>Explicit Serialize/deserialize</li>
- *  </ul>
- * <p>
- * The classes in this package and any sub-package are subject to
- * changes at any time for any reason.
+ * Classes here are not part of the public API and may change without notice. They underpin
+ * wire implementations, marshalling and code generation.
+ *
+ * @see net.openhft.chronicle.wire.Wire
+ * @see net.openhft.chronicle.wire.Marshallable
  */
 package net.openhft.chronicle.wire.internal;

--- a/src/main/resources/common-words.txt
+++ b/src/main/resources/common-words.txt
@@ -1,3 +1,8 @@
+# Words used by net.openhft.chronicle.wire.WordsLongConverter
+# for compact string representation.
+# Words must be unique and their order is significant.
+# One word per line.
+
 act
 aid
 aim

--- a/src/main/resources/more-common-words.txt
+++ b/src/main/resources/more-common-words.txt
@@ -1,3 +1,8 @@
+# Additional words used by net.openhft.chronicle.wire.WordsLongConverter
+# for compact string representation.
+# This file contains more frequently used words.
+# One word per line.
+
 credit
 opinion
 version


### PR DESCRIPTION
## Summary
- expand YAML2SpecificationCompliance to include overview and deviations
- clarify internal package-info description
- add headers to `common-words.txt` and `more-common-words.txt`
- ignore comment lines when loading words

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d82983418832989fc5aef23d7dad6