### PR TITLE
CORE-64: Fix JSONWire to write finite float/double values as JSON numbers regardless of magnitude

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/JSONWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/JSONWire.java
@@ -1193,29 +1193,41 @@ public class JSONWire extends TextWire {
         }
 
         /**
-         * Write a special double value (e.g. NaN) as a string to the given bytes.
+         * Write a double value to the given bytes. IEEE754 non-finite values (NaN, Infinity) are
+         * quoted as JSON strings since they have no numeric representation in JSON. Finite values,
+         * including large magnitudes, are written as unquoted JSON numbers.
          *
          * @param bytes The bytes to append the stringified double value to
          * @param value The double value to convert to a string
          */
         @Override
         protected void writeSpecialDoubleValueToBytes(Bytes<?> bytes, double value) {
-            bytes.append('"');
-            bytes.append(Double.toString(value));
-            bytes.append('"');
+            if (Double.isNaN(value) || Double.isInfinite(value)) {
+                bytes.append('"');
+                bytes.append(Double.toString(value));
+                bytes.append('"');
+            } else {
+                bytes.append(Double.toString(value));
+            }
         }
 
         /**
-         * Write a special float value (e.g. NaN) as a string to the given bytes.
+         * Write a float value to the given bytes. IEEE754 non-finite values (NaN, Infinity) are
+         * quoted as JSON strings since they have no numeric representation in JSON. Finite values,
+         * including large magnitudes, are written as unquoted JSON numbers.
          *
          * @param bytes The bytes to append the stringified float value to
          * @param value The float value to convert to a string
          */
         @Override
         protected void writeSpecialFloatValueToBytes(Bytes<?> bytes, float value) {
-            bytes.append('"');
-            bytes.append(Float.toString(value));
-            bytes.append('"');
+            if (Float.isNaN(value) || Float.isInfinite(value)) {
+                bytes.append('"');
+                bytes.append(Float.toString(value));
+                bytes.append('"');
+            } else {
+                bytes.append(Float.toString(value));
+            }
         }
 
         @NotNull

--- a/src/test/java/net/openhft/chronicle/wire/JsonWireDoubleAndFloatSpecialValuesAcceptanceTests.java
+++ b/src/test/java/net/openhft/chronicle/wire/JsonWireDoubleAndFloatSpecialValuesAcceptanceTests.java
@@ -89,6 +89,30 @@ class JsonWireDoubleAndFloatSpecialValuesAcceptanceTests {
         Assertions.assertTrue(floatTestInput.expectOutputFloatToMatchThisPredicate.test(object.value));
     }
 
+    @ParameterizedTest
+    @MethodSource("largeFiniteFloatInputs")
+    void largeFiniteFloatSerialiseAsJsonNumber(float value) {
+        String json = toJson(value);
+        Assertions.assertFalse(json.startsWith("\""),
+                "Finite float " + value + " must serialise as a JSON number, not a quoted string literal");
+    }
+
+    @ParameterizedTest
+    @MethodSource("largeFiniteDoubleInputs")
+    void largeFiniteDoubleSerialiseAsJsonNumber(double value) {
+        String json = toJson(value);
+        Assertions.assertFalse(json.startsWith("\""),
+                "Finite double " + value + " must serialise as a JSON number, not a quoted string literal");
+    }
+
+    private static Stream<Float> largeFiniteFloatInputs() {
+        return Stream.of(5_000_000.0f, 1e7f, -5_000_000.0f, 1.23456789e10f);
+    }
+
+    private static Stream<Double> largeFiniteDoubleInputs() {
+        return Stream.of(1e15, 1e16, -5e15, 1.23456789e20);
+    }
+
     private static Stream<DoubleTestInput> doubleTestInputs() {
         return Stream.of(
                 new DoubleTestInput(Double.NaN, "NaN", Double::isNaN),


### PR DESCRIPTION
## Summary
- JSONWire.writeSpecialFloatValueToBytes and writeSpecialDoubleValueToBytes now only quote values that are IEEE754 non-finite (NaN, ±Infinity). Finite values with large magnitudes are written as unquoted JSON numbers.

## Motivation
Float values with magnitude ≥ 1e6 were being serialised as quoted string literals (e.g. "5000000.0") rather than JSON numbers (5000000.0). JSON consumers expecting a numeric type rejected the output. The same path affects double values ≥ 1e15.

## Changes
- JSONWire.JSONValueOut.writeSpecialFloatValueToBytes - quotes only NaN/Infinity; writes finite values unquoted
- JSONWire.JSONValueOut.writeSpecialDoubleValueToBytes - same as above
- JsonWireDoubleAndFloatSpecialValuesAcceptanceTests - adds largeFiniteFloatSerialiseAsJsonNumber and largeFiniteDoubleSerialiseAsJsonNumber parameterised tests; existing NaN/±Infinity round-trip tests continue to pass

## Test plan
- JsonWireDoubleAndFloatSpecialValuesAcceptanceTests - all tests pass
- JSONNanTest - NaN still serialises as "NaN"
- FloatDtoTest - existing DTO round-trip unaffected