### PR TITLE
CORE-49 fix nested lists with single entry parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>net.openhft</groupId>
         <artifactId>java-parent-pom</artifactId>
-        <version>2026.XYZ</version>
+        <version>1.27ea1</version>
         <relativePath/>
     </parent>
 

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -1313,9 +1313,6 @@ public class TextWire extends YamlWireOut<TextWire> {
          */
         final ValueInStack stack = new ValueInStack();
 
-        // Limit for sequence reading
-        int sequenceLimit = 0;
-
         // Flag to denote if any kind of reading should be consumed
         private boolean consumeAny;
 
@@ -2182,12 +2179,7 @@ public class TextWire extends YamlWireOut<TextWire> {
                 consumePadding();
                 code = (char) readCode();
             }
-            if (code == '[') {
-                bytes.readSkip(1);
-                sequenceLimit = Integer.MAX_VALUE;
-            } else {
-                sequenceLimit = 1;
-            }
+            checkSequenceLimit(code);
 
             tReader.accept(t, TextWire.this.valueIn);
 
@@ -2199,6 +2191,18 @@ public class TextWire extends YamlWireOut<TextWire> {
             }
             consumePadding(1);
             return true;
+        }
+
+        private void checkSequenceLimit(char code) {
+            final int sequenceLimit;
+            if (code == '[') {
+                bytes.readSkip(1);
+                sequenceLimit = Integer.MAX_VALUE;
+            } else {
+                sequenceLimit = 1;
+            }
+            // save the initial state of the current sequenceLimit
+            stack.curr().savedValue(sequenceLimit);
         }
 
         /**
@@ -2228,12 +2232,7 @@ public class TextWire extends YamlWireOut<TextWire> {
                 consumePadding();
                 code = (char) readCode();
             }
-            if (code == '[') {
-                bytes.readSkip(1);
-                sequenceLimit = Integer.MAX_VALUE;
-            } else {
-                sequenceLimit = 1;
-            }
+            checkSequenceLimit(code);
 
             reader0.accept(this, list, buffer, bufferAdd);
 
@@ -2254,12 +2253,7 @@ public class TextWire extends YamlWireOut<TextWire> {
             consumePadding();
             char code = (char) peekCode();
 
-            if (code == '[') {
-                bytes.readSkip(1);
-                sequenceLimit = Integer.MAX_VALUE;
-            } else {
-                sequenceLimit = 1;
-            }
+            checkSequenceLimit(code);
 
             // this code was added to support empty sets
             consumePadding();
@@ -2289,8 +2283,13 @@ public class TextWire extends YamlWireOut<TextWire> {
 
         @Override
         public boolean hasNextSequenceItem() {
+            // set the sequence limit from the saved state in the case that we have nested sequences
+            int sequenceLimit = (int) stack.curr().savedValue();
             if (sequenceLimit-- <= 0)
                 return false;
+
+            // update the saved position with the decremented sequence limit
+            stack.curr().savedValue(sequenceLimit);
             consumePadding();
             int ch = peekCode();
             // don't test for next char as any comma still left here is to be consumed.

--- a/src/main/java/net/openhft/chronicle/wire/ValueInState.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueInState.java
@@ -20,6 +20,9 @@ class ValueInState {
     // Size of the unexpected values
     private int unexpectedSize;
 
+    // A saved value for reuse
+    private long savedValue;
+
     // An array to hold unexpected values
     @NotNull
     private long[] unexpected = EMPTY_ARRAY;
@@ -31,6 +34,7 @@ class ValueInState {
     public void reset() {
         savedPosition = 0;
         unexpectedSize = 0;
+        savedValue = Long.MIN_VALUE;
     }
 
     /**
@@ -86,6 +90,23 @@ class ValueInState {
         return unexpected[index];
     }
 
+    /**
+     * Stores the given value for later retrieval.
+     *
+     * @param savedValue value to save
+     */
+    public void savedValue(long savedValue) {
+        this.savedValue = savedValue;
+    }
+
+    /**
+     * Retrieves the saved value for the current state.
+     *
+     * @return The saved value
+     */
+    public long savedValue() {
+        return savedValue;
+    }
     /**
      * Removes an unexpected position from the list based on its index.
      *

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/MarshallableWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/MarshallableWireTest.java
@@ -16,10 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeFalse;
@@ -62,7 +59,9 @@ public class MarshallableWireTest extends WireTestCommon {
                 new Nested(new ScalarValues(), Collections.emptyList(), Collections.emptySet(), Collections.emptyMap(), new String[0]),
                 new ScalarValues(),
                 new ScalarValues(1),
-                new ScalarValues(10)
+                new ScalarValues(10),
+                new NestedList(Arrays.asList(new NestedList.Item("item1", 100, Collections.singletonList(new NestedList.SubItem("subItem1", 10)), "other1"),
+                        new NestedList.Item("item2", 200, Arrays.asList(new NestedList.SubItem("subItem2", 20), new NestedList.SubItem("subItem3", 30)), "other2")))
         };
 
         // Populate the test combinations list using each WireType with each Marshallable object

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/MarshallingJSONStringTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/MarshallingJSONStringTest.java
@@ -5,10 +5,12 @@ package net.openhft.chronicle.wire.marshallable;
 
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.io.InvalidMarshallableException;
+import net.openhft.chronicle.core.pool.ClassAliasPool;
 import net.openhft.chronicle.wire.Marshallable;
 import net.openhft.chronicle.wire.WireIn;
 import net.openhft.chronicle.wire.WireOut;
 import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -48,5 +50,51 @@ public class MarshallingJSONStringTest implements Marshallable {
 
         MarshallingJSONStringTest read = Marshallable.fromString(configJson);
         assertEquals(expectedJson, read.configAsJSON);
+    }
+
+    @Test
+    public void readingJsonListWithNestedSingleListAsLastElement() {
+        ClassAliasPool.CLASS_ALIASES.addAlias(NestedList.class);
+        String jsonText = "{\n" +
+                "  items: [\n" +
+                "    { name: item1, value: 100, subItems: { subName: subItem1, subValue: 10 } },\n" +
+                "    { name: item2, value: 200, subItems: [ { subName: subItem2, subValue: 20 },         { subName: subItem3, subValue: 30 } ] }\n" +
+                "  ]\n" +
+                "}";
+
+        String expectedJson = "!NestedList {\n" +
+                "  items: [\n" +
+                "    { name: item1, value: 100, subItems: [ { subName: subItem1, subValue: 10 } ], otherValue: !!null \"\" },\n" +
+                "    { name: item2, value: 200, subItems: [ { subName: subItem2, subValue: 20 },         { subName: subItem3, subValue: 30 } ], otherValue: !!null \"\" }\n" +
+                "  ]\n" +
+                "}\n";
+
+        NestedList read = Marshallable.fromString(NestedList.class, jsonText);
+        Assert.assertNotNull(read);
+        String actualJson = read.toString();
+        assertEquals(expectedJson, actualJson);
+    }
+
+    @Test
+    public void readingJsonListWithNestedSingleListInMiddle() {
+        ClassAliasPool.CLASS_ALIASES.addAlias(NestedList.class);
+        String jsonText = "{\n" +
+                "  items: [\n" +
+                "    { name: item1, value: 100, subItems: { subName: subItem1, subValue: 10 }, otherValue: value1 },\n" +
+                "    { name: item2, value: 200, subItems: [ { subName: subItem2, subValue: 20 },         { subName: subItem3, subValue: 30 } ], otherValue: value2 }\n" +
+                "  ]\n" +
+                "}";
+
+        String expectedJson = "!NestedList {\n" +
+                "  items: [\n" +
+                "    { name: item1, value: 100, subItems: [ { subName: subItem1, subValue: 10 } ], otherValue: value1 },\n" +
+                "    { name: item2, value: 200, subItems: [ { subName: subItem2, subValue: 20 },         { subName: subItem3, subValue: 30 } ], otherValue: value2 }\n" +
+                "  ]\n" +
+                "}\n";
+
+        NestedList read = Marshallable.fromString(NestedList.class, jsonText);
+        Assert.assertNotNull(read);
+        String actualJson = read.toString();
+        assertEquals(expectedJson, actualJson);
     }
 }

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/NestedList.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/NestedList.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.wire.marshallable;
+
+import net.openhft.chronicle.wire.Marshallable;
+import net.openhft.chronicle.wire.SelfDescribingMarshallable;
+
+import java.util.List;
+import java.util.Objects;
+
+public class NestedList extends SelfDescribingMarshallable {
+    List<Item> items;
+
+    public NestedList(List<Item> items) {
+        this.items = items;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        NestedList that = (NestedList) o;
+        return Objects.equals(items, that.items);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(items);
+    }
+
+    public static class Item implements Marshallable {
+        String name;
+        int value;
+        List<SubItem> subItems;
+        String otherValue;
+
+        public Item(String name, int value, List<SubItem> subItems, String otherValue) {
+            this.name = name;
+            this.value = value;
+            this.subItems = subItems;
+            this.otherValue = otherValue;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            Item item = (Item) o;
+            return value == item.value && Objects.equals(name, item.name) && Objects.equals(subItems, item.subItems);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, value, subItems, otherValue);
+        }
+    }
+    public static class SubItem extends SelfDescribingMarshallable {
+        String subName;
+        int subValue;
+
+        public SubItem(String subName, int subValue) {
+            this.subName = subName;
+            this.subValue = subValue;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            SubItem subItem = (SubItem) o;
+            return subValue == subItem.subValue && Objects.equals(subName, subItem.subName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(subName, subValue);
+        }
+    }
+}


### PR DESCRIPTION
TextWire supports single item arrays without square bracket `[` placement. However, if there is a list of multiple items and one of the items has a single array within it without square brackets, all subsequent items in the parent list are not read with an error thrown.

The issue here is that within `TextWire$TextValueIn` there is a variable called `sequenceLimit` which keeps track of how many items should be in a list - this is primarily to handle the case of a singleton list. This breaks when there is an outer list with multiple elements and the inner singleton list is not the last element.

The solution here is to remove this field and make it a local variable and add a new `savedValue` into the parse stack to keep track of the limit for the current marshallable read. This way the outer list limit value is not clobbered by the inner list limit value.