### PR TITLE
Add newline validation for ConfigLoader

### DIFF
--- a/src/main/adoc/security-review.adoc
+++ b/src/main/adoc/security-review.adoc
@@ -111,3 +111,14 @@ Mitigations ::
 * Ensure `reset()` (or `clear()`) nulls/zeroes *all* mutable fields.
 * Add JMH or junit-stress tests with parallel writers/readers.
 
+== Configuration Property Expansion
+
+Why ::
+Provides flexible deployment by replacing `${property}` tokens.
+
+Risks ::
+* Newline characters in a property value may inject extra YAML lines.
+
+Mitigations ::
+* `ConfigLoader` rejects property values containing line breaks.
+

--- a/src/main/java/net/openhft/chronicle/wire/utils/ConfigLoader.java
+++ b/src/main/java/net/openhft/chronicle/wire/utils/ConfigLoader.java
@@ -12,7 +12,9 @@ import static net.openhft.chronicle.bytes.util.PropertyReplacer.replaceTokensWit
 /**
  * Utility class for loading configuration files in YAML format. The class provides methods to load configuration
  * files in YAML format from the classpath and convert them to Java objects. The class will replace
- * tokens in the format {@code ${property}} within strings with System properties or supplied properties.
+ * tokens in the format {@code ${property}} within strings with System properties
+ * or supplied properties. Values containing line breaks are rejected to protect
+ * the YAML structure.
  * <p>
  * Files must be in YAML format that conform to WireType.TEXT. For example:
  * <pre>{@code
@@ -51,13 +53,28 @@ public enum ConfigLoader {
         return loadWithProperties(loadFile(classLoader, filename), properties);
     }
 
+    /**
+     * Fail fast if any supplied property contains a carriage return or line feed.
+     */
+    private static void validateNoNewLines(Properties properties) {
+        properties.forEach((k, v) -> {
+            if (v != null) {
+                String s = v.toString();
+                if (s.contains("\n") || s.contains("\r"))
+                    throw new IllegalArgumentException("Property " + k + " contains line breaks");
+            }
+        });
+    }
+
     @SuppressWarnings("unchecked")
     public static <T> T load(String fileAsString) {
+        validateNoNewLines(System.getProperties());
         return  (T) TextWire.from(replaceTokensWithProperties(fileAsString)).readObject();
     }
 
     @SuppressWarnings("unchecked")
     public static <T> T loadWithProperties(String fileAsString, Properties properties) {
+        validateNoNewLines(properties);
         return (T) TextWire.from(replaceTokensWithProperties(fileAsString, properties)).readObject();
     }
 }

--- a/src/test/java/net/openhft/chronicle/wire/utils/ConfigLoaderInjectionTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/utils/ConfigLoaderInjectionTest.java
@@ -1,0 +1,29 @@
+package net.openhft.chronicle.wire.utils;
+
+import net.openhft.chronicle.wire.WireTestCommon;
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.Properties;
+
+public class ConfigLoaderInjectionTest extends WireTestCommon {
+    private static final String YAML = "name: ${name}";
+
+    @After
+    public void clearProperty() {
+        System.clearProperty("name");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void loadWithPropertiesRejectsNewLine() {
+        Properties p = new Properties();
+        p.setProperty("name", "bad\nvalue");
+        ConfigLoader.loadWithProperties(YAML, p);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void loadRejectsNewLineInSystemProperty() {
+        System.setProperty("name", "bad\nvalue");
+        ConfigLoader.load(YAML);
+    }
+}


### PR DESCRIPTION
## Summary
- validate property values in `ConfigLoader` to protect YAML structure
- test for newline injection attempts
- document configuration property expansion safeguards in security review

## Testing
- `mvn -q verify` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ee23d8ce08329a93e3e694ef536b5