### PR TITLE
Make tuple-generation configurable per-Wire instance (generateTuples flag)

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -77,6 +77,7 @@ public abstract class AbstractWire implements Wire, InternalWire {
     private boolean insideHeader;
     private HeadNumberChecker headNumberChecker;
     private boolean usePadding = DEFAULT_USE_PADDING;
+    private boolean generateTuples = GENERATE_TUPLES;
 
     /**
      * Constructor for AbstractWire.
@@ -660,6 +661,17 @@ public abstract class AbstractWire implements Wire, InternalWire {
      */
     public boolean usePadding() {
         return usePadding;
+    }
+
+    @Override
+    public boolean generateTuples() {
+        return generateTuples;
+    }
+
+    @Override
+    public Wire generateTuples(boolean generateTuples) {
+        this.generateTuples = generateTuples;
+        return this;
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -48,7 +48,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -4277,7 +4276,7 @@ public class BinaryWire extends AbstractWire implements Wire {
             try {
                 return sb == null ? null : classLookup().forName(sb);
             } catch (ClassNotFoundRuntimeException e) {
-                if (Wires.dtoInterface(tClass) && GENERATE_TUPLES) {
+                if (Wires.dtoInterface(tClass) && generateTuples()) {
                     return Wires.tupleFor(tClass, sb.toString());
                 }
                 throw e;

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -2387,7 +2387,7 @@ public class TextWire extends YamlWireOut<TextWire> {
                         return o;
                 }
             }
-            if (Wires.dtoInterface(tClass) && GENERATE_TUPLES && ObjectUtils.implementationToUse(tClass) == tClass)
+            if (Wires.dtoInterface(tClass) && generateTuples() && ObjectUtils.implementationToUse(tClass) == tClass)
                 return Wires.tupleFor(tClass, null);
             return null;
         }
@@ -2395,7 +2395,7 @@ public class TextWire extends YamlWireOut<TextWire> {
         @Nullable
         private Object handleCNFE(Class<?> tClass, ClassNotFoundRuntimeException e, StringBuilder stringBuilder) {
             if (tClass == null) {
-                if (GENERATE_TUPLES) {
+                if (generateTuples()) {
                     return Wires.tupleFor(null, stringBuilder.toString());
                 }
                 String message = "Unable to load " + stringBuilder + ", is a class alias missing.";
@@ -2408,7 +2408,7 @@ public class TextWire extends YamlWireOut<TextWire> {
             if (split[split.length - 1].equalsIgnoreCase(tClass.getSimpleName())) {
                 try {
 
-                    return tClass.isInterface()
+                    return tClass.isInterface() && generateTuples()
                             ? Wires.tupleFor(tClass, stringBuilder.toString())
                             : classLookup().forName(className);
 
@@ -2416,7 +2416,7 @@ public class TextWire extends YamlWireOut<TextWire> {
                     throw e;
                 }
 
-            } else if (GENERATE_TUPLES && tClass.getClassLoader() != null && tClass.isInterface()) {
+            } else if (generateTuples() && tClass.getClassLoader() != null && tClass.isInterface()) {
                 return Wires.tupleFor(tClass, stringBuilder.toString());
             }
 

--- a/src/main/java/net/openhft/chronicle/wire/Wire.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wire.java
@@ -51,4 +51,21 @@ public interface Wire extends WireIn, WireOut {
     @Override
     @NotNull
     Wire headerNumber(long headerNumber);
+
+    /**
+     * Indicates whether tuples should be generated.
+     * By default, this method returns the value of Wires.GENERATE_TUPLES
+     * @return true if tuples should be generated, false otherwise.
+     */
+    default boolean generateTuples() {
+        return Wires.GENERATE_TUPLES;
+    }
+
+    /**
+     * Sets whether tuples should be generated.
+     * @param generateTuples true to enable tuple generation, false to disable it.
+     */
+    default Wire generateTuples(boolean generateTuples) {
+        return this;
+    }
 }

--- a/src/main/java/net/openhft/chronicle/wire/Wires.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wires.java
@@ -1210,6 +1210,7 @@ public enum Wires {
 
     /**
      * Returns a tuple for the specified class and type name.
+     * The caller must check whether tuples are enabled before calling this method.
      *
      * @param <T>       The type parameter.
      * @param tClass    The class type for which the tuple is required.
@@ -1218,12 +1219,6 @@ public enum Wires {
      */
     @Nullable
     public static <T> T tupleFor(Class<T> tClass, String typeName) {
-        // Check if tuple generation is enabled.
-        if (!GENERATE_TUPLES) {
-            Jvm.warn().on(Wires.class, "Cannot find a class for " + typeName + " are you missing an alias?");
-            return null;
-        }
-
         // Set default class if not provided or provided as Object.
         if (tClass == null || tClass == Object.class)
             tClass = (Class<T>) Marshallable.class;

--- a/src/test/java/net/openhft/chronicle/wire/UnknownEnumTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/UnknownEnumTest.java
@@ -94,10 +94,10 @@ public class UnknownEnumTest extends WireTestCommon {
     // This test ensures that TextWire produces a friendly error message for unknown Enum types
     @Test
     public void shouldGenerateFriendlyErrorMessageWhenTypeIsNotKnownInTextWire() {
-        Wires.GENERATE_TUPLES = true;
         try {
-            final TextWire textWire = TextWire.from("enumField: !UnknownEnum QUX");
-            textWire.valueIn.wireIn().read("enumField").object();
+            final Wire textWire = TextWire.from("enumField: !UnknownEnum QUX")
+                                            .generateTuples(true);
+            textWire.getValueIn().wireIn().read("enumField").object();
 
             fail(); // This point should not be reached
         } catch (Exception e) {
@@ -105,8 +105,6 @@ public class UnknownEnumTest extends WireTestCommon {
             String message = e.getMessage().replaceAll(" [a-z0-9.]+.Proxy\\d+", " ProxyXX");
             assertThat(message,
                     is(equalTo("Trying to read marshallable class ProxyXX at [pos: 23, rlim: 27, wlim: 27, cap: 27 ]  QUX expected to find a {")));
-        } finally {
-            Wires.GENERATE_TUPLES = false;
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/wire/WiresTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WiresTest.java
@@ -151,8 +151,6 @@ public class WiresTest extends WireTestCommon {
     public void unknownType() throws NoSuchFieldException {
         Assume.assumeFalse(Jvm.maxDirectMemory() == 0);
 
-        Wires.GENERATE_TUPLES = true;
-
         Marshallable marshallable = Wires.tupleFor(Marshallable.class, "UnknownType");
         marshallable.setField("one", 1);
         marshallable.setField("two", 2.2);
@@ -163,6 +161,9 @@ public class WiresTest extends WireTestCommon {
                 "  two: 2.2,\n" +
                 "  three: three\n" +
                 "}\n", toString);
+
+        Wires.GENERATE_TUPLES = true;
+
         Object o = Marshallable.fromString(toString);
         assertEquals(toString, o.toString());
     }

--- a/src/test/java/net/openhft/chronicle/wire/method/MethodWriterByInterfaceTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/MethodWriterByInterfaceTest.java
@@ -50,26 +50,25 @@ public class MethodWriterByInterfaceTest extends WireTestCommon {
     // Test method writing and reading via implementation with text wire type
     @Test
     public void writeReadViaImplementation() {
-        checkWriteReadViaImplementation(WireType.TEXT);
+        checkWriteReadViaImplementation(WireType.TEXT, false);
     }
 
     // Test method writing and reading with text wire type and tuple generation enabled
     @Test
     public void writeReadViaImplementationGenerateTuples() {
-        Wires.GENERATE_TUPLES = true;
-        checkWriteReadViaImplementation(WireType.TEXT);
+        checkWriteReadViaImplementation(WireType.TEXT, true);
     }
 
     // Test method writing and reading via implementation with YAML wire type
     @Test
     public void writeReadViaImplementationYaml() {
-        checkWriteReadViaImplementation(WireType.YAML_ONLY);
+        checkWriteReadViaImplementation(WireType.YAML_ONLY, false);
     }
 
     // Helper method to perform the core test logic for different wire types
-    private void checkWriteReadViaImplementation(WireType wireType) {
+    private void checkWriteReadViaImplementation(WireType wireType, boolean generateTuples) {
         // Create a new wire instance of the specified wire type
-        Wire tw = wireType.apply(Bytes.allocateElasticOnHeap());
+        Wire tw = wireType.apply(Bytes.allocateElasticOnHeap()).generateTuples(generateTuples);
 
         // Create a method writer for the MWBI0 interface
         MWBI0 mwbi0 = tw.methodWriter(MWBI0.class);

--- a/src/test/java/net/openhft/chronicle/wire/method/VanillaMethodReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/VanillaMethodReaderTest.java
@@ -229,10 +229,9 @@ public class VanillaMethodReaderTest extends WireTestCommon {
     public void testNestedUnknownClass() {
         assumeFalse(Jvm.maxDirectMemory() == 0);
 
-        Wires.GENERATE_TUPLES = true;
-
         Wire wire2 = new TextWire(Bytes.allocateElasticOnHeap())
-                .useTextDocuments();
+                .useTextDocuments()
+                .generateTuples(true);
         MRTListener writer2 = wire2.methodWriter(MRTListener.class);
 
         String text = "unknown: {\n" +
@@ -244,7 +243,8 @@ public class VanillaMethodReaderTest extends WireTestCommon {
                 "}\n" +
                 "...\n";
         Wire wire = TextWire.from(text)
-                .useTextDocuments();
+                .useTextDocuments()
+                .generateTuples(true);
         MethodReader reader = wire.methodReader(writer2);
         checkReaderType(reader);
         assertTrue(reader.readOne());
@@ -256,10 +256,9 @@ public class VanillaMethodReaderTest extends WireTestCommon {
     public void testUnknownClassDoesntThrow() {
         assumeFalse(Jvm.maxDirectMemory() == 0);
 
-        Wires.GENERATE_TUPLES = true;
-
         Wire wire2 = new TextWire(Bytes.allocateElasticOnHeap())
-                .useTextDocuments();
+                .useTextDocuments()
+                .generateTuples(true);
         MRTListener writer2 = wire2.methodWriter(MRTListener.class);
 
         String text = "top: !UnknownClass {\n" +
@@ -275,7 +274,8 @@ public class VanillaMethodReaderTest extends WireTestCommon {
                 "}\n" +
                 "...\n";
         Wire wire = TextWire.from(text)
-                .useTextDocuments();
+                .useTextDocuments()
+                .generateTuples(true);
         MethodReader reader = wire.methodReader(writer2);
         checkReaderType(reader);
         assertTrue(reader.readOne());
@@ -288,10 +288,9 @@ public class VanillaMethodReaderTest extends WireTestCommon {
     public void testUnknownClassThrow() {
         assumeFalse(Jvm.maxDirectMemory() == 0);
 
-        Wires.GENERATE_TUPLES = false;
-
         Wire wire2 = new TextWire(Bytes.allocateElasticOnHeap())
-                .useTextDocuments();
+                .useTextDocuments()
+                .generateTuples(false);
         MRTListener writer2 = wire2.methodWriter(MRTListener.class);
 
         String text = "top: !UnknownClass {\n" +
@@ -307,7 +306,8 @@ public class VanillaMethodReaderTest extends WireTestCommon {
                 "}\n" +
                 "...\n";
         Wire wire = TextWire.from(text)
-                .useTextDocuments();
+                .useTextDocuments()
+                .generateTuples(false);
         MethodReader reader = wire.methodReader(writer2);
         checkReaderType(reader);
         assertTrue(reader.readOne());
@@ -340,11 +340,6 @@ public class VanillaMethodReaderTest extends WireTestCommon {
         } finally {
             MessageHistory.clear();
         }
-    }
-
-    @After
-    public void resetGenerateTuples() {
-        Wires.GENERATE_TUPLES = false;
     }
 
     @Test(expected = IllegalStateException.class)


### PR DESCRIPTION
**Description (what & why)**
This change allows `Wire` instances to enable tuple generation on a per-instance basis rather than relying solely on the static `Wires.GENERATE_TUPLES` flag.

Motivation:

* Shared configuration files may contain types not present on every service’s classpath. With the previous global behaviour every class mentioned had to be resolvable — otherwise reading the shared config forced reserialization or threw `ClassNotFoundException`.
* Making tuple generation instance-scoped allows a single reader/service that needs tolerant deserialisation to enable it without enabling the behaviour globally for the entire JVM.
* The feature is off by default to avoid surprising behaviour in existing deployments.

Summary of changes:

* Add `boolean generateTuples` field to `AbstractWire` and accessor/mutator (`generateTuples()` and `generateTuples(boolean)`).
* Add default methods `generateTuples()` and `generateTuples(boolean)` to the `Wire` interface so callers can enable/disable on a per-wire instance.
* Replace checks of the static `GENERATE_TUPLES` constant in `BinaryWire`/`TextWire` with calls to the instance `generateTuples()` where appropriate.
* Remove the global guard from `Wires.tupleFor(...)` with the comment that callers must check whether tuples are enabled.
* Update tests to use the new instance-level API instead of mutating `Wires.GENERATE_TUPLES`.

Files changed (high-level)

* `AbstractWire.java` — add instance field + getter/setter
* `Wire.java` — add default `generateTuples()` / `generateTuples(boolean)` methods
* `BinaryWire.java`, `TextWire.java` — use `generateTuples()` on `this` instead of `GENERATE_TUPLES`
* `Wires.java` — remove global guard from `tupleFor(...)` (caller must check)
* Unit tests updated to call `.generateTuples(true/false)` on wire instances instead of setting the static flag

**Testing**

* Unit tests updated to use the instance-level API (see `UnknownEnumTest`, `WiresTest`, `MethodWriterByInterfaceTest`, `VanillaMethodReaderTest`).
* Run full test suite: `./mvnw -T1C -DskipTests=false test` (or `mvn test` in CI). Pay attention to tests that previously relied on toggling `Wires.GENERATE_TUPLES` globally.

**Compatibility & migration notes**

* Public API change: `Wire` gains two default methods. Because these have default implementations, this is binary compatible with existing callers; no source changes required for callers that don't use the new methods.
* Behaviour change: tuple generation can now be toggled per instance. Code that relied on `Wires.GENERATE_TUPLES` still works (the static flag still exists), but the preferred approach is per-Wire. Consider documenting the migration path and deprecating `Wires.GENERATE_TUPLES` if you intend to phase it out.
* `Wires.tupleFor(...)` no longer enforces the global flag — callers must check whichever source of truth they care about. This was done intentionally, but it increases responsibility on callers and can silently create tuples if they don’t check. See suggested follow-ups below.
