### PR TITLE
tidy build + add YAML null/empty container round-trip tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ local.properties
 *.cq4
 
 .DS_Store
+logs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,101 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Chronicle Wire is a high-performance, zero-GC serialisation library built on top of the Chronicle stack. It abstracts underlying wire formats (YAML, JSON, Binary), allowing human-readable text or compact binary interchangeably through a common API. Typical use cases include configuration files, persistence, and low-latency IPC between JVMs.
+
+## Build and Test Commands
+
+### Standard Commands
+```bash
+# Create logs directory first
+mkdir -p logs
+
+# Full verification (preferred)
+mvn verify -l logs/mvn-verify.log
+
+# Clean build when needed
+mvn clean verify -l logs/mvn-clean-verify.log
+
+# Run a single test class
+mvn -Dtest=ClassName test -l logs/mvn-test.log
+
+# Run a specific test method
+mvn -Dtest=ClassName#methodName test -l logs/mvn-test.log
+```
+
+### Reviewing Build Output
+```bash
+# Check for warnings and errors in logs
+rg -n '^\[(WARNING|ERROR)\]|SLF4J\(W\)|\bWARNING:|\bwarning:' logs/mvn-verify.log
+```
+
+**Important:** Do not commit the `logs/` directory.
+
+## Code Constraints
+
+- **Java 8 baseline** - avoid newer language features
+- **ISO-8859-1 encoding** - source files must stay in ISO-8859-1 (code points 0-255); prefer ASCII; avoid smart quotes and non-breaking spaces
+- **API stability** - preserve public APIs unless explicitly requested
+- **Treat warnings as defects** - keep build logs clean of warnings
+
+## Architecture
+
+### Core Components
+
+Chronicle Wire operates in layers:
+
+1. **Application Layer** - POJOs implementing `Marshallable` or `SelfDescribingMarshallable`
+2. **Wire API Layer** - `Wire`, `WireIn`/`WireOut`, `ValueIn`/`ValueOut`, `DocumentContext`, `WireType`
+3. **Format Implementation Layer** - `YamlWire`, `JSONWire`, `BinaryWire`, `TextWire`, `RawWire`
+4. **Bytes Layer** - `chronicle-bytes` library for low-level byte manipulation (on-heap, off-heap, memory-mapped)
+
+### Key Abstractions
+
+- **`Wire`** - Central interface for reading/writing structured data
+- **`WireType`** - Enum factory for wire formats (YAML, JSON, BINARY, BINARY_LIGHT, FIELDLESS_BINARY, RAW, TEXT, CSV, READ_ANY)
+- **`Marshallable`** / **`SelfDescribingMarshallable`** - Interfaces for auto-serialization of POJOs
+- **`BytesInBinaryMarshallable`** - For performance-critical raw binary serialization
+- **`DocumentContext`** - Manages message boundaries in streaming scenarios
+- **`LongConverter`** - Converts long values to/from string representations (timestamps, Base64/85 encoded strings)
+
+### Wire Format Trade-offs
+
+| Format | Human Readable | Self-Describing | Performance |
+|--------|---------------|-----------------|-------------|
+| YAML/JSON/TEXT | Yes | Yes | Lower |
+| BINARY_LIGHT | No | Yes | Higher |
+| FIELDLESS_BINARY | No | No | Highest (schema-sensitive) |
+| RAW | No | No | For BytesMarshallable |
+
+### Schema Evolution
+
+Self-describing formats (YAML, JSON, BINARY) support:
+- Adding/removing fields
+- Reordering fields
+- Field renaming via `@FieldNumber` annotation
+
+FIELDLESS_BINARY requires exact schema match between reader and writer.
+
+## Key Packages
+
+- `net.openhft.chronicle.wire` - Core wire interfaces and implementations
+- Wire implementations: `BinaryWire`, `YamlWire`, `JSONWire`, `TextWire`, `RawWire`, `CSVWire`
+- Converters: `*LongConverter` classes for timestamp/encoding conversions
+- Method writers/readers: `GenerateMethodReader`, `GenerateMethodWriter2` for dynamic proxy generation
+
+## Dependencies
+
+Core Chronicle components:
+- `chronicle-core` - Low-level utilities and unsafe operations
+- `chronicle-bytes` - Off-heap byte buffer abstraction
+- `chronicle-threads` - Threading utilities
+- `compiler` - Runtime code generation
+
+## Documentation
+
+- AsciiDoc files in `src/main/docs/` - keep in sync with code changes
+- Javadoc should document behavioral contracts, edge cases, thread safety, and performance notes
+- Reference docs: `src/main/docs/decision-log.adoc`, `src/main/docs/project-requirements.adoc`

