### PR TITLE
Update copyright years to 2025 in multiple files

### DIFF
--- a/demo/java17setup.sh
+++ b/demo/java17setup.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 #
-# Copyright 2016-2022 chronicle.software
+# Copyright 2016-2025 chronicle.software
 #
 #       https://chronicle.software
 #

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2016 chronicle.software
+  ~ Copyright 2016-2025 chronicle.software
   ~
   ~ Licensed under the *Apache License, Version 2.0* (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/demo/src/main/java/run/chronicle/wire/demo/Data.java
+++ b/demo/src/main/java/run/chronicle/wire/demo/Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/demo/src/main/java/run/chronicle/wire/demo/EventByMethodExamples.java
+++ b/demo/src/main/java/run/chronicle/wire/demo/EventByMethodExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/demo/src/main/java/run/chronicle/wire/demo/Example1.java
+++ b/demo/src/main/java/run/chronicle/wire/demo/Example1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/demo/src/main/java/run/chronicle/wire/demo/Example2.java
+++ b/demo/src/main/java/run/chronicle/wire/demo/Example2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/demo/src/main/java/run/chronicle/wire/demo/Example3.java
+++ b/demo/src/main/java/run/chronicle/wire/demo/Example3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/demo/src/main/java/run/chronicle/wire/demo/Example4.java
+++ b/demo/src/main/java/run/chronicle/wire/demo/Example4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/demo/src/main/java/run/chronicle/wire/demo/Example5.java
+++ b/demo/src/main/java/run/chronicle/wire/demo/Example5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/demo/src/main/java/run/chronicle/wire/demo/Example6.java
+++ b/demo/src/main/java/run/chronicle/wire/demo/Example6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/demo/src/main/java/run/chronicle/wire/demo/Example7.java
+++ b/demo/src/main/java/run/chronicle/wire/demo/Example7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/demo/src/main/java/run/chronicle/wire/demo/ListLookup.java
+++ b/demo/src/main/java/run/chronicle/wire/demo/ListLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/demo/src/main/java/run/chronicle/wire/demo/mapreuse/IntMapper.java
+++ b/demo/src/main/java/run/chronicle/wire/demo/mapreuse/IntMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/demo/src/main/java/run/chronicle/wire/demo/mapreuse/Mapper.java
+++ b/demo/src/main/java/run/chronicle/wire/demo/mapreuse/Mapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/demo/src/main/java/run/chronicle/wire/demo/mapreuse/Security.java
+++ b/demo/src/main/java/run/chronicle/wire/demo/mapreuse/Security.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/demo/src/main/java/run/chronicle/wire/demo/mapreuse/SecurityLookup.java
+++ b/demo/src/main/java/run/chronicle/wire/demo/mapreuse/SecurityLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/demo/system.properties
+++ b/demo/system.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2022 chronicle.software
+# Copyright 2016-2025 chronicle.software
 #
 #       https://chronicle.software
 #

--- a/jlbh-test.sh
+++ b/jlbh-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2016-2022 chronicle.software
+# Copyright 2016-2025 chronicle.software
 #
 #       https://chronicle.software
 #

--- a/marshallingperf/pom.xml
+++ b/marshallingperf/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2016 chronicle.software
+  ~ Copyright 2016-2025 chronicle.software
   ~
   ~ Licensed under the *Apache License, Version 2.0* (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/marshallingperf/system.properties
+++ b/marshallingperf/system.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2022 chronicle.software
+# Copyright 2016-2025 chronicle.software
 #
 #       https://chronicle.software
 #

--- a/microbenchmarks/examples/resources/example-data.xml
+++ b/microbenchmarks/examples/resources/example-data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  ~ Copyright 2016 chronicle.software
+  ~ Copyright 2016-2025 chronicle.software
   ~
   ~  Licensed under the Apache License, Version 2.0 (the "License");
   ~  you may not use this file except in compliance with the License.

--- a/microbenchmarks/pom.xml
+++ b/microbenchmarks/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2016 chronicle.software
+  ~ Copyright 2016-2025 chronicle.software
   ~
   ~ Licensed under the *Apache License, Version 2.0* (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/microbenchmarks/system.properties
+++ b/microbenchmarks/system.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2022 chronicle.software
+# Copyright 2016-2025 chronicle.software
 #
 #       https://chronicle.software
 #

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2016 chronicle.software
+  ~ Copyright 2016-2025 chronicle.software
   ~
   ~ Licensed under the *Apache License, Version 2.0* (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/wire/AbstractAnyWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractAnyWire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/AbstractClassGenerator.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractClassGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/AbstractCommonMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractCommonMarshallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/AbstractEventCfg.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractEventCfg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/AbstractFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractFieldInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/AbstractGeneratedMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractGeneratedMethodReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/AbstractLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractLongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/AbstractMarshallableCfg.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractMarshallableCfg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/AbstractMethodWriterInvocationHandler.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractMethodWriterInvocationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/AbstractTimestampLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractTimestampLongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/AsMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/AsMarshallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/Base32LongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/Base32LongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/Base64LongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/Base64LongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/Base85LongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/Base85LongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/BaseEvent.java
+++ b/src/main/java/net/openhft/chronicle/wire/BaseEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  */
 
 package net.openhft.chronicle.wire;

--- a/src/main/java/net/openhft/chronicle/wire/BinaryMethodWriterInvocationHandler.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryMethodWriterInvocationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/BinaryReadDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryReadDocumentContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWireCode.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWireCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWireHighCode.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWireHighCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWriteDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWriteDocumentContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/BitSetUtil.java
+++ b/src/main/java/net/openhft/chronicle/wire/BitSetUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/BracketType.java
+++ b/src/main/java/net/openhft/chronicle/wire/BracketType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/BytesInBinaryMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/BytesInBinaryMarshallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/CSVWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/CSVWire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/CharSequenceObjectMap.java
+++ b/src/main/java/net/openhft/chronicle/wire/CharSequenceObjectMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/ChronicleBitSet.java
+++ b/src/main/java/net/openhft/chronicle/wire/ChronicleBitSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/Comment.java
+++ b/src/main/java/net/openhft/chronicle/wire/Comment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/CommentAnnotationNotifier.java
+++ b/src/main/java/net/openhft/chronicle/wire/CommentAnnotationNotifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/DefaultValueIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/DefaultValueIn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/Demarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/Demarshallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/DocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/DocumentContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/DocumentContextHolder.java
+++ b/src/main/java/net/openhft/chronicle/wire/DocumentContextHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/DocumentWritten.java
+++ b/src/main/java/net/openhft/chronicle/wire/DocumentWritten.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/DynamicEnum.java
+++ b/src/main/java/net/openhft/chronicle/wire/DynamicEnum.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/Event.java
+++ b/src/main/java/net/openhft/chronicle/wire/Event.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  */
 
 package net.openhft.chronicle.wire;

--- a/src/main/java/net/openhft/chronicle/wire/ExcerptListener.java
+++ b/src/main/java/net/openhft/chronicle/wire/ExcerptListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/FieldInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/FieldNumberParselet.java
+++ b/src/main/java/net/openhft/chronicle/wire/FieldNumberParselet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/GenerateJsonSchemaMain.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateJsonSchemaMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodBridge.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodBridge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodDelegate.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodWriter.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodWriter2.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodWriter2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/GeneratedProxyClass.java
+++ b/src/main/java/net/openhft/chronicle/wire/GeneratedProxyClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/GeneratingMethodReaderInterceptorReturns.java
+++ b/src/main/java/net/openhft/chronicle/wire/GeneratingMethodReaderInterceptorReturns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/HashWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/HashWire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/HeadNumberChecker.java
+++ b/src/main/java/net/openhft/chronicle/wire/HeadNumberChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/HexadecimalLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/HexadecimalLongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/IdentifierLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/IdentifierLongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/InputStreamToWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/InputStreamToWire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/JSONWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/JSONWire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/KeyedMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/KeyedMarshallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/LongArrayValueBitSet.java
+++ b/src/main/java/net/openhft/chronicle/wire/LongArrayValueBitSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/LongConversion.java
+++ b/src/main/java/net/openhft/chronicle/wire/LongConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/LongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/LongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/LongValueBitSet.java
+++ b/src/main/java/net/openhft/chronicle/wire/LongValueBitSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/Marshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/Marshallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/MarshallableIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableIn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/MarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableOut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/MarshallableOutBuilder.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableOutBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/MarshallableParser.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/MessageHistory.java
+++ b/src/main/java/net/openhft/chronicle/wire/MessageHistory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/MessagePathClassifier.java
+++ b/src/main/java/net/openhft/chronicle/wire/MessagePathClassifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/MethodDelegate.java
+++ b/src/main/java/net/openhft/chronicle/wire/MethodDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/MethodFilterOnFirstArg.java
+++ b/src/main/java/net/openhft/chronicle/wire/MethodFilterOnFirstArg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/MethodWireKey.java
+++ b/src/main/java/net/openhft/chronicle/wire/MethodWireKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/MethodWriter.java
+++ b/src/main/java/net/openhft/chronicle/wire/MethodWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/MethodWriterInvocationHandlerSupplier.java
+++ b/src/main/java/net/openhft/chronicle/wire/MethodWriterInvocationHandlerSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/MethodWriterValidationException.java
+++ b/src/main/java/net/openhft/chronicle/wire/MethodWriterValidationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/MicroDurationLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/MicroDurationLongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/MicroTimestampLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/MicroTimestampLongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/MilliTimestampLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/MilliTimestampLongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/NanoDurationLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/NanoDurationLongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/NanoTimestampLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/NanoTimestampLongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/NoDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/NoDocumentContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/ObjectIntObjectConsumer.java
+++ b/src/main/java/net/openhft/chronicle/wire/ObjectIntObjectConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/ParameterHolderSequenceWriter.java
+++ b/src/main/java/net/openhft/chronicle/wire/ParameterHolderSequenceWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/QueryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/QueryWire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/Quotes.java
+++ b/src/main/java/net/openhft/chronicle/wire/Quotes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/RawText.java
+++ b/src/main/java/net/openhft/chronicle/wire/RawText.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/RawWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/RawWire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/ReadAnyWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/ReadAnyWire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/ReadDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/ReadDocumentContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/ReadMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/ReadMarshallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/ReflectionUtil.java
+++ b/src/main/java/net/openhft/chronicle/wire/ReflectionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/RollbackIfNotCompleteNotifier.java
+++ b/src/main/java/net/openhft/chronicle/wire/RollbackIfNotCompleteNotifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/ScalarStrategy.java
+++ b/src/main/java/net/openhft/chronicle/wire/ScalarStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/SelfDescribingMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/SelfDescribingMarshallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/SelfDescribingTriviallyCopyable.java
+++ b/src/main/java/net/openhft/chronicle/wire/SelfDescribingTriviallyCopyable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/Sequence.java
+++ b/src/main/java/net/openhft/chronicle/wire/Sequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
+++ b/src/main/java/net/openhft/chronicle/wire/SerializationStrategies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/SerializationStrategy.java
+++ b/src/main/java/net/openhft/chronicle/wire/SerializationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/ServicesTimestampLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/ServicesTimestampLongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/ShortTextLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/ShortTextLongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/SourceContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/SourceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/TextMethodWriterInvocationHandler.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextMethodWriterInvocationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/TextReadDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextReadDocumentContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/TextStopCharTesters.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextStopCharTesters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/TextStopCharsTesters.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextStopCharsTesters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/TextWriteDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWriteDocumentContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/TriConsumer.java
+++ b/src/main/java/net/openhft/chronicle/wire/TriConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/UnrecoverableTimeoutException.java
+++ b/src/main/java/net/openhft/chronicle/wire/UnrecoverableTimeoutException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/ValueIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueIn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/ValueInStack.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueInStack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/ValueInState.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueInState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/ValueOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueOut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/VanillaMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMethodReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/VanillaMethodReaderBuilder.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMethodReaderBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/VanillaMethodWriterBuilder.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMethodWriterBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/VanillaWireParser.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaWireParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/Wire.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/WireCommon.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/WireDumper.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireDumper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/WireIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireIn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/WireInternal.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/WireKey.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshallerForUnexpectedFields.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshallerForUnexpectedFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/WireObjectInput.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireObjectInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/WireObjectOutput.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireObjectOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/WireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireOut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/WireParselet.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireParselet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/WireParser.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/WireSerializedLambda.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireSerializedLambda.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/WireToOutputStream.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireToOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/WireType.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/Wires.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wires.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/WordsLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/WordsLongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/WrappedDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/WrappedDocumentContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/WriteAfterEOFException.java
+++ b/src/main/java/net/openhft/chronicle/wire/WriteAfterEOFException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/WriteDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/WriteDocumentContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/WriteMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/WriteMarshallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/WriteValue.java
+++ b/src/main/java/net/openhft/chronicle/wire/WriteValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/YamlKeys.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/YamlLogging.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlLogging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/YamlToken.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- * https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/wire/converter/Base16.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/Base16.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/converter/Base64.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/Base64.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/converter/Base85.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/Base85.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/converter/Id.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/Id.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/converter/NanoTime.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/NanoTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/converter/PowerOfTwoLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/PowerOfTwoLongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/converter/ShortText.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/ShortText.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/converter/SizeLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/SizeLongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/converter/SymbolsLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/SymbolsLongConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/converter/Words.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/Words.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/domestic/AutoTailers.java
+++ b/src/main/java/net/openhft/chronicle/wire/domestic/AutoTailers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/domestic/extractor/DocumentExtractor.java
+++ b/src/main/java/net/openhft/chronicle/wire/domestic/extractor/DocumentExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/domestic/extractor/ToDoubleDocumentExtractor.java
+++ b/src/main/java/net/openhft/chronicle/wire/domestic/extractor/ToDoubleDocumentExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/domestic/extractor/ToLongDocumentExtractor.java
+++ b/src/main/java/net/openhft/chronicle/wire/domestic/extractor/ToLongDocumentExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/domestic/package-info.java
+++ b/src/main/java/net/openhft/chronicle/wire/domestic/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/domestic/reduction/ConcurrentCollectors.java
+++ b/src/main/java/net/openhft/chronicle/wire/domestic/reduction/ConcurrentCollectors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/domestic/reduction/Reduction.java
+++ b/src/main/java/net/openhft/chronicle/wire/domestic/reduction/Reduction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/domestic/reduction/Reductions.java
+++ b/src/main/java/net/openhft/chronicle/wire/domestic/reduction/Reductions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/domestic/stream/Streams.java
+++ b/src/main/java/net/openhft/chronicle/wire/domestic/stream/Streams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/internal/FileMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/FileMarshallableOut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/internal/FromStringInterner.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/FromStringInterner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/internal/InternalAutoTailers.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/InternalAutoTailers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/internal/StringConsumerMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/StringConsumerMarshallableOut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/internal/VanillaFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/VanillaFieldInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/internal/extractor/DocumentExtractorBuilder.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/extractor/DocumentExtractorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/internal/extractor/DocumentExtractorUtil.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/extractor/DocumentExtractorUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/CharFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/CharFieldInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/DoubleFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/DoubleFieldInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/IntFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/IntFieldInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/LongFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/LongFieldInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/ObjectFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/ObjectFieldInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/UnsafeFieldInfo.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/fieldinfo/UnsafeFieldInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/internal/package-info.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/internal/reduction/ReductionUtil.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/reduction/ReductionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/internal/stream/StreamsUtil.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/stream/StreamsUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/utils/JavaSourceCodeFormatter.java
+++ b/src/main/java/net/openhft/chronicle/wire/utils/JavaSourceCodeFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/utils/JsonSourceCodeFormatter.java
+++ b/src/main/java/net/openhft/chronicle/wire/utils/JsonSourceCodeFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/utils/MethodReaderStatus.java
+++ b/src/main/java/net/openhft/chronicle/wire/utils/MethodReaderStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/wire/utils/SourceCodeFormatter.java
+++ b/src/main/java/net/openhft/chronicle/wire/utils/SourceCodeFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/AbstractClassGeneratorTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/AbstractClassGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/AbstractCommonMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/AbstractCommonMarshallableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/AbstractFieldTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/AbstractFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/AbstractUntypedFieldTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/AbstractUntypedFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/Base32LongConverterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/Base32LongConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/Base64LongConverterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/Base64LongConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/Base85LongConverterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/Base85LongConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/BinaryInTextTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryInTextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/BinaryMethodWriterInvocationHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryMethodWriterInvocationHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/BinaryToTextTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryToTextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWire2Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWire2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireHighCodeTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireHighCodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireNumbersTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireNumbersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWirePerfTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWirePerfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireStringInternerTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireStringInternerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireWithMappedBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireWithMappedBytesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/BitSetTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BitSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/BytesMarshallableCompatibilityTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BytesMarshallableCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/CSVBytesMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/CSVBytesMarshallableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/CSVWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/CSVWireTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/ChainedMethodsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ChainedMethodsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/CharSequenceObjectMapTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/CharSequenceObjectMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/ChronicleBitSetTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ChronicleBitSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *
@@ -18,7 +18,7 @@
 
 package net.openhft.chronicle.wire;
 /*
- * Copyright 2016-2021 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/ClassAliasPoolTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ClassAliasPoolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/CopyTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/CopyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/DMNestedClass.java
+++ b/src/test/java/net/openhft/chronicle/wire/DMNestedClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/DMOuterClass.java
+++ b/src/test/java/net/openhft/chronicle/wire/DMOuterClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/DefaultMarshallerTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/DefaultMarshallerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/DemarshallableObject.java
+++ b/src/test/java/net/openhft/chronicle/wire/DemarshallableObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/DeserializeFromNakedFileTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/DeserializeFromNakedFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/DocumentContextTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/DocumentContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/DoubleTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/DoubleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/EgMain.java
+++ b/src/test/java/net/openhft/chronicle/wire/EgMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/ElasticByteBufferTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ElasticByteBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/EmbeddedBytesMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/EmbeddedBytesMarshallableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/EndOfDayShort.java
+++ b/src/test/java/net/openhft/chronicle/wire/EndOfDayShort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/EnumSetMarshallingTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/EnumSetMarshallingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/EnumTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/EnumTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/EscapeCharsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/EscapeCharsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/FIX42.java
+++ b/src/test/java/net/openhft/chronicle/wire/FIX42.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/FIX42Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/FIX42Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/FloatDtoTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/FloatDtoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/ForwardAndBackwardCompatibilityMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ForwardAndBackwardCompatibilityMarshallableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/ForwardAndBackwardCompatibilityTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ForwardAndBackwardCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/Fun.java
+++ b/src/test/java/net/openhft/chronicle/wire/Fun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/GenerateFIXWireKey.java
+++ b/src/test/java/net/openhft/chronicle/wire/GenerateFIXWireKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/GenerateJsonSchemaMainTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/GenerateJsonSchemaMainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/GenerateMethodBridgeTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/GenerateMethodBridgeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/GenerateMethodDelegateTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/GenerateMethodDelegateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/GenerateMethodWriterSameInterfaceDifferentOuterClassTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/GenerateMethodWriterSameInterfaceDifferentOuterClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/GenericMethodsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/GenericMethodsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/HashWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/HashWireTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/HexDumpTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/HexDumpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/ILast.java
+++ b/src/test/java/net/openhft/chronicle/wire/ILast.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/IMid.java
+++ b/src/test/java/net/openhft/chronicle/wire/IMid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/IMid2.java
+++ b/src/test/java/net/openhft/chronicle/wire/IMid2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/ITop.java
+++ b/src/test/java/net/openhft/chronicle/wire/ITop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/IdentifierLongConverterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/IdentifierLongConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/IgnoreHighOrderBitsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/IgnoreHighOrderBitsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/InnerMapTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/InnerMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/InvalidYamWithCommonMistakesTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/InvalidYamWithCommonMistakesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/Issue341Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/Issue341Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/JSONNanTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/JSONNanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/JSONTypesWithEnumsAndBoxedTypesTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/JSONTypesWithEnumsAndBoxedTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/JSONTypesWithMapsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/JSONTypesWithMapsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/JSONWireDTOTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/JSONWireDTOTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/JSONWireMiscTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/JSONWireMiscTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/JSONWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/JSONWireTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/JSONWireWithListsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/JSONWireWithListsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/JsonUtil.java
+++ b/src/test/java/net/openhft/chronicle/wire/JsonUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/JsonWireToStringAcceptanceTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/JsonWireToStringAcceptanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *     https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/KubernetesYamlTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/KubernetesYamlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/LongConversionExampleA.java
+++ b/src/test/java/net/openhft/chronicle/wire/LongConversionExampleA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/LongConversionExampleB.java
+++ b/src/test/java/net/openhft/chronicle/wire/LongConversionExampleB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/LongConversionExampleC.java
+++ b/src/test/java/net/openhft/chronicle/wire/LongConversionExampleC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/LongConversionTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/LongConversionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/Marshallable2Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/Marshallable2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/MarshallableOutBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MarshallableOutBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/MarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MarshallableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/MessageHistoryTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MessageHistoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/MessagePathClassifierTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MessagePathClassifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  */
 
 package net.openhft.chronicle.wire;

--- a/src/test/java/net/openhft/chronicle/wire/MethodReaderArgumentsRecycleProxyTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MethodReaderArgumentsRecycleProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/MethodReaderArgumentsRecycleTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MethodReaderArgumentsRecycleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/MethodReaderBuilderExceptionHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MethodReaderBuilderExceptionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/MethodReaderChainedInterceptedGenericInterfaceTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MethodReaderChainedInterceptedGenericInterfaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/MethodReaderDelegationTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MethodReaderDelegationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/MethodReaderInterceptorReturnsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MethodReaderInterceptorReturnsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/MethodReaderMethodIdsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MethodReaderMethodIdsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/MethodReaderNonStandardInstancesTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MethodReaderNonStandardInstancesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/MethodReaderSuperInterfaceForSeveralReturnTypesTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MethodReaderSuperInterfaceForSeveralReturnTypesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/MethodWriterBytesTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MethodWriterBytesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/MethodWriterNestedReturnTypeTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MethodWriterNestedReturnTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/MethodWriterStringTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MethodWriterStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/MicroLongConverterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MicroLongConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/MicroTimestampLongConverterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MicroTimestampLongConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/MilliTimestampLongConverterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MilliTimestampLongConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/MyMarshallable.java
+++ b/src/test/java/net/openhft/chronicle/wire/MyMarshallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/MyTypes.java
+++ b/src/test/java/net/openhft/chronicle/wire/MyTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/MyTypesCustom.java
+++ b/src/test/java/net/openhft/chronicle/wire/MyTypesCustom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/NanoLongConverterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/NanoLongConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/NanoTimestampLongConverterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/NanoTimestampLongConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/NestedMapsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/NestedMapsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/ObjectWithTreeMap.java
+++ b/src/test/java/net/openhft/chronicle/wire/ObjectWithTreeMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/OutOfOrderTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/OutOfOrderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/Outer1.java
+++ b/src/test/java/net/openhft/chronicle/wire/Outer1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/Outer2.java
+++ b/src/test/java/net/openhft/chronicle/wire/Outer2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/OverrideAValueTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/OverrideAValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/PrimArraysTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/PrimArraysTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/PrimitiveTypeWrappersTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/PrimitiveTypeWrappersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/ProjectTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ProjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/QueryWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/QueryWireTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/RFCExamplesTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/RFCExamplesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/RawWirePerfTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/RawWirePerfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/RawWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/RawWireTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/ReadAnyWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ReadAnyWireTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/ReadDocumentContextTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ReadDocumentContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/ReadOneTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ReadOneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/ReadmeChapter1Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/ReadmeChapter1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/ReadmePojoTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ReadmePojoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/SequenceTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/SequenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/SerializableObjectTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/SerializableObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/ShortTextLongConverterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ShortTextLongConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/SizeLongConverterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/SizeLongConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/SkipValueTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/SkipValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/SmallDoublesMarshallingTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/SmallDoublesMarshallingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/StrangeTextCombinationTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/StrangeTextCombinationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/StreamMain.java
+++ b/src/test/java/net/openhft/chronicle/wire/StreamMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/StringConsumerMarshallableOutTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/StringConsumerMarshallableOutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/TWTSingleton.java
+++ b/src/test/java/net/openhft/chronicle/wire/TWTSingleton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  */
 
 package net.openhft.chronicle.wire;

--- a/src/test/java/net/openhft/chronicle/wire/TestJsonIssue467.java
+++ b/src/test/java/net/openhft/chronicle/wire/TestJsonIssue467.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/TestLongConversion.java
+++ b/src/test/java/net/openhft/chronicle/wire/TestLongConversion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/TestMarshallable.java
+++ b/src/test/java/net/openhft/chronicle/wire/TestMarshallable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/TestMarshallableZoneId.java
+++ b/src/test/java/net/openhft/chronicle/wire/TestMarshallableZoneId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/TextBinaryWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TextBinaryWireTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/TextCompatibilityTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TextCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/TextDocumentTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TextDocumentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/TextSkipValueTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TextSkipValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/TextWireAgitatorTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TextWireAgitatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/TextWireCompatibilityTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TextWireCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/TextWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TextWireTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/TextWireTypeArrayTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TextWireTypeArrayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 chronicle.software
+ * Copyright 2014-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/TextWithArraysTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TextWithArraysTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/ThrowableTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ThrowableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/TimestampLongConverterZoneIdsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TimestampLongConverterZoneIdsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/TimestampLongConverterZonedIdsConfigTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TimestampLongConverterZonedIdsConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/TriviallyCopyableJLBH.java
+++ b/src/test/java/net/openhft/chronicle/wire/TriviallyCopyableJLBH.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/TriviallyCopyableTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TriviallyCopyableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/UnicodeStringTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/UnicodeStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/UnknownEnumTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/UnknownEnumTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/UnsupportedChangesTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/UnsupportedChangesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/Update.java
+++ b/src/test/java/net/openhft/chronicle/wire/Update.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/UpdateInterceptorReturnTypeTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/UpdateInterceptorReturnTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/UsingTestMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/UsingTestMarshallableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/ValueOutTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ValueOutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/VanillaMessageHistoryTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/VanillaMessageHistoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/VanillaMethodReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/VanillaMethodReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/WMTwoFields.java
+++ b/src/test/java/net/openhft/chronicle/wire/WMTwoFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/WireDumperTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireDumperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/WireInternalInternTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireInternalInternTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/WireInternalTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireInternalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/WireMarshallerTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireMarshallerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  */
 
 package net.openhft.chronicle.wire;

--- a/src/test/java/net/openhft/chronicle/wire/WireParserTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/WireResetTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireResetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/WireResourcesTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireResourcesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/WireSerializedLambdaTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireSerializedLambdaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/WireStringCollectionTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireStringCollectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/WireTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireTestCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/WireTests.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/WireTextBugTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireTextBugTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
  */
 
 package net.openhft.chronicle.wire;/*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/WireToOutputStreamTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireToOutputStreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/WireTypeTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/WiresFromFileTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WiresFromFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/WiresTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WiresTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/WordsLongConverterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WordsLongConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/WriteDocumentContextTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WriteDocumentContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/YamlSpecTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/YamlSpecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/YamlSpecificationTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/YamlSpecificationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/YamlSpecificationTextWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/YamlSpecificationTextWireTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/YamlTokeniserTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/YamlTokeniserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/YamlWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/YamlWireTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/BenchArrayStringMain.java
+++ b/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/BenchArrayStringMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/BenchBytesMain.java
+++ b/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/BenchBytesMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/BenchFieldsMain.java
+++ b/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/BenchFieldsMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/BenchNullMain.java
+++ b/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/BenchNullMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/BenchRefBytesMain.java
+++ b/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/BenchRefBytesMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/BenchRefStringMain.java
+++ b/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/BenchRefStringMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/BenchStringMain.java
+++ b/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/BenchStringMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/BenchUtf8StringMain.java
+++ b/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/BenchUtf8StringMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/BytesMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/BytesMarshallableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/NestedGenericTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/NestedGenericTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/PerfRegressionHolder.java
+++ b/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/PerfRegressionHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/PerfRegressionTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/bytesmarshallable/PerfRegressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/compact/DotNetTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/compact/DotNetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/converter/Base64Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/converter/Base64Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/converter/NanoTimeTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/converter/NanoTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/domestic/streaming/CreateUtil.java
+++ b/src/test/java/net/openhft/chronicle/wire/domestic/streaming/CreateUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/domestic/streaming/StreamsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/domestic/streaming/StreamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/CollectorTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/CollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/CountAccumulationTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/CountAccumulationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/LastIndexSeenTailerTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/LastIndexSeenTailerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/LastIndexSeenTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/LastIndexSeenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/LastMarketDataPerSymbolTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/LastMarketDataPerSymbolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/MarketData.java
+++ b/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/MarketData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/MethodWriterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/MethodWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/MinMax.java
+++ b/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/MinMax.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/MinMaxLastMarketDataPerSymbolTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/MinMaxLastMarketDataPerSymbolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/StreamingDemoMain.java
+++ b/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/StreamingDemoMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/domestic/streaming/streams/StreamsDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/domestic/streaming/streams/StreamsDemoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/domestic/streaming/streams/StreamsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/domestic/streaming/streams/StreamsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/dynenum/WireDynamicEnumTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/dynenum/WireDynamicEnumTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/examples/MessageRoutingExample.java
+++ b/src/test/java/net/openhft/chronicle/wire/examples/MessageRoutingExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/examples/WireExamples1.java
+++ b/src/test/java/net/openhft/chronicle/wire/examples/WireExamples1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/examples/WireExamples2.java
+++ b/src/test/java/net/openhft/chronicle/wire/examples/WireExamples2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/examples/WireExamples3.java
+++ b/src/test/java/net/openhft/chronicle/wire/examples/WireExamples3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/examples/WireExamples4.java
+++ b/src/test/java/net/openhft/chronicle/wire/examples/WireExamples4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/io/SyncableMethodWriterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/io/SyncableMethodWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/issue/Issue277Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/issue/Issue277Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/issue/Issue327Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/issue/Issue327Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/issue/Issue328Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/issue/Issue328Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/issue/Issue344Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/issue/Issue344Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/issue/Issue609Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/issue/Issue609Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/issue/Issue620Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/issue/Issue620Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/issue/Issue739Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/issue/Issue739Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/issue/JSON222IndividualTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/issue/JSON222IndividualTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/issue/JSON222Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/issue/JSON222Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/issue/JSON322Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/issue/JSON322Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/issue/WireBug35Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/issue/WireBug35Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/issue/WireBug37Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/issue/WireBug37Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/issue/WireBug38Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/issue/WireBug38Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/issue/WireBug39Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/issue/WireBug39Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/java17/Field.java
+++ b/src/test/java/net/openhft/chronicle/wire/java17/Field.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/java17/Group.java
+++ b/src/test/java/net/openhft/chronicle/wire/java17/Group.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/java17/NestedTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/java17/NestedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/java17/Required.java
+++ b/src/test/java/net/openhft/chronicle/wire/java17/Required.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/map/MapCustomTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/map/MapCustomTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/map/MapMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/map/MapMarshallableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/map/MapWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/map/MapWireTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/A2Class.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/A2Class.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/AClass.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/AClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/B2Class.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/B2Class.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/BClass.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/BClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/ByteBufferMarshallingTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/ByteBufferMarshallingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/BytesUsageTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/BytesUsageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/CompareNaNTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/CompareNaNTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/EnumWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/EnumWireTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/FieldInfoTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/FieldInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/JSONWithAMapTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/JSONWithAMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/MarshallableWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/MarshallableWireTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/MarshallableWithOverwriteFalseTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/MarshallableWithOverwriteFalseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/MarshallingEventGroupTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/MarshallingEventGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/Nested.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/Nested.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/NullFieldMarshallingTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/NullFieldMarshallingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/Rung.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/Rung.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/ScalarValues.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/ScalarValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/This0AsTransientTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/This0AsTransientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/ThreeSequence.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/ThreeSequence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/ThreeSequenceTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/ThreeSequenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/TriviallyCopyableMarketData.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/TriviallyCopyableMarketData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/TriviallyCopyableMarketDataTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/TriviallyCopyableMarketDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/TwoArrays.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/TwoArrays.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/TwoArraysTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/TwoArraysTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/UnknownDatatimeTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/UnknownDatatimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  */
 
 package net.openhft.chronicle.wire.marshallable;

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/WithDefaults.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/WithDefaults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/WithDefaultsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/WithDefaultsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/WithSubstitutionTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/WithSubstitutionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/ChronicleEvent.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/ChronicleEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/ChronicleEventHandler.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/ChronicleEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/ClusterCommand.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/ClusterCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/ClusterCommandListener.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/ClusterCommandListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/DefaultMethodHandlingTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/DefaultMethodHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/Event.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/Event.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/EventHandler.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/EventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/Funding.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/Funding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/FundingListener.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/FundingListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/FundingOut.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/FundingOut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/GenerateMethodWriterInheritanceTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/GenerateMethodWriterInheritanceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/GenericMethodWriterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/GenericMethodWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/HandleSkippedValueReadsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/HandleSkippedValueReadsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/MarshallableMethodReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/MarshallableMethodReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/MethodIdTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/MethodIdTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/MethodWriter2Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/MethodWriter2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/MethodWriterByInterfaceTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/MethodWriterByInterfaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/MethodWriterMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/MethodWriterMarshallableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/MethodWriterProxy2Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/MethodWriterProxy2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/MethodWriterProxyTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/MethodWriterProxyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/MethodWriterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/MethodWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/MockMethods.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/MockMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/Service.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/Service.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/SkipsIgnoresEveryThingTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/SkipsIgnoresEveryThingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/VanillaMethodReaderHierarchyTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/VanillaMethodReaderHierarchyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/VanillaMethodReaderTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/VanillaMethodReaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/method/YamlTextWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/method/YamlTextWireTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/passthrough/GenericPassTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/passthrough/GenericPassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/passthrough/PassThroughTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/passthrough/PassThroughTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/reordered/NestedClass.java
+++ b/src/test/java/net/openhft/chronicle/wire/reordered/NestedClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/reordered/NestedReadSubset.java
+++ b/src/test/java/net/openhft/chronicle/wire/reordered/NestedReadSubset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/reordered/OuterClass.java
+++ b/src/test/java/net/openhft/chronicle/wire/reordered/OuterClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/reordered/ReorderedTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/reordered/ReorderedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/reuse/ByteArrayResuseTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/reuse/ByteArrayResuseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/reuse/ModelKeys.java
+++ b/src/test/java/net/openhft/chronicle/wire/reuse/ModelKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/reuse/NestedClass.java
+++ b/src/test/java/net/openhft/chronicle/wire/reuse/NestedClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/reuse/NestedClassTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/reuse/NestedClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/reuse/OuterClass.java
+++ b/src/test/java/net/openhft/chronicle/wire/reuse/OuterClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/reuse/WireCollection.java
+++ b/src/test/java/net/openhft/chronicle/wire/reuse/WireCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/reuse/WireCollectionTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/reuse/WireCollectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/reuse/WireModel.java
+++ b/src/test/java/net/openhft/chronicle/wire/reuse/WireModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/reuse/WireProperty.java
+++ b/src/test/java/net/openhft/chronicle/wire/reuse/WireProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/reuse/WireUtils.java
+++ b/src/test/java/net/openhft/chronicle/wire/reuse/WireUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/security/ApacheStructExploitTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/security/ApacheStructExploitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/serializable/MonetaTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/serializable/MonetaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/serializable/Nested.java
+++ b/src/test/java/net/openhft/chronicle/wire/serializable/Nested.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/serializable/ScalarValues.java
+++ b/src/test/java/net/openhft/chronicle/wire/serializable/ScalarValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/serializable/SerializableWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/serializable/SerializableWireTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/wire/type/conversions/binary/ConventionsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/type/conversions/binary/ConventionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/java/net/openhft/chronicle/wire/utils/JavaSourceCodeFormatterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/utils/JavaSourceCodeFormatterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/test/resources/FIX42.xml
+++ b/src/test/resources/FIX42.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
 <!--
-  ~ Copyright 2016 chronicle.software
+  ~ Copyright 2016-2025 chronicle.software
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/src/test/resources/FIX42.xsd
+++ b/src/test/resources/FIX42.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2016 higherfrequencytrading.com
+  ~ Copyright 2016-2025 chronicle.software
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/src/test/resources/yaml/services.yaml
+++ b/src/test/resources/yaml/services.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 - http://chronicle.software
+# Copyright 2021-2025 chronicle.software
 {
   services: {
     fix-web-gateway: {

--- a/system.properties
+++ b/system.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2022 chronicle.software
+# Copyright 2016-2025 chronicle.software
 #
 #       https://chronicle.software
 #


### PR DESCRIPTION
Standardises copyright headers across the repo to `2016-2025 chronicle.software`.
No functional or behavioural changes.

## What changed

* Updated the year range and holder string in license banners across:

  * `src/main/java/**`, `src/test/java/**`
  * `demo/**`, `microbenchmarks/**`, `marshallingperf/**`
  * `pom.xml` files and various XML/XSD/YAML resources
  * helper scripts (`*.sh`) and `system.properties`
* Normalised formatting to the existing header style (Apache 2.0 text retained).

## Why

* **Legal accuracy**: reflect active maintenance through 2025.
* **Consistency**: remove mixed ranges (`2016-2020`, `2016-2022`, etc.).
* **Tooling**: align with licence header checks and reduce false-positive lint failures.

## Scope / Non-Goals

* **Scope**: text-only header updates.
* **Non-Goals**: no code logic changes, no dependency bumps, no build config changes beyond headers.
