### PR TITLE
Fix flaky test in AbstractMarshallableCfgTest by removing dependence on field…

### DIFF
--- a/src/test/java/net/openhft/chronicle/wire/AbstractMarshallableCfgTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/AbstractMarshallableCfgTest.java
@@ -51,20 +51,22 @@ public class AbstractMarshallableCfgTest extends WireTestCommon{
         myAMC.nestedSDM.bytes.append("Hi");
 
         // Verify modified string representation
-        // Note: Use content-based assertions rather than exact string match
-        // to avoid non-deterministic field ordering from getDeclaredFields()
-        String actual = myAMC.toString();
-        
-        // Verify the class header is present
-        assertEquals(true, actual.startsWith("!net.openhft.chronicle.wire.AbstractMarshallableCfgTest$MyAMC {"));
-        
-        // Verify both nested objects and their fields are present with correct values
-        assertEquals(true, actual.contains("nestedAMC: {"));
-        assertEquals(true, actual.contains("number: 0"));
-        assertEquals(true, actual.contains("flag: true"));
-        assertEquals(true, actual.contains("nestedSDM: {"));
-        assertEquals(true, actual.contains("bytes: Hi"));
-        assertEquals(true, actual.contains("amt: 1.0"));
+        String expected = "" +
+                        "!net.openhft.chronicle.wire.AbstractMarshallableCfgTest$MyAMC {\n" +
+                        "  nestedAMC: {\n" +
+                        "    number: 0,\n" +
+                        "    flag: true\n" +
+                        "  },\n" +
+                        "  nestedSDM: {\n" +
+                        "    bytes: Hi,\n" +
+                        "    amt: 1.0\n" +
+                        "  }\n" +
+                        "}\n";
+        java.util.function.Function<String, String> sort = s -> java.util.Arrays.stream(s.split("\n"))
+                .map(l -> l.replaceAll(",$", ""))
+                .sorted()
+                .collect(java.util.stream.Collectors.joining("\n"));
+        assertEquals(sort.apply(expected), sort.apply(myAMC.toString()));
     }
 
     // Test the deep copy functionality

--- a/src/test/java/net/openhft/chronicle/wire/AbstractMarshallableCfgTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/AbstractMarshallableCfgTest.java
@@ -51,18 +51,20 @@ public class AbstractMarshallableCfgTest extends WireTestCommon{
         myAMC.nestedSDM.bytes.append("Hi");
 
         // Verify modified string representation
-        assertEquals("" +
-                        "!net.openhft.chronicle.wire.AbstractMarshallableCfgTest$MyAMC {\n" +
-                        "  nestedAMC: {\n" +
-                        "    number: 0,\n" +
-                        "    flag: true\n" +
-                        "  },\n" +
-                        "  nestedSDM: {\n" +
-                        "    bytes: Hi,\n" +
-                        "    amt: 1.0\n" +
-                        "  }\n" +
-                        "}\n",
-                myAMC.toString());
+        // Note: Use content-based assertions rather than exact string match
+        // to avoid non-deterministic field ordering from getDeclaredFields()
+        String actual = myAMC.toString();
+        
+        // Verify the class header is present
+        assertEquals(true, actual.startsWith("!net.openhft.chronicle.wire.AbstractMarshallableCfgTest$MyAMC {"));
+        
+        // Verify both nested objects and their fields are present with correct values
+        assertEquals(true, actual.contains("nestedAMC: {"));
+        assertEquals(true, actual.contains("number: 0"));
+        assertEquals(true, actual.contains("flag: true"));
+        assertEquals(true, actual.contains("nestedSDM: {"));
+        assertEquals(true, actual.contains("bytes: Hi"));
+        assertEquals(true, actual.contains("amt: 1.0"));
     }
 
     // Test the deep copy functionality


### PR DESCRIPTION
### Description
Modified `AbstractMarshallableCfgTest.java` to sort the serialized fields before comparing them with the expected output. This ensures that the test is deterministic and doesn't depend on the iteration order of `Class.getDeclaredFields()`, which does not guarantee consistency.

### Motivation
NonDex detected test flakiness in `net.openhft.chronicle.wire.AbstractMarshallableCfgTest.asString` and the cause was that the test asserted a specific order of fields in the serialized YAML string. Since `SelfDescribingMarshallable` uses reflection to discover fields the order is not guaranteed. An example of NonDex output with detected failure is attached.
[nondex_output_AbstractMarshallableCfgTest.txt](https://github.com/user-attachments/files/23890151/nondex_output_AbstractMarshallableCfgTest.txt)
