### PR TITLE
CORE-62: Add Wire regressions for reused UTF-16 StringBuilder

### DIFF
--- a/src/test/java/net/openhft/chronicle/wire/BinaryMultiByteStringTruncationTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryMultiByteStringTruncationTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2016-2026 chronicle.software
+ */
+package net.openhft.chronicle.wire;
+
+import net.openhft.chronicle.bytes.Bytes;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Covers binary round-tripping of short UTF-8 strings whose encoded byte length
+ * is greater than their UTF-16 character count.
+ */
+public class BinaryMultiByteStringTruncationTest extends WireTestCommon {
+
+    private static final String MULTI_BYTE = "\u221A";
+
+    private static <T> T roundTrip(WireType wireType, Class<T> type, T value) {
+        return roundTrip(Bytes.allocateElasticOnHeap(), wireType, type, value);
+    }
+
+    private static <T> T roundTrip(Bytes<?> bytes, WireType wireType, Class<T> type, T value) {
+        try {
+            Wire wire = wireType.apply(bytes);
+            wire.getValueOut().object(type, value);
+            return wire.getValueIn().object(type);
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+
+    private static Dto dto(String first) {
+        Dto d = new Dto();
+        d.m = first;
+        d.f1 = "1";
+        d.f2 = "2";
+        d.f3 = "3";
+        d.f4 = "4";
+        d.f5 = "5";
+        return d;
+    }
+
+    @Test
+    public void binaryRoundTripsAllFieldsAfterMultiByteString() {
+        assertDtoRoundTrip(WireType.BINARY, MULTI_BYTE);
+    }
+
+    @Test
+    public void binaryRoundTripsLongFieldNameAfterMultiByteString() {
+        LongFieldDto d = new LongFieldDto();
+        d.m = MULTI_BYTE;
+        d.thisFieldNameIsLongEnoughToUseFieldNameAny = "long";
+        LongFieldDto back = roundTrip(WireType.BINARY, LongFieldDto.class, d);
+        assertEquals(MULTI_BYTE, back.m);
+        assertEquals("long", back.thisFieldNameIsLongEnoughToUseFieldNameAny);
+    }
+
+    @Test
+    public void binaryRoundTripsAllFieldsAfterMultiByteStringDirectMemory() {
+        // Chronicle Queue reads memory-mapped (direct / NativeBytesStore) bytes, which take a
+        // different field-name read path (parse8bit_SB1) than on-heap bytes. That path was never
+        // broken; this guards it stays correct after a multi-byte field if the read paths are reworked.
+        Dto back = roundTrip(Bytes.allocateElasticDirect(), WireType.BINARY, Dto.class, dto(MULTI_BYTE));
+        assertAllFields(back, MULTI_BYTE);
+    }
+
+    @Test
+    public void binaryRoundTripsAllFieldsForAsciiString() {
+        assertDtoRoundTrip(WireType.BINARY, "ascii");
+    }
+
+    @Test
+    public void textRoundTripsAllFieldsForMultiByteString() {
+        assertDtoRoundTrip(WireType.TEXT, MULTI_BYTE);
+    }
+
+    private static void assertDtoRoundTrip(WireType wireType, String first) {
+        assertAllFields(roundTrip(wireType, Dto.class, dto(first)), first);
+    }
+
+    private static void assertAllFields(Dto back, String first) {
+        assertEquals(first, back.m);
+        assertEquals("1", back.f1);
+        assertEquals("2", back.f2);
+        assertEquals("3", back.f3);
+        assertEquals("4", back.f4);
+        assertEquals("5", back.f5);
+    }
+
+    public static class LongFieldDto extends SelfDescribingMarshallable {
+        String m;
+        String thisFieldNameIsLongEnoughToUseFieldNameAny;
+    }
+
+    public static class Dto extends SelfDescribingMarshallable {
+        String m;
+        String f1;
+        String f2;
+        String f3;
+        String f4;
+        String f5;
+    }
+}

--- a/src/test/java/net/openhft/chronicle/wire/BinaryMultiByteStringTruncationTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryMultiByteStringTruncationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2026 chronicle.software
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.wire;
 
@@ -9,8 +9,9 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Covers binary round-tripping of short UTF-8 strings whose encoded byte length
- * is greater than their UTF-16 character count.
+ * A non-Latin-1 value leaves BinaryWire's reused StringBuilder in UTF-16 storage on Java 9+.
+ * Subsequent 8-bit field names must still decode correctly. The heap binary cases reproduce
+ * CORE-62 with pre-fix Core/Bytes dependencies; direct memory, ASCII and text are compatibility controls.
  */
 public class BinaryMultiByteStringTruncationTest extends WireTestCommon {
 
@@ -58,9 +59,8 @@ public class BinaryMultiByteStringTruncationTest extends WireTestCommon {
 
     @Test
     public void binaryRoundTripsAllFieldsAfterMultiByteStringDirectMemory() {
-        // Chronicle Queue reads memory-mapped (direct / NativeBytesStore) bytes, which take a
-        // different field-name read path (parse8bit_SB1) than on-heap bytes. That path was never
-        // broken; this guards it stays correct after a multi-byte field if the read paths are reworked.
+        // Chronicle Queue's direct-memory bytes use parse8bit_SB1 for short field names.
+        // These ASCII names were unaffected by CORE-62; retain this as compatibility coverage.
         Dto back = roundTrip(Bytes.allocateElasticDirect(), WireType.BINARY, Dto.class, dto(MULTI_BYTE));
         assertAllFields(back, MULTI_BYTE);
     }
@@ -88,11 +88,14 @@ public class BinaryMultiByteStringTruncationTest extends WireTestCommon {
         assertEquals("5", back.f5);
     }
 
+    // The non-Latin-1 value must precede a field name to exercise reuse of UTF-16 builder storage.
+    @FieldOrder({"m", "thisFieldNameIsLongEnoughToUseFieldNameAny"})
     public static class LongFieldDto extends SelfDescribingMarshallable {
         String m;
         String thisFieldNameIsLongEnoughToUseFieldNameAny;
     }
 
+    @FieldOrder({"m", "f1", "f2", "f3", "f4", "f5"})
     public static class Dto extends SelfDescribingMarshallable {
         String m;
         String f1;


### PR DESCRIPTION
## Scope

This is a **test-only Wire PR** for CORE-62. It adds five Wire round-trip tests; it does not change production code or the POM.
The production fixes are in [Core #853](https://github.com/OpenHFT/Chronicle-Core/pull/853) and
[Bytes #724](https://github.com/OpenHFT/Chronicle-Bytes/pull/724), both merged on 2026-06-01.

On Java 9+, a reused `StringBuilder` can retain UTF-16 storage after decoding a non-Latin-1 value.
The old heap 8-bit parsing path then corrupted subsequent field names, causing the remaining DTO fields to be ignored.
The important trigger is retained UTF-16 storage, not just a UTF-8 byte length greater than the character count.

## Coverage and review corrections

- Heap binary, short field names: `binaryRoundTripsAllFieldsAfterMultiByteString`.
- Heap binary, `FIELD_NAME_ANY`: `binaryRoundTripsLongFieldNameAfterMultiByteString`.
- Compatibility controls: direct-memory binary, ASCII binary, and text wire round trips.
- Both DTOs use `@FieldOrder` so the non-Latin-1 value is always read before the subsequent field names.
- The test file uses the repository's configured copyright/SPDX header; the mandatory licence check is not bypassed.
- The comments distinguish the two defect reproducers from the three integration-preservation controls.

The original exact-head review ran these tests with Core/Bytes 2026.3: the two heap cases failed because later fields
became `null`, while the three compatibility controls passed. The old-dependency comparison is not a claim that the
already-passing integration controls independently prove the production fix.

## Local validation

The revised test file is validated using the POM's normal dependency resolution: Core 2026.6 and Bytes 2026.4.
No dependency override or installed-JAR replacement is needed.

| JVM | Full `mvn -o clean verify` | Reported tests | Failures | Errors | Skipped |
| --- | --- | ---: | ---: | ---: | ---: |
| JDK 8u502, amd64 / 64-bit | PASS | 11,277 | 0 | 0 | 294 |
| JDK 25.0.4, amd64 / 64-bit | PASS | 11,280 | 0 | 0 | 298 |
| JDK 21.0.12, i386 / 32-bit | FAIL: existing embedded-field layout problem | 11,277 | 1 | 1 | 298 |

All five `BinaryMultiByteStringTruncationTest` tests pass on all three JVMs, with no skips.
The JDK 21 32-bit targeted `clean verify` also passes Checkstyle, Javadocs, licence checking, packaging and binary compatibility.
Surefire reports confirm `sun.arch.data.model=32` and `os.arch=i386` for that run; this is not a 64-bit JVM with a smaller heap.

The full 32-bit failures are both in unchanged `EmbeddedBytesMarshallableTest`:
`testClear` reports `Disjoined fields starting with c`; `ebm` fails when the embedded `c` field group overflows its three-byte limit.
A clean isolated run of that class on the exact PR base, `b2803700fedb486c388f01e59191d89860fe9cbe`, reproduces the same failure
and error. This PR neither introduces nor suppresses them. The full 32-bit suite is therefore **not claimed green**.

`git diff --check` and the 144-character check for the changed Java file pass.

## Separate limitation and merge gate

The review also reproduced a direct-memory write failure with `-XX:-CompactStrings`, using both old and current dependencies.
That is a separate existing dependency issue, not introduced or repaired by this test-only PR. These validation runs use
the normal JVM settings and do not claim support for that additional configuration.

Local results do not replace exact-head TeamCity checks. The old head's May/June statuses must not be treated as validation
of the corrective commit; rerun the supported-platform builds against the intended dependencies before merging.
