### PR TITLE
Add support for private groups in MarshallingEventGroupTest

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
@@ -721,7 +721,7 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
                 return true;
             for (long i = fromBytes.readPosition(); i < fromBytes.readLimit(); i++) {
                 int ch = fromBytes.readUnsignedByte(i);
-                if ((ch < ' ' && ch != '\t') || ch >= 127)
+                if (ch <= 0|| ch >= 127)
                     return false;
             }
             return true;

--- a/src/test/java/net/openhft/chronicle/wire/InnerMapTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/InnerMapTest.java
@@ -38,7 +38,7 @@ public class InnerMapTest extends WireTestCommon {
         assumeFalse(Jvm.maxDirectMemory() == 0);
 
         // Create a new instance of MyMarshable and set its properties
-        @NotNull MyMarshable myMarshable = new MyMarshable().name("rob");
+        @NotNull MyMarshable myMarshable = new MyMarshable("rob");
         myMarshable.commission().put("hello", 123.4);
         myMarshable.nested = new MyNested("text");
 
@@ -91,7 +91,8 @@ public class InnerMapTest extends WireTestCommon {
         }
 
         // Default constructor
-        public MyMarshable() {
+        public MyMarshable(String name) {
+            this.name = name;
             this.commission = new LinkedHashMap<>();
         }
 

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/MarshallingEventGroupTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/MarshallingEventGroupTest.java
@@ -54,6 +54,7 @@ public class MarshallingEventGroupTest extends WireTestCommon {
                              .withConcurrentPauserSupplier(PauserMode.sleepy)
                              .withBlockingPauserSupplier(PauserMode.sleepy)
                              .withConcurrentThreadsNum(1)
+                             .withPrivateGroup(true)
                              .build()) {
 
             // Convert the EventGroup object to its TEXT representation
@@ -158,13 +159,15 @@ public class MarshallingEventGroupTest extends WireTestCommon {
                     "  referenceId: 0,\n" +
                     "  lifecycle: !net.openhft.chronicle.threads.EventLoopLifecycle NEW,\n" +
                     "  name: test,\n" +
+                    "  privateGroup: true,\n" +
                     "  counter: 0,\n" +
                     "  monitor: !net.openhft.chronicle.threads.MonitorEventLoop {\n" +
                     "    referenceId: 0,\n" +
                     "    lifecycle: !net.openhft.chronicle.threads.EventLoopLifecycle NEW,\n" +
                     "    name: test/~monitortest/event~loop~monitor,\n" +
+                    "    privateGroup: false,\n" +
                     "    handlers: [\n" +
-                    "      !net.openhft.chronicle.threads.MonitorEventLoop$IdempotentLoopStartedEventHandler { referenceId: 0, handler: NOOP_PAUSER_MONITOR, loopStarted: false }\n" +
+                    "      !net.openhft.chronicle.threads.MonitorEventLoop$IdempotentLoopStartedEventHandler { handler: NOOP_PAUSER_MONITOR, loopStarted: false }\n" +
                     "    ],\n" +
                     "    pauser: !net.openhft.chronicle.threads.MilliPauser { pausing: false, pauseTimeMS: 10, timePaused: 0, countPaused: 0, pauseUntilMS: 0 }\n" +
                     "  },\n" +
@@ -172,6 +175,7 @@ public class MarshallingEventGroupTest extends WireTestCommon {
                     "    referenceId: 0,\n" +
                     "    lifecycle: !net.openhft.chronicle.threads.EventLoopLifecycle NEW,\n" +
                     "    name: test/core-event-loop,\n" +
+                    "    privateGroup: true,\n" +
                     "    mediumHandlers: [    ],\n" +
                     "    newHandlers: [    ],\n" +
                     "    pauser: !net.openhft.chronicle.threads.LongPauser { minPauseTimeNS: 500000, maxPauseTimeNS: 20000000, pausing: false, minBusyNS: 0, minYieldNS: 50000, firstPauseNS: 9223372036854775807, pauseTimeNS: 500000, timePaused: 0, countPaused: 0, yieldStart: 0, pauseUntilNS: 0 },\n" +
@@ -200,6 +204,7 @@ public class MarshallingEventGroupTest extends WireTestCommon {
                     "    referenceId: 0,\n" +
                     "    lifecycle: !net.openhft.chronicle.threads.EventLoopLifecycle NEW,\n" +
                     "    name: test/blocking-event-loop,\n" +
+                    "    privateGroup: false,\n" +
                     "    handlers: [    ],\n" +
                     "    runners: [    ],\n" +
                     "    threadFactory: test/blocking-event-loop,\n" +


### PR DESCRIPTION
This PR makes two intentional behaviour changes in the Wire/YAML path and adjusts tests accordingly:

1. **Permit FIX control characters (notably SOH `0x01`) in TEXT output** so FIX messages no longer fall back to `!binary` base64 just because they contain SOH delimiters.
2. **Include the new `privateGroup` field** in the marshalled representation of event loops/groups, and update tests to expect it.

Default behaviours outside these areas are unchanged.

---

## Motivation

* **FIX over YAML:** FIX messages use SOH (`0x01`) as a field delimiter. Our previous `YamlWireOut#isText(...)` classified most ASCII control characters as “non-text,” causing FIX payloads to be emitted as `!binary`. That hurts readability/debuggability and adds base64 overhead.
* **Lifecycle visibility:** Recent work introduced a `privateGroup` mode for short-lived event groups. This should be visible in the YAML/Text representation for diagnostics and golden-file tests.

---

## Changes

### 1) `YamlWireOut#isText(...)`

* **Before:**

  ```java
  if ((ch < ' ' && ch != '\t') || ch >= 127) return false;
  ```
* **After:**

  ```java
  if (ch <= 0 || ch >= 127) return false;
  ```
* **Effect:**

  * Treats bytes `1..126` as text (i.e., allows ASCII control characters including SOH `0x01`).
  * Still **rejects NUL (`0x00`)** and **all bytes ≥ 127** as text.
  * FIX payloads containing SOH now remain in TEXT form instead of being coerced to `!binary`.

### 2) EventGroup marshalling expectations

* **`MarshallingEventGroupTest`**

  * Build with `.withPrivateGroup(true)` to exercise the new field.
  * Update golden TEXT to include `privateGroup: true/false` lines at:

    * Top-level `EventGroup`
    * Core event loop (true)
    * Monitor and blocking loops (false), matching their defaults/roles
  * Reflect minor tidy-up: `MonitorEventLoop$IdempotentLoopStartedEventHandler` no longer emits a `referenceId` in the expected YAML (matches its simpler closeable base).

### 3) Minor test tidy-ups

* **`InnerMapTest`**

  * Use `new MyMarshable("rob")` and set `name` via constructor.
  * Replace the previous no-arg constructor with `MyMarshable(String name)` in the test helper.
  * Keeps the test deterministic and explicit about required fields.

---

## Behaviour & compatibility

* **Wire/YAML writing:**

  * FIX messages with SOH are now emitted as readable TEXT (no `!binary`).
  * Existing readers remain unaffected; this change is in the *writer*’s text/binary decision. `!binary` inputs are still supported on read.
* **EventGroup marshalling:**

  * Text/YAML now includes `privateGroup`. Older tooling that ignores unknown fields stays compatible.
* **No public API changes** in production code paths (test-only helper constructor changes are internal to tests).