### PR TITLE
Add `@FieldOrder` for explicit marshalling field order

### DIFF
--- a/src/main/docs/project-requirements.adoc
+++ b/src/main/docs/project-requirements.adoc
@@ -74,7 +74,7 @@ Schema Evolution and Versioning ::
 * **Comparison:** Explicit comparison of Wire's schema evolution capabilities with those of Protobuf and Avro.
 
 Annotations for Fine-Grained Control and Customisation ::
-* For each key annotation (e.g., `@LongConversion`, `@NanoTime`, `@Base64`, `@Base85`, `@ShortText`, `@MaxUtf8Len`, `@Comment`, `@FieldNumber`):
+* For each key annotation (e.g., `@LongConversion`, `@NanoTime`, `@Base64`, `@Base85`, `@ShortText`, `@MaxUtf8Len`, `@Comment`, `@FieldNumber`, `@FieldOrder`):
 ** **Purpose and Functionality:** Clear explanation of what the annotation does.
 ** **Parameters:** Description of any parameters the annotation takes.
 ** **Impact:** How it affects serialisation in different `WireType`s (e.g., text vs. binary representation).
@@ -268,4 +268,3 @@ Access to Resources :: Development of this documentation will have access to the
 Benchmark Data :: Performance comparisons will rely on publicly available benchmark results, with appropriate attribution and caveats. No new primary benchmarking activities are within the scope of this documentation project itself.
 
 Source Document :: The initial technical review document that prompted this requirements specification serves as a foundational research base.
-