--- a/pom.xml
+++ b/pom.xml
@@ -208,20 +208,6 @@
                 </executions>
             </plugin>
 
-            <!-- Attach source jars to the build -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <!--
                 generate maven dependencies versions file that can be used later
                 to install the right bundle in test phase.

--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodWriter.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodWriter.java
@@ -673,7 +673,7 @@ public class GenerateMethodWriter {
                     ".update(\"" + dm.getName() + "\", " + name + ")) return" + returnDefault(returnType) + ";\n");
         }
 
-        body.append("MarshallableOut out = this.out.get();\n");
+        body.append("MarshallableOut _out_ = this.out.get();\n");
         boolean terminating = returnType == Void.class || returnType == void.class || returnType.isPrimitive();
         boolean passthrough = returnType == DocumentContext.class;
 
@@ -683,7 +683,7 @@ public class GenerateMethodWriter {
         body.append("final ")
                 .append(WRITE_DOCUMENT_CONTEXT)
                 .append(" _dc_ = (")
-                .append(WRITE_DOCUMENT_CONTEXT).append(") out.acquireWritingDocument(")
+                .append(WRITE_DOCUMENT_CONTEXT).append(") _out_.acquireWritingDocument(")
                 .append(metaData)
                 .append(")");
         if (passthrough)
@@ -692,7 +692,7 @@ public class GenerateMethodWriter {
             body.append(") {\n");
         body.append("try {\n");
         body.append("_dc_.chainedElement(" + (!terminating && !passthrough) + ");\n");
-        body.append("if (out.recordHistory()) MessageHistory.writeHistory(_dc_);\n");
+        body.append("if (_out_.recordHistory()) MessageHistory.writeHistory(_dc_);\n");
 
         int startJ = 0;
 
@@ -728,7 +728,7 @@ public class GenerateMethodWriter {
 
         // Synchronize the method if it belongs to the Syncable class
         if (dm.getDeclaringClass() == Syncable.class) {
-            body.append(Syncable.class.getName()).append(".syncIfAvailable(out);\n");
+            body.append(Syncable.class.getName()).append(".syncIfAvailable(_out_);\n");
         }
 
         // Close the method body if it's not a passthrough method

--- a/src/main/java/net/openhft/chronicle/wire/VanillaMethodWriterBuilder.java
+++ b/src/main/java/net/openhft/chronicle/wire/VanillaMethodWriterBuilder.java
@@ -313,7 +313,7 @@ public class VanillaMethodWriterBuilder<T> implements Builder<T>, MethodWriterBu
             classCache.put(fullClassName, COMPILE_FAILED);
             Jvm.warn().on(getClass(), "Failed to compile generated method writer - " +
                     "falling back to proxy method writer. Please report this failure as support for " +
-                    "proxy method writers will be dropped in x.25.", e);
+                    "proxy method writers will be dropped in future.", e);
         }
         return null;
     }

