### PR TITLE
Update object instantiation to include Demarshallable types

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/Wires.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wires.java
@@ -930,9 +930,6 @@ public enum Wires {
             strategy = MAP;
 
         // If no object is provided to populate, instantiate a new one using the strategy.
-//        if (using == null) {
-//            using = strategy.newInstanceOrNull((Class<E>) clazz);
-//        }
 
         if (Demarshallable.class.isAssignableFrom(clazz) || using == null) {
             using = (E) strategy.newInstanceOrNull(clazz);

--- a/src/main/java/net/openhft/chronicle/wire/Wires.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wires.java
@@ -179,7 +179,7 @@ public enum Wires {
      *
      * @param file the name of the input Yaml file containing serialized method calls
      * @param obj  the target object that the method calls will be replayed on
-     * @throws IOException is thrown if there's an error reading the file
+     * @throws IOException                  is thrown if there's an error reading the file
      * @throws InvalidMarshallableException is thrown if the serialized data is invalid or corrupted
      */
     public static void replay(String file, Object obj) throws IOException, InvalidMarshallableException {
@@ -218,8 +218,8 @@ public enum Wires {
      * Converts the provided bytes, representing size-prefixed blobs,
      * into a readable string format with the option to abbreviate.
      *
-     * @param bytes   the bytes representing size-prefixed blobs
-     * @param abbrev  if {@code true}, the output string will be abbreviated
+     * @param bytes  the bytes representing size-prefixed blobs
+     * @param abbrev if {@code true}, the output string will be abbreviated
      * @return the readable string representation of the blobs
      */
     public static String fromSizePrefixedBlobs(@NotNull Bytes<?> bytes, boolean abbrev) {
@@ -355,7 +355,7 @@ public enum Wires {
      * with the option to abbreviate the output.
      *
      * @param wireIn the {@code WireIn} instance holding the wire data
-     * @param abbrev  if {@code true}, the output string will be abbreviated
+     * @param abbrev if {@code true}, the output string will be abbreviated
      * @return the readable string representation of the blobs
      */
     public static String fromSizePrefixedBlobs(@NotNull WireIn wireIn, boolean abbrev) {
@@ -389,7 +389,7 @@ public enum Wires {
     /**
      * Converts the given WireIn instance into a specified wire type representation.
      *
-     * @param wireIn the input wire
+     * @param wireIn       the input wire
      * @param wireProvider a function that provides a specific type of wire based on bytes
      * @return the representation of the wire data in the specified type
      * @throws InvalidMarshallableException if marshalling fails
@@ -556,8 +556,8 @@ public enum Wires {
     /**
      * Reads data from a WireIn up to a specified size using a ReadMarshallable instance.
      *
-     * @param wireIn          the source from which data is read
-     * @param size            the maximum size of data to be read
+     * @param wireIn           the source from which data is read
+     * @param size             the maximum size of data to be read
      * @param readMarshallable the ReadMarshallable instance to interpret the data
      * @return the position in the bytes after reading
      * @throws InvalidMarshallableException if there's an issue during marshalling
@@ -930,8 +930,12 @@ public enum Wires {
             strategy = MAP;
 
         // If no object is provided to populate, instantiate a new one using the strategy.
-        if (using == null) {
-            using = strategy.newInstanceOrNull((Class<E>) clazz);
+//        if (using == null) {
+//            using = strategy.newInstanceOrNull((Class<E>) clazz);
+//        }
+
+        if (Demarshallable.class.isAssignableFrom(clazz) || using == null) {
+            using = (E) strategy.newInstanceOrNull(clazz);
         }
 
         // If the class represents a Throwable, deserialize it using a special method.
@@ -969,7 +973,7 @@ public enum Wires {
     /**
      * Obtains the name of the given object if it's either a CoreDynamicEnum or an Enum.
      *
-     * @param e Object whose name is to be retrieved
+     * @param e   Object whose name is to be retrieved
      * @param <E> Type of the object
      * @return The name of the object or null if the object is neither a CoreDynamicEnum nor an Enum
      */
@@ -1211,9 +1215,9 @@ public enum Wires {
     /**
      * Returns a tuple for the specified class and type name.
      *
-     * @param <T>       The type parameter.
-     * @param tClass    The class type for which the tuple is required.
-     * @param typeName  The type name.
+     * @param <T>      The type parameter.
+     * @param tClass   The class type for which the tuple is required.
+     * @param typeName The type name.
      * @return A tuple of type T or null if not possible to create.
      */
     @Nullable
@@ -1253,9 +1257,9 @@ public enum Wires {
     /**
      * Creates a BinaryWire for reading with the given input, position, and length.
      *
-     * @param in        The input bytes.
-     * @param position  The starting position.
-     * @param length    The length of data to read.
+     * @param in       The input bytes.
+     * @param position The starting position.
+     * @param length   The length of data to read.
      * @return A BinaryWire configured for reading.
      */
     @NotNull
@@ -1270,9 +1274,9 @@ public enum Wires {
     /**
      * Creates a BinaryWire for writing with the given input, position, and length.
      *
-     * @param in        The input bytes.
-     * @param position  The starting position.
-     * @param length    The length of data to write.
+     * @param in       The input bytes.
+     * @param position The starting position.
+     * @param length   The length of data to write.
      * @return A BinaryWire configured for writing.
      */
     @NotNull
@@ -1396,7 +1400,7 @@ public enum Wires {
             return out.writeString(format);
         }
 
-                /**
+        /**
          * Attempts to parse a date string from a ValueIn object and return a corresponding Date object.
          *
          * @param in The ValueIn object containing the date string.
@@ -1475,7 +1479,7 @@ public enum Wires {
         /**
          * Fetches the Class object associated with the name retrieved from the given ValueIn.
          *
-         * @param o The object for which the class needs to be determined. (This parameter is unused in the method.)
+         * @param o  The object for which the class needs to be determined. (This parameter is unused in the method.)
          * @param in The ValueIn object which contains the class name.
          * @return The Class object associated with the name.
          */
@@ -1502,7 +1506,7 @@ public enum Wires {
                     return ScalarStrategy.of(StringBuilder.class, (o, in) -> {
                         StringBuilder builder;
                         try (ScopedResource<StringBuilder> stlSb = Wires.acquireStringBuilderScoped()) {
-                             builder = (o == null)
+                            builder = (o == null)
                                     ? stlSb.get()
                                     : o;
                             in.textTo(builder);

--- a/src/test/java/net/openhft/chronicle/wire/GenericWireMethodReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/GenericWireMethodReaderTest.java
@@ -1,0 +1,83 @@
+package net.openhft.chronicle.wire;
+
+import net.openhft.chronicle.bytes.MethodReader;
+import net.openhft.chronicle.core.annotation.UsedViaReflection;
+import org.junit.Test;
+
+import static net.openhft.chronicle.bytes.Bytes.elasticHeapByteBuffer;
+
+/**
+ * Demonstrates a simple round-trip of writing and reading method calls
+ * over a Chronicle Wire instance using a method writer and method reader.
+ * <p>
+ * This test shows how an object implementing {@link Demarshallable} can be
+ * transmitted via Chronicle Wire and reconstituted on the receiving end.
+ */
+
+public class GenericWireMethodReaderTest {
+
+    /**
+     * A generic message container that supports marshalling and demarshalling
+     * using Chronicle Wire. The payload type is generic, but at runtime
+     * serialization will depend on the actual type provided.
+     *
+     * @param <T> the type of the message payload
+     */
+    public static class Message<T> extends SelfDescribingMarshallable implements Demarshallable {
+        private T payload;
+
+        /**
+         * Constructs a {@code Message} instance by reading its state from the provided
+         * {@link WireIn} source. This is used by Chronicle Wire during demarshalling.
+         *
+         * @param w the {@link WireIn} source to read from
+         */
+        @UsedViaReflection
+        public Message(WireIn w) {
+            readMarshallable(w);
+        }
+
+        /**
+         * Constructs a {@code Message} instance with the given payload.
+         *
+         * @param payload the message content
+         */
+        public Message(T payload) {
+            this.payload = payload;
+        }
+    }
+
+    /**
+     * Listener interface for receiving messages. Uses {@code Object} as the
+     * parameter type to allow flexibility in message payload types.
+     */
+    public interface MessageListener {
+        /**
+         * Handles an incoming message.
+         *
+         * @param value the message payload
+         */
+        void onMessage(Object value);
+    }
+
+    /**
+     * Writes two messages into a {@link BinaryWire} using a method writer,
+     * then reads them back using a method reader.
+     * <p>
+     * This verifies that messages written with Chronicle Wire's method writer
+     * can be correctly deserialized by a method reader implementation.
+     */
+    @Test
+    public void writesAndReadsMultipleMessages() {
+        Wire wire = new BinaryWire(elasticHeapByteBuffer());
+
+        MessageListener writer = wire.methodWriter(MessageListener.class);
+        writer.onMessage(new Message<>("msg1"));
+        writer.onMessage(new Message<>("msg2"));
+
+        try (MethodReader reader = wire.methodReader((MessageListener) System.out::println)) {
+            reader.readOne();
+            reader.readOne();
+        }
+    }
+}


### PR DESCRIPTION
Updated objectMap so that a new instance is created if the target class implements Demarshallable or if the provided using instance is null, ensuring proper reconstruction of Demarshallable objects during deserialization.

Based off a support ticket, and has been tested against all existing tests with no issues.

JIRA: CORE-46