### PR TITLE
Add URL validation with unit tests

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/MarshallableOutBuilder.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableOutBuilder.java
@@ -36,6 +36,9 @@ public class MarshallableOutBuilder implements Supplier<MarshallableOut> {
     // The WireType configuration for the MarshallableOut.
     private WireType wireType;
 
+    // Flag to permit HTTP connections to localhost or site-local addresses
+    private boolean allowLocalhost;
+
     /**
      * Constructs a new {@code MarshallableOutBuilder} with the specified URL.
      *
@@ -94,5 +97,24 @@ public class MarshallableOutBuilder implements Supplier<MarshallableOut> {
     public MarshallableOutBuilder wireType(WireType wireType) {
         this.wireType = wireType;
         return this;
+    }
+
+    /**
+     * Allows HTTP connections to localhost or site-local addresses. Use with
+     * caution as it bypasses SSRF checks.
+     *
+     * @return this builder instance
+     */
+    public MarshallableOutBuilder allowLocalhost() {
+        this.allowLocalhost = true;
+        return this;
+    }
+
+    /**
+     * Exposes whether localhost URLs are permitted. Intended for
+     * internal use.
+     */
+    public boolean allowLocalhostEnabled() {
+        return allowLocalhost;
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
@@ -25,7 +25,9 @@ import net.openhft.chronicle.wire.*;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
 import java.net.URL;
+import java.net.UnknownHostException;
 
 import static net.openhft.chronicle.bytes.Bytes.allocateElasticOnHeap;
 
@@ -97,6 +99,7 @@ public class HTTPMarshallableOut implements MarshallableOut {
      */
     public HTTPMarshallableOut(MarshallableOutBuilder builder, WireType wireType) {
         this.url = builder.url();
+        validateUrl(url, builder.allowLocalhostEnabled());
 
         if (wireType == WireType.JSON)
             this.wire = new JSONWire(allocateElasticOnHeap()).useTypes(true).trimFirstCurly(true).useTextDocuments();
@@ -130,5 +133,19 @@ public class HTTPMarshallableOut implements MarshallableOut {
     public DocumentContext acquireWritingDocument(boolean metaData) throws UnrecoverableTimeoutException {
         dcHolder.documentContext(wire.acquireWritingDocument(metaData));
         return dcHolder;
+    }
+
+    /**
+     * Validate that the supplied URL does not resolve to a local or site-local
+     * address unless explicitly allowed.
+     */
+    static void validateUrl(URL url, boolean allowLocalhost) {
+        try {
+            InetAddress addr = InetAddress.getByName(url.getHost());
+            if (!allowLocalhost && (addr.isAnyLocalAddress() || addr.isLoopbackAddress() || addr.isSiteLocalAddress() || addr.isLinkLocalAddress()))
+                throw new IllegalArgumentException("Refusing to connect to local address: " + url);
+        } catch (UnknownHostException e) {
+            throw new IllegalArgumentException("Unknown host: " + url, e);
+        }
     }
 }

--- a/src/test/java/net/openhft/chronicle/wire/MarshallableOutBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MarshallableOutBuilderTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 
 public class MarshallableOutBuilderTest extends net.openhft.chronicle.wire.WireTestCommon {
 
@@ -96,7 +97,10 @@ public class MarshallableOutBuilderTest extends net.openhft.chronicle.wire.WireT
 
     // Write messages to the specified URL with a given WireType
     private void writeMessages(URL url, WireType wireType) {
-        final MarshallableOut out = MarshallableOut.builder(url).wireType(wireType).get();
+        final MarshallableOut out = MarshallableOut.builder(url)
+                .allowLocalhost()
+                .wireType(wireType)
+                .get();
         ITop top = out.methodWriter(ITop.class);
         top.mid("mid")
                 .next(1)
@@ -175,6 +179,23 @@ public class MarshallableOutBuilderTest extends net.openhft.chronicle.wire.WireT
         }
     }
 
+    // Validate that localhost URLs are rejected by default
+    @Test(expected = IllegalArgumentException.class)
+    public void urlValidationRejectsLocalhost() throws Exception {
+        @SuppressWarnings("deprecation")
+        URL url = new URL("http://localhost:1234/");
+        MarshallableOut.builder(url).get();
+    }
+
+    // Validate that the override allows localhost
+    @Test
+    public void urlValidationAllowLocalhost() throws Exception {
+        @SuppressWarnings("deprecation")
+        URL url = new URL("http://localhost:1234/");
+        MarshallableOut out = MarshallableOut.builder(url).allowLocalhost().get();
+        assertNotNull(out);
+    }
+
     // Interface representing a timed event.
     interface Timed {
         void time(long timeNS);
@@ -233,7 +254,10 @@ public class MarshallableOutBuilderTest extends net.openhft.chronicle.wire.WireT
                 server.start();
                 @SuppressWarnings("deprecation")
                 final URL url = new URL("http://localhost:" + PORT + "/bench");
-                MarshallableOut out = MarshallableOut.builder(url).wireType(WireType.JSON_ONLY).get();
+                MarshallableOut out = MarshallableOut.builder(url)
+                        .allowLocalhost()
+                        .wireType(WireType.JSON_ONLY)
+                        .get();
                 timed = out.methodWriter(Timed.class);
             } catch (IOException ioe) {
                 throw Jvm.rethrow(ioe);


### PR DESCRIPTION
## Summary
- block connections to local addresses by default
- permit localhost via new builder flag `allowLocalhost`
- update HTTP MarshallableOut to validate URL
- adapt existing tests and add new unit tests

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ee2b81fe483299b0ec454fb5e9292