### PR TITLE
Bugfix/bytes length32Fix unsigned BYTES_LENGTH32 handling and guard nested BinaryWire read limits

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -485,14 +485,14 @@ public class BinaryWire extends AbstractWire implements Wire {
                     // Handle byte lengths and read accordingly.
                     case BYTES_LENGTH8: {
                         bytes.uncheckedReadSkipOne();
-                        int len = bytes.readUnsignedByte();
+                        long len = bytes.readUnsignedByte();
                         readWithLength(wire, len);
                         break outerSwitch;
                     }
 
                     case BYTES_LENGTH16: {
                         bytes.uncheckedReadSkipOne();
-                        int len = bytes.readUnsignedShort();
+                        long len = bytes.readUnsignedShort();
                         readWithLength(wire, len);
                         break outerSwitch;
                     }
@@ -671,17 +671,17 @@ public class BinaryWire extends AbstractWire implements Wire {
      * @param wire The wire output stream to write data to.
      * @param len  The length of data to be read, as an unsigned 32-bit value (0 to 4294967295).
      * @throws InvalidMarshallableException If there's an issue during marshalling.
-     * @throws IORuntimeException If the length is outside the unsigned 32-bit range.
+     * @throws IORuntimeException If the length is outside the unsigned 32-bit range,
+     *                            or exceeds the data remaining before the read limit.
      */
     @SuppressWarnings("incomplete-switch")
     public void readWithLength(@NotNull WireOut wire, long len) throws InvalidMarshallableException {
         // A length over 32-bit unsigned is unexpected: BYTES_LENGTH32 cannot encode it.
         if (len < 0 || len > 0xFFFF_FFFFL)
-            throw new IORuntimeException("Invalid length " + len + ", expected an unsigned 32-bit value");
+            throw new IORuntimeException("Invalid length " + len + ", expected an unsigned 32-bit value (0 to 4294967295)");
         long limit = bytes.readLimit();
         long newLimit = guardedReadLimit(len);
-        if (newLimit > limit)
-            throw new IORuntimeException("Can't extend the limit");
+
         try {
             bytes.readLimit(newLimit);
             @NotNull final ValueOut wireValueOut = wire.getValueOut();
@@ -720,21 +720,27 @@ public class BinaryWire extends AbstractWire implements Wire {
         }
     }
 
-    // Can only shrink the readLimit
+    /**
+     * Computes the read limit for a nested, length-prefixed value. A nested value must lie
+     * within the enclosing document, so the read limit can only shrink, never extend past
+     * the current one into data that is not readable.
+     *
+     * @param len The length of the nested value, as an unsigned 32-bit value.
+     * @return The read limit for the nested value: the current read position plus the length.
+     * @throws IORuntimeException If the length exceeds the data remaining before the read limit.
+     */
     private long guardedReadLimit(long len) {
         long start = bytes.readPosition();
         long prevLimit = bytes.readLimit();
 
-        assert len >= 0 && len <= 0xFFFF_FFFFL : len;
+        assert len >= 0 && len <= 0xFFFF_FFFFL : "len: " + len;
         assert start <= prevLimit : "readPosition " + start + " > readLimit " + prevLimit;
 
         if (len > prevLimit - start)
-            throw new IORuntimeException("Can't extend the limit");
+            throw new IORuntimeException("Length " + len + " exceeds the " + (prevLimit - start) +
+                    " bytes remaining between readPosition " + start + " and readLimit " + prevLimit);
 
-        long newLimit = start + len;
-        assert newLimit >= start;
-        assert newLimit <= prevLimit;
-        return newLimit;
+        return start + len;
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -500,7 +500,7 @@ public class BinaryWire extends AbstractWire implements Wire {
                     case BYTES_LENGTH32: {
                         // Handle 32-bit length bytes and read accordingly.
                         bytes.uncheckedReadSkipOne();
-                        int len = bytes.readInt();
+                        long len = bytes.readUnsignedInt();
                         readWithLength(wire, len);
                         break outerSwitch;
                     }
@@ -660,10 +660,26 @@ public class BinaryWire extends AbstractWire implements Wire {
      * @param len  The length of data to be read.
      * @throws InvalidMarshallableException If there's an issue during marshalling.
      */
-    @SuppressWarnings("incomplete-switch")
     public void readWithLength(@NotNull WireOut wire, int len) throws InvalidMarshallableException {
+        readWithLength(wire, (long) len);
+    }
+
+    /**
+     * Reads data of a specified length from the bytes stream and writes to the WireOut stream
+     * while interpreting the type of data (Map, Sequence, or Object).
+     *
+     * @param wire The wire output stream to write data to.
+     * @param len  The length of data to be read, as an unsigned 32-bit value (0 to 4294967295).
+     * @throws InvalidMarshallableException If there's an issue during marshalling.
+     * @throws IORuntimeException If the length is outside the unsigned 32-bit range.
+     */
+    @SuppressWarnings("incomplete-switch")
+    public void readWithLength(@NotNull WireOut wire, long len) throws InvalidMarshallableException {
+        // A length over 32-bit unsigned is unexpected: BYTES_LENGTH32 cannot encode it.
+        if (len < 0 || len > 0xFFFF_FFFFL)
+            throw new IORuntimeException("Invalid length " + len + ", expected an unsigned 32-bit value");
         long limit = bytes.readLimit();
-        long newLimit = bytes.readPosition() + len;
+        long newLimit = guardedReadLimit(len);
         if (newLimit > limit)
             throw new IORuntimeException("Can't extend the limit");
         try {
@@ -702,6 +718,23 @@ public class BinaryWire extends AbstractWire implements Wire {
         } finally {
             bytes.readLimit(limit);  // Reset the read limit to its original value.
         }
+    }
+
+    // Can only shrink the readLimit
+    private long guardedReadLimit(long len) {
+        long start = bytes.readPosition();
+        long prevLimit = bytes.readLimit();
+
+        assert len >= 0 && len <= 0xFFFF_FFFFL : len;
+        assert start <= prevLimit : "readPosition " + start + " > readLimit " + prevLimit;
+
+        if (len > prevLimit - start)
+            throw new IORuntimeException("Can't extend the limit");
+
+        long newLimit = start + len;
+        assert newLimit >= start;
+        assert newLimit <= prevLimit;
+        return newLimit;
     }
 
     /**
@@ -4803,7 +4836,7 @@ public class BinaryWire extends AbstractWire implements Wire {
                             } else {
                                 long pos = bytes.readPosition();
                                 bytes.uncheckedReadSkipOne();
-                                int len = readLength(code);
+                                long len = readLength(code);
                                 code = peekCode();
                                 if (code == U8_ARRAY) {
                                     bytes.readPosition(pos);
@@ -4811,7 +4844,7 @@ public class BinaryWire extends AbstractWire implements Wire {
                                 }
                                 long lim = bytes.readLimit();
                                 try {
-                                    bytes.readLimit(bytes.readPosition() + len);
+                                    bytes.readLimit(guardedReadLimit(len));
                                     Object using1 = using;
                                     if (using1 == null && type != null)
                                         using1 = strategy.newInstanceOrNull(type);
@@ -4910,8 +4943,8 @@ public class BinaryWire extends AbstractWire implements Wire {
          * @param code The code representing the length format.
          * @return The length value read.
          */
-        private int readLength(int code) {
-            int len;
+        private long readLength(int code) {
+            long len;
             // Determine the code and read the corresponding length.
             switch (code) {
                 case BYTES_LENGTH8:
@@ -4921,7 +4954,7 @@ public class BinaryWire extends AbstractWire implements Wire {
                     len = bytes.readUnsignedShort();  // Read an unsigned 16-bit value.
                     break;
                 case BYTES_LENGTH32:
-                    len = bytes.readInt();  // Read a 32-bit integer value.
+                    len = bytes.readUnsignedInt();  // Read an unsigned 32-bit value.
                     break;
                 default:
                     throw new AssertionError(); // Throw an assertion error if the code is unrecognized.

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireReadWithLengthTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireReadWithLengthTest.java
@@ -4,9 +4,12 @@
 package net.openhft.chronicle.wire;
 
 import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.core.io.IORuntimeException;
+import net.openhft.chronicle.core.io.InvalidMarshallableException;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Illustrates Chronicle-Queue style copying of binary fragments into a textual representation.
@@ -74,6 +77,120 @@ public class BinaryWireReadWithLengthTest extends WireTestCommon {
 
         assertTrue(output.contains("say: hello"));
         assertTrue(output.contains("number: 42"));
+    }
+
+    @Test
+    public void readWithLengthLongOverloadCopiesMapFragmentToText() {
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        BinaryWire writer = new BinaryWire(bytes);
+        try (DocumentContext dc = writer.writingDocument(false)) {
+            dc.wire().write("map").marshallable(m -> m.write("key").int32(1));
+        }
+
+        bytes.readPositionRemaining(0, bytes.writePosition());
+        int header = bytes.readInt();
+        long len = Wires.lengthOf(header);
+        long bodyPos = bytes.readPosition();
+
+        TextWire target = new TextWire(Bytes.allocateElasticOnHeap());
+        BinaryWire source = new BinaryWire(bytes);
+        source.bytes().readPosition(bodyPos);
+        source.readWithLength(target, len);
+
+        assertTrue(target.bytes().toString().contains("key: 1"));
+    }
+
+    @Test(expected = net.openhft.chronicle.core.io.IORuntimeException.class)
+    public void readWithLengthRejectsNegativeLength() {
+        BinaryWire source = new BinaryWire(Bytes.allocateElasticOnHeap());
+        source.readWithLength(new TextWire(Bytes.allocateElasticOnHeap()), -1);
+    }
+
+    @Test(expected = net.openhft.chronicle.core.io.IORuntimeException.class)
+    public void readWithLengthRejectsOver32BitLength() {
+        BinaryWire source = new BinaryWire(Bytes.allocateElasticOnHeap());
+        source.readWithLength(new TextWire(Bytes.allocateElasticOnHeap()), 1L << 32);
+    }
+
+    @Test
+    public void bytesLength32WithTopBitSetIsReadAsUnsigned() {
+        expectUnsignedLengthRejected(0x80000000L);
+    }
+
+    @Test
+    public void bytesLength32WithMaxUnsignedValueIsReadAsUnsigned() {
+        expectUnsignedLengthRejected(0xFFFFFFFFL);
+    }
+
+    @Test
+    public void uncheckedBytesLength32WithMaxUnsignedValueIsRejectedBeforeReadLimitIsExtended() {
+        Bytes<?> uncheckedBytes = uncheckedBytesLength32(0xFFFFFFFFL);
+        try {
+            BinaryWire source = new BinaryWire(uncheckedBytes);
+            TextWire target = new TextWire(Bytes.allocateElasticOnHeap());
+            try {
+                source.copyOne(target);
+                fail("Expected IORuntimeException for unchecked unsigned 32-bit length");
+            } catch (IORuntimeException e) {
+                assertTrue("Unexpected message: " + e.getMessage(),
+                        e.getMessage().contains("Can't extend the limit"));
+            }
+        } finally {
+            uncheckedBytes.releaseLast();
+        }
+    }
+
+    @Test
+    public void uncheckedObjectWithLength32BeyondHardLimitIsRejectedBeforeReadLimitIsExtended()
+            throws InvalidMarshallableException {
+        Bytes<?> uncheckedBytes = uncheckedBytesLength32(0xFFFFFFFFL, BinaryWireCode.EVENT_NAME);
+        try {
+            BinaryWire source = new BinaryWire(uncheckedBytes);
+            try {
+                source.getValueIn().object();
+                fail("Expected IORuntimeException for unchecked unsigned 32-bit object length");
+            } catch (IORuntimeException e) {
+                assertTrue("Unexpected message: " + e.getMessage(),
+                        e.getMessage().contains("Can't extend the limit"));
+            }
+        } finally {
+            uncheckedBytes.releaseLast();
+        }
+    }
+
+    private Bytes<?> uncheckedBytesLength32(long length, int... payloadCodes) {
+        Bytes<?> encoded = Bytes.allocateElasticOnHeap();
+        encoded.writeUnsignedByte(BinaryWireCode.BYTES_LENGTH32);
+        encoded.writeUnsignedInt(length);
+        for (int payloadCode : payloadCodes)
+            encoded.writeUnsignedByte(payloadCode);
+        byte[] data = encoded.toByteArray();
+        encoded.releaseLast();
+        return Bytes.wrapForRead(data).unchecked(true);
+    }
+
+    /**
+     * Builds a stream of BYTES_LENGTH32 followed by a 4-byte length with the top bit set,
+     * but no payload. The length must be read as unsigned 32-bit, so the (impossibly large)
+     * length fails the read-limit check with "Can't extend the limit". Before the fix,
+     * {@code copyOne} read the length with the signed {@code readInt()}, so the limit check
+     * passed on a negative length and reading continued with a corrupt read limit.
+     */
+    private void expectUnsignedLengthRejected(long length) {
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        bytes.writeUnsignedByte(BinaryWireCode.BYTES_LENGTH32);
+        bytes.writeUnsignedInt(length);
+        bytes.readPositionRemaining(0, bytes.writePosition());
+
+        BinaryWire source = new BinaryWire(bytes);
+        TextWire target = new TextWire(Bytes.allocateElasticOnHeap());
+        try {
+            source.copyOne(target);
+            fail("Expected IORuntimeException for unsigned 32-bit length " + length);
+        } catch (IORuntimeException e) {
+            assertTrue("Unexpected message: " + e.getMessage(),
+                    e.getMessage().contains("Can't extend the limit"));
+        }
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireReadWithLengthTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireReadWithLengthTest.java
@@ -133,7 +133,7 @@ public class BinaryWireReadWithLengthTest extends WireTestCommon {
                 fail("Expected IORuntimeException for unchecked unsigned 32-bit length");
             } catch (IORuntimeException e) {
                 assertTrue("Unexpected message: " + e.getMessage(),
-                        e.getMessage().contains("Can't extend the limit"));
+                        e.getMessage().contains("bytes remaining between readPosition"));
             }
         } finally {
             uncheckedBytes.releaseLast();
@@ -151,7 +151,7 @@ public class BinaryWireReadWithLengthTest extends WireTestCommon {
                 fail("Expected IORuntimeException for unchecked unsigned 32-bit object length");
             } catch (IORuntimeException e) {
                 assertTrue("Unexpected message: " + e.getMessage(),
-                        e.getMessage().contains("Can't extend the limit"));
+                        e.getMessage().contains("bytes remaining between readPosition"));
             }
         } finally {
             uncheckedBytes.releaseLast();
@@ -172,7 +172,7 @@ public class BinaryWireReadWithLengthTest extends WireTestCommon {
     /**
      * Builds a stream of BYTES_LENGTH32 followed by a 4-byte length with the top bit set,
      * but no payload. The length must be read as unsigned 32-bit, so the (impossibly large)
-     * length fails the read-limit check with "Can't extend the limit". Before the fix,
+     * length fails the read-limit check, reporting the bytes remaining. Before the fix,
      * {@code copyOne} read the length with the signed {@code readInt()}, so the limit check
      * passed on a negative length and reading continued with a corrupt read limit.
      */
@@ -189,7 +189,7 @@ public class BinaryWireReadWithLengthTest extends WireTestCommon {
             fail("Expected IORuntimeException for unsigned 32-bit length " + length);
         } catch (IORuntimeException e) {
             assertTrue("Unexpected message: " + e.getMessage(),
-                    e.getMessage().contains("Can't extend the limit"));
+                    e.getMessage().contains("bytes remaining between readPosition"));
         }
     }
 


### PR DESCRIPTION
This change tightens `BinaryWire` length-prefixed reads so `BYTES_LENGTH32` values are handled as unsigned 32-bit lengths and cannot extend the current read limit.

It adds a `long`-based `readWithLength` path, validates that supplied lengths fit the unsigned 32-bit range, and rejects malformed or unchecked input before it can corrupt the nested read limit.

### Problem

`BYTES_LENGTH32` was previously read using signed `readInt()` in some paths.

For encoded lengths with the top bit set, this could produce a negative `int` length. That made the nested limit calculation unsafe, because the existing check only rejected limits greater than the current limit and did not explicitly reject negative or oversized unsigned lengths.

In malformed or unchecked input, this could allow parsing to continue with a corrupt read limit rather than failing at the length boundary.

### Changes

* Read `BYTES_LENGTH32` with `readUnsignedInt()` instead of signed `readInt()`.
* Promote length handling from `int` to `long` where required.
* Add a `readWithLength(WireOut, long)` overload for unsigned 32-bit lengths.
* Keep the existing `readWithLength(WireOut, int)` method as a delegating compatibility overload.
* Add explicit validation for negative and greater-than-32-bit lengths.
* Add `guardedReadLimit(long)` to ensure nested values stay inside the enclosing read limit.
* Reuse the guarded limit calculation in `objectWithInferredType`.
* Improve failure messages when a declared length exceeds the bytes remaining before the current read limit.

### Tests

Adds coverage for:

* Copying a length-prefixed map fragment through the new `long` overload.
* Rejecting negative lengths.
* Rejecting lengths greater than unsigned 32-bit.
* Treating `BYTES_LENGTH32` values with the top bit set as unsigned.
* Rejecting `0xFFFFFFFF` length values before extending the read limit.
* Rejecting malformed unchecked object input before corrupting the read limit.

### Risk

Low to medium.

The change affects binary length-prefixed read paths, including malformed input handling. Valid encoded data should continue to read as before, while invalid or truncated data now fails earlier with a clearer `IORuntimeException`.

### Validation

Run the updated `BinaryWireReadWithLengthTest` test suite.