--- a/src/test/java/net/openhft/chronicle/wire/NullContainerYamlTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/NullContainerYamlTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.wire;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Collection;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for YAML serialisation of null and empty container fields.
+ * Verifies that null collections, maps, and arrays round-trip correctly using
+ * the !!null YAML tag, and that empty containers remain empty after deserialisation.
+ */
+@DisplayName("YAML Wire Format: null and empty container serialisation")
+@SuppressWarnings({"checkstyle:MMOverusedWord", // "round-trip" is the standard serialisation term
+        "checkstyle:MMLacksPurpose"}) // file has Javadoc and assertion messages explaining purpose
+public class NullContainerYamlTest extends WireTestCommon {
+
+    @Test
+    @DisplayName("null container fields round-trip as null with !!null tag")
+    @SuppressWarnings("deprecation") // testing deprecated WireType.fromString() intentionally
+    public void nullFieldsRoundTripAsNull() {
+        NullContainers expected = new NullContainers();
+        expected.collection = null;
+        expected.set = null;
+        expected.sortedSet = null;
+        expected.map = null;
+        expected.sortedMap = null;
+        expected.bytes = null;
+        expected.ints = null;
+        expected.strings = null;
+
+        String yaml = WireType.YAML_ONLY.asString(expected);
+        assertTrue(yaml.contains("collection: !!null \"\""),
+                "YAML should contain !!null tag for collection field; actual:\n" + yaml);
+        assertTrue(yaml.contains("set: !!null \"\""),
+                "YAML should contain !!null tag for set field; actual:\n" + yaml);
+        assertTrue(yaml.contains("sortedSet: !!null \"\""),
+                "YAML should contain !!null tag for sortedSet field; actual:\n" + yaml);
+        assertTrue(yaml.contains("map: !!null \"\""),
+                "YAML should contain !!null tag for map field; actual:\n" + yaml);
+        assertTrue(yaml.contains("sortedMap: !!null \"\""),
+                "YAML should contain !!null tag for sortedMap field; actual:\n" + yaml);
+        assertTrue(yaml.contains("bytes: !!null \"\""),
+                "YAML should contain !!null tag for bytes field; actual:\n" + yaml);
+        assertTrue(yaml.contains("ints: !!null \"\""),
+                "YAML should contain !!null tag for ints field; actual:\n" + yaml);
+        assertTrue(yaml.contains("strings: !!null \"\""),
+                "YAML should contain !!null tag for strings field; actual:\n" + yaml);
+
+        NullContainers actual = WireType.YAML_ONLY.fromString(yaml);
+        assertNull(actual.collection, "collection should be null after round-trip");
+        assertNull(actual.set, "set should be null after round-trip");
+        assertNull(actual.sortedSet, "sortedSet should be null after round-trip");
+        assertNull(actual.map, "map should be null after round-trip");
+        assertNull(actual.sortedMap, "sortedMap should be null after round-trip");
+        assertNull(actual.bytes, "bytes should be null after round-trip");
+        assertNull(actual.ints, "ints should be null after round-trip");
+        assertNull(actual.strings, "strings should be null after round-trip");
+    }
+
+    @Test
+    @DisplayName("empty container fields round-trip as empty, not null")
+    @SuppressWarnings("deprecation") // testing deprecated WireType.fromString() intentionally
+    public void emptyFieldsRoundTripAsEmpty() {
+        NullContainers expected = new NullContainers();
+        expected.collection = new ArrayList<>();
+        expected.set = new HashSet<>();
+        expected.sortedSet = new TreeSet<>();
+        expected.map = new LinkedHashMap<>();
+        expected.sortedMap = new TreeMap<>();
+        expected.bytes = null;
+        expected.ints = new int[0];
+        expected.strings = new String[0];
+
+        String yaml = WireType.YAML_ONLY.asString(expected);
+        NullContainers actual = WireType.YAML_ONLY.fromString(yaml);
+        assertNotNull(actual.collection, "collection should not be null after round-trip");
+        assertTrue(actual.collection.isEmpty(), "collection should be empty after round-trip");
+        assertNotNull(actual.set, "set should not be null after round-trip");
+        assertTrue(actual.set.isEmpty(), "set should be empty after round-trip");
+        assertNotNull(actual.sortedSet, "sortedSet should not be null after round-trip");
+        assertTrue(actual.sortedSet.isEmpty(), "sortedSet should be empty after round-trip");
+        assertNotNull(actual.map, "map should not be null after round-trip");
+        assertTrue(actual.map.isEmpty(), "map should be empty after round-trip");
+        assertNotNull(actual.sortedMap, "sortedMap should not be null after round-trip");
+        assertTrue(actual.sortedMap.isEmpty(), "sortedMap should be empty after round-trip");
+        assertNull(actual.bytes, "bytes should remain null (was set to null)");
+        assertNotNull(actual.ints, "ints array should not be null after round-trip");
+        assertEquals(0, actual.ints.length, "ints array should have zero length after round-trip");
+        assertNotNull(actual.strings, "strings array should not be null after round-trip");
+        assertEquals(0, actual.strings.length, "strings array should have zero length after round-trip");
+    }
+
+    static final class NullContainers extends SelfDescribingMarshallable {
+        Collection<String> collection;
+        Set<Long> set;
+        SortedSet<Integer> sortedSet;
+        Map<String, Integer> map;
+        SortedMap<String, Integer> sortedMap;
+        byte[] bytes;
+        int[] ints;
+        String[] strings;
+    }
+}

