### PR TITLE
[codex] Polish Wire docs and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ When using AI agents to assist with development, please adhere to the following 
 
 * **Respect the Language & Character-set Policy**: Ensure all AI-generated content follows the British English and ISO-8859-1 guidelines outlined above.
 Focus on Clarity: AI-generated documentation should be clear and concise and add value beyond what is already present in the code or existing documentation.
-* **Avoid Redundancy**: Do not generate content that duplicates existing documentation or code comments unless it provides additional context or clarification.
+* **Avoid Redundancy**: Do not generate content that duplicates existing documentation or code comments unless it adds context or clarification.
 * **Review AI Outputs**: Always review AI-generated content for accuracy, relevance, and adherence to the project's documentation standards before committing it to the repository.
 
 ## Company-Wide Tagging

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,5 +97,5 @@ Core Chronicle components:
 ## Documentation
 
 - AsciiDoc files in `src/main/docs/` - keep in sync with code changes
-- Javadoc should document behavioral contracts, edge cases, thread safety, and performance notes
+- Javadoc should document behavioural contracts, edge cases, thread safety, and performance notes
 - Reference docs: `src/main/docs/decision-log.adoc`, `src/main/docs/project-requirements.adoc`

--- a/README.adoc
+++ b/README.adoc
@@ -967,7 +967,7 @@ assertEquals(60, config.monitoring.interval);
 
 == LongConverter
 
-Provides an abstraction for converting between long values and their string representations, potentially based on a custom character or symbol set.
+Defines an abstraction for converting between long values and their string representations, potentially based on a custom character or symbol set.
 
 The conversion allows encoding long values into compact, human-readable strings and vice versa, useful in contexts where storage efficiency is a concern.
 
