### PR TITLE
Fix flaky tests in LongConvertorFieldsTest by removing dependence on field orde…

### DIFF
--- a/src/test/java/net/openhft/chronicle/wire/converter/LongConvertorFieldsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/converter/LongConvertorFieldsTest.java
@@ -333,7 +333,27 @@ public class LongConvertorFieldsTest {
     private void doTest(Marshallable dto, String expected) {
         Wire wire = new YamlWire();
         wire.getValueOut().object(dto);
-        assertEquals(expected, wire.toString());
+
+        String actual = wire.toString();
+        String[] expectedLines = expected.split("\n");
+        String[] actualLines = actual.split("\n");
+
+        assertEquals(expectedLines.length, actualLines.length);
+        assertEquals(expectedLines[0], actualLines[0]);
+        assertEquals(expectedLines[expectedLines.length - 1], actualLines[actualLines.length - 1]);
+
+        java.util.List<String> expectedFields = java.util.Arrays.stream(java.util.Arrays.copyOfRange(expectedLines, 1, expectedLines.length - 1))
+                .map(s -> s.endsWith(",") ? s.substring(0, s.length() - 1) : s)
+                .sorted()
+                .collect(java.util.stream.Collectors.toList());
+
+        java.util.List<String> actualFields = java.util.Arrays.stream(java.util.Arrays.copyOfRange(actualLines, 1, actualLines.length - 1))
+                .map(s -> s.endsWith(",") ? s.substring(0, s.length() - 1) : s)
+                .sorted()
+                .collect(java.util.stream.Collectors.toList());
+
+        assertEquals(expectedFields, actualFields);
+
         Object object = wire.getValueIn().object();
         assertEquals(dto, object);
     }


### PR DESCRIPTION
### Description
Modified `LongConvertorFieldsTest.java` to sort the serialized fields before comparing them with the expected output. This ensures that the test is deterministic and doesn't depend on the iteration order of `Class.getDeclaredFields()` which don't have guarantee in consistency.

### Motivation
NonDex detected test flakiness in 5 tests:
*   `net.openhft.chronicle.wire.converter.LongConvertorFieldsTest.base16`
*   `net.openhft.chronicle.wire.converter.LongConvertorFieldsTest.base64`
*   `net.openhft.chronicle.wire.converter.LongConvertorFieldsTest.base85`
*   `net.openhft.chronicle.wire.converter.LongConvertorFieldsTest.shortText`
*   `net.openhft.chronicle.wire.converter.LongConvertorFieldsTest.words`

This PR is verified by NonDex to fix them all. The root cause was that the tests asserted a specific order of fields in the serialized YAML string. Since `SelfDescribingMarshallable` uses reflection to discover fields, the order is not guaranteed. An example of NonDex output with detected test failure is attached.
[nondex_output.txt](https://github.com/user-attachments/files/23889739/nondex_output.txt)


