### PR TITLE
Docs rendering fixes, sturdier Binary/CSV/JSON handling, cleaner API surface, and more reliable test/coverage build

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -140,7 +140,7 @@ implementation 'net.openhft:chronicle-wire:REPLACE_WITH_VERSION'
 ----
 
 .Simple Example
-[source,java]
+[source,java,opts=novalidate]
 ----
 Bytes<?> bytes = Bytes.allocateElasticOnHeap();
 Wire wire = WireType.TEXT.apply(bytes);
@@ -173,7 +173,7 @@ System.out.println(bytes.toString());
 First you need to have a buffer to write to.
 This can be a `byte[]`, a `ByteBuffer`, off-heap memory, or even an address and length that you have obtained from some other library.
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
 // Bytes which wraps a byte[]
 Bytes<byte[]> bytes = Bytes.allocateElasticOnHeap();
@@ -185,7 +185,7 @@ Bytes<ByteBuffer> bytes = Bytes.elasticByteBuffer();
 Now you can choose which format you are using.
 As the wire formats are themselves unbuffered, you can use them with the same buffer, but in general using one wire format is easier.
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
 Wire wire = new TextWire(bytes);
 // or
@@ -201,7 +201,7 @@ Wire wire3 = new RawWire(bytes3);
 
 So now you can write to the wire with a simple document.
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
 wire.write("message").text("Hello World")
       .write("number").int64(1234567890L)
@@ -221,7 +221,7 @@ code: SECONDS
 price: 10.5
 ----
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
 // The same code for BinaryWire
 wire2.write("message").text("Hello World")
@@ -245,7 +245,7 @@ prints
 Using `RawWire` strips away all the meta data to reduce the size of the message, and improves speed.
 The down-side is that we cannot easily see what the message contains.
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
 // The same code for RawWire
 wire3.write("message").text("Hello World")
@@ -271,7 +271,7 @@ prints in `RawWire`.
 This example is much the same as the previous section, with the code required wrapped in a method.
 See Section "The code for the class Data" for the code for Data.
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
 // Bytes which wraps a ByteBuffer which is resized as needed.
 Bytes<ByteBuffer> bytes = Bytes.elasticByteBuffer();
@@ -304,7 +304,7 @@ Data{message='Hello World', number=1234567890, timeUnit=NANOSECONDS, price=10.5}
 
 To write in binary instead
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
 Bytes<ByteBuffer> bytes2 = Bytes.elasticByteBuffer();
 Wire wire2 = new BinaryWire(bytes2);
@@ -333,7 +333,7 @@ Data{message='Hello World', number=1234567890, timeUnit=NANOSECONDS, price=10.5}
 
 In this example the data is marshalled as a nested data structure.
 
-[source,java]
+[source,java,opts=novalidate]
 ----
 
 // Bytes which wraps a byte[] which is resized as needed
@@ -369,7 +369,7 @@ Data{message='Hello World', number=1234567890, timeUnit=NANOSECONDS, price=10.5}
 
 To write in binary instead
 
-[source,java]
+[source,java,opts=novalidate]
 ----
 Bytes<?> bytes2 = new HexDumpBytes();
 Wire wire2 = new BinaryWire(bytes2);
@@ -405,7 +405,7 @@ In this example, the type is encoded with the data.
 Instead of showing the entire package name which will almost certainly not work on any other platform, an alias for the type is used.
 It also means the message is shorter and faster.
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
 Wire wire = new TextWire(Bytes.allocateElasticOnHeap());
 
@@ -438,7 +438,7 @@ Data{message='Hello World', number=1234567890, timeUnit=NANOSECONDS, price=10.5}
 
 To write in binary instead
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
 Wire wire2 = new TextWire(Bytes.allocateElasticOnHeap());
 
@@ -469,7 +469,7 @@ Data{message='Hello World', number=1234567890, timeUnit=NANOSECONDS, price=10.5}
 
 === link:https://github.com/OpenHFT/Chronicle-Wire/blob/ea/demo/src/main/java/run/chronicle/wire/demo/Example6.java[Write a message with a sequence of records]
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
 // Bytes which wraps a ByteBuffer which is resized as needed
 Bytes<ByteBuffer> bytes = Bytes.elasticByteBuffer();
@@ -534,7 +534,7 @@ Data{message='Howyall', number=1234567890, timeUnit=SECONDS, price=1000.0}
 
 To write in binary instead
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
 Bytes<ByteBuffer> bytes2 = Bytes.elasticByteBuffer();
 Wire wire2 = new BinaryWire(bytes2);
@@ -591,7 +591,7 @@ Data{message='Howyall', number=1234567890, timeUnit=SECONDS, price=1000.0}
 
 This example shows how to pass your classes to `ClassAliasPool.CLASS_ALIASES.addAlias(Class<?>... classes)`, to create alias names for them so that you can refer to them without using the complete name of their packages.
 
