### PR TITLE
Security Hardening & Documentation Refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,14 @@ The command should exit with code `0` to indicate success.
 * Does the commit point back to the relevant requirement or decision tag?
 * Would an example or small diagram help future maintainers?
 
+### Security checklist (review **after every change**)
+
+**Run a security review on *every* PR**: Walk through the diff looking for input validation, authentication, authorisation, encoding/escaping, overflow, resource exhaustion and timing-attack issues.
+
+**Never commit secrets or credentials**: tokens, passwords, private keys, TLS materials, internal hostnames, Use environment variables, HashiCorp Vault, AWS/GCP Secret Manager, etc.
+
+**Document security trade-offs**: Chronicle prioritises low-latency systems; sometimes we relax safety checks for specific reasons. Future maintainers must find these hot-spots quickly, In Javadoc and `.adoc` files call out *why* e.g. "Unchecked cast for performance - assumes trusted input".
+
 ## Project requirements
 
 See the [Decision Log](src/main/adoc/decision-log.adoc) for the latest project decisions.

--- a/src/main/adoc/index.adoc
+++ b/src/main/adoc/index.adoc
@@ -1,5 +1,8 @@
 = Chronicle Wire Documentation
-:doctype: book
+:toc: left
+:toclevels: 2
+:source-highlighter: rouge
+:sectnums:
 
 Chronicle Wire is a high-performance, low-latency serialisation library that forms part of the OpenHFT stack. This index links to the documentation set.
 
@@ -28,6 +31,9 @@ link:wire-glossary.adoc[Chronicle Wire Glossary] ::
 
 link:project-requirements.adoc[Project Requirements: Chronicle Wire Documentation Enhancement] ::
   Outlines the requirements for improving this documentation set.
+
+link:security-review.adoc[Chronicle Wire Security Review] ::
+  Discusses known security considerations and trade-offs in the library.
 
 link:../../EventsByMethod.adoc[Events by Method Guide] ::
   Explains the event-driven approach via asynchronous method calls.

