### PR TITLE
Add file URL validation

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/MarshallableOutBuilder.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableOutBuilder.java
@@ -51,6 +51,7 @@ public class MarshallableOutBuilder implements Supplier<MarshallableOut> {
             case "tcp":
                 throw new UnsupportedOperationException("Direct TCP connection not implemented");
             case "file":
+                validateFileUrl(url);
                 if (wireType != null && wireType != WireType.YAML_ONLY)
                     throw new IllegalArgumentException("Unsupported wireType; " + wireType);
                 // URL file protocol doesn't support writing...
@@ -73,6 +74,21 @@ public class MarshallableOutBuilder implements Supplier<MarshallableOut> {
      */
     private WireType wireTypeOr(WireType wireType) {
         return this.wireType == null ? wireType : this.wireType;
+    }
+
+    /**
+     * Performs a sanity check on file URLs to reduce the risk of path traversal.
+     * Only absolute paths without parent directory references are allowed.
+     *
+     * @param url the file URL to validate
+     * @throws IllegalArgumentException if the path contains ".." or is empty
+     */
+    private static void validateFileUrl(URL url) {
+        String path = url.getPath();
+        if (path == null || path.isEmpty())
+            throw new IllegalArgumentException("File URL must contain a path");
+        if (path.contains(".."))
+            throw new IllegalArgumentException("Parent directory references are not permitted: " + path);
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/internal/FileMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/FileMarshallableOut.java
@@ -88,6 +88,9 @@ public class FileMarshallableOut implements MarshallableOut {
     public FileMarshallableOut(MarshallableOutBuilder builder, WireType wireType) throws InvalidMarshallableException {
         this.url = builder.url();
         assert url.getProtocol().equals("file"); // Ensure the protocol is "file"
+        String path = url.getPath();
+        if (path == null || path.isEmpty() || path.contains(".."))
+            throw new IllegalArgumentException("Invalid file path: " + path);
 
         // If there's a query in the URL, parse and set the options
         final String query = url.getQuery();

--- a/src/test/java/net/openhft/chronicle/wire/FileMarshallableOutValidationTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/FileMarshallableOutValidationTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openhft.chronicle.wire;
+
+import net.openhft.chronicle.core.OS;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URL;
+
+/**
+ * Tests for URL validation when creating file based MarshallableOut instances.
+ */
+public class FileMarshallableOutValidationTest extends WireTestCommon {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsParentTraversal() throws Exception {
+        File dir = new File(OS.getTarget(), "valtest");
+        dir.mkdirs();
+        @SuppressWarnings("deprecation")
+        URL url = new URL("file://" + dir.getAbsolutePath() + "/../evil");
+        MarshallableOut.builder(url).get();
+    }
+}


### PR DESCRIPTION
## Summary
- validate file URLs in builder and FileMarshallableOut
- add regression test for invalid path traversal

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ee28f890483299ee134bb7c2f832a