### PR TITLE
Implement Reader-aware `ValueIn#sequence(...)` for `TextWire` & `YamlWire`

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -2186,23 +2186,18 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * Handles the processing of a sequence, delegating to an overloaded version of itself.
+         * Handles the processing of a sequence.
          *
          * @param <T> The type of items in the lists.
          * @param list The main list that should be populated based on the buffer.
          * @param buffer A temporary buffer used for staging data.
          * @param bufferAdd A supplier function that can add items to the buffer.
-         * @param reader0 This seems to be an unused reader, possibly for future extensions.
+         * @param reader0 The reader that processes each item in the sequence.
          * @return Returns a boolean indicating success/failure or some other status.
          * @throws InvalidMarshallableException if there's an error during the sequence processing.
          */
-        public <T> boolean sequence(List<T> list, @NotNull List<T> buffer, Supplier<T> bufferAdd, Reader reader0) throws InvalidMarshallableException {
-            // Currently, this method delegates to an overloaded version of itself, ignoring the reader0 parameter.
-            return sequence(list, buffer, bufferAdd);
-        }
-
         @Override
-        public <T> boolean sequence(@NotNull List<T> list, @NotNull List<T> buffer, @NotNull Supplier<T> bufferAdd) throws InvalidMarshallableException {
+        public <T> boolean sequence(@NotNull List<T> list, @NotNull List<T> buffer, @NotNull Supplier<T> bufferAdd, Reader reader0) throws InvalidMarshallableException {
 
             list.clear();
             consumePadding();
@@ -2224,14 +2219,7 @@ public class TextWire extends YamlWireOut<TextWire> {
                 sequenceLimit = 1;
             }
 
-            while (hasNextSequenceItem()) {
-                int size = list.size();
-                if (buffer.size() <= size) buffer.add(bufferAdd.get());
-
-                final T t = buffer.get(size);
-                if (t instanceof Resettable) ((Resettable) t).reset();
-                list.add(object(t, (Class<T>) t.getClass()));
-            }
+            reader0.accept(this, list, buffer, bufferAdd);
 
             if (code == '[') {
                 consumePadding(1);

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -1757,17 +1757,12 @@ public class YamlWire extends YamlWireOut<YamlWire> {
          * @param list The list to populate with the sequence items.
          * @param buffer Temporary storage used during sequence processing.
          * @param bufferAdd Supplier function to add items to the buffer.
-         * @param reader0 Reader to process the tokens.
+         * @param reader0 The reader that processes each item in the sequence.
          * @return true if the sequence was successfully read, false otherwise.
          * @throws InvalidMarshallableException If there's a problem with marshalling.
          */
-        public <T> boolean sequence(List<T> list, @NotNull List<T> buffer, Supplier<T> bufferAdd, Reader reader0) throws InvalidMarshallableException {
-            // Delegate to the other `sequence` method without the reader.
-            return sequence(list, buffer, bufferAdd);
-        }
-
         @Override
-        public <T> boolean sequence(@NotNull List<T> list, @NotNull List<T> buffer, @NotNull Supplier<T> bufferAdd) throws InvalidMarshallableException {
+        public <T> boolean sequence(@NotNull List<T> list, @NotNull List<T> buffer, @NotNull Supplier<T> bufferAdd, Reader reader0) throws InvalidMarshallableException {
             consumePadding();
             if (isNull()) {
                 return false;
@@ -1777,12 +1772,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
                 int minIndent = yt.secondTopContext().indent;
                 yt.next(Integer.MAX_VALUE);
 
-                while (hasNextSequenceItem()) {
-                    if (buffer.size() <= list.size())
-                        buffer.add(bufferAdd.get());
-                    Object using = buffer.get(list.size());
-                    list.add((T) valueIn.object(using, using.getClass()));
-                }
+                reader0.accept(this, list, buffer, bufferAdd);
 
                 if (yt.current() == YamlToken.NONE)
                     yt.next(minIndent);


### PR DESCRIPTION
`ValueIn` exposes a `sequence(List<T> list, List<T> buffer, Supplier<T> bufferAdd, Reader reader)` variant that lets callers control how each element in a sequence is read (e.g., polymorphic elements, custom reuse/reset logic, nested structures).
Until now, **TextWire** and **YamlWire** didn’t override this Reader-aware method and instead had a local loop (plus a shadow overload ignoring the `Reader` argument). This caused:

* Inconsistent behaviour vs. **BinaryWire**, which already honours the `Reader`.
* Limited extensibility: custom sequence readers couldn’t be applied for Text/YAML inputs.
* Dead code: overloads that accepted a `Reader` but never used it.

## What changed

* **TextWire.ValueIn**:

  * Removed the unused delegating overload.
  * Implemented `sequence(list, buffer, bufferAdd, reader0)` to **delegate element reading to `reader0.accept(...)`**.
* **YamlWire.ValueIn**:

  * Removed the unused delegating overload.
  * Implemented `sequence(list, buffer, bufferAdd, reader0)` to **delegate element reading to `reader0.accept(...)`**.
* Preserved existing control flow for:

  * Null/empty detection (`isNull()`).
  * Padding/indent management and closing token consumption.
  * Sequence size hints.

## Behavioural impact

* **Enables** the Reader-driven sequence model on Text/YAML, aligning with Binary/TEXT family behaviour.
* **No change** to tokenisation, null handling, or container boundary logic.
* Improves **extensibility** for custom element readers, polymorphic items, and object reuse (`Resettable`, pooled instances, etc.).
* Removes misleading/unused overloads that silently ignored the `Reader` parameter.

## Compatibility

* **Source/binary compatible** for public APIs; only internal overrides changed.
* Existing callers of `ValueIn#sequence(list, buffer, bufferAdd, reader)` on Text/YAML now get the expected Reader-driven behaviour (previously ignored).