### PR TITLE
Add validation for excessive fields

### DIFF
--- a/src/main/adoc/security-review.adoc
+++ b/src/main/adoc/security-review.adoc
@@ -28,6 +28,7 @@ Mitigations ::
 * Validate at the perimeter (network ingress, IPC boundary).
 * Enforce a *max-message-size* guard.
 * Fuzz the binary and text wire readers.
+* Reject descriptions with more than 256 primitive fields.
 
 Watch for ::
 `bytes.readInt()` (or similar) used straight from the wire without a sanity bound.

--- a/src/main/java/net/openhft/chronicle/wire/SelfDescribingTriviallyCopyable.java
+++ b/src/main/java/net/openhft/chronicle/wire/SelfDescribingTriviallyCopyable.java
@@ -34,6 +34,12 @@ import static net.openhft.chronicle.core.UnsafeMemory.MEMORY;
 @SuppressWarnings("this-escape")
 public abstract class SelfDescribingTriviallyCopyable extends SelfDescribingMarshallable {
 
+    /**
+     * Combined limit for primitive fields to avoid unreasonable copies.
+     * A description requesting more fields than this is rejected.
+     */
+    private static final int FIELD_COUNT_LIMIT = 256;
+
     // Contains the description of the data layout.
     @FieldGroup("header")
     transient int description = $description();
@@ -86,6 +92,10 @@ public abstract class SelfDescribingTriviallyCopyable extends SelfDescribingMars
         int ints0 = (description0 >>> 16) & 0xFF;
         int shorts0 = (description0 >>> 8) & 0x7F;
         int bytes0 = description0 & 0xFF;
+
+        if (longs0 + ints0 + shorts0 + bytes0 > FIELD_COUNT_LIMIT)
+            throw new IllegalStateException("Excessive field count in description: " +
+                    Integer.toHexString(description0));
 
         // Calculate the total length required based on data types
         int length = longs0 * 8 + ints0 * 4 + shorts0 * 2 + bytes0;

--- a/src/test/java/net/openhft/chronicle/wire/EmbeddedBytesMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/EmbeddedBytesMarshallableTest.java
@@ -149,6 +149,21 @@ public class EmbeddedBytesMarshallableTest extends WireTestCommon {
         ebm.readMarshallable(bytes);
     }
 
+    // Test deserialization with field counts exceeding FIELD_COUNT_LIMIT (256).
+    // Expected to throw an IllegalStateException.
+    @Test(expected = IllegalStateException.class)
+    public void excessiveFieldCounts() {
+        int desc = (200 << 24) | (200 << 16) | 1;
+        int length = 200 * 8 + 200 * 4 + 1;
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap(length + 8);
+        bytes.writeInt(desc);
+        for (int i = 0; i < length; i++)
+            bytes.writeByte((byte) 0);
+        bytes.readLimit(bytes.writePosition());
+        EBM1 ebm1 = new EBM1();
+        ebm1.readMarshallable(bytes);
+    }
+
     // A class representing a Marshallable object with fields grouped into embedded Bytes.
     // This class extends SelfDescribingTriviallyCopyable, indicating that it can describe its own serialization format.
     static class EBM extends SelfDescribingTriviallyCopyable {


### PR DESCRIPTION
## Summary
- prevent unbounded loops in `SelfDescribingTriviallyCopyable`
- test high field counts result in an error
- note the limit in the security review

## Testing
- `mvn -q verify` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ee3018c7c83299e570cb077c30dfc