### PR TITLE
CORE-46 remove circular code path when demarshalling a ReadMarshallable

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
@@ -883,7 +883,7 @@ public class GenerateMethodReader {
             final String typeName = argumentType.getCanonicalName();
             boolean multipleNonMarshallableParamTypes = multipleNonMarshallableParamTypes(argumentType);
             if (!Modifier.isFinal(argumentType.getModifiers()) && multipleNonMarshallableParamTypes) {
-                return format("%s = %s.object(%s, %s.class); %sInstances.put(%s.getClass(), %s);\n", argumentName, valueInName, argumentName + "Func", typeName, argumentName, argumentName, argumentName);
+                return format("%s = %s.object(%s, %s.class);\nif (!(%s instanceof Demarshallable)) {\n%sInstances.put(%s.getClass(), %s);\n}\n", argumentName, valueInName, argumentName + "Func", typeName, argumentName, argumentName, argumentName, argumentName);
             }
             if (isRecyclable(argumentType)) {
                 return format("%s = %s.object(checkRecycle(%s), %s.class);\n", argumentName, valueInName, argumentName, typeName);

--- a/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
+++ b/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
@@ -362,7 +362,8 @@ public enum SerializationStrategies implements SerializationStrategy {
                 wrapper.demarshallable = Demarshallable.newInstance(wrapper.type, in.wireIn());
                 return wrapper;
             } else if (using instanceof ReadMarshallable) {
-                return in.object(using, Object.class);
+                ((ReadMarshallable) using).readMarshallable(in.wireIn());
+                return using;
             } else {
                 return Demarshallable.newInstance((Class) using.getClass(), in.wireIn());
             }

--- a/src/test/java/net/openhft/chronicle/wire/DemarshallableMethodReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/DemarshallableMethodReaderTest.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static net.openhft.chronicle.bytes.Bytes.allocateElasticOnHeap;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -62,7 +63,7 @@ public class DemarshallableMethodReaderTest {
             if (marshalledObjectRef.get() == null) {
                 marshalledObjectRef.set(obj);
             } else {
-                assertThat(obj, IsSame.sameInstance(marshalledObjectRef.get()));
+                assertThat(obj, not(IsSame.sameInstance(marshalledObjectRef.get())));
             }
             assertThat(obj.name, IsNot.not(nullValue()));
             assertThat(obj.value, IsNot.not(Double.NaN));

--- a/src/test/java/net/openhft/chronicle/wire/DemarshallableMethodReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/DemarshallableMethodReaderTest.java
@@ -1,0 +1,77 @@
+package net.openhft.chronicle.wire;
+
+import net.openhft.chronicle.bytes.MethodReader;
+import org.hamcrest.core.Is;
+import org.hamcrest.core.IsNot;
+import org.hamcrest.core.IsSame;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static net.openhft.chronicle.bytes.Bytes.allocateElasticOnHeap;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(Parameterized.class)
+public class DemarshallableMethodReaderTest {
+
+    private final Wire wire;
+
+    public DemarshallableMethodReaderTest(Wire wire) {
+        this.wire = wire;
+        System.out.println("Using wire: " + wire.getClass().getSimpleName());
+    }
+
+    @Parameterized.Parameters()
+    public static Collection<Wire> combinations() {
+        return Arrays.asList(
+                new BinaryWire(allocateElasticOnHeap()),
+                Wire.newYamlWireOnHeap(),
+                new TextWire(allocateElasticOnHeap())
+        );
+    }
+
+    /**
+     * Listener interface for receiving messages. Uses {@code Object} as the
+     * parameter type to allow flexibility in message payload types.
+     */
+    public interface MessageListener {
+        /**
+         * Handles an incoming message.
+         *
+         * @param value the message payload
+         */
+        void onMessage(Object value);
+    }
+
+    @Test
+    public void writesAndReadsMultipleMessages() {
+        MessageListener writer = wire.methodWriter(MessageListener.class);
+        writer.onMessage(new SelfDescribingDemarshallableObject("msg1", 1.5));
+        writer.onMessage(new SelfDescribingDemarshallableObject("msg2", 2.3));
+
+        AtomicReference<SelfDescribingDemarshallableObject> marshalledObjectRef = new AtomicReference<>();
+
+        MessageListener messageListenerAssertion = value -> {
+            assertThat(value instanceof SelfDescribingDemarshallableObject, Is.is(true));
+            SelfDescribingDemarshallableObject obj = (SelfDescribingDemarshallableObject) value;
+            if (marshalledObjectRef.get() == null) {
+                marshalledObjectRef.set(obj);
+            } else {
+                assertThat(obj, IsSame.sameInstance(marshalledObjectRef.get()));
+            }
+            assertThat(obj.name, IsNot.not(nullValue()));
+            assertThat(obj.value, IsNot.not(Double.NaN));
+            System.out.println("Received message: " + obj.name + ", id: " + obj.value);
+        };
+
+        try (MethodReader reader = wire.methodReader(messageListenerAssertion)) {
+            reader.readOne();
+            reader.readOne();
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/wire/SelfDescribingDemarshallableObject.java
+++ b/src/test/java/net/openhft/chronicle/wire/SelfDescribingDemarshallableObject.java
@@ -1,0 +1,16 @@
+package net.openhft.chronicle.wire;
+
+public class SelfDescribingDemarshallableObject extends SelfDescribingMarshallable implements Demarshallable {
+
+    String name = null;
+    double value = Double.NaN;
+
+    public SelfDescribingDemarshallableObject(String name, double value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public SelfDescribingDemarshallableObject(WireIn wire) {
+        readMarshallable(wire);
+    }
+}

--- a/src/test/java/net/openhft/chronicle/wire/SelfDescribingDemarshallableObject.java
+++ b/src/test/java/net/openhft/chronicle/wire/SelfDescribingDemarshallableObject.java
@@ -1,5 +1,7 @@
 package net.openhft.chronicle.wire;
 
+import net.openhft.chronicle.core.annotation.UsedViaReflection;
+
 public class SelfDescribingDemarshallableObject extends SelfDescribingMarshallable implements Demarshallable {
 
     String name = null;
@@ -10,6 +12,8 @@ public class SelfDescribingDemarshallableObject extends SelfDescribingMarshallab
         this.value = value;
     }
 
+    @SuppressWarnings("this-escape")
+    @UsedViaReflection
     public SelfDescribingDemarshallableObject(WireIn wire) {
         readMarshallable(wire);
     }


### PR DESCRIPTION
The `object(using, clazz)` method was being called when attempting to read marshal a `Demarshallable`. When called from a method reader, this creates a circular code path - the second time it is entered, the length cannot be read and throws an exception. 

In the case where the `using` object is a `ReadMarshallable` we can safely call `readMarshallable(wireIn)`.

As `Demarshallable` should represent a marshallable that expects a new instance, do not cache `Demarshallable` in a generated `MethodReader` when the method parameter is a non-marshallable and can have multiple implementations