### PR TITLE
Zero-arg constructors + simpler YAML usage (less boilerplate, safer defaults)

### DIFF
--- a/demo/src/main/java/run/chronicle/wire/demo/EventByMethodExamples.java
+++ b/demo/src/main/java/run/chronicle/wire/demo/EventByMethodExamples.java
@@ -129,7 +129,7 @@ public class EventByMethodExamples {
         System.out.println("----");
         System.out.println();
 
-        Wire yamlWire = new YamlWire(Bytes.allocateElasticOnHeap()).useTextDocuments();
+        Wire yamlWire = new YamlWire();
         code.accept(yamlWire.methodWriter(tClass));
 
         System.out.println("." + methodName + " As YAML ");

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -125,6 +125,12 @@ public class BinaryWire extends AbstractWire implements Wire {
     private Boolean overrideSelfDescribing = null;
 
     /**
+     * Constructs a {@code BinaryWire} with default settings and elastic on-heap bytes.
+     */
+    public BinaryWire() {
+        this(Bytes.allocateElasticOnHeap());
+    }
+    /**
      * Constructs a {@code BinaryWire} with default settings.
      *
      * @param bytes the bytes to be processed by this wire

--- a/src/main/java/net/openhft/chronicle/wire/RawWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/RawWire.java
@@ -60,6 +60,13 @@ public class RawWire extends AbstractWire implements Wire {
     private StringBuilder lastSB;
 
     /**
+     * Creates a {@code RawWire} backed by an elastic on-heap buffer. Strings
+     * are encoded using 8-bit length prefixes.
+     */
+    public RawWire() {
+        this(Bytes.allocateElasticOnHeap());
+    }
+    /**
      * Creates a {@code RawWire} backed by the given buffer. Strings are encoded
      * using 8-bit length prefixes.
      *

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -110,6 +110,13 @@ public class TextWire extends YamlWireOut<TextWire> {
     private boolean strict = false;
 
     /**
+     * Default constructor initializing the `TextWire` with elastic on-heap bytes, assume text documents.
+     */
+    public TextWire() {
+        this(Bytes.allocateElasticOnHeap());
+        useTextDocuments();
+    }
+    /**
      * Constructor to initialize the `TextWire` with a specific bytes representation
      * and a flag to determine if 8-bit encoding is to be used.
      *

--- a/src/main/java/net/openhft/chronicle/wire/Wire.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wire.java
@@ -25,7 +25,7 @@ public interface Wire extends WireIn, WireOut {
      * @return A YamlWire instance configured to write to an on-heap Bytes object.
      */
     static Wire newYamlWireOnHeap() {
-        return new YamlWire(Bytes.allocateElasticOnHeap()).useTextDocuments();
+        return new YamlWire();
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -69,6 +69,14 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     private YamlWire rereadWire;
 
     /**
+     * Default constructor that initializes the YamlWire with elastic direct bytes. Assumes text documents.
+     */
+    public YamlWire() {
+        this(Bytes.allocateElasticDirect());
+        useTextDocuments();
+    }
+
+    /**
      * Constructor that initializes the YamlWire with provided bytes and a flag indicating the use of 8-bit.
      *
      * @param bytes Bytes from which YamlWire is initialized

--- a/src/test/java/net/openhft/chronicle/wire/Base32LongConverterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/Base32LongConverterTest.java
@@ -51,7 +51,7 @@ public class Base32LongConverterTest extends WireTestCommon {
     // A test to check the character safety in YamlWire.
     @Test
     public void allSafeCharsYamlWire() {
-        Wire wire = new YamlWire(Bytes.allocateElasticOnHeap()).useTextDocuments();
+        Wire wire = new YamlWire();
         allSafeChars(wire);
     }
 

--- a/src/test/java/net/openhft/chronicle/wire/Base64LongConverterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/Base64LongConverterTest.java
@@ -77,7 +77,7 @@ public class Base64LongConverterTest extends WireTestCommon {
     @Test
     public void allSafeCharsYamlWire() {
         // Create a YamlWire instance with elastic on heap bytes and configure it to use text documents
-        Wire wire = new YamlWire(Bytes.allocateElasticOnHeap()).useTextDocuments();
+        Wire wire = new YamlWire();
         // Execute the generic safe character check
         allSafeChars(wire);
     }

--- a/src/test/java/net/openhft/chronicle/wire/Base85LongConverterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/Base85LongConverterTest.java
@@ -134,7 +134,7 @@ public class Base85LongConverterTest extends WireTestCommon {
     @Test
     public void allSafeCharsYamlWire() {
         // Create a YamlWire instance with elastic on heap bytes and configure it to use text documents
-        Wire wire = new YamlWire(Bytes.allocateElasticOnHeap()).useTextDocuments();
+        Wire wire = new YamlWire();
         // Execute the generic safe character check
         allSafeChars(wire);
     }

--- a/src/test/java/net/openhft/chronicle/wire/IdentifierLongConverterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/IdentifierLongConverterTest.java
@@ -73,7 +73,7 @@ public class IdentifierLongConverterTest extends net.openhft.chronicle.wire.Wire
     // Test using the YamlWire format with safe characters
     @Test
     public void allSafeCharsYamlWire() {
-        Wire wire = new YamlWire(Bytes.allocateElasticOnHeap()).useTextDocuments();
+        Wire wire = new YamlWire();
         allSafeChars(wire);
     }
 

--- a/src/test/java/net/openhft/chronicle/wire/JSONWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/JSONWireTest.java
@@ -68,7 +68,7 @@ public class JSONWireTest extends WireTestCommon {
         JSONWire json = new JSONWire(Bytes.from(str));
 
         // Initialize a YAML wire
-        YamlWire yaml = new YamlWire(Bytes.allocateElasticOnHeap()).useTextDocuments();
+        YamlWire yaml = new YamlWire();
 
         // Initialize another JSONWire for copying back from binary
         JSONWire json2 = new JSONWire(Bytes.allocateElasticOnHeap());

--- a/src/test/java/net/openhft/chronicle/wire/MessageHistoryTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MessageHistoryTest.java
@@ -298,14 +298,14 @@ public class MessageHistoryTest extends WireTestCommon {
         vmh.addTiming(11111111);
         vmh.addTiming(22222222);
 
-        Wire wire = new BinaryWire(Bytes.allocateElasticOnHeap());
+        Wire wire = new BinaryWire();
         vmh.useBytesMarshallable(useBytesMarshallable);
         ValueOut valueOut = useBytesMarshallable
                 ? wire.writeEventId(MESSAGE_HISTORY_METHOD_ID)
                 : wire.writeEventName(MethodReader.HISTORY);
         valueOut.object(SetTimeMessageHistory.class, vmh);
 
-        Wire wire2 = new YamlWire(Bytes.allocateElasticOnHeap());
+        Wire wire2 = new YamlWire();
         wire.copyTo(wire2);
 
         assertEquals("history: {\n" +

--- a/src/test/java/net/openhft/chronicle/wire/ReadOneTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ReadOneTest.java
@@ -68,8 +68,7 @@ public class ReadOneTest extends WireTestCommon {
         ignoreException("Unknown @MethodId='history' called on interface net.openhft.chronicle.wire.ReadOneTest$SnapshotListener");
         ignoreException("Unknown method-name='myDto' called on interface net.openhft.chronicle.wire.ReadOneTest$SnapshotListener");
         // Initialization phase
-        final Bytes<?> b = Bytes.allocateElasticOnHeap();
-        Wire wire = new YamlWire(b) {
+        Wire wire = new YamlWire() {
             @Override
             public boolean recordHistory() {
                 return true;

--- a/src/test/java/net/openhft/chronicle/wire/ShortTextLongConverterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ShortTextLongConverterTest.java
@@ -114,7 +114,7 @@ public class ShortTextLongConverterTest extends WireTestCommon {
 
     @Test
     public void allSafeCharsYamlWire() {
-        Wire wire = new YamlWire(Bytes.allocateElasticOnHeap()).useTextDocuments();
+        Wire wire = new YamlWire();
         allSafeChars(wire);
     }
 

--- a/src/test/java/net/openhft/chronicle/wire/converter/LongConvertorFieldsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/converter/LongConvertorFieldsTest.java
@@ -331,7 +331,7 @@ public class LongConvertorFieldsTest {
      * @param expected The expected string representation of the serialized object.
      */
     private void doTest(Marshallable dto, String expected) {
-        Wire wire = new YamlWire(Bytes.allocateElasticOnHeap());
+        Wire wire = new YamlWire();
         wire.getValueOut().object(dto);
         assertEquals(expected, wire.toString());
         Object object = wire.getValueIn().object();

--- a/src/test/java/net/openhft/chronicle/wire/examples/WireExamples1.java
+++ b/src/test/java/net/openhft/chronicle/wire/examples/WireExamples1.java
@@ -19,10 +19,10 @@ public class WireExamples1 {
 
     public static void example1() {
 
-        // allows the the YAML to refer to car, rather than net.openhft.chronicle.wire.WireExamples$Car
+        // allows the YAML to refer to car, rather than net.openhft.chronicle.wire.WireExamples$Car
         ClassAliasPool.CLASS_ALIASES.addAlias(Car.class);
 
-        Wire wire = new YamlWire(Bytes.allocateElasticOnHeap());
+        Wire wire = new YamlWire();
         wire.getValueOut().object(new Car("Lewis Hamilton", 44));
         System.out.println(wire);
     }

--- a/src/test/java/net/openhft/chronicle/wire/issue/Issue272Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/issue/Issue272Test.java
@@ -27,7 +27,6 @@ public class Issue272Test {
      */
     @Test
     public void arrays() {
-        // Allocate a buffer to hold the serialized data
         Bytes<?> buffer = Bytes.allocateElasticOnHeap();
 
         // Define two int arrays for testing
@@ -145,7 +144,7 @@ public class Issue272Test {
                 bytes.toHexString());
 
         // Convert the BinaryWire back into a YamlWire and verify its string representation
-        Wire wire2 = new YamlWire(Bytes.allocateElasticOnHeap()).useTextDocuments();
+        Wire wire2 = new YamlWire();
         copyAll(copyWire, wire2);
         assertEquals("to: dest1\n" +
                         "send: message\n" +

--- a/src/test/java/net/openhft/chronicle/wire/issue/Issue751Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/issue/Issue751Test.java
@@ -48,7 +48,7 @@ public class Issue751Test extends WireTestCommon {
     public void comparableField() {
         assumeFalse(Jvm.maxDirectMemory() == 0);
 
-        Wire wire = new YamlWire(Bytes.allocateElasticOnHeap());
+        Wire wire = new YamlWire();
         wire.write("first").object(new Three(
                 new One("hello"), new Two(42)));
 


### PR DESCRIPTION
Introduce convenient zero-argument constructors for the core `Wire` implementations and update demos/tests to use them. This removes repetitive `Bytes.allocate…()` + `useTextDocuments()` boilerplate, nudges safer defaults, and makes quickstarts/readability better.

## What changed

### New convenience constructors

* `BinaryWire()` → backs with **elastic on-heap** bytes.
* `RawWire()` → backs with **elastic on-heap** bytes; strings use 8-bit length prefixes (unchanged behavior).
* `TextWire()` → backs with **elastic on-heap** bytes and **calls `useTextDocuments()`** by default.
* `YamlWire()` → backs with **elastic direct** bytes and **calls `useTextDocuments()`** by default.

These delegate to existing constructors; no behavior lost for advanced callers.

### Public factory

* `Wire.newYamlWireOnHeap()` now returns `new YamlWire()` (previously created explicit on-heap bytes + `useTextDocuments()`).

> Note: the method name predates these defaults. The returned instance is still text-document oriented as before; byte storage is now the `YamlWire` default (direct). If we want to preserve naming fidelity, we can deprecate/rename this factory in a follow-up.

### Demo & tests de-boilerplated

Replaced `new YamlWire(Bytes.allocateElasticOnHeap()).useTextDocuments()` with simply `new YamlWire()` (and similar for other wires) across:

* Demo:

  * `EventByMethodExamples`: `YamlWire` construction simplified.
* Tests:

  * `Base32LongConverterTest`, `Base64LongConverterTest`, `Base85LongConverterTest`
  * `IdentifierLongConverterTest`, `ShortTextLongConverterTest`
  * `JSONWireTest`, `MessageHistoryTest`, `ReadOneTest`
  * `LongConvertorFieldsTest`, `WireExamples1`
  * `Issue272Test`, `Issue751Test`
  * Plus places where `BinaryWire` creation is now `new BinaryWire()`.

## Why

* **Ergonomics:** eliminate repetitive setup for the common case (elastic bytes + text documents).
* **Consistency:** `TextWire`/`YamlWire` default to `useTextDocuments()`, matching how most people consume human-readable wire formats.
* **Readability:** demo/tests are easier to scan; fewer details distract from intent.

## Compatibility & notes

* Existing multi-arg constructors remain; no source-compat break.
* `YamlWire` default storage is now **direct** bytes. This is typically a performance win and should be transparent for tests; explicit heap can still be requested via existing constructors if needed.
* `Wire.newYamlWireOnHeap()` now leverages the new default; functionally equivalent for text-document usage, but no longer guarantees heap backing. Consider deprecating/renaming to `newYamlWire()` in a later PR to avoid naming confusion.

## Migration guide (optional)

* Before:

  ```java
  Wire w = new YamlWire(Bytes.allocateElasticOnHeap()).useTextDocuments();
  ```

* After:

  ```java
  Wire w = new YamlWire();
  ```

* Before:

  ```java
  Wire w = new BinaryWire(Bytes.allocateElasticOnHeap());
  ```

* After:

  ```java
  Wire w = new BinaryWire();
  ```