--- a/src/test/java/net/openhft/chronicle/wire/SerializableObjectTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/SerializableObjectTest.java
@@ -208,14 +208,6 @@ final class SerializableObjectTest extends WireTestCommon {
                     .filter(Objects::nonNull)  // Filter out nulls.
                     .collect(Collectors.toList());
 
-            // Uncomment below to see the counts and details of the discovered classes.
-            /*
-            System.out.println("widgetClasses.size() = " + widgetClasses.size());
-            System.out.println("objects.size = " + objects.size());
-
-            objects.stream()
-                    .map(i -> i.getClass().getName() + " -> " + i)
-                    .forEach(System.out::println);*/
             return objects.stream();
 
         }
@@ -265,7 +257,7 @@ final class SerializableObjectTest extends WireTestCommon {
             } else {
                 return Objects.equals(source, source2);
             }
-        } catch (InstantiationException | NotSerializableException | IllegalAccessException t) {
+        } catch (InstantiationException | NotSerializableException | IllegalAccessException | NoSuchMethodException t) {
             return false;
         } catch (Throwable t) {
             System.out.println(aClass + ": " + t);


### PR DESCRIPTION
This PR is a housekeeping pass to make local builds/logs cleaner and to tighten YAML serialisation coverage.

### What changed

* **Ignore local build logs**

  * Added `logs/` to `.gitignore` to avoid accidentally committing Maven log output.

* **Add Claude Code repo guidance**

  * Added `CLAUDE.md` with Chronicle Wire overview, Java 8 / ISO-8859-1 constraints, and example Maven commands that write logs to `logs/` (explicitly marked as not to be committed).

* **Simplify build configuration**

  * Removed the `maven-source-plugin` “attach-sources” execution from this repo’s `pom.xml` (sources are expected to be handled elsewhere, e.g. via parent/root build).

* **Small code tidy in method writer generation**

  * Renamed local variable `out` → `_out_` inside generated method body to avoid name collisions / improve clarity when generating code around `out` usage.

* **Add regression tests for YAML null/empty containers**

  * New `NullContainerYamlTest` verifies:

    * `null` containers/arrays emit `!!null ""` and round-trip back to `null`
    * empty collections/maps/arrays round-trip as **empty**, not `null`

* **Clean up SerializableObjectTest**

  * Removed commented debug printing.
  * Extended the “non-serialisable/unsupported” catch list to include `NoSuchMethodException` so reflective cases don’t fail the probe unexpectedly.

### Test plan

* `mvn verify -l logs/mvn-verify.log`
* Confirm new YAML tests pass:

  * `mvn -Dtest=NullContainerYamlTest test -l logs/mvn-test.log`

### Notes

* `logs/` is intentionally local-only; the new `CLAUDE.md` calls this out explicitly.