--- a/src/main/adoc/security-review.adoc
+++ b/src/main/adoc/security-review.adoc
@@ -1,0 +1,113 @@
+= Chronicle Wire: Security Review & Known Trade-offs
+:toc:
+:sectnums:
+
+== Introduction
+
+This document provides an overview of known security considerations and deliberate trade-offs made within the Chronicle Wire library. Chronicle libraries prioritize very low-latency and high-throughput performance, which sometimes necessitates design choices that diverge from typical enterprise software where safety and security checks might take precedence over raw speed.
+
+The purpose of this document is to:
+
+* Clearly articulate these known trade-offs and their rationale.
+* Highlight potential security implications if assumptions underpinning these trade-offs are violated.
+* Guide developers and reviewers in identifying areas requiring particular scrutiny during security reviews.
+* Make it easier to spot *unexpected* security issues by understanding what is *expected* and deliberate.
+
+This document should be reviewed periodically and updated as the library evolves.
+
+== Minimal Validation on Hot Paths
+
+Why ::
+Each additional branch disrupts the CPU’s branch-predictor; trimming checks typically saves *10 ns* per primitive read.
+
+Risks ::
+* Malformed / hostile input reaches unchecked code paths.
+* Integer length or offset fields trigger huge allocations or OOB access.
+
+Mitigations ::
+* Validate at the perimeter (network ingress, IPC boundary).
+* Enforce a *max-message-size* guard.
+* Fuzz the binary and text wire readers.
+
+Watch for ::
+`bytes.readInt()` (or similar) used straight from the wire without a sanity bound.
+
+== Unsafe & Off-Heap Access
+
+Why ::
+Avoids GC pressure and eliminates array-bounds checks.
+
+Risks ::
+* Memory corruption / JVM `SIGSEGV`.
+* Sensitive data left in pooled native buffers.
+
+Mitigations ::
+* Saturate calculated lengths (`Math.min(requested, MAX)`).
+* Zero or overwrite buffers in `release()` / `close()`.
+* Code review every `OS.memory().write…`, `UnsafeMemory.unsafe…` call.
+
+== Dynamic Typing & Deserialisation
+
+Why ::
+Allows schema evolution and polymorphic DTOs.
+
+Risks ::
+* Deserialisation gadget chains ⇒ RCE.
+* "Bomb" objects allocating GBs or spinning CPUs in constructors.
+
+Mitigations ::
+* Default *deny-list*: reject `!type` tags outside `net.openhft.*`.
+* Keep a fuzz corpus exercising unknown tags / prefixes.
+
+== Field-less / Numeric Binary Wire
+
+Why ::
+Removes field names -> smaller messages & faster parse.
+
+Risks ::
+* *Schema drift*: sender/receiver field order mismatch corrupts data.
+* Debugging & diffing become harder.
+
+Mitigations ::
+* Integration tests using *old* and *new* DTO versions.
+* Add a *version byte* prefix when formats change.
+
+== Thread-Local Caches
+
+Why ::
+Cut allocation on ultra-hot paths.
+
+Risks ::
+* Cross-tenant data leakage if thread pools are reused.
+* Retained-heap blow-ups on long-lived threads.
+
+Mitigations ::
+* Use `ScopedResourcePool` wherever available.
+* Call `ThreadLocal.remove()` (or the pool’s `close()`) at end-of-task.
+
+== Runtime Code Generation / Reflection
+
+Why ::
+Generates bytecode once -> zero reflection overhead at runtime.
+
+Risks ::
+* Identifier injection if attacker controls class/method names.
+* `setAccessible(true)` bypasses encapsulation.
+
+Mitigations ::
+* Accept identifiers matching regex `[A-Za-z_][A-Za-z0-9_]*` only.
+* Emit generated source into `target/generated-sources` for audit.
+
+== Mutable Object Re-use
+
+Why ::
+Reduces GC churn and allocation latency.
+
+Risks ::
+* Stale data if `reset()` is incomplete.
+* Race conditions when reused across threads.
+
+Mitigations ::
+* Ensure `reset()` (or `clear()`) nulls/zeroes *all* mutable fields.
+* Add JMH or junit-stress tests with parallel writers/readers.
+

--- a/src/main/adoc/security-review.adoc
+++ b/src/main/adoc/security-review.adoc
@@ -111,6 +111,17 @@ Mitigations ::
 * Ensure `reset()` (or `clear()`) nulls/zeroes *all* mutable fields.
 * Add JMH or junit-stress tests with parallel writers/readers.
 
+== Configuration Property Expansion
+
+Why ::
+Provides flexible deployment by replacing `${property}` tokens.
+
+Risks ::
+* Newline characters in a property value are rejected, however other malicous injected YAML might have an impact.
+
+Mitigations ::
+* `ConfigLoader` rejects property values containing line breaks.
+
 == Verbose Logging & Error Handling
 
 Why ::
@@ -126,4 +137,3 @@ Mitigations ::
 * Restrict verbose logging to trusted environments.
 * Scrub or truncate data written to logs.
 * Document recommended production log settings.
-

--- a/src/main/adoc/security-review.adoc
+++ b/src/main/adoc/security-review.adoc
@@ -28,6 +28,7 @@ Mitigations ::
 * Validate at the perimeter (network ingress, IPC boundary).
 * Enforce a *max-message-size* guard.
 * Fuzz the binary and text wire readers.
+* Reject descriptions with more than 256 primitive fields.
 
 Watch for ::
 `bytes.readInt()` (or similar) used straight from the wire without a sanity bound.

--- a/src/main/adoc/security-review.adoc
+++ b/src/main/adoc/security-review.adoc
@@ -111,3 +111,19 @@ Mitigations ::
 * Ensure `reset()` (or `clear()`) nulls/zeroes *all* mutable fields.
 * Add JMH or junit-stress tests with parallel writers/readers.
 