@@ -1031,14 +1031,14 @@ public class Person extends SelfDescribingMarshallable {
 
 == A note on `Wires.reset()`
 
-Chronicle Wire allows (and encourages) objects to be re-used in order to reduce allocation rates.
+Chronicle Wire allows (and encourages) objects to be re-used to reduce allocation rates.
 
 When a marshallable object is re-used or initialised by the framework, it is first reset by way of `Marshallable.reset()`
 which is recommended over calling `Wires.reset()`.
 In the case of most DTOs with simple scalar values, this will not cause any issues.
 However, more complicated objects with object instance fields may experience undesired behaviour.
 
-In order to `reset` a marshallable object, the process is as follows:
+To `reset` a marshallable object, the process is as follows:
 
 . create a new instance of the object to be reset (this is done just once per object type, then cached)
 . reset all fields, so that
@@ -1091,7 +1091,7 @@ showing that the field *b* of each container object is now referencing the same 
 An exception to this is when the field value implements `Resettable` interface, when the default value of the field is not null, and the current field value is of exactly the same class as the default value.
 In this case, `value.reset()` will be called instead of overwriting it with default value by reference.
 
-In order to work around this, if necessary, the marshallable class can override `Marshallable.reset`:
+To work around this, if necessary, the marshallable class can override `Marshallable.reset`:
 
 [source,java,opts=novalidate]
 ----
@@ -1124,17 +1124,17 @@ public class ContainedDto implements SelfDescribingMarshallable {
 
 While serialized data can be updated by replacing a whole record, this might not be the most efficient option, nor thread-safe.
 
-Chronicle Wire offers the ability to bind a reference to a fixed value of a field, and perform atomic operations on that field; for example, volatile read/write, and compare-and-swap.
+Chronicle Wire can bind a reference to a fixed field value and perform atomic operations on that field; for example, volatile read/write, and compare-and-swap.
 
 [source,java,opts=novalidate]
 ----
    // field to cache the location and object used to reference a field.
    private LongValue counter = null;
 
-   // find the field and bind an approritae wrapper for the wire format.
+   // find the field and bind an appropriate wrapper for the wire format.
    wire.read(COUNTER).int64(counter, x -> counter = x);
 
-   // thread safe across processes on the same machine.
+   // thread-safe across processes on the same machine.
    long id = counter.getAndAdd(1);
 ----
 
@@ -1348,7 +1348,7 @@ This feature allows Chronicle Wire to de-serialize, manipulate, and serialize an
 
 If the type is unknown at runtime, a proxy is created; assuming that the required type is an interface.
 
-When the tuple is serialized, it will be give the same type as when it was deserialized, even if that class is not available.
+When the tuple is serialized, it will be given the same type as when it was deserialized, even if that class is not available.
 
 Methods following our `getter`/`setter` convention will be treated as `getters` and `setters`.
 
@@ -1433,7 +1433,7 @@ It's possible to capture such fields by overriding method or `ReadMarshallable`:
     }
 ----
 
-One of best practices is saving unexpected fields in order to process them after the deserialization:
+One best practice is saving unexpected fields to process them after the deserialization:
 
 [source,java,opts=novalidate]
 ----
@@ -1489,7 +1489,7 @@ public void testUnknownClass() {
 
 === Filtering with MethodReaders
 
-To support filtering, you need to make sure the first of multiple arguments can be used to filter the method call.
+To support filtering, you need to make sure the first of multiple arguments can filter the method call.
 If you have only one argument, you may need to add an additional argument to support efficient filtering.
 
 This feature calls an implementation of `MethodFilterOnFirstArg` to see if the rest of the method call should be parsed.
@@ -1536,11 +1536,11 @@ For an example, see `net.openhft.chronicle.wire.MethodFilterOnFirstArgTest`.
 
 === Intercepting `MethodReader` calls
 
-You may wish to intercept handling a call in the method reader in order to execute additional logic, to record a call somewhere for monitoring purposes, or to even skip the original method invocation.
+You may wish to intercept handling a call in the method reader to execute additional logic, to record a call somewhere for monitoring purposes, or to even skip the original method invocation.
 
 ==== Intercepting by passing control over the original method call
 
-`MethodReader` provides a flexible feature for supporting all the above use cases -- the option to specify `MethodReaderInterceptorReturns`.
+`MethodReader` supports the above use cases through the option to specify `MethodReaderInterceptorReturns`.
 If set, it will be triggered *instead* of the original call.
 It's possible to either skip the original method or to call it via passed `Invocation` instance:
 
@@ -1559,7 +1559,7 @@ class MyInterceptor implements MethodReaderInterceptorReturns {
 
 ==== Intercepting by modifying `MethodReader` generated source code
 
-`GeneratingMethodReaderInterceptorReturns` allows to change the logic of `MethodReader` without an overhead provided by reflexive calls.
+`GeneratingMethodReaderInterceptorReturns` allows changes to the logic of `MethodReader` without overhead from reflexive calls.
 
 Code returned by `codeBeforeCall` and `codeAfterCall` will be added before and after actual method call in the generated source code of the method reader.
 It's possible to use original call arguments and object instance in the added code.
@@ -1594,7 +1594,7 @@ See `MethodReaderInterceptorReturnsTest` for more examples.
 === Spring Boot and dynamic compilation in Chronicle Wire
 
 Chronicle Wire's `MethodReader` and `MethodWriter` dynamically compile Java code to get around some limitations in Java's underlying proxy mechanism and to do this the Java platform's standard compilation mechanism is used.
-The platform compiler uses the classpath variable to look for classes in directories and JAR files, and is not able to make use of classloaders to find classes.
+The platform compiler uses the classpath variable to look for classes in directories and JAR files, and is not able to use classloaders to find classes.
 Spring Boot uses a custom deployment mechanism - all classes and JARs are deployed in a fat JAR and Spring's classloader can extract classes from this.
 In order for the compiler to be able to see classes from the fat JAR, the classes should be extracted onto the disk somewhere.
 This is easy if the classes are contained in a JAR (i.e. a JAR inside the fat JAR) - Spring can be made to extract the JAR to a temp directory, such as by configuring Maven Spring Boot plugin:
@@ -2114,7 +2114,7 @@ private static final int MASHALLABLE_VERSION = 1;
 === JLBH Benchmark Performance
 
 To explore the efficiency of the examples above, this link:https://github.com/OpenHFT/Chronicle-Wire/blob/develop/src/test/java/net/openhft/chronicle/wire/TriviallyCopyableJLBH.java[TrivallyCopyableJLBH.java] test was created.
-As can be seen on lines 18-26, we have the ability to switch between running the TriviallyCopyable House ("House1"), the BinaryWire House ("House2") or 'UNKNOWN'.Important to note is that trivially copyable objects were used in order to improve java serialisation speeds.For further understanding on trivially copyable objects, refer to link:https://dzone.com/articles/how-to-get-c-speed-in-java-serialisation[this article].
+As can be seen on lines 18-26, we have the ability to switch between running the TriviallyCopyable House ("House1"), the BinaryWire House ("House2") or 'UNKNOWN'.Important to note is that trivially copyable objects were used to improve java serialisation speeds.For further understanding on trivially copyable objects, refer to link:https://dzone.com/articles/how-to-get-c-speed-in-java-serialisation[this article].
 This shows that we can serialise and then de-serialise 100,000 messages in a second.The Trivially Copyable version is even faster, especially at the higher percentiles.
 
 .Benchmark Performance Between TriviallyCopyable and BinaryWire

--- a/docs/EventsByMethod.adoc
+++ b/docs/EventsByMethod.adoc
@@ -30,7 +30,7 @@ sequenceDiagram
 
 Typical use cases include:
 
-* High performance inter-process messaging.
+* High-performance inter-process messaging.
 * Recording events to disk for replay during testing.
 * Converting asynchronous network traffic into method calls.
 
@@ -215,11 +215,11 @@ writer.via("targetQueue")
 
 === Filtering messages with chained calls
 
-A `MethodReader` recognises implementations that extends the marker interface `@IgnoresEverything` as one which doesn't need to the called.
+A `MethodReader` recognises implementations that extend the marker interface `@IgnoresEverything` as ones that do not need to be called.
 As such, if any stage in the chained call returns an implementation of this interface, the rest of the message is discarded and not read.
 For convenience, there is a Mocker for generating such an implementation.
 
-.Provides an implementation of `Saying` that is recognised as ignoring everything
+.Implementation of `Saying` that is recognised as ignoring everything
 [source,java]
 ----
 static final Saying SAY_NOTHING = Mocker.ignoring(Saying.class);

--- a/microbenchmarks/README.md
+++ b/microbenchmarks/README.md
@@ -15,7 +15,7 @@ The tests were run with -Xmx1g -XX:MaxInlineSize=400 on an isolated CPU on an i7
 
 These are latency test with the [full Results Here](https://github.com/OpenHFT/Chronicle-Wire/tree/master/microbenchmarks/results)
 
-Something I found interesting is that while a typical time might be stable for a given run, you can get different results at different time.  
+Something I found interesting is that while a typical time might be stable for a given run, you can get different results at different time.
 For this reason I ran the tests with 10 forks.  By looking at the high percentiles, we tend to pick up the results of the worst run.
 
 | Wire Format | Text encoding | Fixed width values? | Numeric Fields? | field-less?| Bytes | 99.9 %tile | 99.99 %tile | 99.999 %tile | worst |
@@ -64,7 +64,7 @@ public void writeMarshallable(WireOut wire) {
 ```
 
 ## The code for BytesMarshallable
-The code to support BytesMarshallable can eb added to the class marshalled.  While this is faster than using Wire, there is no option to visualise the data without deserializing it, nor does it directly support schema changes.
+The code to support BytesMarshallable can be added to the class marshalled.  While this is faster than using Wire, there is no option to visualise the data without deserializing it, nor does it directly support schema changes.
 
 ```yaml
 @Override
@@ -124,12 +124,12 @@ Tests with "*" on Bytes mean this has been written to/read from direct memory an
 ## SBE (Simple Binary Encoding)
 SBE performs as well are BytesMarshallable.  Even though it was slower in this test, the difference to too small to draw any conclusions. i.e. in a different use case, a different developer might find the difference reversed.
 
-However, I didn't find SBE simple.  Perhaps this is because I didn't use the generation for different languages, but I found it was non-trivial to use and setup.  
+However, I didn't find SBE simple.  Perhaps this is because I didn't use the generation for different languages, but I found it was non-trivial to use and setup.
 For a flat class with just six fields it generated 9 classes, we have three support classes, and I ended up adding methods to the generated class to get it to perform as efficiently as I wanted.
 This is likely to be a lack of understanding on my part, though I might not be alone in this.
 
 ## Snake YAML
-Snake YAML is a fully featured YAML 1.1 parser. The library has to do much more work to support all the features of the YAML standard which necessarily takes longer.  
+Snake YAML is a fully featured YAML 1.1 parser. The library has to do much more work to support all the features of the YAML standard which necessarily takes longer.
 However, it takes a lot longer which means it may not be suitable if you need performance but you don't need a complete YAML parser.
 
 If you need to decode YAML which could come from any sources, Snake YAML is a better choice.
@@ -140,7 +140,7 @@ Here some selected examples.  The UTF-8 encoded and 8-bit encoded tests look the
 ## Text Wire
 The main advantage of YAML based wire format is it is easier to implement with, document and debug.
 
-What you want is the ease of a text wire format but the speed of a binary wire format.  
+What you want is the ease of a text wire format but the speed of a binary wire format.
 Being able to switch from one to the other can save you a lot of time in development and support, but still give you the speed you want.
 
 This uses 91 bytes, Note: the "--- !!data" is added by the method to dump the data. This information is encoded in the first 4 bytes which contains the size.
@@ -179,7 +179,7 @@ longInt: 1234567890
 ```
 
 ## Binary Wire with fixed width fields.
-Fixed width fields support binding to values later and updating them atomically.  
+Fixed width fields support binding to values later and updating them atomically.
 Note: if you want to bind to specific values, there is support for this which will also ensure the values are aligned.
 
 This format uses 84 bytes
@@ -220,7 +220,7 @@ Test bwireTTF used 58 bytes.
 2: 1234567890
 ```
 
-## Binary Wire with variable width values only. 
+## Binary Wire with variable width values only.
 
 Test bwireFTT used 32 bytes.
 ```yaml
@@ -264,7 +264,7 @@ Test bytesMarshallable used 28 bytes.
 # Comparison outputs
 
 ## SnakeYAML
-Snake YAML used the .0 on the end of the price to signify that it was a double.  
+Snake YAML used the .0 on the end of the price to signify that it was a double.
 This added two characters but is an elegant way of encoding that it should be a double.
 
 ```yaml
@@ -305,11 +305,11 @@ Test sbe used 43 chars.
 ```
 00000000 29 00 7B 00 00 00 D2 02  96 49 00 00 00 00 00 00 )·{····· ·I······
 00000010 00 00 00 48 93 40 01 0C  48 65 6C 6C 6F 20 57 6F ···H·@·· Hello Wo
-00000020 72 6C 64 21 00 00 00 00  01 00 00                rld!···· ···     
+00000020 72 6C 64 21 00 00 00 00  01 00 00                rld!···· ···
 ```
 
 ## Externalizable
-While Externalizable is more efficient than Serializable, it is still a heavy weight serialization.  
+While Externalizable is more efficient than Serializable, it is still a heavyweight serialization.
 Where Java Serialization does well is in serializing Object Graphs instead of Object Tree, i.e. objects with circular references.
 
 Test externalizable used 293 chars.
@@ -332,5 +332,5 @@ Test externalizable used 293 chars.
 000000f0 6F 72 6C 64 21 00 02 73  69 64 65 00 05 00 00 00 orld!··s ide·····
 00000100 53 65 6C 6C 00 10 73 6D  61 6C 6C 49 6E 74 00 7B Sell··sm allInt·{
 00000110 00 00 00 12 6C 6F 6E 67  49 6E 74 00 D2 02 96 49 ····long Int····I
-00000120 00 00 00 00 00                                   ·····                  
+00000120 00 00 00 00 00                                   ·····
 ```

--- a/src/main/docs/wire-architecture.adoc
+++ b/src/main/docs/wire-architecture.adoc
@@ -198,7 +198,7 @@ Fluent API Marshalling (Manual Wiring) ::
 
 Only use this where there is no DTO available or when you need to write data that does not map directly to a `Marshallable` POJO.
 
-* This approach is more verbose but allows for dynamic schemas or when the data structure does not map cleanly to a Java class.
+* This approach is more verbose but allows dynamic schemas or when the data structure does not map cleanly to a Java class.
 * Example of using the fluent API to write a trade message:
 [source,java]
 ----

--- a/src/main/docs/wire-cookbook.adoc
+++ b/src/main/docs/wire-cookbook.adoc
@@ -525,7 +525,7 @@ public class MultiDocumentDemo {
 ----
 
 *Discussion:*
-The `try-with-resources` block ensures that each `DocumentContext` is properly closed. When `writingDocument()`'s context is closed, metadata (like message length) is written, allowing the reader to correctly identify document boundaries. `readingDocument()` returns a context; `dc.isPresent()` tells you if a document was found. `dc.isData()` or `dc.isMetaData()` can be used to distinguish message types, a pattern heavily used by Chronicle Queue.
+The `try-with-resources` block ensures that each `DocumentContext` is properly closed. When `writingDocument()`'s context is closed, metadata (like message length) is written, allowing the reader to correctly identify document boundaries. `readingDocument()` returns a context; `dc.isPresent()` tells you if a document was found. `dc.isData()` or `dc.isMetaData()` can distinguish message types, a pattern heavily used by Chronicle Queue.
 
 == Advanced & Performance
 

--- a/src/main/docs/wire-error-handling.adoc
+++ b/src/main/docs/wire-error-handling.adoc
@@ -233,7 +233,7 @@ try {
 === Logging `Bytes` Content
 
 * `bytes.toHexString()`: Provides a hexadecimal dump of the buffer's content.
-Useful for inspecting binary data at a low level.
+Useful for inspecting binary data at a low-level.
 * `bytes.toDebugString()`: Can provide more detailed internal state of the `Bytes` object.
 * `bytes.readRemaining()` / `bytes.writeRemaining()`: Check remaining capacity.
 

--- a/src/main/docs/wire-faq.adoc
+++ b/src/main/docs/wire-faq.adoc
@@ -90,7 +90,7 @@ Can I read data written in one `WireType` with another? ::
 Sometimes, yes. For example, binary data written with `BINARY_LIGHT` can often be "dumped" or inspected using `YAML_ONLY` because `BINARY_LIGHT` can be self-describing. `READ_ANY` wire type attempts to auto-detect the format. However, you cannot reliably read `FIELDLESS_BINARY` as YAML, for instance.
 
 How does `YAML_RETAIN_TYPE` or `JSON_RETAIN_TYPE` work? ::
-These wire types include explicit type information (e.g., `!com.example.MyClass {}` in YAML) in the output. This allows for deserialisation of polymorphic types or when the concrete class is not known by the reader beforehand.
+These wire types include explicit type information (e.g., `!com.example.MyClass {}` in YAML) in the output. This allows deserialisation of polymorphic types or when the concrete class is not known by the reader beforehand.
 
 == Annotations
 

--- a/src/main/docs/wire-schema-evolution.adoc
+++ b/src/main/docs/wire-schema-evolution.adoc
@@ -14,7 +14,7 @@ For systems that store data long-term or communicate across different service ve
 Chronicle Wire's approach to schema evolution is rooted in its flexible, format-agnostic design:
 
 * **Philosophy:** It generally favors flexibility, particularly with its self-describing formats (like YAML, JSON, and `BINARY_LIGHT`).
-These formats inherently carry metadata (field names or numbers) that allows for a degree of tolerance to schema changes.
+These formats inherently carry metadata (field names or numbers) that allows a degree of tolerance to schema changes.
 Conversely, highly optimised, non-self-describing formats like `FIELDLESS_BINARY` offer minimal to no schema evolution support by design, prioritising raw speed and compactness.
 * **No Central Schema Registry:** Unlike systems like Apache Avro or Google Protocol Buffers, Chronicle Wire does not typically rely on separately defined schema files (e.g., `.avsc` or `.proto`).
 The Java class definition (often a `Marshallable` object) itself serves as the primary schema definition.
@@ -284,7 +284,7 @@ Explicit Version Field ::
 `WireParselet` (for Text Formats) ::
 ** A `WireParselet` is a functional interface `(s, v) -> {}` where `s` is a `CharSequence` (the field name/key) and `v` is a `ValueIn`.
 You can provide a `WireParselet` to certain Wire methods (e.g., `wire.read().applyToMarshallable(parselet)`).
-** This allows for completely custom parsing logic for text-based formats.
+** This allows completely custom parsing logic for text-based formats.
 You can inspect field names, skip fields, transform values, or build up your object graph manually.
 It's powerful for very complex transformations or when dealing with loosely structured text data.
 
@@ -334,7 +334,7 @@ Document Your Schemas and Changes :: Maintain clear documentation (even if infor
 While Chronicle Wire offers considerable flexibility, it's important to understand its limitations regarding automatic schema evolution:
 
 Automatic Complex Type Conversion :: Wire will automatically convert an `long` field to a `Date` field, or an `OldCustomer` object to a `NewCustomer` object with a different structure, without custom code.
-However, it is on a best effort basis, and custom logic is often required for non-trivial transformations.
+However, it is on a best-effort basis, and custom logic is often required for non-trivial transformations.
 No Built-in Data Migration Framework :: Chronicle Wire provides the serialisation tools, but large-scale data migration (transforming existing stored data from one schema to another) is typically an application-level concern requiring custom utilities.
 `FIELDLESS_BINARY` Rigidity:: As emphasized, this format is not designed for evolution.
 

--- a/src/main/java/net/openhft/chronicle/wire/AbstractCommonMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractCommonMarshallable.java
@@ -23,7 +23,7 @@ abstract class AbstractCommonMarshallable implements Marshallable, BytesMarshall
 
     @Override
     public String toString() {
-        // this allows even invalid DTOs to be written to dump on a best effort basis.
+        // this allows even invalid DTOs to be written to dump on a best-effort basis.
         ValidatableUtil.startValidateDisabled();
         try {
             return Marshallable.$toString(this);

--- a/src/main/java/net/openhft/chronicle/wire/AbstractEventCfg.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractEventCfg.java
@@ -115,7 +115,7 @@ public class AbstractEventCfg<E extends AbstractEventCfg<E>> extends AbstractMar
      * Checks if this event is intended for the given destination service.
      *
      * @param destServiceId The destination service ID to check against
-     * @return true if the event is routed to the specified service, false otherwise
+     * @return {@code true} if the event is routed to the specified service, false otherwise
      */
     public boolean routedTo(String destServiceId) {
         return this.serviceId == null || this.serviceId().isEmpty() || this.serviceId().equals(destServiceId);

--- a/src/main/java/net/openhft/chronicle/wire/AbstractGeneratedMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractGeneratedMethodReader.java
@@ -475,7 +475,7 @@ public abstract class AbstractGeneratedMethodReader implements MethodReader {
         }
 
         /**
-         * Returns the thread local message history.
+         * Returns the thread-local message history.
          */
         public MessageHistory get() {
             return messageHistoryTL.get();

--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -440,7 +440,7 @@ public abstract class AbstractWire implements Wire, InternalWire {
 
     /**
      * Checks that no data is written after the end of the message. If data is found, an exception is thrown.
-     * This method returns true if no extra data is found after the end or if the check isn't feasible.
+     * This method returns {@code true} if no extra data is found after the end or if the check isn't feasible.
      *
      * @param pos The position to start the check from.
      * @return True if there's no data after the end or if the check isn't feasible.
@@ -533,7 +533,7 @@ public abstract class AbstractWire implements Wire, InternalWire {
                     }
 
                 } else {
-                    // mis-aligned check, assume only one writer (best effort)
+                    // mis-aligned check, assume only one writer (best-effort)
                     MEMORY.loadFence();
                     if (bytes.readInt(pos) == 0) {
                         if (!writeEOF)

--- a/src/main/java/net/openhft/chronicle/wire/BaseEvent.java
+++ b/src/main/java/net/openhft/chronicle/wire/BaseEvent.java
@@ -27,7 +27,7 @@ public interface BaseEvent<E extends BaseEvent<E>> extends Marshallable {
      * an event generated externally to the system first entered the system).
      * <p>
      * By default, the time is represented in nanoseconds. System property 'service.time.unit'
-     * can be changed in order to represent time in different units.
+     * can be changed to represent time in different units.
      *
      * @param eventTime the time to store, expressed in the service time unit
      *                  (see {@link ServicesTimestampLongConverter}).
@@ -44,7 +44,7 @@ public interface BaseEvent<E extends BaseEvent<E>> extends Marshallable {
      * current time.
      * <p>
      * By default, the time is represented in nanoseconds. System property 'service.time.unit'
-     * can be changed in order to represent time in different units.
+     * can be changed to represent time in different units.
      *
      * @return this event instance
      */

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -80,7 +80,7 @@ public class BinaryWire extends AbstractWire implements Wire {
     private static final ThreadLocal<VanillaMessageHistory> VANILLA_MESSAGE_HISTORY_TL = ThreadLocal.withInitial(VanillaMessageHistory::new);
 
     /**
-     * Used when the wire is configured for fixed size output. Provides more
+     * Used when the wire is configured for fixed-size output. Provides more
      * predictable writes when value types are constrained.
      */
     private final FixedBinaryValueOut fixedValueOut = new FixedBinaryValueOut();
@@ -194,7 +194,7 @@ public class BinaryWire extends AbstractWire implements Wire {
      * This method checks each byte of the BytesStore to ensure it's a printable character or a newline.
      *
      * @param bytes The BytesStore to check
-     * @return true if the BytesStore can be treated as text, false otherwise
+     * @return {@code true} if the BytesStore can be treated as text, false otherwise
      */
     static boolean textable(BytesStore<?, ?> bytes) {
         if (bytes == null)
@@ -212,7 +212,7 @@ public class BinaryWire extends AbstractWire implements Wire {
      * This method checks each character of the CharSequence to ensure it's a printable character.
      *
      * @param cs The CharSequence to check
-     * @return true if the CharSequence can be treated as text, false otherwise
+     * @return {@code true} if the CharSequence can be treated as text, false otherwise
      */
     static boolean textable(CharSequence cs) {
         if (cs == null)
@@ -229,7 +229,7 @@ public class BinaryWire extends AbstractWire implements Wire {
      * Checks if the provided character is a digit (0-9).
      *
      * @param c The character to check
-     * @return true if the character is a digit, false otherwise
+     * @return {@code true} if the character is a digit, false otherwise
      */
     static boolean isDigit(char c) {
         // use underflow to make digits below '0' large.
@@ -321,7 +321,7 @@ public class BinaryWire extends AbstractWire implements Wire {
     /**
      * Checks and returns if this BinaryWire instance is field-less.
      *
-     * @return true if the BinaryWire is field-less, false otherwise.
+     * @return {@code true} if the BinaryWire is field-less, false otherwise.
      */
     public boolean fieldLess() {
         return fieldLess;
@@ -2080,7 +2080,7 @@ public class BinaryWire extends AbstractWire implements Wire {
      * it uses the self-describing value from the provided object.
      *
      * @param object The object whose self-describing status needs to be checked.
-     * @return true if the object should use the self-describing message format, false otherwise.
+     * @return {@code true} if the object should use the self-describing message format, false otherwise.
      */
     public boolean useSelfDescribingMessage(@NotNull CommonMarshallable object) {
         // Check for override or get the value from the object.
@@ -3092,7 +3092,7 @@ public class BinaryWire extends AbstractWire implements Wire {
          *
          * @param l The float value.
          * @param l6 The float value multiplied by 1e6 and rounded.
-         * @return true if the float was written as fixed-point, otherwise false.
+         * @return {@code true} if the float was written as fixed-point, otherwise false.
          */
         private boolean writeAsFixedPoint(float l, long l6) {
             // Try 2 decimal precision
@@ -3128,7 +3128,7 @@ public class BinaryWire extends AbstractWire implements Wire {
          *
          * @param l The double value.
          * @param l6 The double value multiplied by 1e6 and rounded.
-         * @return true if the double was written as fixed-point, otherwise false.
+         * @return {@code true} if the double was written as fixed-point, otherwise false.
          */
         private boolean writeAsFixedPoint(double l, long l6) {
             // (The logic here is the same as for the float method)
@@ -3321,7 +3321,7 @@ public class BinaryWire extends AbstractWire implements Wire {
          * Checks if the provided code corresponds to text data.
          *
          * @param code The code to be checked.
-         * @return true if the code corresponds to text, false otherwise.
+         * @return {@code true} if the code corresponds to text, false otherwise.
          */
         private boolean isText(int code) {
             // Check for general string code or specific length-based codes

--- a/src/main/java/net/openhft/chronicle/wire/BytesInBinaryMarshallable.java
+++ b/src/main/java/net/openhft/chronicle/wire/BytesInBinaryMarshallable.java
@@ -7,7 +7,7 @@ package net.openhft.chronicle.wire;
  * Represents an abstract base class for binary marshallables that primarily deal with bytes.
  * By default, this class does not use self-describing messages.
  * <p>
- * This class extends the {@link AbstractCommonMarshallable} to provide common functionalities
+ * This class extends the {@link AbstractCommonMarshallable} to provide common functionality
  * shared among marshallables.
  */
 public abstract class BytesInBinaryMarshallable extends AbstractCommonMarshallable {

--- a/src/main/java/net/openhft/chronicle/wire/CSVWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/CSVWire.java
@@ -24,7 +24,7 @@ import java.util.List;
 public class CSVWire extends TextWire {
 
     /**
-     * Thread local tester used when parsing CSV fields to honour escaping rules
+     * Thread-local tester used when parsing CSV fields to honour escaping rules
      * for commas within quoted text.
      */
     private static final ThreadLocal<StopCharTester> ESCAPED_END_OF_TEXT = ThreadLocal.withInitial(
@@ -89,7 +89,7 @@ public class CSVWire extends TextWire {
     }
 
     /**
-     * Returns a thread local tester configured for CSV fields and resets its
+     * Returns a thread-local tester configured for CSV fields and resets its
      * state before use.
      */
     @NotNull

--- a/src/main/java/net/openhft/chronicle/wire/DocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/DocumentContext.java
@@ -24,7 +24,7 @@ public interface DocumentContext extends Closeable, SourceContext {
      * Checks it the {@code DocumentContext} is metadata. If it is, {@code true} is
      * returned, otherwise {@code false}.
      *
-     * @return true if the entry is metadata
+     * @return {@code true} if the entry is metadata
      */
     boolean isMetaData();
 
@@ -32,7 +32,7 @@ public interface DocumentContext extends Closeable, SourceContext {
      * Checks if the {@code DocumentContext} is present. If it is, {@code true} is returned,
      * otherwise {@code false}.
      *
-     * @return true if the entry is present
+     * @return {@code true} if the entry is present
      */
     boolean isPresent();
 

--- a/src/main/java/net/openhft/chronicle/wire/GenerateJsonSchemaMain.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateJsonSchemaMain.java
@@ -234,7 +234,7 @@ public class GenerateJsonSchemaMain {
      * This method is typically used to check if a field has a NotNull validation constraint.
      *
      * @param annotations The array of annotations to be checked.
-     * @return true if an annotation with name ending in '.NotNull' is found, false otherwise.
+     * @return {@code true} if an annotation with name ending in '.NotNull' is found, false otherwise.
      */
     private boolean hasNotNull(Annotation[] annotations) {
         for (Annotation annotation : annotations) {

--- a/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
+++ b/src/main/java/net/openhft/chronicle/wire/GenerateMethodReader.java
@@ -689,7 +689,7 @@ public class GenerateMethodReader {
      *
      * @param m                 Method that is being processed.
      * @param instanceFieldName In generated code, method is executed on field with this name.
-     * @param chainedCallPrefix Prefix for method call statement, passed in order to save method result for chaining.
+     * @param chainedCallPrefix Prefix for method call statement, passed to save method result for chaining.
      * @return Code that performs a method call.
      */
     private String methodCall(Method m, String instanceFieldName, String chainedCallPrefix, @Nullable Class<?> returnType) {
@@ -1011,7 +1011,7 @@ public class GenerateMethodReader {
 
         final int packageDelimiterIndex = name.lastIndexOf('.');
 
-        // Intentionally using this instead of class.simpleName() in order to support anonymous class
+        // Intentionally using this instead of class.simpleName() to support anonymous class
         String nameWithoutPackage = packageDelimiterIndex == -1 ? name : name.substring(packageDelimiterIndex + 1);
 
         // Further refine the name for specific synthetic class scenarios.

--- a/src/main/java/net/openhft/chronicle/wire/IdentifierLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/IdentifierLongConverter.java
@@ -11,7 +11,7 @@ import net.openhft.chronicle.wire.converter.SymbolsLongConverter;
  * <p>
  * The base 66 encoding support 0-9, A-Z, a-z, period, underscore, tilde and caret. Leading zeros are truncated.
  * <p>
- * As this is intended for timestamps based on the wall clock, these shouldn't conflict.
+ * As this is intended for timestamps based on the wall-clock, these shouldn't conflict.
  * <p>
  * Negative ids are reserved for application specific encodings.
  */

--- a/src/main/java/net/openhft/chronicle/wire/JSONWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/JSONWire.java
@@ -31,8 +31,8 @@ import static net.openhft.chronicle.bytes.NativeBytes.nativeBytes;
 /**
  * Represents the JSON wire format for text-based marshalling and parsing.
  * <p>
- * This class provides functionality for managing JSON data in a wire format.
- * It currently provides a subset of functionalities similar to the YAML wire format.
+ * This class supports managing JSON data in a wire format.
+ * It currently supports a subset of the YAML wire format's functionality.
  * The core capability of this class is to handle JSON data structures as {@code Bytes}
  * objects, allowing for efficient manipulation and parsing.
  */
@@ -1459,7 +1459,7 @@ public class JSONWire extends TextWire {
          *
          * @param using The object instance to use, or null if not provided.
          * @param clazz The class to parse the object as, or null if not provided.
-         * @param bestEffort Indicates whether to give a best effort attempt to parse the object even if it's partially incorrect.
+         * @param bestEffort Indicates whether to give a best-effort attempt to parse the object even if it's partially incorrect.
          * @return The parsed object.
          * @throws InvalidMarshallableException If there's an issue with unmarshalling the data.
          * @throws ClassCastException If there's a type mismatch between the provided class or instance and the type definition.
@@ -1497,7 +1497,7 @@ public class JSONWire extends TextWire {
          * Checks if the next set of characters in the bytes stream represents a type definition.
          * A type definition is expected to start with the pattern {"@ after consuming any padding.
          *
-         * @return true if a type definition is found, false otherwise.
+         * @return {@code true} if a type definition is found, false otherwise.
          */
         boolean hasTypeDefinition() {
             final long readPos = bytes.readPosition();
@@ -1539,7 +1539,7 @@ public class JSONWire extends TextWire {
         /**
          * Indicates whether types are being used in the current context or not.
          *
-         * @return true if types are being used, false otherwise.
+         * @return {@code true} if types are being used, false otherwise.
          */
         public boolean useTypes() {
             return useTypes;

--- a/src/main/java/net/openhft/chronicle/wire/LongValueBitSet.java
+++ b/src/main/java/net/openhft/chronicle/wire/LongValueBitSet.java
@@ -465,7 +465,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
      * is currently set in this {@code ChronicleBitSet}; otherwise, the result is {@code false}.
      *
      * @param bitIndex the index of the bit to check
-     * @return true if the bit at the specified index is set, false otherwise
+     * @return {@code true} if the bit at the specified index is set, false otherwise
      */
     public boolean get(int bitIndex) {
         throwExceptionIfClosed();
@@ -1014,7 +1014,7 @@ public class LongValueBitSet extends AbstractCloseable implements Marshallable, 
      * This is the {@code long}-consuming and {@code long}-producing primitive specialization for
      * {@link java.util.function.Function}.
      *
-     * <p>For example, this interface can be used to represent functions like addition:
+     * <p>For example, this interface can represent functions like addition:
      * <pre>
      * {@code
      * LongFunction add = (oldValue, param) -> oldValue + param;

--- a/src/main/java/net/openhft/chronicle/wire/MarshallableIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableIn.java
@@ -35,7 +35,7 @@ public interface MarshallableIn {
     int MARSHALLABLE_IN_INTERN_SIZE = Integer.getInteger("marshallableIn.intern.size", 128);
 
     /**
-     * Provides a {@code DocumentContext} that can be used to read data from a source. The specific
+     * Provides a {@code DocumentContext} that can read data from a source. The specific
      * source and the means of reading are determined by the concrete implementation.
      *
      * @return A {@code DocumentContext} appropriate for reading from the underlying source.
@@ -76,7 +76,7 @@ public interface MarshallableIn {
     }
 
     /**
-     * Reads bytes from the source into the provided {@code Bytes} object. This method allows for
+     * Reads bytes from the source into the provided {@code Bytes} object. This method allows
      * direct population of a {@code Bytes} instance without additional translation or processing.
      *
      * @param using The {@code Bytes} object to populate with read data.
@@ -183,7 +183,7 @@ public interface MarshallableIn {
     }
 
     /**
-     * Provides a builder instance that can be used to construct and configure a {@code MethodReader}
+     * Provides a builder instance that can construct and configure a {@code MethodReader}
      * suitable for this reader's content. The builder offers flexibility in configuring the
      * {@code MethodReader} to suit specific requirements.
      *

--- a/src/main/java/net/openhft/chronicle/wire/MarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableOut.java
@@ -47,7 +47,7 @@ public interface MarshallableOut extends DocumentWritten, RollbackIfNotCompleteN
      * WARNING : any data written inside the writingDocument(), should be performed as quickly as
      * possible because a write lock is held until the DocumentContext is closed by the
      * try-with-resources.
-     * For thread safe implementation such as Queue this blocks other appenders. Tailers are never blocked.
+     * For thread-safe implementation such as Queue this blocks other appenders. Tailers are never blocked.
      * <pre>
      * try (DocumentContext dc = appender.writingDocument()) {
      *      // this should be performed as quickly as possible for implementations that support cocurrent writers
@@ -75,7 +75,7 @@ public interface MarshallableOut extends DocumentWritten, RollbackIfNotCompleteN
     DocumentContext acquireWritingDocument(boolean metaData) throws UnrecoverableTimeoutException;
 
     /**
-     * @return true if this output is configured to expect the history of the message to be written
+     * @return {@code true} if this output is configured to expect the history of the message to be written
      * to.
      */
     default boolean recordHistory() {
@@ -251,7 +251,7 @@ public interface MarshallableOut extends DocumentWritten, RollbackIfNotCompleteN
     }
 
     /**
-     * Returns a {@code MethodWriterBuilder} that can be used to create a proxy for an interface.
+     * Returns a {@code MethodWriterBuilder} that can create a proxy for an interface.
      * Each message called on the proxy will be written for replay. This is a convenience method
      * that assumes metadata is not required.
      *
@@ -264,7 +264,7 @@ public interface MarshallableOut extends DocumentWritten, RollbackIfNotCompleteN
     }
 
     /**
-     * Returns a {@code MethodWriterBuilder} that can be used to create a proxy for an interface.
+     * Returns a {@code MethodWriterBuilder} that can create a proxy for an interface.
      * Depending on the {@code metaData} parameter, every method may be written as metadata. Each
      * message called on the proxy will be written to a file for method replay.
      *

--- a/src/main/java/net/openhft/chronicle/wire/MarshallableOutBuilder.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableOutBuilder.java
@@ -11,7 +11,7 @@ import java.util.function.Supplier;
 
 /**
  * This is the {@code MarshallableOutBuilder} class.
- * It provides functionality to construct instances of {@link MarshallableOut} based on a specified URL.
+ * It constructs instances of {@link MarshallableOut} based on a specified URL.
  * The class follows the builder pattern, enabling the caller to set desired configurations and then retrieve
  * the appropriate {@code MarshallableOut} implementation based on the URL's protocol.
  */

--- a/src/main/java/net/openhft/chronicle/wire/MessageHistory.java
+++ b/src/main/java/net/openhft/chronicle/wire/MessageHistory.java
@@ -26,7 +26,7 @@ public interface MessageHistory extends Marshallable {
     /**
      * You only need to call this if you wish to override its behaviour.
      *
-     * @param md to change to the default implementation for this thread. Null to clear the thread local
+     * @param md to change to the default implementation for this thread. Null to clear the thread-local
      *           and force withInitial to be called again
      */
     static void set(MessageHistory md) {

--- a/src/main/java/net/openhft/chronicle/wire/MethodFilterOnFirstArg.java
+++ b/src/main/java/net/openhft/chronicle/wire/MethodFilterOnFirstArg.java
@@ -23,7 +23,7 @@ public interface MethodFilterOnFirstArg<T> {
      * @param methodName The name of the method being evaluated.
      * @param firstArg   The first argument passed to the method.
      *
-     * @return true if the method should be ignored, otherwise false.
+     * @return {@code true} if the method should be ignored, otherwise false.
      */
     boolean ignoreMethodBasedOnFirstArg(String methodName, T firstArg);
 }

--- a/src/main/java/net/openhft/chronicle/wire/RollbackIfNotCompleteNotifier.java
+++ b/src/main/java/net/openhft/chronicle/wire/RollbackIfNotCompleteNotifier.java
@@ -33,7 +33,7 @@ public interface RollbackIfNotCompleteNotifier {
      * reflect the actual completion status of their write operation (for
      * example, the inverse of {@link DocumentContext#isNotComplete()}).
      *
-     * @return true if the current operation is complete, false otherwise
+     * @return {@code true} if the current operation is complete, false otherwise
      */
     default boolean writingIsComplete() {
         return true;

--- a/src/main/java/net/openhft/chronicle/wire/ServicesTimestampLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/ServicesTimestampLongConverter.java
@@ -91,7 +91,7 @@ public class ServicesTimestampLongConverter implements LongConverter {
      * Fetches the current time in the system-configured time unit using the provided TimeProvider.
      *
      * @param clock The {@link net.openhft.chronicle.core.time.TimeProvider} instance used to obtain
-     *              the current time. This allows for custom time sources, for example in tests.
+     *              the current time. This allows custom time sources, for example in tests.
      * @return The current time in the system-configured time unit.
      */
     public static long currentTime(TimeProvider clock) {

--- a/src/main/java/net/openhft/chronicle/wire/ShortTextLongConverter.java
+++ b/src/main/java/net/openhft/chronicle/wire/ShortTextLongConverter.java
@@ -29,7 +29,7 @@ public class ShortTextLongConverter extends AbstractLongConverter {
 
     /**
      * Provides a readily available instance of ShortTextLongConverter for ease of use.
-     * This shared instance allows for convenient access to the converter functionality
+     * This shared instance allows convenient access to the converter functionality
      * without the need for repeated instantiations.
      */
     public static final ShortTextLongConverter INSTANCE = new ShortTextLongConverter();

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -34,7 +34,7 @@ import static net.openhft.chronicle.bytes.NativeBytes.nativeBytes;
 import static net.openhft.chronicle.wire.TextStopCharTesters.END_OF_TYPE;
 
 /**
- * A representation of the YAML-based wire format. `TextWire` provides functionalities
+ * A representation of the YAML-based wire format. `TextWire` supports functionality
  * for reading and writing objects in a YAML-based format, and encapsulates various characteristics
  * of the YAML text format.
  *
@@ -55,7 +55,7 @@ public class TextWire extends YamlWireOut<TextWire> {
     // A set of characters considered as "end characters" in this wire format.
     static final BitSet END_CHARS = new BitSet();
 
-    // Thread locals for stop char testers that might need escaping in specific contexts.
+    // Thread locals for stop-char testers that might need escaping in specific contexts.
     // They are weakly referenced to avoid potential memory leaks in multithreaded environments.
     static final ThreadLocal<WeakReference<StopCharTester>> ESCAPED_QUOTES = new ThreadLocal<>();//ThreadLocal.withInitial(StopCharTesters.QUOTES::escaping);
     static final ThreadLocal<WeakReference<StopCharTester>> ESCAPED_SINGLE_QUOTES = new ThreadLocal<>();//ThreadLocal.withInitial(() -> StopCharTesters.SINGLE_QUOTES.escaping());
@@ -63,7 +63,7 @@ public class TextWire extends YamlWireOut<TextWire> {
     static final ThreadLocal<WeakReference<StopCharsTester>> STRICT_ESCAPED_END_OF_TEXT = new ThreadLocal<>();// ThreadLocal.withInitial(() -> TextStopCharsTesters.END_OF_TEXT.escaping());
     static final Pattern REGX_PATTERN = Pattern.compile("\\.|\\$");
 
-    // Suppliers for various stop char testers.
+    // Suppliers for various stop-char testers.
     static final Supplier<StopCharTester> QUOTES_ESCAPING = StopCharTesters.QUOTES::escaping;
     static final Supplier<StopCharTester> SINGLE_QUOTES_ESCAPING = StopCharTesters.SINGLE_QUOTES::escaping;
     static final Supplier<StopCharTester> END_OF_TEXT_ESCAPING = TextStopCharTesters.END_OF_TEXT::escaping;
@@ -855,7 +855,7 @@ public class TextWire extends YamlWireOut<TextWire> {
      * returns {@code true} if the next string is {@code str}
      *
      * @param source string
-     * @return true if the strings are the same
+     * @return {@code true} if the strings are the same
      */
     protected boolean peekStringIgnoreCase(@NotNull final String source) {
         if (source.isEmpty())
@@ -1774,7 +1774,7 @@ public class TextWire extends YamlWireOut<TextWire> {
          * Checks whether the provided character acts as a separator.
          *
          * @param nextChar Character to be checked
-         * @return true if it's a separator, otherwise false
+         * @return {@code true} if it's a separator, otherwise false
          */
         protected boolean isASeparator(int nextChar) {
             return TextStopCharsTesters.isASeparator(nextChar);
@@ -2843,7 +2843,7 @@ public class TextWire extends YamlWireOut<TextWire> {
         }
 
         /**
-         * @return true if !!null "", if {@code true} reads the !!null "" up to the next STOP, if
+         * @return {@code true} if !!null "", if {@code true} reads the !!null "" up to the next STOP, if
          * {@code false} no  data is read  ( data is only peaked if {@code false} )
          */
         @Override

--- a/src/main/java/net/openhft/chronicle/wire/TextWriteDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWriteDocumentContext.java
@@ -9,10 +9,10 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Provides a concrete implementation of the {@link WriteDocumentContext} for text-based wire representations.
- * This class manages and tracks the state of the document being written and contains functionalities
- * for starting a new write transaction in the document.
+ * This class manages and tracks the state of the document being written and supports
+ * starting a new write transaction in the document.
  * <p>
- * While writing, it can be ensured that meta-data is correctly specified, and the position of the write
+ * While writing, it can ensure that meta-data is correctly specified, and the position of the write
  * operation is recorded.
  */
 public class TextWriteDocumentContext implements WriteDocumentContext {

--- a/src/main/java/net/openhft/chronicle/wire/ValueIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueIn.java
@@ -541,7 +541,7 @@ public interface ValueIn {
      * @param list      of items to populate
      * @param buffer    of objects of the same type to reuse
      * @param bufferAdd supplier to call when the buffer needs extending
-     * @return true if there is any data.
+     * @return {@code true} if there is any data.
      */
     default <T> boolean sequence(@NotNull List<T> list,
                                  @NotNull List<T> buffer,
@@ -888,7 +888,7 @@ public interface ValueIn {
 
     /**
      * Retrieves a {@link ClassLookup} instance associated with the current {@link WireIn}.
-     * The ClassLookup allows for the resolution of class names to actual {@link Class} objects.
+     * The ClassLookup allows the resolution of class names to actual {@link Class} objects.
      *
      * @return The associated ClassLookup instance.
      */
@@ -1239,7 +1239,7 @@ public interface ValueIn {
      * @param <E>        The type of the object to read.
      * @param using      An instance of the object to reuse, or null to create a new instance.
      * @param clazz      The class of the object to read.
-     * @param bestEffort Set to true for best effort reading, which may not throw exceptions for some errors.
+     * @param bestEffort Set to true for best-effort reading, which may not throw exceptions for some errors.
      * @return The object read from the wire, or null if it cannot be read.
      * @throws InvalidMarshallableException if the object is invalid
      */

--- a/src/main/java/net/openhft/chronicle/wire/ValueOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueOut.java
@@ -48,7 +48,7 @@ import static net.openhft.chronicle.wire.Wires.isScalar;
 public interface ValueOut {
 
     /**
-     * Thread local {@link MapMarshaller} to support thread-safe marshalling operations.
+     * Thread-local {@link MapMarshaller} to support thread-safe marshalling operations.
      */
     ThreadLocal<MapMarshaller> MM_TL = ThreadLocal.withInitial(MapMarshaller::new);
 

--- a/src/main/java/net/openhft/chronicle/wire/Wire.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wire.java
@@ -41,7 +41,7 @@ public interface Wire extends WireIn, WireOut {
     /**
      * Indicates whether tuples should be generated.
      * By default, this method returns the value of Wires.GENERATE_TUPLES
-     * @return true if tuples should be generated, false otherwise.
+     * @return {@code true} if tuples should be generated, false otherwise.
      */
     default boolean generateTuples() {
         return Wires.GENERATE_TUPLES;

--- a/src/main/java/net/openhft/chronicle/wire/WireCommon.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireCommon.java
@@ -128,7 +128,7 @@ public interface WireCommon {
     /**
      * If a message is marked as NOT_COMPLETE is it still present.
      *
-     * @return true if NOT_COMPLETE messages can be seen, false if they cannot.
+     * @return {@code true} if NOT_COMPLETE messages can be seen, false if they cannot.
      */
     default boolean notCompleteIsNotPresent() {
         return true;

--- a/src/main/java/net/openhft/chronicle/wire/WireIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireIn.java
@@ -193,7 +193,7 @@ public interface WireIn extends WireCommon, MarshallableIn {
     /**
      * Checks if the WireIn is empty.
      *
-     * @return true if empty, otherwise false.
+     * @return {@code true} if empty, otherwise false.
      */
     default boolean isEmpty() {
         return bytes().isEmpty();
@@ -218,7 +218,7 @@ public interface WireIn extends WireCommon, MarshallableIn {
      *
      * @param metaDataConsumer Consumer that processes the metadata section of the document.
      * @param dataConsumer     Consumer that processes the main data section of the document.
-     * @return true if the document was successfully read, otherwise false.
+     * @return {@code true} if the document was successfully read, otherwise false.
      * @throws InvalidMarshallableException if there's an error during marshalling.
      */
     default boolean readDocument(@Nullable ReadMarshallable metaDataConsumer,
@@ -232,7 +232,7 @@ public interface WireIn extends WireCommon, MarshallableIn {
      * @param position         The position from which to start reading the document.
      * @param metaDataConsumer Consumer that processes the metadata section of the document.
      * @param dataConsumer     Consumer that processes the main data section of the document.
-     * @return true if the document was successfully read from the given position, otherwise false.
+     * @return {@code true} if the document was successfully read from the given position, otherwise false.
      * @throws InvalidMarshallableException if there's an error during marshalling.
      */
     default boolean readDocument(long position,
@@ -347,7 +347,7 @@ public interface WireIn extends WireCommon, MarshallableIn {
     /**
      * Checks if the current position in the stream represents the end of an event or method flow.
      *
-     * @return true if the current position is the end of an event, otherwise false.
+     * @return {@code true} if the current position is the end of an event, otherwise false.
      */
     default boolean isEndEvent() {
         return false;
@@ -362,7 +362,7 @@ public interface WireIn extends WireCommon, MarshallableIn {
     /**
      * Provides a hint about the order in which the input should be read.
      *
-     * @return true if the input should be read in a specific order, otherwise false.
+     * @return {@code true} if the input should be read in a specific order, otherwise false.
      */
     default boolean hintReadInputOrder() {
         return false;
@@ -371,7 +371,7 @@ public interface WireIn extends WireCommon, MarshallableIn {
     /**
      * Checks if the current position in the stream has a metadata prefix.
      *
-     * @return true if there's a metadata prefix at the current position, otherwise false.
+     * @return {@code true} if there's a metadata prefix at the current position, otherwise false.
      */
     default boolean hasMetaDataPrefix() {
         return false;

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -161,7 +161,7 @@ public class WireMarshaller<T> {
      * {@link ReadMarshallable#unexpectedField(Object, ValueIn)} implementation.
      *
      * @param tClass the type to check
-     * @return true if {@code tClass} overrides the method
+     * @return {@code true} if {@code tClass} overrides the method
      */
     private static <T> boolean overridesUnexpectedFields(Class<T> tClass) {
         try {
@@ -716,7 +716,7 @@ public class WireMarshaller<T> {
     }
 
     /**
-     * @return true if this marshaller is for a leaf type
+     * @return {@code true} if this marshaller is for a leaf type
      */
     public boolean isLeaf() {
         return isLeaf;
@@ -1164,7 +1164,7 @@ public class WireMarshaller<T> {
          *
          * @param o  First object.
          * @param o2 Second object.
-         * @return true if values are the same, false otherwise.
+         * @return {@code true} if values are the same, false otherwise.
          * @throws IllegalAccessException If unable to access the field.
          */
         protected boolean sameValue(Object o, Object o2) throws IllegalAccessException {
@@ -2242,7 +2242,7 @@ public class WireMarshaller<T> {
      * for fields that are of type {@link Map}.
      * <p>
      * This extension is designed to manage the parsing and instantiation of the correct {@link Map} type
-     * and provides functionality to work with the key-value pairs within the map.
+     * and works with the key-value pairs within the map.
      */
     static class MapFieldAccess extends FieldAccess {
 

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshallerForUnexpectedFields.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshallerForUnexpectedFields.java
@@ -9,9 +9,9 @@ import net.openhft.chronicle.core.scoped.ScopedResource;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * This class extends the WireMarshaller and provides the ability to handle unexpected fields.
+ * This class extends the WireMarshaller and can handle unexpected fields.
  * It maps fields by their name (both in their original form and lower-cased) for easy access.
- * It overrides the method to read marshallable objects and provides specialized logic to
+ * It overrides the method to read marshallable objects and applies specialized logic to
  * handle unexpected fields that might be present in the data source.
  */
 public class WireMarshallerForUnexpectedFields<T> extends WireMarshaller<T> {

--- a/src/main/java/net/openhft/chronicle/wire/WireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireOut.java
@@ -260,7 +260,7 @@ public interface WireOut extends WireCommon, MarshallableOut {
      * Start the first header, if there is none This will increment the headerNumber as appropriate
      * if successful <p> Note: the file might contain other data and the caller has to check this.
      *
-     * @return true if the header needs to be written, false if there is a data already
+     * @return {@code true} if the header needs to be written, false if there is a data already
      */
     boolean writeFirstHeader();
 

--- a/src/main/java/net/openhft/chronicle/wire/WireType.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireType.java
@@ -97,7 +97,7 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
         }
     },
     /**
-     * High performance binary wire format. This is an alias for
+     * High-performance binary wire format. This is an alias for
      * {@link #BINARY_LIGHT}.
      */
     BINARY {
@@ -120,7 +120,7 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
         }
     },
     /**
-     * High performance binary wire format optimised for speed and size.
+     * High-performance binary wire format optimised for speed and size.
      * Does not support legacy DeltaWire features.
      */
     BINARY_LIGHT {
@@ -764,7 +764,7 @@ public enum WireType implements Function<Bytes<?>, Wire>, LicenceCheck {
      * Indicates if this WireType is of a textual nature.
      * This implementation returns false, indicating it's not textual.
      *
-     * @return true if the WireType is textual; false otherwise.
+     * @return {@code true} if the WireType is textual; false otherwise.
      */
     public boolean isText() {
         return false;

--- a/src/main/java/net/openhft/chronicle/wire/Wires.java
+++ b/src/main/java/net/openhft/chronicle/wire/Wires.java
@@ -221,7 +221,7 @@ public enum Wires {
 
     /**
      * Reads the content of a specified Yaml file and replays the serialized method calls
-     * to the specified object. This can be used to re-execute or simulate a sequence of
+     * to the specified object. This can re-execute or simulate a sequence of
      * operations captured in the Yaml file.
      *
      * @param file the name of the input Yaml file containing serialized method calls
@@ -239,7 +239,7 @@ public enum Wires {
     }
 
     /**
-     * Dumps a sequence of size-prefixed binary messages as a human readable
+     * Dumps a sequence of size-prefixed binary messages as a human-readable
      * string.  The first four bytes of each message contain the length and
      * status flags.  See the <a href="https://github.com/OpenHFT/RFC/tree/master/Size-Prefixed-Blob">Size Prefixed Blob</a>
      * specification.
@@ -383,7 +383,7 @@ public enum Wires {
     }
 
     /**
-     * Dumps the messages from a {@link WireIn} as a human readable string.
+     * Dumps the messages from a {@link WireIn} as a human-readable string.
      *
      * @param wireIn the input wire
      * @return textual dump of the blobs
@@ -567,7 +567,7 @@ public enum Wires {
      * Checks if the given length exceeds the maximum allowed length.
      *
      * @param length the length to check
-     * @return true if the length exceeds the maximum, false otherwise
+     * @return {@code true} if the length exceeds the maximum, false otherwise
      */
     public static boolean exceedsMaxLength(long length) {
         return length > LENGTH_MASK;
@@ -808,7 +808,7 @@ public enum Wires {
      *
      * @param o1 First object
      * @param o2 Second object
-     * @return true if objects are of the same type and equal, false otherwise
+     * @return {@code true} if objects are of the same type and equal, false otherwise
      */
     public static boolean isEquals(@NotNull Object o1, @NotNull Object o2) {
         return o1.getClass() == o2.getClass() && WireMarshaller.WIRE_MARSHALLER_CL.get(o1.getClass()).isEqual(o1, o2);
@@ -1933,7 +1933,7 @@ public enum Wires {
     /**
      * Represents the field information specific to a tuple.
      * <p>
-     * This class extends {@link AbstractFieldInfo} to provide additional functionalities
+     * This class extends {@link AbstractFieldInfo} to provide additional functionality
      * tailored to tuples. It mainly provides a way to deduce the {@link BracketType} of
      * a given serialization strategy and a mechanism to retrieve the fields of a tuple.
      */

--- a/src/main/java/net/openhft/chronicle/wire/YamlKeys.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlKeys.java
@@ -53,7 +53,7 @@ public class YamlKeys {
 
     /**
      * Resets the count of offsets to zero.
-     * This method does not clear the offset data but allows for reuse of the storage.
+     * This method does not clear the offset data but allows reuse of the storage.
      */
     public void reset() {
         count = 0;

--- a/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlTokeniser.java
@@ -902,7 +902,7 @@ public class YamlTokeniser {
     /**
      * Checks if the current position in the stream marks the end of a field (denoted by a colon).
      *
-     * @return true if the current position is a field end, false otherwise.
+     * @return {@code true} if the current position is a field end, false otherwise.
      */
     private boolean isFieldEnd() {
         consumeSpaces(); // Consume any spaces or tabs.
@@ -1145,7 +1145,7 @@ public class YamlTokeniser {
      * Checks if the text of the current block is equal to the provided string.
      *
      * @param s The string to be checked.
-     * @return true if the text of the current block is equal to 's', false otherwise.
+     * @return {@code true} if the text of the current block is equal to 's', false otherwise.
      */
     public boolean isText(String s) {
         // TODO: This method can potentially be optimized for efficiency.

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -623,7 +623,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
      * Determines if the current YAML structure has reached the end of its document.
      * It checks based on the current token from the YamlTokeniser.
      *
-     * @return true if the current token represents the end of a document or the stream; false otherwise.
+     * @return {@code true} if the current token represents the end of a document or the stream; false otherwise.
      */
     private boolean endOfDocument() {
         // Check if there's nothing to read
@@ -885,7 +885,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
      * Checks if the next token's text matches the given key name after handling any escape sequences.
      *
      * @param keyName The expected key name.
-     * @return true if the next token's text matches the given key name; false otherwise.
+     * @return {@code true} if the next token's text matches the given key name; false otherwise.
      */
     private boolean checkForMatch(@NotNull String keyName) {
         YamlToken next = yt.next();
@@ -1745,7 +1745,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
          * @param buffer Temporary storage used during sequence processing.
          * @param bufferAdd Supplier function to add items to the buffer.
          * @param reader0 The reader that processes each item in the sequence.
-         * @return true if the sequence was successfully read, false otherwise.
+         * @return {@code true} if the sequence was successfully read, false otherwise.
          * @throws InvalidMarshallableException If there's a problem with marshalling.
          */
         @Override
@@ -2269,7 +2269,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
         }
 
         /**
-         * @return true if !!null "", if {@code true} reads the !!null "" up to the next STOP, if
+         * @return {@code true} if !!null "", if {@code true} reads the !!null "" up to the next STOP, if
          * {@code false} no  data is read  ( data is only peaked if {@code false} )
          */
         @Override

--- a/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
@@ -35,7 +35,7 @@ import java.util.function.BiConsumer;
 import static net.openhft.chronicle.bytes.BytesStore.empty;
 
 /**
- * Provides functionality for writing data in a YAML-based wire format.
+ * Supports writing data in a YAML-based wire format.
  * This class encapsulates methods and attributes to handle data serialization into YAML format.
  *
  * @param <T> The type that extends YamlWireOut
@@ -494,8 +494,8 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     }
 
     /**
-     * This internal class represents an output value in the YAML format. It provides functionalities related
-     * to appending separators, handling whitespace, and maintaining indentation among others.
+     * This internal class represents an output value in the YAML format. It supports
+     * appending separators, handling whitespace, and maintaining indentation, among other operations.
      */
     class YamlValueOut implements ValueOut, CommentAnnotationNotifier {
         protected boolean hasCommentAnnotation = false;
@@ -885,7 +885,7 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
             prependSeparator();
             bytes.append(i64);
             elementSeparator();
-            // 2001 to 2100 best effort basis.
+            // 2001 to 2100 best-effort basis.
             boolean addTimeStamp = YamlWireOut.this.addTimeStamps && !leaf;
             if (addTimeStamp) {
                 addTimeStamp(i64);

--- a/src/main/java/net/openhft/chronicle/wire/converter/Base16.java
+++ b/src/main/java/net/openhft/chronicle/wire/converter/Base16.java
@@ -15,7 +15,7 @@ import java.lang.annotation.Target;
  * Annotation for fields or parameters to indicate that the annotated long value
  * represents a string of 0 to 16 characters encoded in Base16.
  * <p>
- * This allows for consistent, self-descriptive annotations in fields or parameters,
+ * This allows consistent, self-descriptive annotations in fields or parameters,
  * guiding developers and API users about the intended format of the long value.
  * <p>
  * The Base16 format is often used for representing binary data in an ASCII string format,

--- a/src/main/java/net/openhft/chronicle/wire/domestic/extractor/DocumentExtractor.java
+++ b/src/main/java/net/openhft/chronicle/wire/domestic/extractor/DocumentExtractor.java
@@ -111,7 +111,7 @@ public interface DocumentExtractor<T> {
     // peek
 
     /**
-     * Generic builder that can be used to build DocumentExtractor objects of common types.
+     * Generic builder that can build DocumentExtractor objects of common types.
      *
      * @param <E> element type to extract
      */
@@ -120,7 +120,7 @@ public interface DocumentExtractor<T> {
         /**
          * Specifies a {@code supplier} of element that shall be reused when extracting elements from excerpts.
          * <p>
-         * By default, thread local reuse objects are created on demand but this can be changed by means of the
+         * By default, thread-local reuse objects are created on demand but this can be changed by means of the
          * {@link #withThreadConfinedReuse()} method.
          * <p>
          * The provided supplier must provide distinct objects on each invocation. This can be accomplished
@@ -165,7 +165,7 @@ public interface DocumentExtractor<T> {
     }
 
     /**
-     * Creates and returns a new Builder that can be used to create DocumentExtractor objects
+     * Creates and returns a new Builder that can create DocumentExtractor objects
      * of the provided {@code elementType}.
      *
      * @param elementType type of element to extract

--- a/src/main/java/net/openhft/chronicle/wire/domestic/extractor/ToLongDocumentExtractor.java
+++ b/src/main/java/net/openhft/chronicle/wire/domestic/extractor/ToLongDocumentExtractor.java
@@ -15,7 +15,7 @@ import java.util.function.LongUnaryOperator;
 import static net.openhft.chronicle.core.util.ObjectUtils.requireNonNull;
 
 /**
- * The ToLongDocumentExtractor functional interface allows for the extraction of long values
+ * The ToLongDocumentExtractor functional interface allows the extraction of long values
  * from documents using a given wire and index. It also includes methods to transform
  * and map the extracted values to other types.
  */

--- a/src/main/java/net/openhft/chronicle/wire/domestic/reduction/Reduction.java
+++ b/src/main/java/net/openhft/chronicle/wire/domestic/reduction/Reduction.java
@@ -49,7 +49,7 @@ public interface Reduction<T> extends ExcerptListener {
      * Accepts the input of the provided {@code tailer } and reduces (folds) the contents of it
      * into this Reduction returning the last seen index or -1 if no index was seen.
      * <p>
-     * This method can be used to initialise a Reduction before appending new values.
+     * This method can initialise a Reduction before appending new values.
      * <p>
      * It is the responsibility of the caller to make sure no simultaneous appenders are using
      * this Reduction during the entire fold operation.

--- a/src/main/java/net/openhft/chronicle/wire/domestic/reduction/Reductions.java
+++ b/src/main/java/net/openhft/chronicle/wire/domestic/reduction/Reductions.java
@@ -22,8 +22,8 @@ import static net.openhft.chronicle.core.util.ObjectUtils.requireNonNull;
 
 /**
  * This is the Reductions utility class.
- * It provides static methods to create various types of Reductions, offering functionalities
- * related to longs, doubles, and counting excerpts.
+ * It provides static methods to create various types of Reductions for
+ * longs, doubles, and counting excerpts.
  */
 public final class Reductions {
 

--- a/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
@@ -17,7 +17,7 @@ import java.net.URL;
 import static net.openhft.chronicle.bytes.Bytes.allocateElasticOnHeap;
 
 /**
- * This class allows for the serialization of {@link Marshallable} objects and their transmission over HTTP using the POST method.
+ * This class allows the serialization of {@link Marshallable} objects and their transmission over HTTP using the POST method.
  * It is conceptually similar to the command {@code wget --post-data='{data}' http://{host}:{port}/url...}.
  * <p>
  * The class encapsulates a {@link Wire} which holds the serialized representation. On closure of a document context,

--- a/src/main/java/net/openhft/chronicle/wire/internal/reduction/ReductionUtil.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/reduction/ReductionUtil.java
@@ -23,7 +23,7 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * The ReductionUtil class provides utility methods and inner classes related to the reduction process.
- * It offers functionalities to work with marshallable objects and listeners to read excerpts
+ * It supports marshallable objects and listeners that read excerpts
  * from documents and perform various reduction operations on them.
  */
 public final class ReductionUtil {
@@ -60,7 +60,7 @@ public final class ReductionUtil {
     }
 
     /**
-     * The CollectorReduction class provides functionalities to perform reduction operations using
+     * The CollectorReduction class performs reduction operations using
      * a specific collector and an extractor. It extracts data from a wire, collects it using the
      * provided collector, and then performs the final reduction.
      *
@@ -124,9 +124,9 @@ public final class ReductionUtil {
     }
 
     /**
-     * The LongSupplierReduction class provides functionalities to perform reduction operations
+     * The LongSupplierReduction class performs reduction operations
      * over long values extracted from documents. It reads long values from a wire, accumulates them,
-     * and then offers a final reduction in the form of a LongSupplier.
+     * and then exposes a final reduction in the form of a LongSupplier.
      *
      * @param <A> Intermediate accumulation type.
      */
@@ -186,9 +186,9 @@ public final class ReductionUtil {
     }
 
     /**
-     * The DoubleSupplierReduction class provides functionalities to perform reduction operations
+     * The DoubleSupplierReduction class performs reduction operations
      * over double values extracted from documents. It reads double values from a wire, accumulates them,
-     * and then offers a final reduction in the form of a DoubleSupplier.
+     * and then exposes a final reduction in the form of a DoubleSupplier.
      *
      * @param <A> Intermediate accumulation type.
      */

--- a/src/main/java/net/openhft/chronicle/wire/internal/stream/StreamsUtil.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/stream/StreamsUtil.java
@@ -33,7 +33,7 @@ public final class StreamsUtil {
     }
 
     /**
-     * The VanillaSpliterator class provides basic spliterator functionalities
+     * The VanillaSpliterator class provides basic spliterator functionality
      * over an iterator without any concurrent modifications.
      *
      * @param <T> the type of elements returned by this spliterator.
@@ -102,7 +102,7 @@ public final class StreamsUtil {
 
     /**
      * The VanillaSpliteratorOfLong is a spliterator over a PrimitiveIterator.OfLong,
-     * providing basic spliterator functionalities for long elements.
+     * providing basic spliterator functionality for long elements.
      */
     @SuppressWarnings("overloads")
     public static final class VanillaSpliteratorOfLong
@@ -137,7 +137,7 @@ public final class StreamsUtil {
 
     /**
      * The VanillaSpliteratorOfDouble is a spliterator over a PrimitiveIterator.OfDouble,
-     * providing basic spliterator functionalities for double elements.
+     * providing basic spliterator functionality for double elements.
      */
     @SuppressWarnings("overloads")
     public static final class VanillaSpliteratorOfDouble

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireNumbersTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireNumbersTest.java
@@ -104,7 +104,7 @@ public class BinaryWireNumbersTest extends WireTestCommon {
         perform.writeValue(wire2.write());
 
         // Compare the lengths of the serialized values
-        assertEquals("Lengths for variable length expected " + bytes1
+        assertEquals("Lengths for variable-length expected " + bytes1
                         + " and actual " + bytes2 + " don't match for " + TextWire.asText(wire1),
                 bytes1.readRemaining(), bytes2.readRemaining());
 

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireStringInternerTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireStringInternerTest.java
@@ -64,7 +64,7 @@ public final class BinaryWireStringInternerTest extends WireTestCommon {
 
     // Prepares test data before the test runs
     @Before
-    public void createTestData() throws Exception {
+    public void createTestData() {
         // Populate testData with random strings
         for (int i = 0; i < DATA_SET_SIZE; i++) {
             testData[i] = makeString(random.nextInt(250) + 32, random);
@@ -173,7 +173,7 @@ public final class BinaryWireStringInternerTest extends WireTestCommon {
         private final Consumer<RuntimeException> exceptionConsumer;
 
         private BinaryTextReaderWriter(final Consumer<RuntimeException> exceptionConsumer,
-                                       final Supplier<BinaryWire> binaryWireSupplier) throws IOException {
+                                       final Supplier<BinaryWire> binaryWireSupplier) {
             this.exceptionConsumer = exceptionConsumer;
             this.binaryWireSupplier = binaryWireSupplier;
 

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireTest.java
@@ -1586,7 +1586,7 @@ public class BinaryWireTest extends WireTestCommon {
     }
 
     @Test
-    public void testUsingEvents() throws Exception {
+    public void testUsingEvents() {
         // Creating a wire instance with binary format
         final Wire w = WireType.BINARY.apply(Bytes.allocateElasticOnHeap());
         w.usePadding(true);

--- a/src/test/java/net/openhft/chronicle/wire/CSVBytesMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/CSVBytesMarshallableTest.java
@@ -22,7 +22,7 @@ public class CSVBytesMarshallableTest extends WireTestCommon {
                     "1.50935,1.50936,GBPUSD,5,1,RTRS\n" +
                     "1.0906,1.09065,EURCHF,3,1,EBS\n");
 
-    // Test for low level bytes marshalling using FXPrice
+    // Test for low-level bytes marshalling using FXPrice
     @Test
     public void bytesMarshallable() {
         Bytes<?> bytes2 = Bytes.allocateElasticOnHeap();

--- a/src/test/java/net/openhft/chronicle/wire/ForwardAndBackwardCompatibilityMarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ForwardAndBackwardCompatibilityMarshallableTest.java
@@ -49,7 +49,7 @@ public class ForwardAndBackwardCompatibilityMarshallableTest extends WireTestCom
 
     // Test to check the compatibility of a marshallable StringBuilder
     @Test
-    public void marshableStringBuilderTest() throws Exception {
+    public void marshableStringBuilderTest() {
         final Wire wire = wireType.apply(bytes);
         wire.usePadding(wire.isBinary());
         ClassLookup wrap1 = CLASS_ALIASES.wrap();

--- a/src/test/java/net/openhft/chronicle/wire/JSONLCoverageTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/JSONLCoverageTest.java
@@ -778,8 +778,7 @@ public class JSONLCoverageTest extends WireTestCommon {
             assertNotNull(writer, "methodWriter should return non-null proxy");
 
             // Should also implement the additional interface
-            assertTrue(writer instanceof Events2,
-                    "Proxy should implement additional interface Events2");
+            assertInstanceOf(Events2.class, writer, "Proxy should implement additional interface Events2");
 
             // Write via primary interface
             writer.event("test", 1);

--- a/src/test/java/net/openhft/chronicle/wire/MarshallableOutBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MarshallableOutBuilderTest.java
@@ -151,7 +151,7 @@ public class MarshallableOutBuilderTest extends net.openhft.chronicle.wire.WireT
 
     // Test to ensure only JSON Wire is supported and if BINARY_LIGHT is used, an IllegalArgumentException is thrown.
     @Test(expected = IllegalArgumentException.class)
-    public void httpBinary() throws IOException, InterruptedException {
+    public void httpBinary() throws IOException {
         InetSocketAddress address = new InetSocketAddress(0);
         HttpServer server = HttpServer.create(address, 0);
         int port = server.getAddress().getPort();

--- a/src/test/java/net/openhft/chronicle/wire/MethodReaderDelegationTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MethodReaderDelegationTest.java
@@ -262,10 +262,10 @@ public class MethodReaderDelegationTest extends WireTestCommon {
         };
 
         // Set up the MethodReader to read methods from the wire and handle the designed exception
-        final MethodReader reader = wire.methodReader(useMethodId ? (MyInterfaceMethodId) () -> myInterface.myCall() : myInterface);
+        final MethodReader reader = wire.methodReader(useMethodId ? (MyInterfaceMethodId) myInterface::myCall : myInterface);
 
         // Assert that an InvocationTargetRuntimeException is thrown when trying to read a method
-        assertThrows(InvocationTargetRuntimeException.class, () -> reader.readOne());
+        assertThrows(InvocationTargetRuntimeException.class, reader::readOne);
     }
 
     // TODO: test below with interceptor
@@ -327,13 +327,13 @@ public class MethodReaderDelegationTest extends WireTestCommon {
                 throw new IllegalStateException("This is an exception by design");
             };
             // Set up the MethodReader to read methods from the wire
-            final MethodReader reader = wire.methodReader(useMethodId ? (MyInterfaceMethodId) () -> myInterface.myCall() : myInterface);
+            final MethodReader reader = wire.methodReader(useMethodId ? (MyInterfaceMethodId) myInterface::myCall : myInterface);
 
             // Check if the reader is of type VanillaMethodReader when proxy is enabled
             assertEquals(proxy, reader instanceof VanillaMethodReader);
 
             // Assert that an InvocationTargetRuntimeException is thrown when trying to read a method
-            assertThrows(InvocationTargetRuntimeException.class, () -> reader.readOne());
+            assertThrows(InvocationTargetRuntimeException.class, reader::readOne);
         } finally {
             // Clear the system property to reset its original state
             System.clearProperty(DISABLE_READER_PROXY_CODEGEN);
@@ -375,13 +375,13 @@ public class MethodReaderDelegationTest extends WireTestCommon {
                 throw new IllegalStateException("This is an exception by design");
             };
             // Set up the MethodReader to read methods from the wire
-            final MethodReader reader = wire.methodReader(useMethodId ? (MyInterfaceLongMethodId) (l) -> myInterface.myCall(l) : myInterface);
+            final MethodReader reader = wire.methodReader(useMethodId ? (MyInterfaceLongMethodId) myInterface::myCall : myInterface);
 
             // Check if the reader is of type VanillaMethodReader when proxy is enabled
             assertEquals(proxy, reader instanceof VanillaMethodReader);
 
             // Assert that an InvocationTargetRuntimeException is thrown when trying to read a method
-            assertThrows(InvocationTargetRuntimeException.class, () -> reader.readOne());
+            assertThrows(InvocationTargetRuntimeException.class, reader::readOne);
         } finally {
             // Clear the system property to reset its original state
             System.clearProperty(DISABLE_READER_PROXY_CODEGEN);

--- a/src/test/java/net/openhft/chronicle/wire/ProjectTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ProjectTest.java
@@ -42,7 +42,7 @@ public class ProjectTest extends WireTestCommon {
     // Test case to verify the projection functionality between two data transfer objects.
     @SuppressWarnings("unchecked")
     @Test
-    public void testProject() throws Exception {
+    public void testProject() {
         assumeFalse(Jvm.maxDirectMemory() == 0);
 
         // Initialize the first DTO with sample data

--- a/src/test/java/net/openhft/chronicle/wire/RawWirePerfMain.java
+++ b/src/test/java/net/openhft/chronicle/wire/RawWirePerfMain.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertTrue;
 
 public class RawWirePerfMain extends WireTestCommon {
 
-    public static void main(String[] args) throws StreamCorruptedException {
+    public static void main(String[] args) {
         // Create an instance of BinaryWirePerfTest with specific parameters.
         // These parameters typically control the test conditions.
         @NotNull BinaryWirePerfTest test = new BinaryWirePerfTest(-1, true, false, true);

--- a/src/test/java/net/openhft/chronicle/wire/ReadDocumentContextTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ReadDocumentContextTest.java
@@ -158,7 +158,7 @@ public class ReadDocumentContextTest extends WireTestCommon {
     }
 
     @Test
-    public void testReadingADocumentThatHasNotBeenFullyReadFromTheTcpSocketAt2Bytes() throws Exception {
+    public void testReadingADocumentThatHasNotBeenFullyReadFromTheTcpSocketAt2Bytes() {
         // Create an elastic byte buffer
         Bytes<?> b = Bytes.allocateElasticOnHeap();
 

--- a/src/test/java/net/openhft/chronicle/wire/ReadOneTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ReadOneTest.java
@@ -64,7 +64,7 @@ public class ReadOneTest extends WireTestCommon {
     }
 
     // Core testing method that simulates writing to and reading from the Wire
-    private void doTest(boolean scanning) throws InterruptedException {
+    private void doTest(boolean scanning) {
         ignoreException("Unknown @MethodId='history' called on interface net.openhft.chronicle.wire.ReadOneTest$SnapshotListener");
         ignoreException("Unknown method-name='myDto' called on interface net.openhft.chronicle.wire.ReadOneTest$SnapshotListener");
         // Initialization phase

--- a/src/test/java/net/openhft/chronicle/wire/ReadmeChapter1Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/ReadmeChapter1Test.java
@@ -301,7 +301,7 @@ Data{message='Hello World', number=1234567890, timeUnit=NANOSECONDS, price=10.5}
     @Test
     public void example5() {
 /*
-## Write a message with a thread safe size prefix.
+## Write a message with a thread-safe size prefix.
 
 The benefits of using this approach ares that
  - the reader can block until the message is complete.

--- a/src/test/java/net/openhft/chronicle/wire/ReadmePojoTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ReadmePojoTest.java
@@ -49,7 +49,7 @@ public class ReadmePojoTest extends WireTestCommon {
     }
 
     @Test
-    public void testMapDump() throws IOException {
+    public void testMapDump() {
         // Creating a LinkedHashMap with various key-value pairs
         @NotNull Map<String, Object> map = new LinkedHashMap<>();
         map.put("text", "words");

--- a/src/test/java/net/openhft/chronicle/wire/SkipValueTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/SkipValueTest.java
@@ -113,7 +113,7 @@ public class SkipValueTest extends net.openhft.chronicle.wire.WireTestCommon {
                 {null, STRING_ANY, wr(v -> v.text("Long string 012345678901234567890123456789"))},
 //        public static final int EVENT_NAME = 0xB9;
 //        public static final int FIELD_NUMBER = 0xBA;
-                {null, NULL, wr(v -> v.nu11())},
+                {null, NULL, wr(ValueOut::nu11)},
                 {null, TYPE_LITERAL, wr(v -> v.typeLiteral(String.class))},
 //        public static final int EVENT_OBJECT = 0xBD;
                 {null, COMMENT, wr(v -> v.wireOut().writeComment("hi").getValueOut().text("hi"))},

--- a/src/test/java/net/openhft/chronicle/wire/TextWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TextWireTest.java
@@ -220,7 +220,7 @@ public class TextWireTest extends WireTestCommon {
 
     // Test to check the license validation for different WireTypes.
     @Test
-    public void licenseCheck() {
+    public void licenceCheck() {
         // Verify that TEXT WireType doesn't require any license check.
         WireType.TEXT.licenceCheck();
         assertTrue(WireType.TEXT.isAvailable());
@@ -1967,13 +1967,13 @@ public class TextWireTest extends WireTestCommon {
 
     // Test for attempting to serialize a non-serializable object (current thread).
     @Test(expected = IllegalArgumentException.class)
-    public void writeUnserializable1() throws IOException {
+    public void writeUnserializable1() {
         System.out.println(TEXT.asString(Thread.currentThread()));
     }
 
     // Test for attempting to serialize a non-serializable object (socket instance).
     @Test(expected = IllegalArgumentException.class)
-    public void writeUnserializable2() throws IOException {
+    public void writeUnserializable2() {
         @NotNull Socket s = new Socket();
         System.out.println(TEXT.asString(s));
     }

--- a/src/test/java/net/openhft/chronicle/wire/TupleInvocationHandlerTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/TupleInvocationHandlerTest.java
@@ -36,8 +36,8 @@ public class TupleInvocationHandlerTest extends WireTestCommon {
 
         int hash = tuple.hashCode();
         assertTrue(hash != 0);
-        assertTrue(tuple.equals(tuple));
-        assertFalse(tuple.equals("other"));
+        assertEquals(tuple, tuple);
+        assertNotEquals("other", tuple);
 
         SampleTuple copy = tuple.deepCopy();
         assertNotNull(copy);
@@ -58,9 +58,9 @@ public class TupleInvocationHandlerTest extends WireTestCommon {
     }
 
     interface SampleTuple extends Marshallable {
-        void setField(String name, Object value) throws NoSuchFieldException;
+        void setField(String name, Object value);
 
-        <T> T getField(String name, Class<T> type) throws NoSuchFieldException;
+        <T> T getField(String name, Class<T> type);
 
         List<FieldInfo> $fieldInfos();
     }

--- a/src/test/java/net/openhft/chronicle/wire/WireTypeConverterTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireTypeConverterTest.java
@@ -38,7 +38,7 @@ public class WireTypeConverterTest extends net.openhft.chronicle.wire.WireTestCo
     }
 
     @Test
-    public void testYamlToJsonUnknownClass() throws Exception {
+    public void testYamlToJsonUnknownClass() {
         Assert.assertEquals(jsonUnknownClass, new WireTypeConverter().yamlToJson(yamlUnknownClass).toString());
         Assert.assertEquals(yamlUnknownClass, new WireTypeConverter().jsonToYaml(jsonUnknownClass).toString());
     }

--- a/src/test/java/net/openhft/chronicle/wire/YamlWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/YamlWireTest.java
@@ -1697,14 +1697,14 @@ public class YamlWireTest extends WireTestCommon {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void writeUnserializable() throws IOException {
+    public void writeUnserializable() {
         assumeFalse(Jvm.maxDirectMemory() == 0);
 
         System.out.println(WireType.YAML_ONLY.asString(Thread.currentThread()));
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void writeUnserializable2() throws IOException {
+    public void writeUnserializable2() {
         assumeFalse(Jvm.maxDirectMemory() == 0);
 
         @NotNull Socket s = new Socket();

--- a/src/test/java/net/openhft/chronicle/wire/examples/MessageRoutingExample.java
+++ b/src/test/java/net/openhft/chronicle/wire/examples/MessageRoutingExample.java
@@ -44,7 +44,7 @@ public class MessageRoutingExample {
     }
 
     /**
-     * A example of a simple business event
+     * An example of a simple business event
      */
     static class Product extends SelfDescribingMarshallable {
         String name;

--- a/src/test/java/net/openhft/chronicle/wire/issue/Issue886Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/issue/Issue886Test.java
@@ -33,7 +33,7 @@ public class Issue886Test {
     }
 
     @Test
-    public void test() throws IOException {
+    public void test() {
         String data = "{\n" +
                 "  \"a\": 1.234,\n" +
                 "  \"a1\": '1.234'\n" +

--- a/src/test/java/net/openhft/chronicle/wire/map/MapCustomTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/map/MapCustomTest.java
@@ -13,6 +13,7 @@ import java.math.BigDecimal;
 import java.util.*;
 import java.util.function.Function;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -35,7 +36,7 @@ public class MapCustomTest extends WireTestCommon {
         MapsHolder<Integer> result = Wires.deepCopy(mapsHolder);
 
         // Assert that the copied object is equivalent to the original
-        assertTrue(result.equals(mapsHolder));
+        assertEquals(result, mapsHolder);
     }
 
     /**

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/B2Class.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/B2Class.java
@@ -17,14 +17,14 @@ public class B2Class extends BClass {
         super(id, flag, b, ch, s, i, l, f, d, text);
     }
 
-    // Overrides the writeMarshallable method to first serialize the data from the superclass and then write the current version number using stop bit encoding.
+    // Overrides the writeMarshallable method to first serialize the data from the superclass and then write the current version number using stop-bit encoding.
     @Override
     public void writeMarshallable(BytesOut<?> out) {
         super.writeMarshallable(out);
         out.writeStopBit(MASHALLABLE_VERSION);
     }
 
-    // Overrides the readMarshallable method to first deserialize the data from the superclass and then read the version number using stop bit decoding.
+    // Overrides the readMarshallable method to first deserialize the data from the superclass and then read the version number using stop-bit decoding.
     @Override
     public void readMarshallable(BytesIn<?> in) {
         super.readMarshallable(in);

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/JSONWithAMapTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/JSONWithAMapTest.java
@@ -91,7 +91,7 @@ public class JSONWithAMapTest extends net.openhft.chronicle.wire.WireTestCommon 
         }
 
         // check the number of '{' match the number of '}'
-        Assert.assertTrue("openBracket=" + openBracket + ",closeBracket=" + closeBracket, openBracket == closeBracket);
+        Assert.assertEquals("openBracket=" + openBracket + ",closeBracket=" + closeBracket, openBracket, closeBracket);
 
         // DON'T CHANGE THE EXPECTED JSON IT IS CORRECT ! - please use this website to validate the json - https://jsonformatter.org
         Assert.assertEquals(expected, actual);

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/UnknownDatatimeTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/UnknownDatatimeTest.java
@@ -22,7 +22,7 @@ public class UnknownDatatimeTest extends WireTestCommon {
      * Tests if an unknown datetime can be ignored during deserialization.
      */
     @Test
-    public void ignoreAnUnknownDateTime() throws IOException {
+    public void ignoreAnUnknownDateTime() {
         // Deserialize an instance of AClass from a string.
         // The string contains a datetime field 'eventTime' which is not expected to exist in AClass.
         AClass aClass = Marshallable.fromString("!" + AClass.class.getName() + " { eventTime: 2019-04-02T11:20:41.616653, id: 123456 }");


### PR DESCRIPTION
## Summary

Polishes wording across repository docs, Wire API Javadocs, internal helper docs, and test comments/fixtures.

## Impact

Most changes are wording-only standardisation, including terms such as best-effort, thread-local, thread-safe, high-performance, and low-level. The test cleanup removes unused checked exceptions, uses clearer assertion helpers, and simplifies a few lambdas to method references without changing test intent.

## Validation

- `git diff --check origin/develop..HEAD`
- `mvn -q -DskipTests test-compile`