-[source,java]
+[source,java,opts=novalidate]
 ----
 // Create two classes Data1 and Data2 and add only the Data1.class to alias pool.
 static {
@@ -674,7 +674,7 @@ Data2 object should be loaded from a yaml file with the complete name of class (
 
 Create instances of Data1 and Data2 by reading the above configuration files and print the created objects:
 
-[source,java]
+[source,java,opts=novalidate]
 ----
 Data1 o1 = WireType.TEXT.fromFile("cfg1.yaml");
 System.out.println("o1 = " + o1);
@@ -693,7 +693,7 @@ address: "21 High street, Liverpool"
 
 and
 
-[source,java]
+[source,java,opts=novalidate]
 ----
 Data2 o2 = WireType.TEXT.fromFile("cfg2.yaml");
 System.out.println("o2 = " + o2);
@@ -714,7 +714,7 @@ You will see the complete package name for `o2` object.
 
 === link:https://github.com/OpenHFT/Chronicle-Wire/blob/ea/demo/src/main/java/run/chronicle/wire/demo/Data.java[The code for the class Data]
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
 class Data implements Marshallable {
     private String message;
@@ -843,7 +843,7 @@ backup:
 
 These are the simple DTO (Data Transfer Object) classes used for deserializing the YAML.
 
-[source,java]
+[source,java,opts=novalidate]
 ----
 static class DatabaseConfig extends SelfDescribingMarshallable {
     String host;
@@ -875,7 +875,7 @@ static class SystemConfig extends SelfDescribingMarshallable {
 This test shows how a string value for `host` is defined once with an anchor (`&dbHost`) and reused twice with an alias (`*dbHost`).
 Chronicle Wire ensures that the reused string is the same instance in memory.
 
-[source,java]
+[source,java,opts=novalidate]
 ----
 String yaml = "" +
         "database: {\n" +
@@ -909,7 +909,7 @@ This is powerful for defining default configurations that can be applied to mult
 
 ==== Server Config Classes
 
-[source,java]
+[source,java,opts=novalidate]
 ----
 static class ServerConfig extends SelfDescribingMarshallable {
     int timeout;
@@ -935,7 +935,7 @@ static class ServerSystemConfig extends SelfDescribingMarshallable {
 In this example, a complete `ServerConfig` object is defined and anchored as `&defaultServer`.
 This exact same object instance is then referenced for the `primary`, `secondary`, and `monitoring` server configurations.
 
-[source,java]
+[source,java,opts=novalidate]
 ----
 String yaml = "" +
         "defaults: &defaultServer !net.openhft.chronicle.wire.YamlAnchorExamplesTest$ServerConfig {\n" +
@@ -977,7 +977,7 @@ Some example `LongConverters` are `NanoTimestampLongConverter` which stores a na
 
 For example:
 
-[source,java]
+[source,java,opts=novalidate]
 ----
     long ts = NanoTimestampLongConverter.INSTANCE.parse("2023-02-15T05:31:49.856123456");
     System.out.println(ts); // 1676439109856123456
@@ -986,7 +986,7 @@ For example:
 
 and
 
-[source,java]
+[source,java,opts=novalidate]
 ----
     long code = Base64LongConverter.INSTANCE.parse("UXX0UXZ0");
     System.out.println(code); // 94034908776117
@@ -1054,7 +1054,7 @@ The object created in step `1` is cached for performance reasons, meaning that b
 While this will not be a problem for primitive or immutable values (for example, `int`, `Long`, `String`), a mutable field such as `ByteBuffer` will cause problems.
 Consider the following case:
 
-[source,java]
+[source,java,opts=novalidate]
 ----
 public class BufferContainer {
     private final ByteBuffer b = ByteBuffer.allocate(16);
@@ -1093,7 +1093,7 @@ In this case, `value.reset()` will be called instead of overwriting it with defa
 
 In order to work around this, if necessary, the marshallable class can override `Marshallable.reset`:
 
-[source,java]
+[source,java,opts=novalidate]
 ----
 public class BufferContainer implements Marshallable {
     private ByteBuffer b = ByteBuffer.allocate(16);
@@ -1109,7 +1109,7 @@ public class BufferContainer implements Marshallable {
 
 If the field type implements `Resettable` (including `Marshallable` classes), and the field has non-`null` default value, the existing value will be reset without creating any extra garbage:
 
-[source,java]
+[source,java,opts=novalidate]
 ----
 public class ComplexDto implements SelfDescribingMarshallable {
     private ContainedDto v = new ContainedDto(); // reset() will be propagated to this value
@@ -1126,7 +1126,7 @@ While serialized data can be updated by replacing a whole record, this might not
 
 Chronicle Wire offers the ability to bind a reference to a fixed value of a field, and perform atomic operations on that field; for example, volatile read/write, and compare-and-swap.
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
    // field to cache the location and object used to reference a field.
    private LongValue counter = null;
@@ -1146,7 +1146,7 @@ Chronicle Wire supports passing objects reference by the `name()` of the object 
 This is supported trivially with `enum` which define a `name()` for you. e.g.
 
 .Passing a reference to an enum using it's name
-[source,java]
+[source,java,opts=novalidate]
 ----
 enum ServerId {
     LN_A
@@ -1168,7 +1168,7 @@ serverId: LN_A
 
 However, we might wish to alter metadata associated with the enum
 
-[source,java]
+[source,java,opts=novalidate]
 ----
 enum ServerId implements DynamicEnum {
     LN_A(101);
@@ -1182,7 +1182,7 @@ enum ServerId implements DynamicEnum {
 Sometimes you need to pass the actually data, esp the first time.
 This can be achieved by using the `@AsMarshallable` annotation which will always pass the object as a typedMarshallable.
 
-[source,java]
+[source,java,opts=novalidate]
 ----
 public class RefData extends AbstractEventCfg<RefData> {
     @AsMarshallable
@@ -1200,7 +1200,7 @@ public class RefData extends AbstractEventCfg<RefData> {
 
 You can choose to update the existing `enum` with this information.
 
-[source,java]
+[source,java,opts=novalidate]
 ----
 public void refData(RefData refData) {
     DynamicEnum.updateEnum(refData.data);
@@ -1240,7 +1240,7 @@ NOTE: You can't use an enum before it is defined, this is assumed to be in input
 You may wish to pass by reference a data type which is not an enum.
 This can be done by adding `DynamicEnum` to a regular class and adding a `name` field.
 
-[source,java]
+[source,java,opts=novalidate]
 ----
 class MyData implements DynamicEnum {
     public static final MyData ONE = new MyData("One"); // used as a predefined object
@@ -1255,10 +1255,13 @@ NOTE: This is particularly useful if you have a class which must extend another 
 
 [source,yaml]
 ----
+---
 myData: One # uses predefined value
 ...
+---
 myData: Two # uses predefined value
 ...
+---
 refData: {
     eventId: GUI,
     eventTime: 2020-09-09T09:09:09.999,
@@ -1267,15 +1270,17 @@ refData: {
    }
 }
 ...
+---
 myData: Three # use the one just defined
 ...
+---
 myData: Four # will error as doesn't exist.
 ...
 ----
 
 The consumer doesn't need to do anything special to use the new enum, however the producer need to create it in code as follows.
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
 ServerId serverId = EnumCache.of(ServerId.class).nameFor("HK_A");
 serverId.priority(200);
@@ -1296,7 +1301,7 @@ Only use them when there is likely to be a limited number of them over the life 
 You can assign a method id to a method using the annotation `@MethodId(long int: id)`.
 The provided id should be unique across all classes using the same MethodReader/Writer, therefore it is safe practice to use unique method id in your entire system.A method name can be determined from its method id and this results in saving memory when calling the method.The following example shows the difference between memory usage when using method id and when not using it.In this example the method `saysomethingnice()` has been annotated with `MethodId(7)` and it has been called from `shouldDetermineMethodNamesFromMethodIds()`.
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
 
  interface Speaker {
@@ -1355,7 +1360,7 @@ NOTE: This only works when the expected type is not a class.
 
 === LongConversionExample
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
 @Test
 public void unknownType() throws NoSuchFieldException {
@@ -1421,7 +1426,7 @@ interface ThreeValues {
 By default, Chronicle Wire skips fields which names don't match any field of the DTO class.
 It's possible to capture such fields by overriding method or `ReadMarshallable`:
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
     default void unexpectedField(Object event, ValueIn valueIn) {
         valueIn.skipValue();
@@ -1430,7 +1435,7 @@ It's possible to capture such fields by overriding method or `ReadMarshallable`:
 
 One of best practices is saving unexpected fields in order to process them after the deserialization:
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
         transient Map<String, Object> others = new LinkedHashMap<>();
 
@@ -1442,7 +1447,7 @@ One of best practices is saving unexpected fields in order to process them after
 
 It's also possible to use fail-fast approach and throw an exception:
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
         @Override
         public void unexpectedField(Object event, ValueIn valueIn) {
@@ -1454,7 +1459,7 @@ Exceptions that are thrown from this method are never swallowed, they are wrappe
 
 == LongConversionExample with `MethodReaders`
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
 @Test
 public void testUnknownClass() {
@@ -1490,7 +1495,7 @@ If you have only one argument, you may need to add an additional argument to sup
 This feature calls an implementation of `MethodFilterOnFirstArg` to see if the rest of the method call should be parsed.
 For example, today you have:
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
 interface MyInterface {
     void method(ExpensiveDto dto);
@@ -1499,7 +1504,7 @@ interface MyInterface {
 
 This can be migrated to:
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
 interface MyInterface extends MethodFilterOnFirstArg<String> {
     @Deprecated
@@ -1510,7 +1515,7 @@ interface MyInterface extends MethodFilterOnFirstArg<String> {
 
 where the implementation can look like this:
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
 class MyInterfaceImpl extends MyInterface {
     public void method(ExpensiveDto dto) {
@@ -1539,7 +1544,7 @@ You may wish to intercept handling a call in the method reader in order to execu
 If set, it will be triggered *instead* of the original call.
 It's possible to either skip the original method or to call it via passed `Invocation` instance:
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
 class MyInterceptor implements MethodReaderInterceptorReturns {
     @Override
@@ -1561,7 +1566,7 @@ It's possible to use original call arguments and object instance in the added co
 
 Simple example that enforces skipping the original call in case the second agrument is `null`:
 
-[source,Java]
+[source,java,opts=novalidate]
 ----
 class SkippingInterceptor implements GeneratingMethodReaderInterceptorReturns {
     @Override
@@ -1847,7 +1852,7 @@ $class.name ${field.name}($field.type $paramName) {
 }
 ----
 
-See also <<code-generation-for-marshallable,Marshallable code generation templates>>
+See also <<_code_generation_for_marshallable,Marshallable code generation templates>>
 
 == Why use Marshallable objects
 
@@ -1864,7 +1869,7 @@ Marshallable objects have been designed to allow you to
 The following is a simple example of a POJO with a nested data type in a List.
 
 .A Simple Pojo without needing to define toString/hashCode/equals
-[source,java]
+[source,java,opts=novalidate]
 ----
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 
@@ -1902,7 +1907,7 @@ The object can be reconstructed from the output of the `toString()` method.
 This is useful for building sample data in unit tests for from a file.
 It also means that you can take the dump of an object in a log file and reconstruct the original object.
 
-[source,java]
+[source,java,opts=novalidate]
 ----
 MyPojos mps = new MyPojos("test-list");
 mps.myPojos.add(new MyPojo("text1", 1, 1.1));
@@ -1928,7 +1933,7 @@ prints
 
 You can take the same output and reconstruct the original object.
 
-[source,java]
+[source,java,opts=novalidate]
 ----
 MyPojos mps2 = Marshallable.fromString(mps.toString());
 assertEquals(mps, mps2); // <1>
@@ -1948,7 +1953,7 @@ assertEquals(mps, mps3); // <1>
 
 Finally, you can take data from a file and build the object.
 
-[source,java]
+[source,java,opts=novalidate]
 ----
 MyPojos mps4 = Marshallable.fromFile("my-pojos.yaml");
 assertEquals(mps, mps4);
@@ -2135,7 +2140,7 @@ That `ChronicleChannel` acts as `MarshallableIn` and `MarshallableOut`, as `Wire
 When you create a channel, you specify what type of connection you want.
 The simplest is an EchoHandler that echos everything you send it.
 
-[source,java]
+[source,java,opts=novalidate]
 ----
 // start a server on an unused port
 String url = "tcp://:0";

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,17 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>com.github.ekryd.sortpom</groupId>
+                <artifactId>sortpom-maven-plugin</artifactId>
+                <version>3.0.1</version>
+                <configuration>
+                    <nrOfIndentSpace>4</nrOfIndentSpace>
+                </configuration>
+                <!-- Do not bind to lifecycle to avoid mutating pom on normal builds.
+                     Run on demand via: mvn sortpom:sort -->
+            </plugin>
+
             <!-- Check API compatibility against previous releases -->
             <plugin>
                 <groupId>net.openhft</groupId>
@@ -196,21 +207,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-
-            <!-- Runs unit tests -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- required for Issue327Test.date -->
-                    <systemPropertyVariables>
-                        <user.timezone>UTC</user.timezone>
-                    </systemPropertyVariables>
-                    <forkCount>1</forkCount>
-                    <reuseForks>true</reuseForks>
-                    <runOrder>hourly</runOrder>
-                </configuration>
             </plugin>
 
             <!-- Attach source jars to the build -->
@@ -248,6 +244,24 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- Runs unit tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- required for Issue327Test.date -->
+                    <systemPropertyVariables>
+                        <user.timezone>UTC</user.timezone>
+                    </systemPropertyVariables>
+                    <forkCount>1</forkCount>
+                    <reuseForks>true</reuseForks>
+                    <runOrder>hourly</runOrder>
+                    <!-- Allow other tools to prepend; include JPMS flags from parent for JDK 11+ -->
+                    <argLine>@{argLine} ${jvm.requiredArgs}</argLine>
+                </configuration>
+            </plugin>
+
             <!-- Build the OSGi bundle used by downstream projects -->
             <plugin>
                 <groupId>org.apache.felix</groupId>
@@ -462,20 +476,45 @@
         <!-- Profile used when publishing sonar metrics -->
         <profile>
             <id>sonar</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.sonarsource.scanner.maven</groupId>
                         <artifactId>sonar-maven-plugin</artifactId>
                     </plugin>
+                    <!-- Ensure JPMS flags from parent are propagated during sonar runs -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <!-- Use JaCoCo-prepared argLine and append JPMS flags + coverage flag -->
+                            <argLine>${surefireArgLine} ${jvm.requiredArgs} -Djvm.coverage=true</argLine>
+                        </configuration>
+                    </plugin>
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco-maven-plugin.version}</version>
+                        <configuration>
+                            <!-- Save exec and site reports -->
+                            <outputDirectory>${project.build.directory}/site/jacoco</outputDirectory>
+                            <excludes>
+                                <exclude>net/openhft/chronicle/wire/ReadmeChapter1Test*</exclude>
+                            </excludes>
+                        </configuration>
                         <executions>
                             <execution>
+                                <id>prepare-agent</id>
                                 <goals>
                                     <goal>prepare-agent</goal>
                                 </goals>
+                                <configuration>
+                                    <!-- Provide agent args via this property for Surefire -->
+                                    <propertyName>surefireArgLine</propertyName>
+                                </configuration>
                             </execution>
                             <execution>
                                 <id>report</id>
@@ -496,14 +535,6 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-invoker-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <phase>test</phase>
-                                <goals>
-                                    <goal>run</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                         <configuration>
                             <pom>marshallingperf/pom.xml</pom>
                             <goals>clean,test</goals>
@@ -513,6 +544,14 @@
                             </properties>
                             <streamLogs>true</streamLogs>
                         </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <phase>test</phase>
+                            </execution>
+                        </executions>
                     </plugin>
                     <!-- Launch JLBH benchmarks under this profile -->
                     <plugin>

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -545,6 +545,9 @@ public class BinaryWire extends AbstractWire implements Wire {
                     }
                     case U8_ARRAY:
                         unexpectedCode();
+                        break;
+                    default:
+                        break;
                 }
                 unknownCode(wire);
                 break;
@@ -598,6 +601,12 @@ public class BinaryWire extends AbstractWire implements Wire {
                 bytes.uncheckedReadSkipOne();
                 @Nullable StringBuilder sb = readText(peekCode, acquireStringBuilder());
                 wire.getValueOut().text(sb);
+                break;
+
+            default:
+                // Unknown high code group: report the code only if data remains; otherwise exit quietly
+                if (bytes.readRemaining() > 0)
+                    unknownCode(wire);
                 break;
         }
     }
@@ -680,6 +689,8 @@ public class BinaryWire extends AbstractWire implements Wire {
                         }
                     }
                     wireValueOut.object(object);
+                    break;
+                default:
                     break;
             }
         } finally {
@@ -1050,6 +1061,8 @@ public class BinaryWire extends AbstractWire implements Wire {
                 // Skip the peek code and read the event object.
                 bytes.uncheckedReadSkipOne();
                 return valueIn.object(expectedClass);
+            default:
+                break;
         }
 
         // If the peek code doesn't match any known type, return null.
@@ -1403,8 +1416,10 @@ public class BinaryWire extends AbstractWire implements Wire {
                 wire.getValueOut().bool(true);
                 break;
             default:
-                unknownCode(wire);
-        }
+                // Only throw if there is still data to read; avoid spurious EndOfFile at stream end
+                if (bytes.readRemaining() > 0)
+                    unknownCode(wire);
+                }
     }
 
     /**
@@ -1439,6 +1454,8 @@ public class BinaryWire extends AbstractWire implements Wire {
                         return 0;
                     case TRUE:
                         return 1;
+                    default:
+                        break;
                 }
                 break;
 
@@ -1450,6 +1467,8 @@ public class BinaryWire extends AbstractWire implements Wire {
             case BinaryWireHighCode.INT:
                 // For integer codes, decode the integer.
                 return readInt0(code);
+            default:
+                break;
         }
 
         // If we can't decode, throw an exception.
@@ -1485,6 +1504,8 @@ public class BinaryWire extends AbstractWire implements Wire {
             case FLOAT64:
                 // 64-bit floating point representation.
                 return bytes.readDouble();
+            default:
+                break;
         }
         throw new UnsupportedOperationException(stringForCode(code));
     }
@@ -1521,6 +1542,8 @@ public class BinaryWire extends AbstractWire implements Wire {
             case FLOAT64:
                 // 64-bit floating point representation.
                 return bytes.readDouble();
+            default:
+                break;
         }
 
         // If we can't decode, throw an exception.
@@ -1564,6 +1587,8 @@ public class BinaryWire extends AbstractWire implements Wire {
             case INT64_0x:
                 // 64-bit signed integer.
                 return bytes.readLong();
+            default:
+                break;
         }
 
         // If we can't decode, throw an exception.
@@ -1642,6 +1667,8 @@ public class BinaryWire extends AbstractWire implements Wire {
             case BinaryWireHighCode.INT:
                 // Convert the integer to double.
                 return readInt0(code);
+            default:
+                break;
         }
 
         // If the encoding is unrecognized, throw an exception.
@@ -1888,6 +1915,8 @@ public class BinaryWire extends AbstractWire implements Wire {
                     case PADDING32:
                         bytes.readSkip(bytes.readUnsignedInt());
                         return readText(bytes.readUnsignedByte(), sb);
+                    default:
+                        break;
                 }
                 throw unknownCode(code);
 
@@ -1917,6 +1946,8 @@ public class BinaryWire extends AbstractWire implements Wire {
                     case EVENT_OBJECT:
                         valueIn.text((StringBuilder) sb);
                         return sb;
+                    default:
+                        break;
                 }
                 throw unknownCode(code);
 
@@ -5003,6 +5034,8 @@ public class BinaryWire extends AbstractWire implements Wire {
                         case FLOAT_SET_LOW_4:
                             bytes.readUnsignedByte();  // Read a byte and treat it as unsigned
                             return;
+                        default:
+                            break;
                     }
                     // If none of the known float codes were matched, throw an exception
                     throw new UnsupportedOperationException(stringForCode(code));
@@ -5040,6 +5073,8 @@ public class BinaryWire extends AbstractWire implements Wire {
                         case INT64_0x:
                             bytes.readLong();  // Read a 64-bit signed integer
                             return;
+                        default:
+                            break;
                     }
                     // If none of the known integer codes were matched, throw an exception
                     throw new UnsupportedOperationException(stringForCode(code));

--- a/src/main/java/net/openhft/chronicle/wire/CSVWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/CSVWire.java
@@ -341,6 +341,9 @@ public class CSVWire extends TextWire {
                         case 0:
                         case -1:
                             return bytes.readPosition() - start - 1;
+                        default:
+                            // Continue scanning until an end-of-line marker is found
+                            break;
                     }
                 }
             } finally {

--- a/src/main/java/net/openhft/chronicle/wire/JSONWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/JSONWire.java
@@ -907,6 +907,7 @@ public class JSONWire extends TextWire {
 
         @Override
         protected void popState() {
+            // Do nothing: JSON writer has no stack state to restore here
         }
 
         @Override
@@ -921,15 +922,17 @@ public class JSONWire extends TextWire {
 
         @Override
         protected void afterClose() {
-
+            // Do nothing: separator and state handled by higher-level logic
         }
 
         @Override
         protected void addNewLine(long pos) {
+            // Do nothing: JSON output remains on a single line by design here
         }
 
         @Override
         protected void newLine() {
+            // Do nothing: pretty printing not enabled in this writer
         }
 
         @Override
@@ -944,6 +947,7 @@ public class JSONWire extends TextWire {
 
         @Override
         public void writeComment(@NotNull CharSequence s) {
+            // Do nothing: JSON has no native comments
         }
 
         /**

--- a/src/main/java/net/openhft/chronicle/wire/WireType.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireType.java
@@ -510,6 +510,7 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
      * Internal helper that removes a single {@code null} element from
      * collections created when reading certain empty lists.
      */
+    @SuppressWarnings("java:S3011")
     private void cleanNullCollections(Object object) {
         if (object == null) return;
         Field[] declaredFields = object.getClass().getDeclaredFields();

--- a/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
@@ -6,7 +6,6 @@ package net.openhft.chronicle.wire;
 import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.bytes.BytesIn;
 import net.openhft.chronicle.bytes.BytesStore;
-import net.openhft.chronicle.bytes.internal.BytesInternal;
 import net.openhft.chronicle.core.pool.StringBuilderPool;
 import net.openhft.chronicle.core.scoped.ScopedResource;
 import net.openhft.chronicle.core.scoped.ScopedResourcePool;
@@ -377,6 +376,9 @@ public class YamlTokeniser {
             case '^':
             case '_':
             case '~':
+                break;
+            default:
+                break;
         }
 
         // If changing context, don't read the symbol
@@ -789,6 +791,8 @@ public class YamlTokeniser {
                 case '\r':
                     unreadLast();
                     return;
+                default:
+                    break;
             }
             if (ch > ' ')
                 blockEnd = in.readPosition();

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -2501,4 +2501,3 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         writeContext.rollbackIfNotComplete();
     }
 }
-

--- a/src/main/java/net/openhft/chronicle/wire/internal/MapMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/MapMarshaller.java
@@ -18,10 +18,10 @@ import java.util.Map;
  * Its primary function is to loop through a Map's entries and write each key-value pair to the Wire.
  */
 public class MapMarshaller<K, V> implements WriteMarshallable {
-    public Map<K, V> map;
-    public Class<K> kClass;
-    public Class<V> vClass;
-    public boolean leaf;
+    private Map<K, V> map;
+    private Class<K> kClass;
+    private Class<V> vClass;
+    private boolean leaf;
 
     /**
      * Configures the MapMarshaller with the provided parameters.

--- a/src/main/java/net/openhft/chronicle/wire/internal/MethodWriterClassNameGenerator.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/MethodWriterClassNameGenerator.java
@@ -3,7 +3,6 @@
  */
 package net.openhft.chronicle.wire.internal;
 
-import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.Maths;
 import net.openhft.chronicle.wire.Base32LongConverter;
 import net.openhft.chronicle.wire.LongConverter;

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWirePerfTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWirePerfTest.java
@@ -66,7 +66,7 @@ public class BinaryWirePerfTest extends WireTestCommon {
 
     // Performance test for Wire serialization and deserialization
     @Test
-    public void wirePerf() throws StreamCorruptedException {
+    public void wirePerf() {
        // System.out.println("Custom TestId: " + testId + ", fixed: " + fixed + ", numberField: " + numericField + ", fieldLess: " + fieldLess);
         @NotNull Wire wire = createBytes();
 
@@ -88,7 +88,6 @@ public class BinaryWirePerfTest extends WireTestCommon {
     }
 
     private void wirePerf0(@NotNull Wire wire, @NotNull MyTypes a, @NotNull MyTypes b, int t) {
-        long start = System.nanoTime();
         int runs = 200000;
         for (int i = 0; i < runs; i++) {
             wire.clear();
@@ -100,9 +99,6 @@ public class BinaryWirePerfTest extends WireTestCommon {
 
             b.readMarshallable(wire);
         }
-        //long rate = (System.nanoTime() - start) / runs;
-
-       // System.out.printf("(vars) %,d : %,d ns avg, len= %,d%n", t, rate, wire.bytes().readPosition());
     }
 
     // Performance test for serializing and deserializing integers with Wire
@@ -118,7 +114,6 @@ public class BinaryWirePerfTest extends WireTestCommon {
 
     // Common method to test serialization and deserialization for type MyType2
     private void wirePerf0(@NotNull Wire wire, @NotNull MyType2 a, @NotNull MyType2 b, int t) {
-        long start = System.nanoTime();
         int runs = 300000;
         for (int i = 0; i < runs; i++) {
             wire.clear();
@@ -128,8 +123,6 @@ public class BinaryWirePerfTest extends WireTestCommon {
 
             b.readMarshallable(wire);
         }
-        long rate = (System.nanoTime() - start) / runs;
-       // System.out.printf("(ints) %,d : %,d ns avg, len= %,d%n", t, rate, wire.bytes().readPosition());
     }
 
     // *************************************************************************

--- a/src/test/java/net/openhft/chronicle/wire/JsonWireDoubleAndFloatSpecialValuesAcceptanceTests.java
+++ b/src/test/java/net/openhft/chronicle/wire/JsonWireDoubleAndFloatSpecialValuesAcceptanceTests.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *     <li>{@link JSONWire.JSONValueOut#writeSpecialFloatValueToBytes(Bytes, float)} </li>
  * </ul>
  */
-public class JsonWireDoubleAndFloatSpecialValuesAcceptanceTests {
+class JsonWireDoubleAndFloatSpecialValuesAcceptanceTests {
 
     @ParameterizedTest
     @MethodSource("doubleTestInputs")

--- a/src/test/java/net/openhft/chronicle/wire/JsonWireToStringAcceptanceTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/JsonWireToStringAcceptanceTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertEquals;
  * Verify that unicode characters can be properly represented in JSON output.
  */
 @SuppressWarnings("UnnecessaryUnicodeEscape")
-public class JsonWireToStringAcceptanceTest {
+class JsonWireToStringAcceptanceTest {
 
     private static Collection<WireType> WIRE_TYPES = Arrays.asList(WireType.JSON, WireType.JSON_ONLY);
 

--- a/src/test/java/net/openhft/chronicle/wire/MarshallableOutBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MarshallableOutBuilderTest.java
@@ -98,7 +98,7 @@ public class MarshallableOutBuilderTest extends net.openhft.chronicle.wire.WireT
     }
 
     // Test writing messages to an HTTP endpoint and validate the response
-    @Ignore(/* long running test */)
+    @Ignore("long running test")
     @Test
     public void http() throws IOException, InterruptedException {
         InetSocketAddress address = new InetSocketAddress(0);

--- a/src/test/java/net/openhft/chronicle/wire/RawWirePerfTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/RawWirePerfTest.java
@@ -7,7 +7,6 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.io.StreamCorruptedException;
 
 // This class tests the performance of raw wire operations.
 @Ignore("Long running test")
@@ -15,7 +14,7 @@ public class RawWirePerfTest extends WireTestCommon {
 
     // Test case to measure the performance of raw wire operations.
     @Test
-    public void testRawPerf() throws StreamCorruptedException {
+    public void testRawPerf() {
 
         // Create an instance of BinaryWirePerfTest with specific parameters.
         // These parameters typically control the test conditions.

--- a/src/test/java/net/openhft/chronicle/wire/ReadOneTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ReadOneTest.java
@@ -4,7 +4,6 @@
 package net.openhft.chronicle.wire;
 
 import net.openhft.chronicle.bytes.Bytes;
-import net.openhft.chronicle.bytes.MethodId;
 import net.openhft.chronicle.bytes.MethodReader;
 import net.openhft.chronicle.core.Jvm;
 import org.jetbrains.annotations.NotNull;

--- a/src/test/java/net/openhft/chronicle/wire/SerializableObjectTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/SerializableObjectTest.java
@@ -339,7 +339,7 @@ final class SerializableObjectTest extends WireTestCommon {
     }
 
     @BeforeEach
-    public void hasDirect() {
+    void hasDirect() {
         assumeFalse(Jvm.maxDirectMemory() == 0);
     }
 

--- a/src/test/java/net/openhft/chronicle/wire/TestJsonIssue467.java
+++ b/src/test/java/net/openhft/chronicle/wire/TestJsonIssue467.java
@@ -113,7 +113,7 @@ public class TestJsonIssue467 {
         }
 
         // check the number of '{' match the number of '}'
-        Assert.assertTrue("openBracket=" + openBracket + ",closeBracket=" + closeBracket, openBracket == closeBracket);
+        Assert.assertEquals("openBracket and closeBracket should match", openBracket, closeBracket);
 
         // DON'T CHANGE THE EXPECTED JSON IT IS CORRECT ! - please use this website to validate the json - https://jsonformatter.org
         Assert.assertEquals("{\"@ResponseItem467\":{\"index\":\"4ab100000005\",\"key\":\"seqNumber\",\"payload\":{\"eventId\":\"periodicUpdate\",\"eventTime\":1652109920838805734,\"seqNumbers\":[ {\"sessionID\":{\"localCompID\":\"SERVER\",\"remoteCompID\":\"CLIENT\",\"localSubID\":null,\"remoteSubID\":null},\"rSeq\":1517,\"wSeq\":1519,\"isActive\":true,\"isConnected\":false} ]}}}", actual);

--- a/src/test/java/net/openhft/chronicle/wire/TextWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TextWireTest.java
@@ -2623,6 +2623,7 @@ public class TextWireTest extends WireTestCommon {
     }
 
     // Class with fields of Bytes type initialized with various Byte buffers
+    @SuppressWarnings("java:S116") // Keep A,B,C,D uppercase to match expected YAML keys in assertions
     static class ABCD extends SelfDescribingMarshallable implements Monitorable {
         Bytes<?> A = Bytes.allocateElasticDirect();
         Bytes<?> B = Bytes.allocateDirect(64);
@@ -2647,6 +2648,7 @@ public class TextWireTest extends WireTestCommon {
     }
 
     // Class containing three StringBuilder fields
+    @SuppressWarnings("java:S116") // Keep A,B,C uppercase to match expected YAML keys in assertions
     static class ABC extends SelfDescribingMarshallable {
         StringBuilder A = new StringBuilder();
         StringBuilder B = new StringBuilder();

--- a/src/test/java/net/openhft/chronicle/wire/WireResourcesTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireResourcesTest.java
@@ -14,7 +14,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.StreamCorruptedException;
 import java.nio.file.Files;
 
 import static net.openhft.chronicle.core.io.ReferenceOwner.INIT;
@@ -164,7 +163,7 @@ public class WireResourcesTest extends WireTestCommon {
     }
 
     // Helper method to write a message into the given wire.
-    private static void writeMessage(@NotNull Wire wire) throws StreamCorruptedException {
+    private static void writeMessage(@NotNull Wire wire) {
         try (DocumentContext dc = wire.writingDocument()) {
             final Bytes<?> bytes = dc.wire().bytes();
             bytes.writeSkip(128000);

--- a/src/test/java/net/openhft/chronicle/wire/internal/MethodWriterClassNameGeneratorTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/internal/MethodWriterClassNameGeneratorTest.java
@@ -11,7 +11,6 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import static org.junit.Assume.assumeFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/CNFREOnMissingClassTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/CNFREOnMissingClassTest.java
@@ -8,7 +8,6 @@ import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.pool.ClassAliasPool;
 import net.openhft.chronicle.core.util.ClassNotFoundRuntimeException;
 import net.openhft.chronicle.wire.*;
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
This PR delivers three main tracks:

1. **Docs polish** so README code blocks always render and copy/paste cleanly.
2. **Build reliability** for tests and coverage (Surefire/JaCoCo/JPMS, Sonar), with an opt-in `sortpom` and clearer plugin ordering.
3. **Runtime correctness & resilience** in wire readers/writers (Binary/CSV/JSON/YAML) with safer default handling, plus small API hygiene and test modernisation.

---

## What changed

### 1) Documentation (README.adoc)

* Add `opts=novalidate` to all `source,java` blocks to avoid Asciidoctor validation warnings on partial snippets.
* Normalise `source,java` capitalisation and fix anchor: `<<_code_generation_for_marshallable,...>>`.
* Insert YAML document separators (`---`) in multi-doc sections to prevent accidental concatenation.

**Why:** Better readability, consistent syntax highlighting, and fewer false positives in doc tools.

---

### 2) Build & Coverage (pom.xml)

* **Add** `sortpom-maven-plugin` (not bound to lifecycle; run `mvn sortpom:sort` on demand).
* **Surefire (default build):**

  * Keep timezone for legacy tests; use:

    ```
    <argLine>@{argLine} ${jvm.requiredArgs}</argLine>
    ```

    so other tools (e.g., JaCoCo) can prepend, and JPMS flags propagate.
* **Sonar profile:**

  * Ensure JPMS flags and coverage flag are passed:

    ```
    <argLine>${surefireArgLine} ${jvm.requiredArgs} -Djvm.coverage=true</argLine>
    ```
  * Configure JaCoCo with `<propertyName>surefireArgLine</propertyName>` and an explicit plugin version; add report site output and a small exclude.
  * Reorder invoker execution to standard `<executions>` after `<configuration>` and bind to `test` phase.
* Minor housekeeping: plugin ordering for readability.

**Why:** Stabilises coverage collection and JPMS behaviour across local/CI/Sonar runs without surprising pom mutations in normal builds.

---

### 3) Runtime robustness & small API hygiene

#### BinaryWire

* Many `switch` statements now include `default`/extra `break`s to:

  * **Avoid false positives** from `unknownCode(wire)` at clean end-of-stream.
  * Fall through safely for genuinely unknown high codes.
* Guard `unknownCode` with `bytes.readRemaining() > 0` in some paths to suppress spurious exceptions at EOF.

#### CSVWire

* Continue scanning until an end-of-line marker for length reads (default branch) to be tolerant of unusual characters.

#### JSONWire

* Implement explicit **no-op** overrides in writer where JSON doesn’t have comments, pretty newlines, or internal stack state (documents intent; no behaviour change).

#### YamlTokeniser / YamlWire

* Add default `break`s in token handling; whitespace-only housekeeping in `YamlWire`.

#### WireType

* Add `@SuppressWarnings("java:S3011")` with justification for the reflective cleaner used to remove lone `null` placeholders in certain empty list deserialisations.

#### MapMarshaller

* Encapsulate fields (`private`) to follow typical marshaller style and reduce accidental external mutation.

#### MethodWriterClassNameGenerator

* Remove unused import.

**Why:** Improves edge-case handling without changing normal decoding/encoding; clarifies intent in code.

---

### 4) Tests: modernise & de-flake

* Convert several JUnit 5 test classes to package-private `class` (no need for `public`).
* Replace brittle assertions (e.g., manual compare) with `assertEquals` messages.
* Remove unnecessary `throws` from tests; clarify `@Ignore` reasons.
* Add targeted suppressions for naming expectations in YAML-driven tests.
* Trim dead code and timing/printing in perf tests (still `@Ignore` long-running).

**Why:** Cleaner, less noisy tests that better express intent and don’t depend on checked exceptions or output timing.

---

## Backwards compatibility & risk

* **Binary/CSV/JSON/YAML**: Changes are defensive defaults (extra `break`s, EOF checks); they **reduce** spurious exceptions without altering recognised encodings.
* **MapMarshaller**: Field visibility tightened; no API surface change (class is internal marshaller).
* Build system changes are additive or ordering clarifications; default `surefire` remains single fork with reuse, now JPMS/agent-friendly.