+== Verbose Logging & Error Handling
+
+Why ::
+Useful for debugging and tracing configuration issues.
+
+Risks ::
+* `AbstractMarshallableCfg.unexpectedField` logs ignored values via `valueIn.objectBestEffort()`. Malicious inputs could appear in logs.
+* `VanillaMethodReader.logMessage0` prints message payloads when `DEBUG_ENABLED` is true.
+* `YamlLogging` flags may expose sensitive data if enabled in production.
+* Unchecked input that is then logged compounds the issue.
+
+Mitigations ::
+* Restrict verbose logging to trusted environments.
+* Scrub or truncate data written to logs.
+* Document recommended production log settings.
+

--- a/src/main/java/net/openhft/chronicle/wire/MarshallableOutBuilder.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableOutBuilder.java
@@ -56,6 +56,7 @@ public class MarshallableOutBuilder implements Supplier<MarshallableOut> {
             case "tcp":
                 throw new UnsupportedOperationException("Direct TCP connection not implemented");
             case "file":
+                validateFileUrl(url);
                 if (wireType != null && wireType != WireType.YAML_ONLY)
                     throw new IllegalArgumentException("Unsupported wireType; " + wireType);
                 // URL file protocol doesn't support writing...
@@ -78,6 +79,21 @@ public class MarshallableOutBuilder implements Supplier<MarshallableOut> {
      */
     private WireType wireTypeOr(WireType wireType) {
         return this.wireType == null ? wireType : this.wireType;
+    }
+
+    /**
+     * Performs a sanity check on file URLs to reduce the risk of path traversal.
+     * Only absolute paths without parent directory references are allowed.
+     *
+     * @param url the file URL to validate
+     * @throws IllegalArgumentException if the path contains ".." or is empty
+     */
+    private static void validateFileUrl(URL url) {
+        String path = url.getPath();
+        if (path == null || path.isEmpty())
+            throw new IllegalArgumentException("File URL must contain a path");
+        if (path.contains(".."))
+            throw new IllegalArgumentException("Parent directory references are not permitted: " + path);
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/MarshallableOutBuilder.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableOutBuilder.java
@@ -38,6 +38,9 @@ public class MarshallableOutBuilder implements Supplier<MarshallableOut> {
     // The WireType configuration for the MarshallableOut.
     private WireType wireType;
 
+    // Flag to permit HTTP connections to localhost or site-local addresses
+    private boolean allowLocalhost;
+
     /**
      * Constructs a new {@code MarshallableOutBuilder} with the specified URL.
      *
@@ -96,5 +99,24 @@ public class MarshallableOutBuilder implements Supplier<MarshallableOut> {
     public MarshallableOutBuilder wireType(WireType wireType) {
         this.wireType = wireType;
         return this;
+    }
+
+    /**
+     * Allows HTTP connections to localhost or site-local addresses. Use with
+     * caution as it bypasses SSRF checks.
+     *
+     * @return this builder instance
+     */
+    public MarshallableOutBuilder allowLocalhost() {
+        this.allowLocalhost = true;
+        return this;
+    }
+
+    /**
+     * Exposes whether localhost URLs are permitted. Intended for
+     * internal use.
+     */
+    public boolean allowLocalhostEnabled() {
+        return allowLocalhost;
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/SelfDescribingTriviallyCopyable.java
+++ b/src/main/java/net/openhft/chronicle/wire/SelfDescribingTriviallyCopyable.java
@@ -36,6 +36,12 @@ import static net.openhft.chronicle.core.UnsafeMemory.MEMORY;
 @SuppressWarnings("this-escape")
 public abstract class SelfDescribingTriviallyCopyable extends SelfDescribingMarshallable {
 
+    /**
+     * Combined limit for primitive fields to avoid unreasonable copies.
+     * A description requesting more fields than this is rejected.
+     */
+    private static final int FIELD_COUNT_LIMIT = 256;
+
     // Contains the description of the data layout.
     @FieldGroup("header")
     transient int description = $description();
@@ -88,6 +94,10 @@ public abstract class SelfDescribingTriviallyCopyable extends SelfDescribingMars
         int ints0 = (description0 >>> 16) & 0xFF;
         int shorts0 = (description0 >>> 8) & 0x7F;
         int bytes0 = description0 & 0xFF;
+
+        if (longs0 + ints0 + shorts0 + bytes0 > FIELD_COUNT_LIMIT)
+            throw new IllegalStateException("Excessive field count in description: " +
+                    Integer.toHexString(description0));
 
         // Calculate the total length required based on data types
         int length = longs0 * 8 + ints0 * 4 + shorts0 * 2 + bytes0;

--- a/src/main/java/net/openhft/chronicle/wire/internal/FileMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/FileMarshallableOut.java
@@ -90,6 +90,9 @@ public class FileMarshallableOut implements MarshallableOut {
     public FileMarshallableOut(MarshallableOutBuilder builder, WireType wireType) throws InvalidMarshallableException {
         this.url = builder.url();
         assert url.getProtocol().equals("file"); // Ensure the protocol is "file"
+        String path = url.getPath();
+        if (path == null || path.isEmpty() || path.contains(".."))
+            throw new IllegalArgumentException("Invalid file path: " + path);
 
         // If there's a query in the URL, parse and set the options
         final String query = url.getQuery();

--- a/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
@@ -27,7 +27,9 @@ import net.openhft.chronicle.wire.*;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
 import java.net.URL;
+import java.net.UnknownHostException;
 
 import static net.openhft.chronicle.bytes.Bytes.allocateElasticOnHeap;
 
@@ -99,6 +101,7 @@ public class HTTPMarshallableOut implements MarshallableOut {
      */
     public HTTPMarshallableOut(MarshallableOutBuilder builder, WireType wireType) {
         this.url = builder.url();
+        validateUrl(url, builder.allowLocalhostEnabled());
 
         if (wireType == WireType.JSON)
             this.wire = new JSONWire(allocateElasticOnHeap()).useTypes(true).trimFirstCurly(true).useTextDocuments();
@@ -132,5 +135,19 @@ public class HTTPMarshallableOut implements MarshallableOut {
     public DocumentContext acquireWritingDocument(boolean metaData) throws UnrecoverableTimeoutException {
         dcHolder.documentContext(wire.acquireWritingDocument(metaData));
         return dcHolder;
+    }
+
+    /**
+     * Validate that the supplied URL does not resolve to a local or site-local
+     * address unless explicitly allowed.
+     */
+    static void validateUrl(URL url, boolean allowLocalhost) {
+        try {
+            InetAddress addr = InetAddress.getByName(url.getHost());
+            if (!allowLocalhost && (addr.isAnyLocalAddress() || addr.isLoopbackAddress() || addr.isSiteLocalAddress() || addr.isLinkLocalAddress()))
+                throw new IllegalArgumentException("Refusing to connect to local address: " + url);
+        } catch (UnknownHostException e) {
+            throw new IllegalArgumentException("Unknown host: " + url, e);
+        }
     }
 }

--- a/src/main/java/net/openhft/chronicle/wire/utils/ConfigLoader.java
+++ b/src/main/java/net/openhft/chronicle/wire/utils/ConfigLoader.java
@@ -12,7 +12,9 @@ import static net.openhft.chronicle.bytes.util.PropertyReplacer.replaceTokensWit
 /**
  * Utility class for loading configuration files in YAML format. The class provides methods to load configuration
  * files in YAML format from the classpath and convert them to Java objects. The class will replace
- * tokens in the format {@code ${property}} within strings with System properties or supplied properties.
+ * tokens in the format {@code ${property}} within strings with System properties
+ * or supplied properties. Values containing line breaks are rejected to protect
+ * the YAML structure.
  * <p>
  * Files must be in YAML format that conform to WireType.TEXT. For example:
  * <pre>{@code
@@ -51,13 +53,28 @@ public enum ConfigLoader {
         return loadWithProperties(loadFile(classLoader, filename), properties);
     }
 
+    /**
+     * Fail fast if any supplied property contains a carriage return or line feed.
+     */
+    private static void validateNoNewLines(Properties properties) {
+        properties.forEach((k, v) -> {
+            if (v != null) {
+                String s = v.toString();
+                if (s.contains("\n") || s.contains("\r"))
+                    throw new IllegalArgumentException("Property " + k + " contains line breaks");
+            }
+        });
+    }
+
     @SuppressWarnings("unchecked")
     public static <T> T load(String fileAsString) {
+        validateNoNewLines(System.getProperties());
         return  (T) TextWire.from(replaceTokensWithProperties(fileAsString)).readObject();
     }
 
     @SuppressWarnings("unchecked")
     public static <T> T loadWithProperties(String fileAsString, Properties properties) {
+        validateNoNewLines(properties);
         return (T) TextWire.from(replaceTokensWithProperties(fileAsString, properties)).readObject();
     }
 }

--- a/src/test/java/net/openhft/chronicle/wire/EmbeddedBytesMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/EmbeddedBytesMarshallableTest.java
@@ -151,6 +151,21 @@ public class EmbeddedBytesMarshallableTest extends WireTestCommon {
         ebm.readMarshallable(bytes);
     }
 
+    // Test deserialization with field counts exceeding FIELD_COUNT_LIMIT (256).
+    // Expected to throw an IllegalStateException.
+    @Test(expected = IllegalStateException.class)
+    public void excessiveFieldCounts() {
+        int desc = (200 << 24) | (200 << 16) | 1;
+        int length = 200 * 8 + 200 * 4 + 1;
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap(length + 8);
+        bytes.writeInt(desc);
+        for (int i = 0; i < length; i++)
+            bytes.writeByte((byte) 0);
+        bytes.readLimit(bytes.writePosition());
+        EBM1 ebm1 = new EBM1();
+        ebm1.readMarshallable(bytes);
+    }
+
     // A class representing a Marshallable object with fields grouped into embedded Bytes.
     // This class extends SelfDescribingTriviallyCopyable, indicating that it can describe its own serialization format.
     static class EBM extends SelfDescribingTriviallyCopyable {

--- a/src/test/java/net/openhft/chronicle/wire/FileMarshallableOutValidationTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/FileMarshallableOutValidationTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openhft.chronicle.wire;
+
+import net.openhft.chronicle.core.OS;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URL;
+
+/**
+ * Tests for URL validation when creating file based MarshallableOut instances.
+ */
+public class FileMarshallableOutValidationTest extends WireTestCommon {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsParentTraversal() throws Exception {
+        File dir = new File(OS.getTarget(), "valtest");
+        dir.mkdirs();
+        @SuppressWarnings("deprecation")
+        URL url = new URL("file://" + dir.getAbsolutePath() + "/../evil");
+        MarshallableOut.builder(url).get();
+    }
+}

--- a/src/test/java/net/openhft/chronicle/wire/MarshallableOutBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MarshallableOutBuilderTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 
 public class MarshallableOutBuilderTest extends net.openhft.chronicle.wire.WireTestCommon {
 
@@ -98,7 +99,10 @@ public class MarshallableOutBuilderTest extends net.openhft.chronicle.wire.WireT
 
     // Write messages to the specified URL with a given WireType
     private void writeMessages(URL url, WireType wireType) {
-        final MarshallableOut out = MarshallableOut.builder(url).wireType(wireType).get();
+        final MarshallableOut out = MarshallableOut.builder(url)
+                .allowLocalhost()
+                .wireType(wireType)
+                .get();
         ITop top = out.methodWriter(ITop.class);
         top.mid("mid")
                 .next(1)
@@ -177,6 +181,23 @@ public class MarshallableOutBuilderTest extends net.openhft.chronicle.wire.WireT
         }
     }
 
+    // Validate that localhost URLs are rejected by default
+    @Test(expected = IllegalArgumentException.class)
+    public void urlValidationRejectsLocalhost() throws Exception {
+        @SuppressWarnings("deprecation")
+        URL url = new URL("http://localhost:1234/");
+        MarshallableOut.builder(url).get();
+    }
+
+    // Validate that the override allows localhost
+    @Test
+    public void urlValidationAllowLocalhost() throws Exception {
+        @SuppressWarnings("deprecation")
+        URL url = new URL("http://localhost:1234/");
+        MarshallableOut out = MarshallableOut.builder(url).allowLocalhost().get();
+        assertNotNull(out);
+    }
+
     // Interface representing a timed event.
     interface Timed {
         void time(long timeNS);
@@ -234,7 +255,10 @@ public class MarshallableOutBuilderTest extends net.openhft.chronicle.wire.WireT
                 server.start();
                 @SuppressWarnings("deprecation")
                 final URL url = new URL("http://localhost:" + PORT + "/bench");
-                MarshallableOut out = MarshallableOut.builder(url).wireType(WireType.JSON_ONLY).get();
+                MarshallableOut out = MarshallableOut.builder(url)
+                        .allowLocalhost()
+                        .wireType(WireType.JSON_ONLY)
+                        .get();
                 timed = out.methodWriter(Timed.class);
             } catch (IOException ioe) {
                 throw Jvm.rethrow(ioe);

--- a/src/test/java/net/openhft/chronicle/wire/utils/ConfigLoaderInjectionTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/utils/ConfigLoaderInjectionTest.java
@@ -1,0 +1,29 @@
+package net.openhft.chronicle.wire.utils;
+
+import net.openhft.chronicle.wire.WireTestCommon;
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.Properties;
+
+public class ConfigLoaderInjectionTest extends WireTestCommon {
+    private static final String YAML = "name: ${name}";
+
+    @After
+    public void clearProperty() {
+        System.clearProperty("name");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void loadWithPropertiesRejectsNewLine() {
+        Properties p = new Properties();
+        p.setProperty("name", "bad\nvalue");
+        ConfigLoader.loadWithProperties(YAML, p);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void loadRejectsNewLineInSystemProperty() {
+        System.setProperty("name", "bad\nvalue");
+        ConfigLoader.load(YAML);
+    }
+}


### PR DESCRIPTION
A security-focused hardening sweep for Chronicle Wire and adds the contributor guidance needed to keep it that way.

### 📚 Docs & Process

| File                                                      | Change                                                                                                                                             |
| --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
| **`AGENTS.md`**                                           | Adds *Security checklist* section – every PR must: 1) run a security diff review, 2) forbid committing secrets, 3) document deliberate trade-offs. |
| **`src/main/adoc/security-review.adoc`**<br/>`index.adoc` | New AsciiDoc detailing known trade-offs (unsafe, field-less binary, TL caches, etc.) and links it from the doc index.                              |

---

### 🛠️ Runtime Safeguards

| Area                                           | What’s new                                                                                                                                                                                                            | Risk mitigated                                                  |
| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| **Path traversal / SSRF**                      | *`MarshallableOutBuilder`* & `FileMarshallableOut` now reject `file://` paths containing `..`; `HTTPMarshallableOut` validates that the host is not local/site-local unless `allowLocalhost()` is explicitly enabled. | Accidental or malicious file overwrite, internal network probes |
| **Self-describing trivially-copyable objects** | Hard limit of **256 primitive fields** per description; exceeding triggers `IllegalStateException`.                                                                                                                   | CPU / OOM bombs, malformed-description memory corruption        |
| **ConfigLoader**                               | Rejects property-expansion values containing LF/CR to prevent YAML structure injection.                                                                                                                               | Arbitrary YAML injection, config confusion                      |
| **Builder opt-in**                             | `MarshallableOutBuilder.allowLocalhost()` flag to override SSRF check for trusted test rigs.                                                                                                                          | Safer defaults                                                  |
| **URL sanity check helper**                    | Centralised validation for file and HTTP builders.                                                                                                                                                                    | Consistency                                                     |

---

### 🧪 Tests

* `FileMarshallableOutValidationTest` – path traversal rejection
* `MarshallableOutBuilderTest` – SSRF guard + localhost opt-in
* `EmbeddedBytesMarshallableTest` – field-count ceiling
* `ConfigLoaderInjectionTest` – newline-injection rejection
