### PR TITLE
Fix flaky test in Base64Test by removing dependence on field ordering

### DIFF
--- a/src/test/java/net/openhft/chronicle/wire/converter/Base64Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/converter/Base64Test.java
@@ -68,7 +68,13 @@ public class Base64Test extends net.openhft.chronicle.wire.WireTestCommon {
                 "...\n";
 
         // Validate the wire's output against the expected output
-        assertEquals(expected, wire.toString());
+        java.util.function.Function<String, String> sort = s -> java.util.Arrays.stream(s.split("\n"))
+                .map(l -> l.trim().replaceAll(",$", ""))
+                .filter(l -> !l.isEmpty() && !l.equals("...") && !l.equals("}") && !l.equals("send: {"))
+                .sorted()
+                .collect(java.util.stream.Collectors.joining("\n"));
+
+        assertEquals(sort.apply(expected), sort.apply(wire.toString()));
 
         // Create another YAML wire for reading the encoded data
         Wire wire2 = Wire.newYamlWireOnHeap();
@@ -79,7 +85,7 @@ public class Base64Test extends net.openhft.chronicle.wire.WireTestCommon {
             assertEquals(i < 5, reader.readOne());
 
         // Ensure the read wire's content matches the expected output
-        assertEquals(expected, wire2.toString());
+        assertEquals(sort.apply(expected), sort.apply(wire2.toString()));
     }
 
     /**


### PR DESCRIPTION
### Description
Modified `Base64Test.java` to sort the serialized fields before comparing them with the expected output. This ensures that the test is deterministic and doesn't depend on the iteration order of `Class.getDeclaredFields()`, which does not guarantee consistency.

### Motivation
NonDex detected test flakiness in `net.openhft.chronicle.wire.converter.Base64Test.onAnField` and the cause was that the test asserted a specific order of fields in the serialized YAML string. Since `SelfDescribingMarshallable` uses reflection to discover fields, the order is not guaranteed. An example of NonDex output with detected test failure is attached.
[nondex_output_base64test.txt](https://github.com/user-attachments/files/23890002/nondex_output_base64test.txt)