--- a/src/main/docs/wire-annotations.adoc
+++ b/src/main/docs/wire-annotations.adoc
@@ -205,6 +205,45 @@ public class FinancialInstrument extends SelfDescribingMarshallable {
 
 IMPORTANT: Ensure field numbers are unique within a class hierarchy if polymorphism and shared binary formats are involved.
 
+=== `@FieldOrder`
+
+Purpose :: To give a `Marshallable` type an explicit, repeatable field serialisation order instead of relying on reflection order.
+
+Target :: Type
+
+Attributes ::
+`value` (String[]):: The names of all non-static, non-transient marshallable fields declared directly on the annotated class, in the order they should be written. Names are trimmed before validation and lookup.
+
+Behaviour ::
+* **Text Formats:** Fields are emitted in the declared order, which keeps string and YAML assertions stable across JVMs.
+* **Binary Formats:** Named-field binary formats use the same marshaller field order when writing fields. Formats that omit field names remain sensitive to sender and receiver schema agreement.
+* **Inheritance:** The annotation applies only to fields declared directly on the annotated class. Inherited fields keep the order declared by their own class.
+* **Validation:** Chronicle Wire rejects incomplete lists, duplicate names, blank names, and names that do not resolve to marshallable fields.
+
+Use Case :: Stabilising serialised output for classes whose field order is part of a test fixture, text dump, or fieldless/named binary compatibility contract.
+
+Example ::
+[source,java]
+----
+import net.openhft.chronicle.wire.FieldOrder;
+import net.openhft.chronicle.wire.SelfDescribingMarshallable;
+
+@FieldOrder({"baseId", "createdTime"})
+class Base extends SelfDescribingMarshallable {
+    long createdTime;
+    long baseId;
+}
+
+@FieldOrder({"symbol", "price", "quantity"})
+class Trade extends Base {
+    double price;
+    String symbol;
+    long quantity;
+}
+----
+
+The resulting order is `baseId`, `createdTime`, then `symbol`, `price`, `quantity`.
+
 === `@Comment`
 
 Purpose :: To add a descriptive comment to a field, which will be included in some text-based wire formats, typically YAML.
@@ -248,10 +287,10 @@ AppConfig {
 
 == Best Practices for Using Annotations
 
-* **Be Purposeful:** Use annotations where they add clear value, such as improving readability in text formats (`@Comment`, `@NanoTime`), optimising binary size/performance (`@LongConversion`, `@FieldNumber`), or ensuring schema stability (`@FieldNumber`).
+* **Be Purposeful:** Use annotations where they add clear value, such as improving readability in text formats (`@Comment`, `@NanoTime`), optimising binary size/performance (`@LongConversion`, `@FieldNumber`), or ensuring schema stability (`@FieldNumber`, `@FieldOrder`).
 * **Understand Format Impact:** Be aware that some annotations only affect text formats (e.g., `@Comment`), while others primarily impact binary formats (e.g., `@FieldNumber`'s core use).
 * **Consistency:** Apply annotations consistently across related `Marshallable` classes for predictable behaviour.
-* **Test Thoroughly:** When using annotations that affect data representation or schema (like `@LongConversion` or `@FieldNumber`), thoroughly test both serialisation and deserialisation, especially across different versions of your classes if schema evolution is a concern.
+* **Test Thoroughly:** When using annotations that affect data representation or schema (like `@LongConversion`, `@FieldNumber`, or `@FieldOrder`), thoroughly test both serialisation and deserialisation, especially across different versions of your classes if schema evolution is a concern.
 * **Consult Javadoc:** The Javadoc for each annotation is the ultimate source of truth for its specific attributes and behaviour in the version of Chronicle Wire you are using.
 * **Keep it Simple:** While powerful, avoid over-using annotations if simpler solutions suffice. The default behaviour of `SelfDescribingMarshallable` is often sufficient for many use cases.
 

--- a/src/main/docs/wire-schema-evolution.adoc
+++ b/src/main/docs/wire-schema-evolution.adoc
@@ -184,7 +184,7 @@ Strategy :: When a field type must change, the safest approach is often to:
 
 The `FIELDLESS_BINARY` `WireType` is designed for extreme performance and compactness by omitting all field names and numbers.
 
-* **Mechanism:** Data is written as a direct sequence of field values in the exact order they are declared in the `Marshallable` class.
+* **Mechanism:** Data is written as a direct sequence of field values in the marshaller order. By default this is the order fields are discovered on the `Marshallable` class; `@FieldOrder` can make that order explicit for fields declared directly on a class.
 +
 [source,java]
 ----
@@ -195,7 +195,7 @@ class MyFieldlessData extends SelfDescribingMarshallable {
 }
 ----
 * **Brittleness:** This format is *extremely* intolerant of schema changes:
-** **Order Matters:** Changing the order of fields in the class breaks deserialisation.
+** **Order Matters:** Changing the marshaller order of fields breaks deserialisation. `@FieldOrder` can stabilise the order, but the reader and writer must still use the same field order, types, and count.
 ** **Type Matters:** Changing a field's type (e.g., `int` to `long`) breaks deserialisation as the number of bytes read/written will mismatch.
 ** **Count Matters:** Adding or removing fields breaks deserialisation.
 * **Consequences of Mismatch:** `BufferUnderflowException`, `BufferOverflowException`, reading garbage data, or application-level errors due to incorrect field values.

--- a/src/main/java/net/openhft/chronicle/wire/FieldOrder.java
+++ b/src/main/java/net/openhft/chronicle/wire/FieldOrder.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.wire;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Defines the marshalling order for fields declared directly on the annotated class.
+ * Field names are trimmed before validation and lookup.
+ * Inherited fields keep the order declared by their own class.
+ * <p>
+ * The value must name every non-static, non-transient marshallable field declared
+ * directly on the annotated class exactly once. It must not include inherited,
+ * static, transient, blank, duplicate, or unknown field names.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface FieldOrder {
+    /**
+     * Returns the ordered names of all directly declared marshallable fields.
+     *
+     * @return the field names in marshalling order
+     */
+    String[] value();
+}

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -207,28 +207,104 @@ public class WireMarshaller<T> {
      * Recursively fetches all non-static, non-transient fields from the provided class and its superclasses,
      * up to but not including Object or AbstractCommonMarshallable, and adds them to the provided map.
      * Fields that are flagged for exclusion (e.g., the "ordinal" field for Enum types) are skipped.
+     * If a class declares {@link FieldOrder}, that annotation controls the insertion order for fields
+     * declared directly on that class and invalid declarations are rejected.
      *
      * @param clazz The class type from which fields are to be extracted.
      * @param map   The map to populate with field names and their corresponding Field objects.
+     * @throws IllegalArgumentException if {@link FieldOrder} is incomplete, duplicated, blank,
+     *                                  or names an unknown or non-marshallable field
      */
-    public static void getAllField(@NotNull Class<?> clazz, @NotNull Map<String, Field> map) {
+    public static void getAllField(@NotNull Class<?> clazz,
+                                   @NotNull Map<String, Field> map) {
         if (clazz != Object.class && clazz != AbstractCommonMarshallable.class)
             getAllField(clazz.getSuperclass(), map);
-        for (@NotNull Field field : clazz.getDeclaredFields()) {
-            if ((field.getModifiers() & (Modifier.STATIC | Modifier.TRANSIENT)) != 0)
-                continue;
-            String fieldName = field.getName();
-            if (("ordinal".equals(fieldName) || "hash".equals(fieldName)) && Enum.class.isAssignableFrom(clazz))
-                continue;
-            String name = fieldName;
-            if (name.startsWith("this$0")) {
-                if (ValidatableUtil.validateEnabled())
-                    Jvm.warn().on(WireMarshaller.class, "Found " + name + ", in " + clazz + " which will be ignored!");
-                continue;
-            }
+
+        for (@NotNull Field field : orderedDeclaredFields(clazz)) {
+            String name = field.getName();
             Jvm.setAccessible(field);
             map.put(name, field);
         }
+    }
+
+    private static Field[] orderedDeclaredFields(@NotNull Class<?> clazz) {
+        boolean isEnum = Enum.class.isAssignableFrom(clazz);
+        Map<String, Field> marshallable = new LinkedHashMap<>();
+        Map<String, Field> declared = new LinkedHashMap<>();
+
+        for (@NotNull Field field : clazz.getDeclaredFields()) {
+            declared.put(field.getName(), field);
+            if (isMarshallableField(clazz, field, isEnum))
+                marshallable.put(field.getName(), field);
+        }
+
+        FieldOrder order = clazz.getAnnotation(FieldOrder.class);
+
+        if (order == null)
+            return marshallable.values().toArray(new Field[0]);
+
+        String[] names = order.value();
+        Field[] ordered = new Field[names.length];
+        Set<String> seen = new HashSet<>();
+
+        for (int i = 0; i < names.length; i++) {
+            String name = Objects.requireNonNull(names[i],
+                    clazz.getName() + " @FieldOrder contains null at index " + i).trim();
+
+            if (name.isEmpty()) {
+                throw new IllegalArgumentException(clazz.getName()
+                        + " @FieldOrder contains blank field name at index " + i);
+            }
+
+            if (!seen.add(name)) {
+                throw new IllegalArgumentException(clazz.getName()
+                        + " @FieldOrder contains duplicate field: " + name);
+            }
+
+            Field field = marshallable.get(name);
+            if (field == null) {
+                if (declared.containsKey(name)) {
+                    throw new IllegalArgumentException(clazz.getName()
+                            + " @FieldOrder references non-marshallable field: " + name
+                            + " (static, transient, or otherwise excluded)");
+                }
+                throw new IllegalArgumentException(clazz.getName()
+                        + " @FieldOrder references unknown field: " + name
+                        + "; declared marshallable fields are " + marshallable.keySet());
+            }
+
+            ordered[i] = field;
+        }
+
+        if (seen.size() != marshallable.size()) {
+            Set<String> missing = new LinkedHashSet<>(marshallable.keySet());
+            missing.removeAll(seen);
+            throw new IllegalArgumentException(clazz.getName()
+                    + " @FieldOrder is missing marshallable fields: " + missing);
+        }
+
+        return ordered;
+    }
+
+    private static boolean isMarshallableField(@NotNull Class<?> clazz,
+                                               @NotNull Field field,
+                                               boolean isEnum) {
+        if ((field.getModifiers() & (Modifier.STATIC | Modifier.TRANSIENT)) != 0)
+            return false;
+
+        String fieldName = field.getName();
+
+        if (isEnum && ("ordinal".equals(fieldName) || "hash".equals(fieldName)))
+            return false;
+
+        if (fieldName.startsWith("this$0")) {
+            if (ValidatableUtil.validateEnabled())
+                Jvm.warn().on(WireMarshaller.class,
+                        "Found " + fieldName + ", in " + clazz + " which will be ignored!");
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/test/java/net/openhft/chronicle/wire/AbstractMarshallableCfgTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/AbstractMarshallableCfgTest.java
@@ -14,18 +14,21 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assume.assumeFalse;
 
 public class AbstractMarshallableCfgTest extends WireTestCommon{
+    @FieldOrder({"nestedAMC", "nestedSDM"})
     static class MyAMC extends AbstractMarshallableCfg {
         NestedAMC nestedAMC = new NestedAMC();  // Configuration nested inside MyAMC
         NestedSDM nestedSDM = new NestedSDM();  // Self-describing data nested inside MyAMC
     }
 
     // Define a nested configuration class that also extends AbstractMarshallableCfg
+    @FieldOrder({"number", "flag"})
     static class NestedAMC extends AbstractMarshallableCfg {
         long number = 128;    // Default value for the number
         boolean flag;        // Boolean flag
     }
 
     // Define a nested self-describing data class
+    @FieldOrder({"bytes", "amt"})
     static class NestedSDM extends SelfDescribingMarshallable {
         Bytes<ByteBuffer> bytes = Bytes.elasticHeapByteBuffer();
         double amt = 1.0;

--- a/src/test/java/net/openhft/chronicle/wire/WireMarshallerTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireMarshallerTest.java
@@ -3,12 +3,18 @@
  */
 package net.openhft.chronicle.wire;
 
+import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.bytes.HexDumpBytes;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.pool.ClassAliasPool;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeFalse;
 
 public class WireMarshallerTest extends WireTestCommon {
@@ -61,5 +67,185 @@ public class WireMarshallerTest extends WireTestCommon {
 
         // Release the resources used by the HexDumpBytes object.
         bytes.releaseLast();
+    }
+
+    @Test
+    public void fieldOrderAppliesPerClassInInheritanceHierarchy() {
+        Map<String, Field> fields = new LinkedHashMap<>();
+        WireMarshaller.getAllField(Trade.class, fields);
+
+        assertEquals("baseId,createdTime,symbol,price,quantity",
+                String.join(",", fields.keySet()));
+    }
+
+    @Test
+    public void fieldOrderControlsSelfDescribingMarshallableOutput() {
+        Trade trade = new Trade();
+        trade.baseId = 17;
+        trade.createdTime = 123456789L;
+        trade.symbol = "EURUSD";
+        trade.price = 1.2345;
+        trade.quantity = 1_000;
+
+        assertEquals("!net.openhft.chronicle.wire.WireMarshallerTest$Trade {\n" +
+                "  baseId: 17,\n" +
+                "  createdTime: 123456789,\n" +
+                "  symbol: EURUSD,\n" +
+                "  price: 1.2345,\n" +
+                "  quantity: 1000\n" +
+                "}\n", trade.toString());
+    }
+
+    @Test
+    public void fieldOrderRejectsIncompleteFieldList() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> WireMarshaller.of(IncompleteFieldOrder.class));
+
+        assertEquals(WireMarshallerTest.class.getName()
+                        + "$IncompleteFieldOrder @FieldOrder is missing marshallable fields: [second]",
+                e.getMessage());
+    }
+
+    @Test
+    public void fieldOrderRejectsDuplicateFieldNames() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> WireMarshaller.of(DuplicateFieldOrder.class));
+
+        assertEquals(WireMarshallerTest.class.getName()
+                        + "$DuplicateFieldOrder @FieldOrder contains duplicate field: first",
+                e.getMessage());
+    }
+
+    @Test
+    public void fieldOrderRejectsBlankFieldNames() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> WireMarshaller.of(BlankFieldOrder.class));
+
+        assertEquals(WireMarshallerTest.class.getName()
+                        + "$BlankFieldOrder @FieldOrder contains blank field name at index 1",
+                e.getMessage());
+    }
+
+    @Test
+    public void fieldOrderTrimsWhitespaceAroundFieldNames() {
+        Map<String, Field> fields = new LinkedHashMap<>();
+        WireMarshaller.getAllField(WhitespaceFieldOrder.class, fields);
+
+        assertEquals("second,first", String.join(",", fields.keySet()));
+    }
+
+    @Test
+    public void fieldOrderRejectsDuplicateFieldNamesAfterTrimming() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> WireMarshaller.of(TrimmedDuplicateFieldOrder.class));
+
+        assertEquals(WireMarshallerTest.class.getName()
+                        + "$TrimmedDuplicateFieldOrder @FieldOrder contains duplicate field: first",
+                e.getMessage());
+    }
+
+    @Test
+    public void fieldOrderRejectsTransientField() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> WireMarshaller.of(UnknownFieldOrder.class));
+
+        assertEquals(WireMarshallerTest.class.getName()
+                        + "$UnknownFieldOrder @FieldOrder references non-marshallable field: ignored (static, transient, or otherwise excluded)",
+                e.getMessage());
+    }
+
+    @Test
+    public void fieldOrderRejectsInheritedFieldName() {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> WireMarshaller.of(InheritedFieldOrder.class));
+
+        assertEquals(WireMarshallerTest.class.getName()
+                        + "$InheritedFieldOrder @FieldOrder references unknown field: parentField; declared marshallable fields are [childField]",
+                e.getMessage());
+    }
+
+    @Test
+    public void fieldlessBinaryWithMismatchedFieldOrderSwapsValues() {
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        try {
+            WireType.FIELDLESS_BINARY.apply(bytes).getValueOut().object(new SenderXYZ(1, 2, 3));
+            ReceiverZYX r = WireType.FIELDLESS_BINARY.apply(bytes).getValueIn().object(ReceiverZYX.class);
+            assertEquals(3, r.x);
+            assertEquals(2, r.y);
+            assertEquals(1, r.z);
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+
+    @FieldOrder({"baseId", "createdTime"})
+    static class Base extends SelfDescribingMarshallable {
+        long createdTime;
+        long baseId;
+    }
+
+    @FieldOrder({"symbol", "price", "quantity"})
+    static class Trade extends Base {
+        double price;
+        String symbol;
+        long quantity;
+    }
+
+    @FieldOrder({"first"})
+    static class IncompleteFieldOrder extends SelfDescribingMarshallable {
+        int first;
+        int second;
+    }
+
+    @FieldOrder({"first", "first"})
+    static class DuplicateFieldOrder extends SelfDescribingMarshallable {
+        int first;
+        int second;
+    }
+
+    @FieldOrder({"first", " "})
+    static class BlankFieldOrder extends SelfDescribingMarshallable {
+        int first;
+        int second;
+    }
+
+    @FieldOrder({" second ", " first "})
+    static class WhitespaceFieldOrder extends SelfDescribingMarshallable {
+        int first;
+        int second;
+    }
+
+    @FieldOrder({"first", " first "})
+    static class TrimmedDuplicateFieldOrder extends SelfDescribingMarshallable {
+        int first;
+        int second;
+    }
+
+    @FieldOrder({"first", "ignored"})
+    static class UnknownFieldOrder extends SelfDescribingMarshallable {
+        int first;
+        int second;
+        transient int ignored;
+    }
+
+    static class InheritedFieldOrderParent extends SelfDescribingMarshallable {
+        int parentField;
+    }
+
+    @FieldOrder({"parentField", "childField"})
+    static class InheritedFieldOrder extends InheritedFieldOrderParent {
+        int childField;
+    }
+
+    @FieldOrder({"x", "y", "z"})
+    static class SenderXYZ extends SelfDescribingMarshallable {
+        int x, y, z;
+        @SuppressWarnings("unused") SenderXYZ() {}
+        SenderXYZ(int x, int y, int z) { this.x = x; this.y = y; this.z = z; }
+    }
+
+    @FieldOrder({"z", "y", "x"})
+    static class ReceiverZYX extends SelfDescribingMarshallable {
+        int x, y, z;
     }
 }

--- a/src/test/java/net/openhft/chronicle/wire/converter/Base64Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/converter/Base64Test.java
@@ -4,6 +4,7 @@
 package net.openhft.chronicle.wire.converter;
 
 import net.openhft.chronicle.bytes.MethodReader;
+import net.openhft.chronicle.wire.FieldOrder;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 import net.openhft.chronicle.wire.Wire;
 import org.junit.Test;
@@ -87,6 +88,7 @@ public class Base64Test extends net.openhft.chronicle.wire.WireTestCommon {
     /**
      * The Data64 class represents a set of data fields to be serialized using Base64 encoding.
      */
+    @FieldOrder({"b", "s", "i", "data"})
     static class Data64 extends SelfDescribingMarshallable {
         @Base64
         byte b;

--- a/src/test/java/net/openhft/chronicle/wire/converter/LongConvertorFieldsTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/converter/LongConvertorFieldsTest.java
@@ -17,6 +17,7 @@ public class LongConvertorFieldsTest {
     /**
      * DTO class representing data fields to be serialized using Base16 encoding.
      */
+    @FieldOrder({"b", "ch", "s", "i", "l"})
     static class Base16DTO extends SelfDescribingMarshallable {
         @Base16
         byte b;
@@ -76,6 +77,7 @@ public class LongConvertorFieldsTest {
     /**
      * DTO class representing data fields to be serialized using Base64 encoding.
      */
+    @FieldOrder({"b", "ch", "s", "i", "l"})
     static class Base64DTO extends SelfDescribingMarshallable {
         @Base64
         byte b;
@@ -135,6 +137,7 @@ public class LongConvertorFieldsTest {
     /**
      * DTO class representing data fields to be serialized using Base85 encoding.
      */
+    @FieldOrder({"b", "ch", "s", "i", "l"})
     static class Base85DTO extends SelfDescribingMarshallable {
         @Base85
         byte b;
@@ -207,6 +210,7 @@ public class LongConvertorFieldsTest {
         }
     }
 
+    @FieldOrder({"b", "ch", "s", "i", "l"})
     static class ShortTextDTO extends SelfDescribingMarshallable {
         @ShortText
         byte b;
@@ -265,6 +269,7 @@ public class LongConvertorFieldsTest {
         }
     }
 
+    @FieldOrder({"b", "ch", "s", "i", "l"})
     static class WordsDTO extends SelfDescribingMarshallable {
         @Words
         byte b;

--- a/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/MarketData.java
+++ b/src/test/java/net/openhft/chronicle/wire/domestic/streaming/reduction/MarketData.java
@@ -7,6 +7,7 @@ import net.openhft.chronicle.core.io.InvalidMarshallableException;
 import net.openhft.chronicle.core.io.Validatable;
 import net.openhft.chronicle.core.io.ValidatableUtil;
 import net.openhft.chronicle.wire.Base85LongConverter;
+import net.openhft.chronicle.wire.FieldOrder;
 import net.openhft.chronicle.wire.LongConversion;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 
@@ -16,6 +17,7 @@ import static net.openhft.chronicle.core.util.ObjectUtils.requireNonNull;
  * Represents the market data for a particular stock symbol.
  * This class is self-describing, marshallable, and validatable.
  */
+@FieldOrder({"symbol", "last", "high", "low"})
 public final class MarketData extends SelfDescribingMarshallable implements Validatable {
 
     // Symbol for the market data, stored as a long but represented in base85 format for human readability

--- a/src/test/java/net/openhft/chronicle/wire/domestic/streaming/streams/StreamsDemoTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/domestic/streaming/streams/StreamsDemoTest.java
@@ -6,6 +6,7 @@ package net.openhft.chronicle.wire.domestic.streaming.streams;
 import net.openhft.chronicle.core.io.InvalidMarshallableException;
 import net.openhft.chronicle.core.pool.ClassAliasPool;
 import net.openhft.chronicle.wire.DocumentContext;
+import net.openhft.chronicle.wire.FieldOrder;
 import net.openhft.chronicle.wire.MarshallableIn;
 import net.openhft.chronicle.wire.SelfDescribingMarshallable;
 import net.openhft.chronicle.wire.Wire;
@@ -433,6 +434,7 @@ final class StreamsDemoTest extends net.openhft.chronicle.wire.WireTestCommon {
 
     }
 
+    @FieldOrder({"symbol", "noShares"})
     static final class Shares extends SelfDescribingMarshallable {
 
         String symbol;
@@ -463,6 +465,7 @@ final class StreamsDemoTest extends net.openhft.chronicle.wire.WireTestCommon {
         }
     }
 
+    @FieldOrder({"symbol", "header", "body"})
     public static final class News extends SelfDescribingMarshallable {
 
         String symbol;


### PR DESCRIPTION
This PR adds a new `@FieldOrder` type annotation to Chronicle Wire so `Marshallable` classes can define a stable, explicit serialisation order for fields declared directly on the annotated class.

## Why

Some serialisation paths and tests currently depend on reflection-discovered field order, which can be brittle across JVMs, compiler output, or source changes. This is especially important for text/YAML assertions and `FIELDLESS_BINARY`, where field order is part of the compatibility contract.

## What changed

* Added `@FieldOrder(String[] value)` for declaring marshalling order at type level.
* Updated `WireMarshaller.getAllField(...)` to honour `@FieldOrder` per class in an inheritance hierarchy.
* Added validation for:

  * missing marshallable fields
  * duplicate names, including after trimming
  * blank names
  * unknown fields
  * static/transient/non-marshallable fields
  * inherited fields listed on the wrong class
* Preserved existing default reflection-discovery behaviour when `@FieldOrder` is absent.
* Added tests covering inheritance, stable `SelfDescribingMarshallable` output, validation failures, whitespace trimming, and `FIELDLESS_BINARY` order mismatch behaviour.
* Applied `@FieldOrder` to affected test DTOs and examples to stabilise expected output.
* Updated Wire documentation and project requirements to describe `@FieldOrder` and clarify its role in schema evolution and fieldless binary formats.

## Notes

`@FieldOrder` applies only to fields declared directly on the annotated class. Inherited fields keep the order defined by their own declaring class. For `FIELDLESS_BINARY`, this can stabilise the marshaller order, but reader and writer must still agree on field order, field types, and field count.
