### PR TITLE
WIP: CORE-68 - BinaryWire length-prefixed reads can bypass current logical readLimit under unchecked bytes

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -479,20 +479,20 @@ public class BinaryWire extends AbstractWire implements Wire {
                     case PADDING32:
                         // Handle 32-bit padding and skip reading.
                         bytes.uncheckedReadSkipOne();
-                        bytes.readSkip(bytes.readUnsignedInt());
+                        guardedSkipDecodedLength(readPadding32Length());
                         break outerSwitch;
 
                     // Handle byte lengths and read accordingly.
                     case BYTES_LENGTH8: {
                         bytes.uncheckedReadSkipOne();
-                        long len = bytes.readUnsignedByte();
+                        long len = readGuardedUnsignedByteLength();
                         readWithLength(wire, len);
                         break outerSwitch;
                     }
 
                     case BYTES_LENGTH16: {
                         bytes.uncheckedReadSkipOne();
-                        long len = bytes.readUnsignedShort();
+                        long len = readGuardedUnsignedShortLength();
                         readWithLength(wire, len);
                         break outerSwitch;
                     }
@@ -500,7 +500,7 @@ public class BinaryWire extends AbstractWire implements Wire {
                     case BYTES_LENGTH32: {
                         // Handle 32-bit length bytes and read accordingly.
                         bytes.uncheckedReadSkipOne();
-                        long len = bytes.readUnsignedInt();
+                        long len = readGuardedUnsignedIntLength();
                         readWithLength(wire, len);
                         break outerSwitch;
                     }
@@ -730,10 +730,11 @@ public class BinaryWire extends AbstractWire implements Wire {
      * @throws IORuntimeException If the length exceeds the data remaining before the read limit.
      */
     private long guardedReadLimit(long len) {
+        if (len < 0 || len > 0xFFFF_FFFFL)
+            throw new IORuntimeException("Invalid length " + len + ", expected an unsigned 32-bit value (0 to 4294967295)");
         long start = bytes.readPosition();
         long prevLimit = bytes.readLimit();
 
-        assert len >= 0 && len <= 0xFFFF_FFFFL : "len: " + len;
         assert start <= prevLimit : "readPosition " + start + " > readLimit " + prevLimit;
 
         if (len > prevLimit - start)
@@ -741,6 +742,225 @@ public class BinaryWire extends AbstractWire implements Wire {
                     " bytes remaining between readPosition " + start + " and readLimit " + prevLimit);
 
         return start + len;
+    }
+
+    private void requireReadablePrefixBytes(long prefixLength) {
+        long start = bytes.readPosition();
+        long limit = bytes.readLimit();
+        long remaining = limit - start;
+        if (prefixLength < 0 || remaining < 0 || prefixLength > remaining)
+            throw new IORuntimeException("Length prefix " + prefixLength + " exceeds the " + remaining +
+                    " bytes remaining between readPosition " + start + " and readLimit " + limit);
+    }
+
+    private long readGuardedUnsignedByteLength() {
+        requireReadablePrefixBytes(Byte.BYTES);
+        return bytes.readUnsignedByte();
+    }
+
+    private long readGuardedUnsignedShortLength() {
+        requireReadablePrefixBytes(Short.BYTES);
+        return bytes.readUnsignedShort();
+    }
+
+    private long readGuardedUnsignedIntLength() {
+        requireReadablePrefixBytes(Integer.BYTES);
+        return bytes.readUnsignedInt();
+    }
+
+    private long readGuardedStopBitLength() {
+        long start = bytes.readPosition();
+        long limit = bytes.readLimit();
+        long remaining = limit - start;
+
+        // Validate the stop-bit prefix terminates inside the current readLimit before decoding it.
+        for (long pos = start; pos < limit; pos++) {
+            if ((bytes.readUnsignedByte(pos) & 0x80) == 0)
+                return bytes.readStopBit();
+        }
+
+        throw new IORuntimeException("Stop bit length prefix exceeds the " + remaining +
+                " bytes remaining between readPosition " + start + " and readLimit " + limit);
+    }
+
+    private long guardedTextEnd(long len) {
+        long start = bytes.readPosition();
+        long limit = bytes.readLimit();
+        long remaining = limit - start;
+        if (len < 0 || remaining < 0 || len > remaining)
+            throw new IORuntimeException("Text length " + len + " exceeds the " + remaining +
+                    " bytes remaining between readPosition " + start + " and readLimit " + limit);
+        return start + len;
+    }
+
+    @Nullable
+    private String readGuardedUtf8String() {
+        long len0 = readGuardedStopBitLength();
+        if (len0 == -1L)
+            return null;
+        if (len0 < -1L)
+            throw new IORuntimeException("Invalid text length " + len0);
+
+        long limit = bytes.readLimit();
+        long end = guardedTextEnd(len0);
+        Maths.toUInt31(len0);
+        String text;
+        try {
+            bytes.readLimit(end);
+            text = UTF8.intern(bytes);
+        } finally {
+            bytes.readLimit(limit);
+        }
+        bytes.readPosition(end);
+        return text;
+    }
+
+    private boolean readGuardedUtf8(@NotNull StringBuilder sb) {
+        String original = sb.toString();
+        long len0 = readGuardedStopBitLength();
+        if (len0 == -1L) {
+            sb.setLength(0);
+            return false;
+        }
+        if (len0 < -1L)
+            throw new IORuntimeException("Invalid text length " + len0);
+
+        long limit = bytes.readLimit();
+        long end = guardedTextEnd(len0);
+        int len = Maths.toUInt31(len0);
+        try {
+            bytes.readLimit(end);
+            if (len > 0)
+                bytes.parseUtf8(sb, true, len);
+            else
+                sb.setLength(0);
+        } catch (RuntimeException | Error e) {
+            sb.setLength(0);
+            sb.append(original);
+            throw e;
+        } finally {
+            bytes.readLimit(limit);
+        }
+        bytes.readPosition(end);
+        return true;
+    }
+
+    private boolean readGuardedUtf8(@NotNull Bytes<?> target) {
+        long len0 = readGuardedStopBitLength();
+        if (len0 == -1L) {
+            target.clear();
+            return false;
+        }
+        if (len0 < -1L)
+            throw new IORuntimeException("Invalid text length " + len0);
+
+        long limit = bytes.readLimit();
+        long end = guardedTextEnd(len0);
+        int len = Maths.toUInt31(len0);
+        Bytes<?> tmp = Bytes.allocateElasticOnHeap();
+        try {
+            if (len > 0)
+                try {
+                    bytes.readLimit(end);
+                    bytes.parseUtf8(tmp, true, len);
+                } finally {
+                    bytes.readLimit(limit);
+                }
+            else
+                tmp.clear();
+            bytes.readPosition(end);
+            target.clear();
+            tmp.readPosition(0);
+            target.write(tmp, 0, tmp.writePosition());
+            return true;
+        } finally {
+            bytes.readLimit(limit);
+            tmp.releaseLast();
+        }
+    }
+
+    private void readGuardedUtf8(int len, @NotNull StringBuilder sb) {
+        String original = sb.toString();
+        long limit = bytes.readLimit();
+        long end = guardedTextEnd(len);
+        try {
+            bytes.readLimit(end);
+            if (len > 0)
+                bytes.parseUtf8(sb, true, len);
+            else
+                sb.setLength(0);
+        } catch (RuntimeException | Error e) {
+            sb.setLength(0);
+            sb.append(original);
+            throw e;
+        } finally {
+            bytes.readLimit(limit);
+        }
+        bytes.readPosition(end);
+    }
+
+    private void readGuardedUtf8(int len, @NotNull Bytes<?> target) {
+        long limit = bytes.readLimit();
+        long end = guardedTextEnd(len);
+        Bytes<?> tmp = Bytes.allocateElasticOnHeap();
+        try {
+            if (len > 0)
+                try {
+                    bytes.readLimit(end);
+                    bytes.parseUtf8(tmp, true, len);
+                } finally {
+                    bytes.readLimit(limit);
+                }
+            else
+                tmp.clear();
+            bytes.readPosition(end);
+            target.clear();
+            tmp.readPosition(0);
+            target.write(tmp, 0, tmp.writePosition());
+        } finally {
+            bytes.readLimit(limit);
+            tmp.releaseLast();
+        }
+    }
+
+    @Nullable
+    private <T extends Appendable & CharSequence> T readGuardedUtf8Text(@NotNull T target) {
+        if (target instanceof StringBuilder)
+            return readGuardedUtf8((StringBuilder) target) ? target : null;
+        if (target instanceof Bytes)
+            return readGuardedUtf8((Bytes<?>) target) ? target : null;
+        @Nullable String text = readGuardedUtf8String();
+        if (text == null)
+            return null;
+        AppendableUtil.append(target, text);
+        return target;
+    }
+
+    @NotNull
+    private <T extends Appendable & CharSequence> T readGuardedUtf8Text(int len, @NotNull T target) {
+        if (target instanceof StringBuilder) {
+            readGuardedUtf8(len, (StringBuilder) target);
+            return target;
+        }
+        if (target instanceof Bytes) {
+            readGuardedUtf8(len, (Bytes<?>) target);
+            return target;
+        }
+        StringBuilder tmp = acquireStringBuilder();
+        readGuardedUtf8(len, tmp);
+        AppendableUtil.append(target, tmp, 0, tmp.length());
+        return target;
+    }
+
+
+    // The code and length prefix must already be consumed; len starts at the current payload position.
+    private void guardedSkipDecodedLength(long len) {
+        long newPosition = guardedReadLimit(len);
+        bytes.readPosition(newPosition);
+    }
+
+    private long readPadding32Length() {
+        return readGuardedUnsignedIntLength();
     }
 
     /**
@@ -980,7 +1200,7 @@ public class BinaryWire extends AbstractWire implements Wire {
     public Wire readComment(@NotNull StringBuilder s) {
         if (peekCode() == COMMENT) {
             bytes.uncheckedReadSkipOne();
-            bytes.readUtf8(s);
+            readGuardedUtf8(s);
         } else {
             s.setLength(0);
         }
@@ -1137,7 +1357,7 @@ public class BinaryWire extends AbstractWire implements Wire {
 
                 case PADDING32:
                     bytes.uncheckedReadSkipOne();
-                    bytes.readSkip(bytes.readUnsignedInt());
+                    guardedSkipDecodedLength(readPadding32Length());
                     break;
 
                 case COMMENT: {
@@ -1303,8 +1523,7 @@ public class BinaryWire extends AbstractWire implements Wire {
     @NotNull
     <T extends Appendable & CharSequence> T getStringBuilder(int code, @NotNull T sb) {
         // Parse the UTF-8 encoded data from bytes based on the provided code and populate the StringBuilder.
-        bytes.parseUtf8(sb, true, code & 0x1f);
-        return sb;
+        return readGuardedUtf8Text(code & 0x1f, sb);
     }
 
     /**
@@ -1958,7 +2177,7 @@ public class BinaryWire extends AbstractWire implements Wire {
                     case PADDING:
                         return readText(bytes.readUnsignedByte(), sb);
                     case PADDING32:
-                        bytes.readSkip(bytes.readUnsignedInt());
+                        guardedSkipDecodedLength(readPadding32Length());
                         return readText(bytes.readUnsignedByte(), sb);
                     default:
                         break;
@@ -1985,9 +2204,7 @@ public class BinaryWire extends AbstractWire implements Wire {
                     case TYPE_LITERAL:
                     case STRING_ANY:
                         // Handle various string/textual representations.
-                        if (bytes.readUtf8(sb))
-                            return sb;
-                        return null;
+                        return readGuardedUtf8Text(sb);
                     case EVENT_OBJECT:
                         valueIn.text((StringBuilder) sb);
                         return sb;
@@ -2109,7 +2326,7 @@ public class BinaryWire extends AbstractWire implements Wire {
     StringBuilder readUtf8() {
         @NotNull StringBuilder sb = acquireStringBuilder();
         // Read the UTF-8 encoded string into the StringBuilder.
-        return bytes.readUtf8(sb) ? sb : null;
+        return readGuardedUtf8(sb) ? sb : null;
     }
 
     /**
@@ -3338,14 +3555,14 @@ public class BinaryWire extends AbstractWire implements Wire {
 
                 case STRING_ANY:
                     // Read the UTF-8 string from bytes and consume it
-                    s.accept(bytes.readUtf8());
+                    s.accept(readGuardedUtf8String());
                     break;
                 default:
                     // Check for special string codes
                     if (code >= STRING_0 && code <= STRING_31) {
                         @NotNull StringBuilder sb = acquireStringBuilder();
                         // Parse the UTF-8 string based on its length code and consume it
-                        bytes.parseUtf8(sb, code & 0b11111);
+                        readGuardedUtf8(code & 0b11111, sb);
                         s.accept(WireInternal.INTERNER.intern(sb));
 
                     } else {
@@ -3411,21 +3628,7 @@ public class BinaryWire extends AbstractWire implements Wire {
                     return null;
 
                 case STRING_ANY: { // NOSONAR
-                    long len0 = bytes.readStopBit();
-                    if (len0 == -1L) {
-                        return null;
-
-                    }
-                    int len = Maths.toUInt31(len0);
-                    long limit = bytes.readLimit();
-                    long end = bytes.readPosition() + len;
-                    try {
-                        bytes.readLimit(end);
-                        return UTF8.intern(bytes);
-                    } finally {
-                        bytes.readLimit(limit);
-                        bytes.readPosition(end);
-                    }
+                    return readGuardedUtf8String();
                 }
 
                 case TYPE_PREFIX: {
@@ -3459,30 +3662,96 @@ public class BinaryWire extends AbstractWire implements Wire {
         @Override
         public WireIn bytes(@NotNull BytesOut<?> toBytes, boolean clearBytes) {
             long length = readLength();
+            long bodyStart = bytes.readPosition();
+            requireReadableBodyWithCode(length);
+            long declaredEnd = guardDeclaredBodyEnd(length, bodyStart);
             int code = readCode();
-            if (clearBytes)
-                toBytes.clear();
             if (code == NULL) {
+                if (clearBytes)
+                    toBytes.clear();
                 return BinaryWire.this;
             }
             if (code == TYPE_PREFIX) {
-                @Nullable StringBuilder sb = readUtf8();
-                assert sb != null;
+                Bytes<?> tmp = Bytes.allocateElasticOnHeap();
+                try {
+                    long limit0 = bytes.readLimit();
+                    try {
+                        bytes.readLimit(declaredEnd);
+                        @Nullable StringBuilder sb = readUtf8();
+                        assert sb != null;
 
-                long length2 = readLength();
-                int code2 = readCode();
-                if (code2 != U8_ARRAY)
-                    cantRead(code);
+                        long length2 = readLength();
+                        long bodyStart2 = bytes.readPosition();
+                        requireReadableBodyWithCode(length2);
+                        long declaredEnd2 = guardDeclaredBodyEnd(length2, bodyStart2);
+                        int code2 = readCode();
+                        if (code2 != U8_ARRAY)
+                            cantRead(code);
 
-                bytes.readWithLength0(length2 - 1, (b, sb1, toBytes1) -> Compression.uncompress(sb1, b, toBytes1), sb, toBytes);
+                        long payloadLength = length2 - 1;
+                        requireReadableLength(payloadLength);
+                        long limit1 = bytes.readLimit();
+                        try {
+                            bytes.readLimit(declaredEnd2);
+                            bytes.readWithLength0(payloadLength, (b, sb1, toBytes1) -> Compression.uncompress(sb1, b, toBytes1), sb, tmp);
+                        } finally {
+                            bytes.readLimit(limit1);
+                        }
+                        bytes.readPosition(declaredEnd);
+                    } catch (AssertionError e) {
+                        if (bytes.readPosition() > declaredEnd)
+                            bytes.readPosition(declaredEnd);
+                        throw new IORuntimeException(e);
+                    } catch (RuntimeException e) {
+                        if (bytes.readPosition() > declaredEnd)
+                            bytes.readPosition(declaredEnd);
+                        throw e;
+                    } finally {
+                        bytes.readLimit(limit0);
+                    }
+                    if (clearBytes)
+                        toBytes.clear();
+                    tmp.readPosition(0);
+                    toBytes.write(tmp, 0, tmp.writePosition());
+                } finally {
+                    tmp.releaseLast();
+                }
                 return wireIn();
 
             }
             if (code == U8_ARRAY) {
-                ((Bytes) bytes).readWithLength(length - 1, toBytes);
+                long payloadLength = length - 1;
+                requireReadableLength(payloadLength);
+                if (clearBytes)
+                    toBytes.clear();
+                ((Bytes) bytes).readWithLength(payloadLength, toBytes);
             } else {
-                bytes.uncheckedReadSkipBackOne();
-                textTo((Bytes) toBytes);
+                Bytes<?> tmp = Bytes.allocateElasticOnHeap();
+                try {
+                    bytes.uncheckedReadSkipBackOne();
+                    long limit0 = bytes.readLimit();
+                    try {
+                        bytes.readLimit(declaredEnd);
+                        textTo((Bytes) tmp);
+                        bytes.readPosition(declaredEnd);
+                    } catch (AssertionError e) {
+                        if (bytes.readPosition() > declaredEnd)
+                            bytes.readPosition(declaredEnd);
+                        throw new IORuntimeException(e);
+                    } catch (RuntimeException e) {
+                        if (bytes.readPosition() > declaredEnd)
+                            bytes.readPosition(declaredEnd);
+                        throw e;
+                    } finally {
+                        bytes.readLimit(limit0);
+                    }
+                    if (clearBytes)
+                        toBytes.clear();
+                    tmp.readPosition(0);
+                    toBytes.write(tmp, 0, tmp.writePosition());
+                } finally {
+                    tmp.releaseLast();
+                }
             }
             return wireIn();
         }
@@ -3491,6 +3760,7 @@ public class BinaryWire extends AbstractWire implements Wire {
         @Override
         public WireIn bytesLiteral(@NotNull BytesOut<?> toBytes) {
             long length = readLength();
+            requireReadableLength(length);
             toBytes.clear();
             toBytes.write(bytes, bytes.readPosition(), length);
             bytes.readSkip(length);
@@ -3500,10 +3770,12 @@ public class BinaryWire extends AbstractWire implements Wire {
         @NotNull
         @Override
         public BytesStore<?, ?> bytesLiteral() {
-            int length = Maths.toUInt31(readLength());
-            @NotNull BytesStore<?, ?> toBytes = BytesStore.wrap(new byte[length]);
-            toBytes.write(0, bytes, bytes.readPosition(), length);
-            bytes.readSkip(length);
+            long length = readLength();
+            requireReadableLength(length);
+            int length31 = Maths.toUInt31(length);
+            @NotNull BytesStore<?, ?> toBytes = BytesStore.wrap(new byte[length31]);
+            toBytes.write(0, bytes, bytes.readPosition(), length31);
+            bytes.readSkip(length31);
             return toBytes;
         }
 
@@ -3511,15 +3783,18 @@ public class BinaryWire extends AbstractWire implements Wire {
         @Nullable
         public WireIn bytesSet(@NotNull PointerBytesStore toBytes) {
             long length = readLength();
+            requireReadableBodyWithCode(length);
             int code = readCode();
             if (code == NULL) {
                 return BinaryWire.this;
             }
             if (code != U8_ARRAY)
                 cantRead(code);
+            long payloadLength = length - 1;
+            requireReadableLength(payloadLength);
             long startAddr = bytes.addressForRead(bytes.readPosition());
-            toBytes.set(startAddr, length - 1);
-            bytes.readSkip(length - 1);
+            toBytes.set(startAddr, payloadLength);
+            bytes.readSkip(payloadLength);
             return wireIn();
         }
 
@@ -3527,39 +3802,84 @@ public class BinaryWire extends AbstractWire implements Wire {
         @Override
         public WireIn bytesMatch(@NotNull BytesStore<?, ?> compareBytes, @NotNull BooleanConsumer consumer) {
             long length = readLength();
+            requireReadableBodyWithCode(length);
             int code = readCode();
             if (code != U8_ARRAY)
                 cantRead(code);
-            length--;
-            if (compareBytes.readRemaining() == length) {
-                consumer.accept(bytes.equalBytes(compareBytes, length));
+            long payloadLength = length - 1;
+            requireReadableLength(payloadLength);
+            if (compareBytes.readRemaining() == payloadLength) {
+                consumer.accept(bytes.equalBytes(compareBytes, payloadLength));
             } else {
                 consumer.accept(false);
             }
-            bytes.readSkip(length);
+            bytes.readSkip(payloadLength);
             return wireIn();
 
+        }
+
+        private void requireReadableLength(long length) {
+            long remaining = bytes.readRemaining();
+            if (length < 0 || length > remaining)
+                throw new IORuntimeException("Length " + length + " exceeds the " + remaining +
+                        " bytes remaining between readPosition " + bytes.readPosition() + " and readLimit " + bytes.readLimit());
+        }
+
+        private void requireReadableBodyWithCode(long length) {
+            if (length < 1)
+                throw new IORuntimeException("Length " + length + " does not include a value code");
+            requireReadableLength(length);
+        }
+
+        private long guardDeclaredBodyEnd(long length, long bodyStart) {
+            long limit = bytes.readLimit();
+            long remaining = limit - bodyStart;
+            if (length < 0 || length > remaining)
+                throw new IORuntimeException("Length " + length + " exceeds the " + remaining +
+                        " bytes remaining between readPosition " + bodyStart + " and readLimit " + limit);
+            return bodyStart + length;
         }
 
         @Override
         @Nullable
         public BytesStore<?, ?> bytesStore() {
-            long length = readLength() - 1;
+            long length = readLength();
+            long bodyStart = bytes.readPosition();
+            requireReadableBodyWithCode(length);
+            long declaredEnd = guardDeclaredBodyEnd(length, bodyStart);
+            long payloadLength = length - 1;
             int code = readCode();
             switch (code) {
                 case I64_ARRAY:
                 case U8_ARRAY:
-                    @NotNull BytesStore<?, ?> toBytes = BytesStore.lazyNativeBytesStoreWithFixedCapacity(length);
-                    toBytes.write(0, bytes, bytes.readPosition(), length);
-                    bytes.readSkip(length);
+                    requireReadableLength(payloadLength);
+                    @NotNull BytesStore<?, ?> toBytes = BytesStore.lazyNativeBytesStoreWithFixedCapacity(payloadLength);
+                    toBytes.write(0, bytes, bytes.readPosition(), payloadLength);
+                    bytes.readSkip(payloadLength);
                     return toBytes;
 
                 case TYPE_PREFIX: {
-                    @Nullable StringBuilder sb = readUtf8();
-                    @Nullable byte[] bytes = Compression.uncompress(sb, this, ValueIn::bytes);
-                    if (bytes != null)
-                        return BytesStore.wrap(bytes);
-                    throw new UnsupportedOperationException("Unsupported type " + sb);
+                    long limit0 = bytes.readLimit();
+                    try {
+                        bytes.readLimit(declaredEnd);
+                        @Nullable StringBuilder sb = readUtf8();
+                        @Nullable byte[] uncompressed = Compression.uncompress(sb, this, ValueIn::bytes);
+                        if (uncompressed != null) {
+                            bytes.readPosition(declaredEnd);
+                            return BytesStore.wrap(uncompressed);
+                        }
+                        throw new UnsupportedOperationException("Unsupported type " + sb);
+                    } catch (AssertionError e) {
+                        if (bytes.readPosition() > declaredEnd)
+                            bytes.readPosition(declaredEnd);
+                        throw new IORuntimeException(e);
+                    } catch (RuntimeException e) {
+                        if (bytes.readPosition() > declaredEnd)
+                            bytes.readPosition(declaredEnd);
+                        throw e;
+                    } finally {
+                        bytes.readLimit(limit0);
+                    }
                 }
                 case NULL:
                     return null;
@@ -3576,37 +3896,44 @@ public class BinaryWire extends AbstractWire implements Wire {
          * @param sb The StringBuilder to store the read bytes.
          */
         public void bytesStore(@NotNull StringBuilder sb) {
-            sb.setLength(0);
-
             // Consume any padding before reading bytes
             consumePadding();
             long pos = bytes.readPosition();
             long length = readLength();
+            long bodyStart = bytes.readPosition();
 
             // Validate if the read length is valid or recognized
             if (length < 0)
                 throw cantRead(peekCode());
 
             // Ensure enough bytes remain for reading the length specified
-            if (length > bytes.readRemaining())
-                throw new BufferUnderflowException();
+            requireReadableBodyWithCode(length);
 
             int code = readCode();
             if (code == U8_ARRAY) {
+                long payloadLength = length - 1;
+                requireReadableLength(payloadLength);
+                sb.setLength(0);
                 // Read each byte and cast to char to store in StringBuilder
-                for (long i = 1; i < length; i++)
+                for (long i = 0; i < payloadLength; i++)
                     sb.append((char) bytes.readUnsignedByte());
             } else {
                 // Reset the reading position and store from size-prefixed blobs
                 bytes.readPosition(pos);
                 long limit = bytes.readLimit();
-                bytes.readLimit(pos + 4 + length);
+                long remaining = limit - bodyStart;
+                if (length < 0 || length > remaining)
+                    throw new IORuntimeException("Length " + length + " exceeds the " + remaining +
+                            " bytes remaining between readPosition " + bodyStart + " and readLimit " + limit);
+                long declaredEnd = bodyStart + length;
+                sb.setLength(0);
+                bytes.readLimit(declaredEnd);
                 try {
                     sb.append(Wires.fromSizePrefixedBlobs(bytes));
                 } finally {
                     // Restore the original limit and position after reading
                     bytes.readLimit(limit);
-                    bytes.readPosition(limit);
+                    bytes.readPosition(declaredEnd);
                 }
             }
         }
@@ -3617,41 +3944,42 @@ public class BinaryWire extends AbstractWire implements Wire {
          * @param toBytes The Bytes object to store the read bytes.
          */
         public void bytesStore(@NotNull Bytes<?> toBytes) {
-            // Clear the provided Bytes object before storing
-            toBytes.clear();
-            long length = readLength() - 1;
+            long length = readLength();
+            requireReadableBodyWithCode(length);
+            long payloadLength = length - 1;
             int code = readCode();
 
             // If null code is encountered, terminate early
             if (code == NULL) {
+                toBytes.clear();
                 return;
             }
             if (code != U8_ARRAY)
                 cantRead(code);
 
             // Validate length to ensure no reading past available bytes
-            if (length > bytes.readRemaining())
-                throw new IllegalStateException("Length of Bytes " + length + " > " + bytes.readRemaining());
+            requireReadableLength(payloadLength);
 
             // Write the bytes read into the provided Bytes object
-            toBytes.ensureCapacity(toBytes.writePosition() + length);
-            toBytes.write(0, bytes, bytes.readPosition(), length);
-            toBytes.readLimit(length);
-            bytes.readSkip(length);
+            toBytes.clear();
+            toBytes.ensureCapacity(toBytes.writePosition() + payloadLength);
+            toBytes.write(0, bytes, bytes.readPosition(), payloadLength);
+            toBytes.readLimit(payloadLength);
+            bytes.readSkip(payloadLength);
         }
 
         @Override
         @NotNull
         public WireIn bytes(@NotNull ReadBytesMarshallable bytesConsumer) {
-            long length = readLength() - 1;
+            long length = readLength();
+            requireReadableBodyWithCode(length);
+            long payloadLength = length - 1;
             int code = readCode();
             if (code != U8_ARRAY)
                 cantRead(code);
 
-            if (length > bytes.readRemaining())
-                throw new BufferUnderflowException();
             long limit0 = bytes.readLimit();
-            long limit = bytes.readPosition() + length;
+            long limit = guardedReadLimit(payloadLength);
             try {
                 bytes.readLimit(limit);
                 bytesConsumer.readMarshallable(bytes);
@@ -3666,23 +3994,58 @@ public class BinaryWire extends AbstractWire implements Wire {
         @Override
         public byte[] bytes(byte[] using) {
             long length = readLength();
+            long bodyStart = bytes.readPosition();
+            requireReadableBodyWithCode(length);
+            long declaredEnd = guardDeclaredBodyEnd(length, bodyStart);
             int code = readCode();
             if (code == NULL) {
                 return null;
             }
 
             if (code == TYPE_PREFIX) {
-                @Nullable StringBuilder sb = readUtf8();
-                assert "byte[]".contentEquals(sb);
-                length = readLength();
-                code = readCode();
+                long limit0 = bytes.readLimit();
+                try {
+                    bytes.readLimit(declaredEnd);
+                    @Nullable StringBuilder sb = readUtf8();
+                    assert "byte[]".contentEquals(sb);
+                    long length2 = readLength();
+                    long bodyStart2 = bytes.readPosition();
+                    requireReadableBodyWithCode(length2);
+                    long declaredEnd2 = guardDeclaredBodyEnd(length2, bodyStart2);
+                    int code2 = readCode();
+                    if (code2 != U8_ARRAY)
+                        cantRead(code2);
+                    long payloadLength = length2 - 1;
+                    requireReadableLength(payloadLength);
+                    @NotNull byte[] bytes2 = using != null && using.length == payloadLength ? using : new byte[Maths.toUInt31(payloadLength)];
+                    long limit1 = bytes.readLimit();
+                    try {
+                        bytes.readLimit(declaredEnd2);
+                        bytes.readWithLength(payloadLength, b -> b.read(bytes2));
+                    } finally {
+                        bytes.readLimit(limit1);
+                    }
+                    bytes.readPosition(declaredEnd);
+                    return bytes2;
+                } catch (AssertionError e) {
+                    if (bytes.readPosition() > declaredEnd)
+                        bytes.readPosition(declaredEnd);
+                    throw new IORuntimeException(e);
+                } catch (RuntimeException e) {
+                    if (bytes.readPosition() > declaredEnd)
+                        bytes.readPosition(declaredEnd);
+                    throw e;
+                } finally {
+                    bytes.readLimit(limit0);
+                }
             }
 
             if (code != U8_ARRAY)
                 cantRead(code);
-            length--;
-            @NotNull byte[] bytes2 = using != null && using.length == length ? using : new byte[Maths.toUInt31(length)];
-            bytes.readWithLength(length, b -> b.read(bytes2));
+            long payloadLength = length - 1;
+            requireReadableLength(payloadLength);
+            @NotNull byte[] bytes2 = using != null && using.length == payloadLength ? using : new byte[Maths.toUInt31(payloadLength)];
+            bytes.readWithLength(payloadLength, b -> b.read(bytes2));
             return bytes2;
         }
 
@@ -3703,19 +4066,20 @@ public class BinaryWire extends AbstractWire implements Wire {
 
                 case BYTES_LENGTH8:
                     bytes.uncheckedReadSkipOne();
-                    return bytes.uncheckedReadUnsignedByte();
+                    return readGuardedUnsignedByteLength();
 
                 case BYTES_LENGTH16:
                     bytes.uncheckedReadSkipOne();
-                    return bytes.readUnsignedShort();
+                    return readGuardedUnsignedShortLength();
 
                 case BYTES_LENGTH32:
                     bytes.uncheckedReadSkipOne();
-                    return bytes.readUnsignedInt();
+                    return readGuardedUnsignedIntLength();
 
                 case TYPE_PREFIX:
                     bytes.uncheckedReadSkipOne();
-                    long len = bytes.readStopBit();
+                    long len = readGuardedStopBitLength();
+                    requireReadableLength(len);
                     bytes.readSkip(len);
                     return readLength();
                 case FALSE:
@@ -3771,8 +4135,15 @@ public class BinaryWire extends AbstractWire implements Wire {
                     long pos0 = bytes.readPosition();
                     try {
                         bytes.uncheckedReadSkipOne();
-                        long len2 = bytes.readStopBit();
-                        return bytes.readPosition() - pos0 + len2;
+                        long len2 = readGuardedStopBitLength();
+                        if (len2 == -1L)
+                            return bytes.readPosition() - pos0;
+                        if (len2 < -1L)
+                            throw new IORuntimeException("Invalid text length " + len2);
+                        long bodyStart = bytes.readPosition();
+                        guardedTextEnd(len2);
+                        Maths.toUInt31(len2);
+                        return bodyStart - pos0 + len2;
                     } finally {
                         bytes.readPosition(pos0);
                     }
@@ -3800,8 +4171,10 @@ public class BinaryWire extends AbstractWire implements Wire {
             final long length = readLength();
             if (length < 0)
                 objectBestEffort();
-            else
+            else {
+                requireReadableLength(length);
                 bytes.readSkip(length);
+            }
 
             return BinaryWire.this;
         }
@@ -4188,7 +4561,7 @@ public class BinaryWire extends AbstractWire implements Wire {
                 throw cantRead(peekCode());
 
             long limit = bytes.readLimit();
-            long limit2 = bytes.readPosition() + length;
+            long limit2 = guardedReadLimit(length);
             bytes.readLimit(limit2);
             try {
                 tReader.accept(t, this);
@@ -4219,7 +4592,7 @@ public class BinaryWire extends AbstractWire implements Wire {
                 throw cantRead(peekCode());
 
             long limit = bytes.readLimit();
-            long limit2 = bytes.readPosition() + length;
+            long limit2 = guardedReadLimit(length);
             bytes.readLimit(limit2);
             try {
                 tReader.accept(this, list, buffer, bufferAdd);
@@ -4237,7 +4610,7 @@ public class BinaryWire extends AbstractWire implements Wire {
             int code = readCode();
             long length = readLengthPrefixed(code);
             long limit = bytes.readLimit();
-            long limit2 = bytes.readPosition() + length;
+            long limit2 = guardedReadLimit(length);
             bytes.readLimit(limit2);
             try {
                 tReader.accept(t, kls, this);
@@ -4260,15 +4633,15 @@ public class BinaryWire extends AbstractWire implements Wire {
             switch (code) {
                 case BYTES_LENGTH8:
                     // Read an 8-bit unsigned integer as the length
-                    length = bytes.readUnsignedByte();
+                    length = readGuardedUnsignedByteLength();
                     break;
                 case BYTES_LENGTH16:
                     // Read a 16-bit unsigned integer as the length
-                    length = bytes.readUnsignedShort();
+                    length = readGuardedUnsignedShortLength();
                     break;
                 case BYTES_LENGTH32:
                     // Read a 32-bit unsigned integer as the length
-                    length = bytes.readUnsignedInt();
+                    length = readGuardedUnsignedIntLength();
                     break;
                 default:
                     // If an unrecognized code is encountered, throw an exception
@@ -4283,7 +4656,7 @@ public class BinaryWire extends AbstractWire implements Wire {
             int code = readCode();
             long length = readLengthPrefixed(code);
             long limit = bytes.readLimit();
-            long limit2 = bytes.readPosition() + length;
+            long limit2 = guardedReadLimit(length);
             bytes.readLimit(limit2);
             try {
                 return tReader.applyAsInt(this, t);
@@ -4301,7 +4674,7 @@ public class BinaryWire extends AbstractWire implements Wire {
                 long length = readLength();
                 if (length >= 0) {
                     long limit = bytes.readLimit();
-                    long limit2 = bytes.readPosition() + length;
+                    long limit2 = guardedReadLimit(length);
                     bytes.readLimit(limit2);
                     try {
                         return marshallableReader.apply(BinaryWire.this);
@@ -4441,7 +4814,7 @@ public class BinaryWire extends AbstractWire implements Wire {
             int code = readCode();
             switch (code) {
                 case TYPE_PREFIX:
-                    bytes.readUtf8(sb);
+                    readGuardedUtf8(sb);
 
                     break;
                 case NULL:
@@ -4523,32 +4896,34 @@ public class BinaryWire extends AbstractWire implements Wire {
             if (this.isNull())
                 return false;
             pushState();
-
-            // Get the length of the data to be read
-            long length = readLength();
-            if (length >= 0) {
-                long limit = bytes.readLimit();
-                long limit2 = bytes.readPosition() + length;
-                bytes.readLimit(limit2);
-                try {
-                    // Read the object based on its type
-                    if (useSelfDescribingMessage(object)) {
-                        if (overwrite)
-                            object.readMarshallable(BinaryWire.this);
-                        else
-                            Wires.readMarshallable(object, BinaryWire.this, false);
-                    } else {
-                        ((ReadBytesMarshallable) object).readMarshallable(BinaryWire.this.bytes);
+            try {
+                // Get the length of the data to be read
+                long length = readLength();
+                if (length >= 0) {
+                    long limit = bytes.readLimit();
+                    long limit2 = guardedReadLimit(length);
+                    bytes.readLimit(limit2);
+                    try {
+                        // Read the object based on its type
+                        if (useSelfDescribingMessage(object)) {
+                            if (overwrite)
+                                object.readMarshallable(BinaryWire.this);
+                            else
+                                Wires.readMarshallable(object, BinaryWire.this, false);
+                        } else {
+                            ((ReadBytesMarshallable) object).readMarshallable(BinaryWire.this.bytes);
+                        }
+                    } finally {
+                        bytes.readLimit(limit);
+                        bytes.readPosition(limit2);
                     }
-                } finally {
-                    bytes.readLimit(limit);
-                    bytes.readPosition(limit2);
-                    popState();
+                } else {
+                    throw new IORuntimeException("Length unknown");
                 }
-            } else {
-                throw new IORuntimeException("Length unknown");
+                return true;
+            } finally {
+                popState();
             }
-            return true;
         }
 
         @Override
@@ -4568,24 +4943,27 @@ public class BinaryWire extends AbstractWire implements Wire {
             if (this.isNull())
                 return null;
             pushState();
-            consumePadding();
-            long length = readLength();
-            if (length >= 0) {
-                long limit = bytes.readLimit();
-                long limit2 = bytes.readPosition() + length;
-                bytes.readLimit(limit2);
-                try {
-                    strategy.readUsing(null, Jvm.uncheckedCast(object), this, BracketType.MAP);
+            try {
+                consumePadding();
+                long length = readLength();
+                if (length >= 0) {
+                    long limit = bytes.readLimit();
+                    long limit2 = guardedReadLimit(length);
+                    bytes.readLimit(limit2);
+                    try {
+                        strategy.readUsing(null, Jvm.uncheckedCast(object), this, BracketType.MAP);
 
-                } finally {
-                    bytes.readLimit(limit);
-                    bytes.readPosition(limit2);
-                    popState();
+                    } finally {
+                        bytes.readLimit(limit);
+                        bytes.readPosition(limit2);
+                    }
+                } else {
+                    throw new IORuntimeException("Length unknown " + length);
                 }
-            } else {
-                throw new IORuntimeException("Length unknown " + length);
+                return object;
+            } finally {
+                popState();
             }
-            return object;
         }
 
         /**
@@ -4604,7 +4982,7 @@ public class BinaryWire extends AbstractWire implements Wire {
             long length = readLength();  // Read the expected length of the data.
             if (length >= 0) {  // If length is valid, proceed.
                 long limit = bytes.readLimit();
-                long limit2 = bytes.readPosition() + length;
+                long limit2 = guardedReadLimit(length);
                 bytes.readLimit(limit2);  // Set a temporary limit for the buffer based on the expected length.
                 try {
                     return Demarshallable.newInstance(clazz, wireIn());  // Deserialize the object using the current wire input.
@@ -4843,14 +5221,21 @@ public class BinaryWire extends AbstractWire implements Wire {
                                 long pos = bytes.readPosition();
                                 bytes.uncheckedReadSkipOne();
                                 long len = readLength(code);
+                                long nestedLimit = guardedReadLimit(len);
                                 code = peekCode();
                                 if (code == U8_ARRAY) {
                                     bytes.readPosition(pos);
-                                    return bytesStore();
+                                    long lim = bytes.readLimit();
+                                    try {
+                                        bytes.readLimit(nestedLimit);
+                                        return bytesStore();
+                                    } finally {
+                                        bytes.readLimit(lim);
+                                    }
                                 }
                                 long lim = bytes.readLimit();
                                 try {
-                                    bytes.readLimit(guardedReadLimit(len));
+                                    bytes.readLimit(nestedLimit);
                                     Object using1 = using;
                                     if (using1 == null && type != null)
                                         using1 = strategy.newInstanceOrNull(type);
@@ -4954,13 +5339,13 @@ public class BinaryWire extends AbstractWire implements Wire {
             // Determine the code and read the corresponding length.
             switch (code) {
                 case BYTES_LENGTH8:
-                    len = bytes.readUnsignedByte();  // Read an unsigned 8-bit value.
+                    len = readGuardedUnsignedByteLength();  // Read an unsigned 8-bit value.
                     break;
                 case BYTES_LENGTH16:
-                    len = bytes.readUnsignedShort();  // Read an unsigned 16-bit value.
+                    len = readGuardedUnsignedShortLength();  // Read an unsigned 16-bit value.
                     break;
                 case BYTES_LENGTH32:
-                    len = bytes.readUnsignedInt();  // Read an unsigned 32-bit value.
+                    len = readGuardedUnsignedIntLength();  // Read an unsigned 32-bit value.
                     break;
                 default:
                     throw new AssertionError(); // Throw an assertion error if the code is unrecognized.
@@ -5002,18 +5387,18 @@ public class BinaryWire extends AbstractWire implements Wire {
                         // For lengths, skip the bytes that define the length and then
                         // skip the number of bytes specified by the length.
                         case BYTES_LENGTH8:
-                            bytes.readSkip(1);  // Skip length definition byte.
-                            bytes.readSkip(bytes.readUnsignedByte());  // Skip the specified bytes.
+                            bytes.uncheckedReadSkipOne();
+                            guardedSkipDecodedLength(readGuardedUnsignedByteLength());
                             return;
 
                         case BYTES_LENGTH16:
-                            bytes.readSkip(1);
-                            bytes.readSkip(bytes.readUnsignedShort());
+                            bytes.uncheckedReadSkipOne();
+                            guardedSkipDecodedLength(readGuardedUnsignedShortLength());
                             return;
 
                         case BYTES_LENGTH32:
-                            bytes.readSkip(1);
-                            bytes.readSkip(bytes.readUnsignedInt());
+                            bytes.uncheckedReadSkipOne();
+                            guardedSkipDecodedLength(readGuardedUnsignedIntLength());
 
                             return;
 

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -485,14 +485,14 @@ public class BinaryWire extends AbstractWire implements Wire {
                     // Handle byte lengths and read accordingly.
                     case BYTES_LENGTH8: {
                         bytes.uncheckedReadSkipOne();
-                        int len = bytes.readUnsignedByte();
+                        long len = bytes.readUnsignedByte();
                         readWithLength(wire, len);
                         break outerSwitch;
                     }
 
                     case BYTES_LENGTH16: {
                         bytes.uncheckedReadSkipOne();
-                        int len = bytes.readUnsignedShort();
+                        long len = bytes.readUnsignedShort();
                         readWithLength(wire, len);
                         break outerSwitch;
                     }
@@ -671,17 +671,17 @@ public class BinaryWire extends AbstractWire implements Wire {
      * @param wire The wire output stream to write data to.
      * @param len  The length of data to be read, as an unsigned 32-bit value (0 to 4294967295).
      * @throws InvalidMarshallableException If there's an issue during marshalling.
-     * @throws IORuntimeException If the length is outside the unsigned 32-bit range.
+     * @throws IORuntimeException If the length is outside the unsigned 32-bit range,
+     *                            or exceeds the data remaining before the read limit.
      */
     @SuppressWarnings("incomplete-switch")
     public void readWithLength(@NotNull WireOut wire, long len) throws InvalidMarshallableException {
         // A length over 32-bit unsigned is unexpected: BYTES_LENGTH32 cannot encode it.
         if (len < 0 || len > 0xFFFF_FFFFL)
-            throw new IORuntimeException("Invalid length " + len + ", expected an unsigned 32-bit value");
+            throw new IORuntimeException("Invalid length " + len + ", expected an unsigned 32-bit value (0 to 4294967295)");
         long limit = bytes.readLimit();
         long newLimit = guardedReadLimit(len);
-        if (newLimit > limit)
-            throw new IORuntimeException("Can't extend the limit");
+
         try {
             bytes.readLimit(newLimit);
             @NotNull final ValueOut wireValueOut = wire.getValueOut();
@@ -720,21 +720,27 @@ public class BinaryWire extends AbstractWire implements Wire {
         }
     }
 
-    // Can only shrink the readLimit
+    /**
+     * Computes the read limit for a nested, length-prefixed value. A nested value must lie
+     * within the enclosing document, so the read limit can only shrink, never extend past
+     * the current one into data that is not readable.
+     *
+     * @param len The length of the nested value, as an unsigned 32-bit value.
+     * @return The read limit for the nested value: the current read position plus the length.
+     * @throws IORuntimeException If the length exceeds the data remaining before the read limit.
+     */
     private long guardedReadLimit(long len) {
         long start = bytes.readPosition();
         long prevLimit = bytes.readLimit();
 
-        assert len >= 0 && len <= 0xFFFF_FFFFL : len;
+        assert len >= 0 && len <= 0xFFFF_FFFFL : "len: " + len;
         assert start <= prevLimit : "readPosition " + start + " > readLimit " + prevLimit;
 
         if (len > prevLimit - start)
-            throw new IORuntimeException("Can't extend the limit");
+            throw new IORuntimeException("Length " + len + " exceeds the " + (prevLimit - start) +
+                    " bytes remaining between readPosition " + start + " and readLimit " + prevLimit);
 
-        long newLimit = start + len;
-        assert newLimit >= start;
-        assert newLimit <= prevLimit;
-        return newLimit;
+        return start + len;
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -500,7 +500,7 @@ public class BinaryWire extends AbstractWire implements Wire {
                     case BYTES_LENGTH32: {
                         // Handle 32-bit length bytes and read accordingly.
                         bytes.uncheckedReadSkipOne();
-                        int len = bytes.readInt();
+                        long len = bytes.readUnsignedInt();
                         readWithLength(wire, len);
                         break outerSwitch;
                     }
@@ -660,10 +660,26 @@ public class BinaryWire extends AbstractWire implements Wire {
      * @param len  The length of data to be read.
      * @throws InvalidMarshallableException If there's an issue during marshalling.
      */
-    @SuppressWarnings("incomplete-switch")
     public void readWithLength(@NotNull WireOut wire, int len) throws InvalidMarshallableException {
+        readWithLength(wire, (long) len);
+    }
+
+    /**
+     * Reads data of a specified length from the bytes stream and writes to the WireOut stream
+     * while interpreting the type of data (Map, Sequence, or Object).
+     *
+     * @param wire The wire output stream to write data to.
+     * @param len  The length of data to be read, as an unsigned 32-bit value (0 to 4294967295).
+     * @throws InvalidMarshallableException If there's an issue during marshalling.
+     * @throws IORuntimeException If the length is outside the unsigned 32-bit range.
+     */
+    @SuppressWarnings("incomplete-switch")
+    public void readWithLength(@NotNull WireOut wire, long len) throws InvalidMarshallableException {
+        // A length over 32-bit unsigned is unexpected: BYTES_LENGTH32 cannot encode it.
+        if (len < 0 || len > 0xFFFF_FFFFL)
+            throw new IORuntimeException("Invalid length " + len + ", expected an unsigned 32-bit value");
         long limit = bytes.readLimit();
-        long newLimit = bytes.readPosition() + len;
+        long newLimit = guardedReadLimit(len);
         if (newLimit > limit)
             throw new IORuntimeException("Can't extend the limit");
         try {
@@ -702,6 +718,23 @@ public class BinaryWire extends AbstractWire implements Wire {
         } finally {
             bytes.readLimit(limit);  // Reset the read limit to its original value.
         }
+    }
+
+    // Can only shrink the readLimit
+    private long guardedReadLimit(long len) {
+        long start = bytes.readPosition();
+        long prevLimit = bytes.readLimit();
+
+        assert len >= 0 && len <= 0xFFFF_FFFFL : len;
+        assert start <= prevLimit : "readPosition " + start + " > readLimit " + prevLimit;
+
+        if (len > prevLimit - start)
+            throw new IORuntimeException("Can't extend the limit");
+
+        long newLimit = start + len;
+        assert newLimit >= start;
+        assert newLimit <= prevLimit;
+        return newLimit;
     }
 
     /**
@@ -4803,7 +4836,7 @@ public class BinaryWire extends AbstractWire implements Wire {
                             } else {
                                 long pos = bytes.readPosition();
                                 bytes.uncheckedReadSkipOne();
-                                int len = readLength(code);
+                                long len = readLength(code);
                                 code = peekCode();
                                 if (code == U8_ARRAY) {
                                     bytes.readPosition(pos);
@@ -4811,7 +4844,7 @@ public class BinaryWire extends AbstractWire implements Wire {
                                 }
                                 long lim = bytes.readLimit();
                                 try {
-                                    bytes.readLimit(bytes.readPosition() + len);
+                                    bytes.readLimit(guardedReadLimit(len));
                                     Object using1 = using;
                                     if (using1 == null && type != null)
                                         using1 = strategy.newInstanceOrNull(type);
@@ -4910,8 +4943,8 @@ public class BinaryWire extends AbstractWire implements Wire {
          * @param code The code representing the length format.
          * @return The length value read.
          */
-        private int readLength(int code) {
-            int len;
+        private long readLength(int code) {
+            long len;
             // Determine the code and read the corresponding length.
             switch (code) {
                 case BYTES_LENGTH8:
@@ -4921,7 +4954,7 @@ public class BinaryWire extends AbstractWire implements Wire {
                     len = bytes.readUnsignedShort();  // Read an unsigned 16-bit value.
                     break;
                 case BYTES_LENGTH32:
-                    len = bytes.readInt();  // Read a 32-bit integer value.
+                    len = bytes.readUnsignedInt();  // Read an unsigned 32-bit value.
                     break;
                 default:
                     throw new AssertionError(); // Throw an assertion error if the code is unrecognized.

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireNegativeLengthTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireNegativeLengthTest.java
@@ -1,0 +1,1551 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.wire;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.BytesStore;
+import net.openhft.chronicle.bytes.PointerBytesStore;
+import net.openhft.chronicle.bytes.ReadBytesMarshallable;
+import net.openhft.chronicle.core.io.IORuntimeException;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.*;
+
+public class BinaryWireNegativeLengthTest extends WireTestCommon {
+
+    @Test
+    public void readWithLengthRejectsNegativeLengthBeforeMutatingOutput() {
+        Bytes<?> bytes = Bytes.wrapForRead(new byte[5]);
+        bytes.readPosition(5);
+
+        BinaryWire source = new BinaryWire(bytes);
+        Bytes<?> outputBytes = Bytes.allocateElasticOnHeap();
+        Wire outputWire = WireType.TEXT.apply(outputBytes);
+        long outputWritePosition = outputBytes.writePosition();
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> source.readWithLength(outputWire, -1));
+
+        assertTrue(e.getMessage().contains("Invalid length"));
+        assertEquals(outputWritePosition, outputBytes.writePosition());
+        assertTrue(bytes.readLimit() >= bytes.readPosition());
+    }
+
+    @Test
+    public void copyOneRejectsBytesLength32MaxUnsignedLength() {
+        Bytes<?> bytes = Bytes.wrapForRead(negativeBytesLength32Payload());
+        BinaryWire source = new BinaryWire(bytes);
+        Bytes<?> outputBytes = Bytes.allocateElasticOnHeap();
+        Wire outputWire = WireType.TEXT.apply(outputBytes);
+        long outputWritePosition = outputBytes.writePosition();
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> source.copyOne(outputWire));
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertEquals(5, bytes.readPosition());
+        assertTrue(bytes.readLimit() >= bytes.readPosition());
+        assertEquals(outputWritePosition, outputBytes.writePosition());
+    }
+
+    @Test
+    public void copyOneRejectsMaxUnsignedLengthWithoutConsumingFollowingBytes() {
+        byte[] payload = {
+                (byte) BinaryWireCode.BYTES_LENGTH32,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+                0x01, 0x02, 0x03, 0x04
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload);
+        BinaryWire source = new BinaryWire(bytes);
+        Bytes<?> outputBytes = Bytes.allocateElasticOnHeap();
+        Wire outputWire = WireType.TEXT.apply(outputBytes);
+        long outputWritePosition = outputBytes.writePosition();
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> source.copyOne(outputWire));
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertEquals(5, bytes.readPosition());
+        assertEquals(0x01, bytes.readUnsignedByte(5));
+        assertEquals(0x02, bytes.readUnsignedByte(6));
+        assertEquals(0x03, bytes.readUnsignedByte(7));
+        assertEquals(0x04, bytes.readUnsignedByte(8));
+        assertEquals(outputWritePosition, outputBytes.writePosition());
+    }
+
+    @Test
+    public void objectRejectsBytesLength32MaxUnsignedLength() {
+        byte[] payload = {
+                (byte) BinaryWireCode.BYTES_LENGTH32,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+                (byte) BinaryWireCode.TRUE
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload);
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().object());
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertEquals(5, bytes.readPosition());
+        assertTrue(bytes.readLimit() >= bytes.readPosition());
+        assertEquals(BinaryWireCode.TRUE, bytes.readUnsignedByte(5));
+    }
+
+    @Test
+    public void objectRejectsBytesLength32LengthBeyondCurrentReadLimit() {
+        byte[] payload = {
+                (byte) BinaryWireCode.BYTES_LENGTH32,
+                0x04, 0x00, 0x00, 0x00,
+                (byte) BinaryWireCode.TRUE,
+                0x01, 0x02, 0x03
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload);
+        assertEquals(4, bytes.readInt(1));
+        bytes.readLimit(6);
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().object());
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertEquals(5, bytes.readPosition());
+        assertEquals(6, bytes.readLimit());
+        assertTrue(bytes.readRemaining() >= 0);
+        assertEquals(BinaryWireCode.TRUE, bytes.readUnsignedByte(5));
+        assertEquals(0x01, bytes.readUnsignedByte(6));
+        assertEquals(0x02, bytes.readUnsignedByte(7));
+        assertEquals(0x03, bytes.readUnsignedByte(8));
+    }
+
+    @Test
+    public void objectRejectsUncheckedBytesLength32U8ArrayBeyondCurrentReadLimit() {
+        byte[] payload = {
+                (byte) BinaryWireCode.BYTES_LENGTH32,
+                0x04, 0x00, 0x00, 0x00,
+                (byte) BinaryWireCode.U8_ARRAY,
+                0x01, 0x02, 0x03
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload).unchecked(true);
+        assertEquals(4, bytes.readInt(1));
+        bytes.readLimit(6);
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().object());
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertEquals(5, bytes.readPosition());
+        assertEquals(6, bytes.readLimit());
+        assertTrue(bytes.readRemaining() >= 0);
+        assertEquals(BinaryWireCode.U8_ARRAY, bytes.readUnsignedByte(5));
+        assertEquals(0x01, bytes.readUnsignedByte(6));
+        assertEquals(0x02, bytes.readUnsignedByte(7));
+        assertEquals(0x03, bytes.readUnsignedByte(8));
+    }
+
+    @Test
+    public void bytesStoreRejectsUncheckedBytesLength32U8ArrayBeyondCurrentReadLimit() {
+        Bytes<?> bytes = uncheckedLength32U8ArrayWithNarrowReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().bytesStore());
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertEquals(5, bytes.readPosition());
+        assertReadableStateAndPayload(bytes, 5);
+    }
+
+    @Test
+    public void bytesStoreRejectsZeroLengthBodyBeforeReadingNestedCode() {
+        Bytes<?> bytes = uncheckedLength32WithZeroDeclaredBody();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().bytesStore());
+
+        assertTrue(e.getMessage().contains("does not include a value code"));
+        assertZeroLengthBodyState(bytes);
+    }
+
+    @Test
+    public void bytesLiteralToBytesRejectsUncheckedBytesLength32U8ArrayBeyondCurrentReadLimit() {
+        Bytes<?> bytes = uncheckedLength32U8ArrayWithNarrowReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+        Bytes<?> output = Bytes.allocateElasticOnHeap();
+        long outputWritePosition = output.writePosition();
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().bytesLiteral(output));
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertEquals(outputWritePosition, output.writePosition());
+        assertEquals(5, bytes.readPosition());
+        assertReadableStateAndPayload(bytes, 5);
+    }
+
+    @Test
+    public void bytesLiteralRejectsUncheckedBytesLength32U8ArrayBeyondCurrentReadLimit() {
+        Bytes<?> bytes = uncheckedLength32U8ArrayWithNarrowReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().bytesLiteral());
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertEquals(5, bytes.readPosition());
+        assertReadableStateAndPayload(bytes, 5);
+    }
+
+    @Test
+    public void bytesSetRejectsUncheckedBytesLength32U8ArrayBeyondCurrentReadLimit() {
+        Bytes<?> bytes = uncheckedLength32U8ArrayWithNarrowReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+        PointerBytesStore pointer = BytesStore.nativePointer();
+
+        try {
+            IORuntimeException e = assertThrows(IORuntimeException.class,
+                    () -> wire.getValueIn().bytesSet(pointer));
+
+            assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+            assertEquals(5, bytes.readPosition());
+            assertReadableStateAndPayload(bytes, 5);
+        } finally {
+            pointer.releaseLast();
+        }
+    }
+
+    @Test
+    public void bytesSetRejectsZeroLengthBodyBeforeReadingNestedCode() {
+        Bytes<?> bytes = uncheckedLength32WithZeroDeclaredBody();
+        BinaryWire wire = new BinaryWire(bytes);
+        PointerBytesStore pointer = BytesStore.nativePointer();
+
+        try {
+            IORuntimeException e = assertThrows(IORuntimeException.class,
+                    () -> wire.getValueIn().bytesSet(pointer));
+
+            assertTrue(e.getMessage().contains("does not include a value code"));
+            assertZeroLengthBodyState(bytes);
+        } finally {
+            pointer.releaseLast();
+        }
+    }
+
+    @Test
+    public void bytesMatchRejectsUncheckedBytesLength32U8ArrayBeyondCurrentReadLimit() {
+        Bytes<?> bytes = uncheckedLength32U8ArrayWithNarrowReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+        Bytes<?> compare = Bytes.wrapForRead(new byte[]{0x01, 0x02, 0x03});
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().bytesMatch(compare, matched -> fail("Should not compare bytes")));
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertEquals(5, bytes.readPosition());
+        assertReadableStateAndPayload(bytes, 5);
+    }
+
+    @Test
+    public void bytesMatchRejectsZeroLengthBodyBeforeInvokingConsumer() {
+        Bytes<?> bytes = uncheckedLength32WithZeroDeclaredBody();
+        BinaryWire wire = new BinaryWire(bytes);
+        Bytes<?> compare = Bytes.wrapForRead(new byte[0]);
+        AtomicBoolean invoked = new AtomicBoolean();
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().bytesMatch(compare, matched -> invoked.set(true)));
+
+        assertTrue(e.getMessage().contains("does not include a value code"));
+        assertFalse(invoked.get());
+        assertZeroLengthBodyState(bytes);
+    }
+
+    @Test
+    public void bytesToBytesOutRejectsBeforeClearingOutput() {
+        Bytes<?> bytes = uncheckedLength32U8ArrayWithNarrowReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+        Bytes<?> output = Bytes.allocateElasticOnHeap();
+        output.writeByte((byte) 0x55);
+        long outputWritePosition = output.writePosition();
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().bytes(output));
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertEquals(outputWritePosition, output.writePosition());
+        assertEquals(0x55, output.readUnsignedByte(0));
+        assertEquals(5, bytes.readPosition());
+        assertReadableStateAndPayload(bytes, 5);
+    }
+
+    @Test
+    public void bytesToBytesOutRejectsZeroLengthBodyBeforeClearingOutput() {
+        Bytes<?> bytes = uncheckedLength32WithZeroDeclaredBody();
+        BinaryWire wire = new BinaryWire(bytes);
+        Bytes<?> output = Bytes.allocateElasticOnHeap();
+        output.writeByte((byte) 0x66);
+        long outputWritePosition = output.writePosition();
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().bytes(output));
+
+        assertTrue(e.getMessage().contains("does not include a value code"));
+        assertEquals(outputWritePosition, output.writePosition());
+        assertEquals(0x66, output.readUnsignedByte(0));
+        assertZeroLengthBodyState(bytes);
+    }
+
+    @Test
+    public void bytesToBytesOutFallbackRejectsWithoutConsumingBeyondDeclaredBody() {
+        Bytes<?> bytes = bytesLength8OneByteBodyWithTrailingPaddingAndTrue();
+        long originalLimit = bytes.readLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+        Bytes<?> output = Bytes.allocateElasticOnHeap();
+        output.writeByte((byte) 0x66);
+        long outputWritePosition = output.writePosition();
+
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> wire.getValueIn().bytes(output));
+
+        assertNotNull(e);
+        assertEquals(outputWritePosition, output.writePosition());
+        assertEquals(0x66, output.readUnsignedByte(0));
+        assertTrue(bytes.readPosition() <= 3);
+        assertEquals(originalLimit, bytes.readLimit());
+        assertTrailingPaddingAndTrue(bytes);
+    }
+
+    @Test
+    public void bytesToBytesOutTypePrefixRejectsWithoutConsumingBeyondDeclaredBody() {
+        Bytes<?> bytes = bytesLength8OneByteBodyTypePrefixWithTrailingBytes();
+        long originalLimit = bytes.readLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+        Bytes<?> output = Bytes.allocateElasticOnHeap();
+        output.writeByte((byte) 0x66);
+        long outputWritePosition = output.writePosition();
+
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> wire.getValueIn().bytes(output));
+
+        assertNotNull(e);
+        assertEquals(outputWritePosition, output.writePosition());
+        assertEquals(0x66, output.readUnsignedByte(0));
+        assertTrue(bytes.readPosition() <= 3);
+        assertEquals(originalLimit, bytes.readLimit());
+        assertTrailingTypePrefixBytes(bytes);
+    }
+
+    @Test
+    public void bytesToBytesOutReadsEmptyU8ArrayLengthOne() {
+        byte[] payload = {
+                (byte) BinaryWireCode.BYTES_LENGTH8,
+                0x01,
+                (byte) BinaryWireCode.U8_ARRAY,
+                0x55
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload);
+        BinaryWire wire = new BinaryWire(bytes);
+        Bytes<?> output = Bytes.allocateElasticOnHeap();
+        output.writeByte((byte) 0x66);
+
+        wire.getValueIn().bytes(output);
+
+        assertEquals(0, output.writePosition());
+        assertEquals(3, bytes.readPosition());
+        assertEquals(payload.length, bytes.readLimit());
+        assertEquals(0x55, bytes.readUnsignedByte(3));
+    }
+
+    @Test
+    public void bytesToBytesOutReadsNullLengthOne() {
+        byte[] payload = {
+                (byte) BinaryWireCode.BYTES_LENGTH8,
+                0x01,
+                (byte) BinaryWireCode.NULL,
+                0x55
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload);
+        BinaryWire wire = new BinaryWire(bytes);
+        Bytes<?> output = Bytes.allocateElasticOnHeap();
+        output.writeByte((byte) 0x66);
+
+        wire.getValueIn().bytes(output);
+
+        assertEquals(0, output.writePosition());
+        assertEquals(3, bytes.readPosition());
+        assertEquals(payload.length, bytes.readLimit());
+        assertEquals(0x55, bytes.readUnsignedByte(3));
+    }
+
+    @Test
+    public void bytesStoreToBytesRejectsBeforeClearingTarget() {
+        Bytes<?> bytes = uncheckedLength32U8ArrayWithNarrowReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+        Bytes<?> target = Bytes.allocateElasticOnHeap();
+        target.writeByte((byte) 0x55);
+        long targetWritePosition = target.writePosition();
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> ((BinaryWire.BinaryValueIn) wire.getValueIn()).bytesStore(target));
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertEquals(targetWritePosition, target.writePosition());
+        assertEquals(0x55, target.readUnsignedByte(0));
+        assertEquals(5, bytes.readPosition());
+        assertReadableStateAndPayload(bytes, 5);
+    }
+
+    @Test
+    public void bytesStoreToBytesRejectsZeroLengthBodyBeforeClearingTarget() {
+        Bytes<?> bytes = uncheckedLength32WithZeroDeclaredBody();
+        BinaryWire wire = new BinaryWire(bytes);
+        Bytes<?> target = Bytes.allocateElasticOnHeap();
+        target.writeByte((byte) 0x66);
+        long targetWritePosition = target.writePosition();
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> ((BinaryWire.BinaryValueIn) wire.getValueIn()).bytesStore(target));
+
+        assertTrue(e.getMessage().contains("does not include a value code"));
+        assertEquals(targetWritePosition, target.writePosition());
+        assertEquals(0x66, target.readUnsignedByte(0));
+        assertZeroLengthBodyState(bytes);
+    }
+
+    @Test
+    public void bytesMarshallableRejectsBeforeInvokingCallback() {
+        Bytes<?> bytes = uncheckedLength32U8ArrayWithZeroPayloadLength();
+        BinaryWire wire = new BinaryWire(bytes);
+        AtomicBoolean invoked = new AtomicBoolean();
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().bytes((ReadBytesMarshallable) in -> invoked.set(true)));
+
+        assertTrue(e.getMessage().contains("does not include a value code"));
+        assertFalse(invoked.get());
+        assertEquals(5, bytes.readPosition());
+        assertEquals(6, bytes.readLimit());
+        assertTrue(bytes.readRemaining() >= 0);
+    }
+
+    @Test
+    public void bytesMarshallableRejectsZeroLengthBodyBeforeInvokingCallback() {
+        Bytes<?> bytes = uncheckedLength32WithZeroDeclaredBody();
+        BinaryWire wire = new BinaryWire(bytes);
+        AtomicBoolean invoked = new AtomicBoolean();
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().bytes((ReadBytesMarshallable) in -> invoked.set(true)));
+
+        assertTrue(e.getMessage().contains("does not include a value code"));
+        assertFalse(invoked.get());
+        assertZeroLengthBodyState(bytes);
+    }
+
+    @Test
+    public void bytesArrayRejectsBeforeAllocationOrRead() {
+        Bytes<?> bytes = uncheckedLength32U8ArrayWithNarrowReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().bytes((byte[]) null));
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertEquals(5, bytes.readPosition());
+        assertReadableStateAndPayload(bytes, 5);
+    }
+
+    @Test
+    public void bytesArrayRejectsZeroLengthBodyBeforeAllocationOrRead() {
+        Bytes<?> bytes = uncheckedLength32WithZeroDeclaredBody();
+        BinaryWire wire = new BinaryWire(bytes);
+        byte[] using = {(byte) 0x66};
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().bytes(using));
+
+        assertTrue(e.getMessage().contains("does not include a value code"));
+        assertEquals((byte) 0x66, using[0]);
+        assertZeroLengthBodyState(bytes);
+    }
+
+    @Test
+    public void skipValueRejectsBeforeSkippingPastReadLimit() {
+        Bytes<?> bytes = uncheckedLength32U8ArrayWithNarrowReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().skipValue());
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertEquals(5, bytes.readPosition());
+        assertReadableStateAndPayload(bytes, 5);
+    }
+
+    @Test
+    public void sequenceRejectsLengthBeyondCurrentReadLimitBeforeInvokingReader() {
+        Bytes<?> bytes = length32BodyWithNarrowReadLimit((byte) BinaryWireCode.TRUE);
+        BinaryWire wire = new BinaryWire(bytes);
+        AtomicBoolean invoked = new AtomicBoolean();
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().sequence("holder", (holder, valueIn) -> invoked.set(true)));
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertFalse(invoked.get());
+        assertEquals(5, bytes.readPosition());
+        assertLength32BodyState(bytes, 5, BinaryWireCode.TRUE);
+    }
+
+    @Test
+    public void marshallableRejectsLengthBeyondCurrentReadLimitBeforeInvokingReader() {
+        Bytes<?> bytes = length32BodyWithNarrowReadLimit((byte) BinaryWireCode.TRUE);
+        BinaryWire wire = new BinaryWire(bytes);
+        AtomicBoolean invoked = new AtomicBoolean();
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().marshallable((ReadMarshallable) in -> invoked.set(true)));
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertFalse(invoked.get());
+        assertEquals(5, bytes.readPosition());
+        assertLength32BodyState(bytes, 5, BinaryWireCode.TRUE);
+    }
+
+    @Test
+    public void consumePaddingRejectsPadding32BeyondCurrentReadLimit() {
+        Bytes<?> bytes = padding32WithNarrowReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class, wire::consumePadding);
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertEquals(5, bytes.readPosition());
+        assertEquals(5, bytes.readLimit());
+        assertEquals(0, bytes.readRemaining());
+        assertTrue(bytes.readPosition() <= bytes.readLimit());
+    }
+
+    @Test
+    public void consumePaddingRejectsPadding32TruncatedLengthPrefix() {
+        Bytes<?> bytes = padding32WithTruncatedLengthPrefix();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class, wire::consumePadding);
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertTruncatedPadding32PrefixState(bytes);
+    }
+
+    @Test
+    public void copyOneRejectsPadding32BeyondCurrentReadLimit() {
+        Bytes<?> bytes = padding32WithNarrowReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+        Wire outputWire = WireType.TEXT.apply(Bytes.allocateElasticOnHeap());
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.copyOne(outputWire));
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertEquals(5, bytes.readPosition());
+        assertEquals(5, bytes.readLimit());
+        assertEquals(0, bytes.readRemaining());
+        assertTrue(bytes.readPosition() <= bytes.readLimit());
+    }
+
+    @Test
+    public void copyOneRejectsPadding32TruncatedLengthPrefix() {
+        Bytes<?> bytes = padding32WithTruncatedLengthPrefix();
+        BinaryWire wire = new BinaryWire(bytes);
+        Bytes<?> outputBytes = Bytes.allocateElasticOnHeap();
+        outputBytes.writeByte((byte) 0x66);
+        Wire outputWire = WireType.TEXT.apply(outputBytes);
+        long outputWritePosition = outputBytes.writePosition();
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.copyOne(outputWire));
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertEquals(outputWritePosition, outputBytes.writePosition());
+        assertEquals(0x66, outputBytes.readUnsignedByte(0));
+        assertTruncatedPadding32PrefixState(bytes);
+    }
+
+    @Test
+    public void consumePaddingSkipsPadding32WithinCurrentReadLimit() {
+        byte[] payload = {
+                (byte) BinaryWireCode.PADDING32,
+                0x04, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00,
+                (byte) BinaryWireCode.TRUE
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload);
+        BinaryWire wire = new BinaryWire(bytes);
+
+        wire.consumePadding();
+
+        assertEquals(9, bytes.readPosition());
+        assertEquals(payload.length, bytes.readLimit());
+        assertEquals(BinaryWireCode.TRUE, bytes.readUnsignedByte(9));
+    }
+
+    @Test
+    public void consumeNextRejectsBytesLength32BeyondCurrentReadLimit() {
+        Bytes<?> bytes = uncheckedLength32U8ArrayWithNarrowReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> ((BinaryWire.BinaryValueIn) wire.getValueIn()).consumeNext());
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertEquals(5, bytes.readPosition());
+        assertReadableStateAndPayload(bytes, 5);
+    }
+
+    @Test
+    public void copyOneRejectsBytesLength32TruncatedLengthPrefix() {
+        Bytes<?> bytes = bytesLength32WithTruncatedLengthPrefix();
+        BinaryWire wire = new BinaryWire(bytes);
+        Bytes<?> outputBytes = Bytes.allocateElasticOnHeap();
+        outputBytes.writeByte((byte) 0x66);
+        Wire outputWire = WireType.TEXT.apply(outputBytes);
+        long outputWritePosition = outputBytes.writePosition();
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.copyOne(outputWire));
+
+        assertTrue(e.getMessage().contains("Length prefix"));
+        assertEquals(outputWritePosition, outputBytes.writePosition());
+        assertEquals(0x66, outputBytes.readUnsignedByte(0));
+        assertTruncatedLength32PrefixState(bytes);
+    }
+
+    @Test
+    public void skipValueRejectsBytesLength32TruncatedLengthPrefix() {
+        Bytes<?> bytes = bytesLength32WithTruncatedLengthPrefix();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().skipValue());
+
+        assertTrue(e.getMessage().contains("Length prefix"));
+        assertTruncatedLength32PrefixState(bytes);
+    }
+
+    @Test
+    public void bytesStoreRejectsBytesLength32TruncatedLengthPrefix() {
+        Bytes<?> bytes = bytesLength32WithTruncatedLengthPrefix();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().bytesStore());
+
+        assertTrue(e.getMessage().contains("Length prefix"));
+        assertTruncatedLength32PrefixState(bytes);
+    }
+
+    @Test
+    public void objectRejectsBytesLength32TruncatedLengthPrefix() {
+        Bytes<?> bytes = bytesLength32WithTruncatedLengthPrefix();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().object());
+
+        assertTrue(e.getMessage().contains("Length prefix"));
+        assertTruncatedLength32PrefixState(bytes);
+    }
+
+    @Test
+    public void consumeNextRejectsBytesLength32TruncatedLengthPrefix() {
+        Bytes<?> bytes = bytesLength32WithTruncatedLengthPrefix();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> ((BinaryWire.BinaryValueIn) wire.getValueIn()).consumeNext());
+
+        assertTrue(e.getMessage().contains("Length prefix"));
+        assertTruncatedLength32PrefixState(bytes);
+    }
+
+    @Test
+    public void skipValueRejectsBytesLength16TruncatedLengthPrefix() {
+        Bytes<?> bytes = bytesLength16WithTruncatedLengthPrefix();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().skipValue());
+
+        assertTrue(e.getMessage().contains("Length prefix"));
+        assertTruncatedLength16PrefixState(bytes);
+    }
+
+    @Test
+    public void skipValueRejectsBytesLength8TruncatedLengthPrefix() {
+        Bytes<?> bytes = bytesLength8WithTruncatedLengthPrefix();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().skipValue());
+
+        assertTrue(e.getMessage().contains("Length prefix"));
+        assertTruncatedLength8PrefixState(bytes);
+    }
+
+    @Test
+    public void skipValueRejectsTypePrefixTruncatedStopBitPrefix() {
+        Bytes<?> bytes = typePrefixWithTruncatedStopBitPrefix();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().skipValue());
+
+        assertTrue(e.getMessage().contains("Stop bit length prefix"));
+        assertTruncatedTypePrefixStopBitState(bytes);
+    }
+
+    @Test
+    public void textRejectsStringAnyTruncatedStopBitPrefix() {
+        Bytes<?> bytes = stringAnyWithTruncatedStopBitPrefix();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().text());
+
+        assertTrue(e.getMessage().contains("Stop bit length prefix"));
+        assertStringAnyState(bytes, 1, 1);
+    }
+
+    @Test
+    public void textRejectsStringAnyBodyBeyondCurrentReadLimit() {
+        Bytes<?> bytes = stringAnyWithBodyBeyondCurrentReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().text());
+
+        assertTrue(e.getMessage().contains("Text length"));
+        assertStringAnyState(bytes, 2, 2);
+    }
+
+    @Test
+    public void objectRejectsStringAnyBodyBeyondCurrentReadLimit() {
+        Bytes<?> bytes = stringAnyWithBodyBeyondCurrentReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().object());
+
+        assertTrue(e.getMessage().contains("Text length"));
+        assertStringAnyState(bytes, 2, 2);
+    }
+
+    @Test
+    public void skipValueRejectsStringAnyTruncatedStopBitPrefix() {
+        Bytes<?> bytes = stringAnyWithTruncatedStopBitPrefix();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().skipValue());
+
+        assertTrue(e.getMessage().contains("Stop bit length prefix"));
+        assertEquals(0, bytes.readPosition());
+        assertEquals(1, bytes.readLimit());
+        assertTrue(bytes.readPosition() <= bytes.readLimit());
+        assertStringAnyBytes(bytes);
+    }
+
+    @Test
+    public void consumeNextRejectsStringAnyBodyBeyondCurrentReadLimit() {
+        Bytes<?> bytes = stringAnyWithBodyBeyondCurrentReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> ((BinaryWire.BinaryValueIn) wire.getValueIn()).consumeNext());
+
+        assertTrue(e.getMessage().contains("Text length"));
+        assertStringAnyState(bytes, 2, 2);
+    }
+
+    @Test
+    public void readTextRejectsStringAnyBodyBeyondCurrentReadLimit() {
+        Bytes<?> bytes = stringAnyBodyWithBodyBeyondCurrentReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+        StringBuilder sb = new StringBuilder("sentinel");
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.readText(BinaryWireCode.STRING_ANY, sb));
+
+        assertTrue(e.getMessage().contains("Text length"));
+        assertEquals("sentinel", sb.toString());
+        assertStringAnyBodyState(bytes, 1, 1);
+    }
+
+    @Test
+    public void textToStringBuilderRejectsStringAnyBodyBeyondCurrentReadLimitWithoutMutation() {
+        Bytes<?> bytes = stringAnyWithBodyBeyondCurrentReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+        StringBuilder sb = new StringBuilder("sentinel");
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().textTo(sb));
+
+        assertTrue(e.getMessage().contains("Text length"));
+        assertEquals("sentinel", sb.toString());
+        assertStringAnyState(bytes, 2, 2);
+    }
+
+    @Test
+    public void textToBytesRejectsStringAnyBodyBeyondCurrentReadLimitWithoutMutation() {
+        Bytes<?> bytes = stringAnyWithBodyBeyondCurrentReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+        Bytes<?> target = Bytes.allocateElasticOnHeap();
+        target.writeByte((byte) 0x66);
+        long writePosition = target.writePosition();
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().textTo(target));
+
+        assertTrue(e.getMessage().contains("Text length"));
+        assertEquals(writePosition, target.writePosition());
+        assertEquals(0x66, target.readUnsignedByte(0));
+        assertStringAnyState(bytes, 2, 2);
+    }
+
+    @Test
+    public void copyOneRejectsStringAnyTruncatedStopBitPrefixWithoutOutputMutation() {
+        Bytes<?> bytes = stringAnyWithTruncatedStopBitPrefix();
+        BinaryWire wire = new BinaryWire(bytes);
+        Bytes<?> outputBytes = Bytes.allocateElasticOnHeap();
+        outputBytes.writeByte((byte) 0x66);
+        Wire outputWire = WireType.TEXT.apply(outputBytes);
+        long outputWritePosition = outputBytes.writePosition();
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.copyOne(outputWire));
+
+        assertTrue(e.getMessage().contains("Stop bit length prefix"));
+        assertEquals(outputWritePosition, outputBytes.writePosition());
+        assertEquals(0x66, outputBytes.readUnsignedByte(0));
+        assertStringAnyState(bytes, 1, 1);
+    }
+
+    @Test
+    public void copyOneRejectsStringAnyBodyBeyondCurrentReadLimitWithoutOutputMutation() {
+        Bytes<?> bytes = stringAnyWithBodyBeyondCurrentReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+        Bytes<?> outputBytes = Bytes.allocateElasticOnHeap();
+        outputBytes.writeByte((byte) 0x66);
+        Wire outputWire = WireType.TEXT.apply(outputBytes);
+        long outputWritePosition = outputBytes.writePosition();
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.copyOne(outputWire));
+
+        assertTrue(e.getMessage().contains("Text length"));
+        assertEquals(outputWritePosition, outputBytes.writePosition());
+        assertEquals(0x66, outputBytes.readUnsignedByte(0));
+        assertStringAnyState(bytes, 2, 2);
+    }
+
+    @Test
+    public void copyOneStillCopiesValidStringAny() {
+        Bytes<?> bytes = validStringAny();
+        Bytes<?> outputBytes = Bytes.allocateElasticOnHeap();
+        Wire outputWire = WireType.TEXT.apply(outputBytes);
+
+        new BinaryWire(bytes).copyOne(outputWire);
+
+        assertTrue(outputBytes.toString().contains("test"));
+    }
+
+    @Test
+    public void textToStringBuilderStillReadsValidStringAny() {
+        Bytes<?> bytes = validStringAny();
+        BinaryWire wire = new BinaryWire(bytes);
+        StringBuilder sb = new StringBuilder("sentinel");
+
+        wire.getValueIn().textTo(sb);
+
+        assertEquals("test", sb.toString());
+        assertEquals(6, bytes.readPosition());
+        assertEquals(BinaryWireCode.TRUE, bytes.readUnsignedByte(6));
+    }
+
+    @Test
+    public void stringAnyValidTextStillReads() {
+        Bytes<?> bytes = validStringAny();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        assertEquals("test", wire.getValueIn().text());
+        assertEquals(6, bytes.readPosition());
+        assertEquals(BinaryWireCode.TRUE, bytes.readUnsignedByte(6));
+    }
+
+    @Test
+    public void stringAnyValidNullStillReads() {
+        Bytes<?> bytes = stringAnyNull();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        assertNull(wire.getValueIn().text());
+        assertEquals(bytes.readLimit(), bytes.readPosition());
+    }
+
+    @Test
+    public void textRejectsCompactStringBodyBeyondCurrentReadLimit() {
+        Bytes<?> bytes = compactStringWithBodyBeyondCurrentReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().text());
+
+        assertTrue(e.getMessage().contains("Text length"));
+        assertCompactStringState(bytes, 1, 1);
+    }
+
+    @Test
+    public void textToStringBuilderRejectsCompactStringBodyBeyondCurrentReadLimitWithoutMutation() {
+        Bytes<?> bytes = compactStringWithBodyBeyondCurrentReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+        StringBuilder sb = new StringBuilder("sentinel");
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().textTo(sb));
+
+        assertTrue(e.getMessage().contains("Text length"));
+        assertEquals("sentinel", sb.toString());
+        assertCompactStringState(bytes, 1, 1);
+    }
+
+    @Test
+    public void textToBytesRejectsCompactStringBodyBeyondCurrentReadLimitWithoutMutation() {
+        Bytes<?> bytes = compactStringWithBodyBeyondCurrentReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+        Bytes<?> target = Bytes.allocateElasticOnHeap();
+        target.writeByte((byte) 0x66);
+        long writePosition = target.writePosition();
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().textTo(target));
+
+        assertTrue(e.getMessage().contains("Text length"));
+        assertEquals(writePosition, target.writePosition());
+        assertEquals(0x66, target.readUnsignedByte(0));
+        assertCompactStringState(bytes, 1, 1);
+    }
+
+    @Test
+    public void compactStringValidTextStillReads() {
+        Bytes<?> bytes = validCompactString();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        assertEquals("test", wire.getValueIn().text());
+        assertEquals(5, bytes.readPosition());
+        assertEquals(BinaryWireCode.TRUE, bytes.readUnsignedByte(5));
+    }
+
+    @Test
+    public void readLengthRejectsTypePrefixBeyondCurrentReadLimit() {
+        Bytes<?> bytes = typePrefixWithNarrowReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.getValueIn().skipValue());
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertEquals(2, bytes.readPosition());
+        assertEquals(2, bytes.readLimit());
+        assertEquals(0, bytes.readRemaining());
+        assertTrue(bytes.readPosition() <= bytes.readLimit());
+    }
+
+    @Test
+    public void readTextRejectsPadding32BeyondCurrentReadLimit() {
+        Bytes<?> bytes = padding32BodyWithNarrowReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+        StringBuilder sb = new StringBuilder();
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.readText(BinaryWireCode.PADDING32, sb));
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertEquals(4, bytes.readPosition());
+        assertEquals(4, bytes.readLimit());
+        assertEquals(0, bytes.readRemaining());
+        assertTrue(bytes.readPosition() <= bytes.readLimit());
+    }
+
+    @Test
+    public void readTextRejectsPadding32TruncatedLengthPrefix() {
+        Bytes<?> bytes = padding32BodyWithTruncatedLengthPrefix();
+        BinaryWire wire = new BinaryWire(bytes);
+        StringBuilder sb = new StringBuilder("sentinel");
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> wire.readText(BinaryWireCode.PADDING32, sb));
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertEquals("sentinel", sb.toString());
+        assertTruncatedPadding32BodyPrefixState(bytes);
+    }
+
+    @Test
+    public void bytesStoreStringBuilderRejectsBeforeClearingTarget() {
+        Bytes<?> bytes = uncheckedLength32U8ArrayWithNarrowReadLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+        StringBuilder sb = new StringBuilder("sentinel");
+
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> ((BinaryWire.BinaryValueIn) wire.getValueIn()).bytesStore(sb));
+
+        assertNotNull(e);
+        assertEquals("sentinel", sb.toString());
+        assertEquals(5, bytes.readPosition());
+        assertReadableStateAndPayload(bytes, 5);
+    }
+
+    @Test
+    public void bytesStoreStringBuilderRejectsZeroLengthBodyBeforeClearingTarget() {
+        Bytes<?> bytes = uncheckedLength32WithZeroDeclaredBody();
+        BinaryWire wire = new BinaryWire(bytes);
+        StringBuilder sb = new StringBuilder("sentinel");
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> ((BinaryWire.BinaryValueIn) wire.getValueIn()).bytesStore(sb));
+
+        assertTrue(e.getMessage().contains("does not include a value code"));
+        assertEquals("sentinel", sb.toString());
+        assertZeroLengthBodyState(bytes);
+    }
+
+    @Test
+    public void bytesStoreTypePrefixRejectsWithoutConsumingBeyondDeclaredBody() {
+        Bytes<?> bytes = bytesLength8OneByteBodyTypePrefixWithTrailingBytes();
+        long originalLimit = bytes.readLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> wire.getValueIn().bytesStore());
+
+        assertNotNull(e);
+        assertTrue(bytes.readPosition() <= 3);
+        assertEquals(originalLimit, bytes.readLimit());
+        assertTrailingTypePrefixBytes(bytes);
+    }
+
+    @Test
+    public void bytesStoreStringBuilderReadsValidPayloadOnly() {
+        byte[] payload = {
+                (byte) BinaryWireCode.BYTES_LENGTH32,
+                0x04, 0x00, 0x00, 0x00,
+                (byte) BinaryWireCode.U8_ARRAY,
+                'a', 'b', 'c'
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload);
+        BinaryWire wire = new BinaryWire(bytes);
+        StringBuilder sb = new StringBuilder("sentinel");
+
+        ((BinaryWire.BinaryValueIn) wire.getValueIn()).bytesStore(sb);
+
+        assertEquals("abc", sb.toString());
+        assertEquals(payload.length, bytes.readPosition());
+        assertEquals(payload.length, bytes.readLimit());
+    }
+
+    @Test
+    public void bytesStoreStringBuilderFallbackStopsAtDeclaredEnd() {
+        byte[] payload = {
+                (byte) BinaryWireCode.BYTES_LENGTH8,
+                0x01,
+                (byte) BinaryWireCode.TRUE,
+                0x55, 0x66
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload);
+        BinaryWire wire = new BinaryWire(bytes);
+        StringBuilder sb = new StringBuilder("sentinel");
+
+        ((BinaryWire.BinaryValueIn) wire.getValueIn()).bytesStore(sb);
+
+        assertNotEquals("sentinel", sb.toString());
+        assertEquals(3, bytes.readPosition());
+        assertEquals(payload.length, bytes.readLimit());
+        assertTrue(bytes.readPosition() < bytes.readLimit());
+        assertEquals(0x55, bytes.readUnsignedByte(3));
+        assertEquals(0x66, bytes.readUnsignedByte(4));
+    }
+
+    @Test
+    public void bytesStoreStringBuilderFallbackRejectsBeforeClearingTarget() {
+        byte[] payload = {
+                (byte) BinaryWireCode.BYTES_LENGTH8,
+                0x01,
+                (byte) BinaryWireCode.TRUE
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload).unchecked(true);
+        bytes.readLimit(2);
+        BinaryWire wire = new BinaryWire(bytes);
+        StringBuilder sb = new StringBuilder("sentinel");
+
+        IORuntimeException e = assertThrows(IORuntimeException.class,
+                () -> ((BinaryWire.BinaryValueIn) wire.getValueIn()).bytesStore(sb));
+
+        assertTrue(e.getMessage().contains("bytes remaining between readPosition"));
+        assertEquals("sentinel", sb.toString());
+        assertEquals(2, bytes.readPosition());
+        assertEquals(2, bytes.readLimit());
+        assertTrue(bytes.readPosition() <= bytes.readLimit());
+    }
+
+    private static Bytes<?> uncheckedLength32U8ArrayWithNarrowReadLimit() {
+        byte[] payload = {
+                (byte) BinaryWireCode.BYTES_LENGTH32,
+                0x04, 0x00, 0x00, 0x00,
+                (byte) BinaryWireCode.U8_ARRAY,
+                0x01, 0x02, 0x03
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload).unchecked(true);
+        assertEquals(4, bytes.readInt(1));
+        bytes.readLimit(6);
+        return bytes;
+    }
+
+    private static Bytes<?> bytesLength8OneByteBodyWithTrailingPaddingAndTrue() {
+        byte[] payload = {
+                (byte) BinaryWireCode.BYTES_LENGTH8,
+                0x01,
+                (byte) BinaryWireCode.PADDING32,
+                0x04, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00,
+                (byte) BinaryWireCode.TRUE
+        };
+        return Bytes.wrapForRead(payload).unchecked(true);
+    }
+
+    private static Bytes<?> bytesLength8OneByteBodyTypePrefixWithTrailingBytes() {
+        byte[] payload = {
+                (byte) BinaryWireCode.BYTES_LENGTH8,
+                0x01,
+                (byte) BinaryWireCode.TYPE_PREFIX,
+                0x03,
+                'x', 'x', 'x',
+                (byte) BinaryWireCode.U8_ARRAY,
+                0x55
+        };
+        return Bytes.wrapForRead(payload).unchecked(true);
+    }
+
+    private static Bytes<?> padding32WithNarrowReadLimit() {
+        byte[] payload = {
+                (byte) BinaryWireCode.PADDING32,
+                0x04, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload).unchecked(true);
+        bytes.readLimit(5);
+        return bytes;
+    }
+
+    private static Bytes<?> padding32WithTruncatedLengthPrefix() {
+        // Backing bytes include the full length prefix; readLimit is narrowed to prove they are not consumed.
+        byte[] payload = {
+                (byte) BinaryWireCode.PADDING32,
+                0x04, 0x00, 0x00, 0x00
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload).unchecked(true);
+        bytes.readLimit(1);
+        return bytes;
+    }
+
+    private static Bytes<?> padding32BodyWithNarrowReadLimit() {
+        byte[] payload = {
+                0x04, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload).unchecked(true);
+        bytes.readLimit(4);
+        return bytes;
+    }
+
+    private static Bytes<?> padding32BodyWithTruncatedLengthPrefix() {
+        // Backing bytes include the full length prefix; readLimit is narrowed to prove they are not consumed.
+        byte[] payload = {
+                0x04, 0x00, 0x00, 0x00
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload).unchecked(true);
+        bytes.readLimit(0);
+        return bytes;
+    }
+
+    private static Bytes<?> typePrefixWithNarrowReadLimit() {
+        byte[] payload = {
+                (byte) BinaryWireCode.TYPE_PREFIX,
+                0x04,
+                't', 'y', 'p', 'e',
+                (byte) BinaryWireCode.TRUE
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload).unchecked(true);
+        bytes.readLimit(2);
+        return bytes;
+    }
+
+    private static Bytes<?> typePrefixWithTruncatedStopBitPrefix() {
+        // Backing bytes include the stop-bit length and type name; readLimit exposes only the dispatched code byte.
+        byte[] payload = {
+                (byte) BinaryWireCode.TYPE_PREFIX,
+                0x04,
+                't', 'y', 'p', 'e',
+                (byte) BinaryWireCode.TRUE
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload).unchecked(true);
+        bytes.readLimit(1);
+        return bytes;
+    }
+
+    private static Bytes<?> bytesLength8WithTruncatedLengthPrefix() {
+        byte[] payload = {
+                (byte) BinaryWireCode.BYTES_LENGTH8,
+                0x04,
+                (byte) BinaryWireCode.U8_ARRAY,
+                0x01, 0x02, 0x03
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload).unchecked(true);
+        bytes.readLimit(1);
+        return bytes;
+    }
+
+    private static Bytes<?> bytesLength16WithTruncatedLengthPrefix() {
+        byte[] payload = {
+                (byte) BinaryWireCode.BYTES_LENGTH16,
+                0x04, 0x00,
+                (byte) BinaryWireCode.U8_ARRAY,
+                0x01, 0x02, 0x03
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload).unchecked(true);
+        bytes.readLimit(1);
+        return bytes;
+    }
+
+    private static Bytes<?> bytesLength32WithTruncatedLengthPrefix() {
+        byte[] payload = {
+                (byte) BinaryWireCode.BYTES_LENGTH32,
+                0x04, 0x00, 0x00, 0x00,
+                (byte) BinaryWireCode.U8_ARRAY,
+                0x01, 0x02, 0x03
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload).unchecked(true);
+        assertEquals(4, bytes.readInt(1));
+        bytes.readLimit(1);
+        return bytes;
+    }
+
+    private static Bytes<?> stringAnyWithTruncatedStopBitPrefix() {
+        Bytes<?> bytes = stringAnyPayload().unchecked(true);
+        bytes.readLimit(1);
+        return bytes;
+    }
+
+    private static Bytes<?> stringAnyWithBodyBeyondCurrentReadLimit() {
+        Bytes<?> bytes = stringAnyPayload().unchecked(true);
+        bytes.readLimit(2);
+        return bytes;
+    }
+
+    private static Bytes<?> stringAnyBodyWithBodyBeyondCurrentReadLimit() {
+        byte[] payload = {
+                0x04,
+                't', 'e', 's', 't',
+                (byte) BinaryWireCode.TRUE
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload).unchecked(true);
+        bytes.readLimit(1);
+        return bytes;
+    }
+
+    private static Bytes<?> validStringAny() {
+        return stringAnyPayload();
+    }
+
+    private static Bytes<?> stringAnyPayload() {
+        byte[] payload = {
+                (byte) BinaryWireCode.STRING_ANY,
+                0x04,
+                't', 'e', 's', 't',
+                (byte) BinaryWireCode.TRUE
+        };
+        return Bytes.wrapForRead(payload);
+    }
+
+    private static Bytes<?> stringAnyNull() {
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        bytes.writeByte((byte) BinaryWireCode.STRING_ANY);
+        bytes.writeUtf8((String) null);
+        bytes.readPositionRemaining(0, bytes.writePosition());
+        return bytes;
+    }
+
+    private static Bytes<?> compactStringWithBodyBeyondCurrentReadLimit() {
+        Bytes<?> bytes = compactStringPayload().unchecked(true);
+        bytes.readLimit(1);
+        return bytes;
+    }
+
+    private static Bytes<?> validCompactString() {
+        return compactStringPayload();
+    }
+
+    private static Bytes<?> compactStringPayload() {
+        byte[] payload = {
+                (byte) (BinaryWireCode.STRING_0 + 4),
+                't', 'e', 's', 't',
+                (byte) BinaryWireCode.TRUE
+        };
+        return Bytes.wrapForRead(payload);
+    }
+
+    private static Bytes<?> uncheckedLength32U8ArrayWithZeroPayloadLength() {
+        byte[] payload = {
+                (byte) BinaryWireCode.BYTES_LENGTH32,
+                0x00, 0x00, 0x00, 0x00,
+                (byte) BinaryWireCode.U8_ARRAY
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload).unchecked(true);
+        assertEquals(0, bytes.readInt(1));
+        bytes.readLimit(6);
+        return bytes;
+    }
+
+    private static Bytes<?> uncheckedLength32WithZeroDeclaredBody() {
+        byte[] payload = {
+                (byte) BinaryWireCode.BYTES_LENGTH32,
+                0x00, 0x00, 0x00, 0x00,
+                (byte) BinaryWireCode.U8_ARRAY,
+                0x55
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload).unchecked(true);
+        assertEquals(0, bytes.readInt(1));
+        bytes.readLimit(5);
+        return bytes;
+    }
+
+    private static Bytes<?> length32BodyWithNarrowReadLimit(byte bodyCode) {
+        byte[] payload = {
+                (byte) BinaryWireCode.BYTES_LENGTH32,
+                0x04, 0x00, 0x00, 0x00,
+                bodyCode,
+                0x01, 0x02, 0x03
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload).unchecked(true);
+        assertEquals(4, bytes.readInt(1));
+        bytes.readLimit(6);
+        return bytes;
+    }
+
+    private static void assertReadableStateAndPayload(Bytes<?> bytes, long expectedPosition) {
+        assertEquals(expectedPosition, bytes.readPosition());
+        assertEquals(6, bytes.readLimit());
+        assertTrue(bytes.readRemaining() >= 0);
+        assertTrue(bytes.readPosition() <= bytes.readLimit());
+        assertEquals(BinaryWireCode.U8_ARRAY, bytes.readUnsignedByte(5));
+        assertEquals(0x01, bytes.readUnsignedByte(6));
+        assertEquals(0x02, bytes.readUnsignedByte(7));
+        assertEquals(0x03, bytes.readUnsignedByte(8));
+    }
+
+    private static void assertLength32BodyState(Bytes<?> bytes, long expectedPosition, int expectedBodyCode) {
+        assertEquals(expectedPosition, bytes.readPosition());
+        assertEquals(6, bytes.readLimit());
+        assertTrue(bytes.readRemaining() >= 0);
+        assertTrue(bytes.readPosition() <= bytes.readLimit());
+        assertEquals(expectedBodyCode, bytes.readUnsignedByte(5));
+        assertEquals(0x01, bytes.readUnsignedByte(6));
+        assertEquals(0x02, bytes.readUnsignedByte(7));
+        assertEquals(0x03, bytes.readUnsignedByte(8));
+    }
+
+    private static void assertZeroLengthBodyState(Bytes<?> bytes) {
+        assertEquals(5, bytes.readPosition());
+        assertEquals(5, bytes.readLimit());
+        assertEquals(0, bytes.readRemaining());
+        assertTrue(bytes.readPosition() <= bytes.readLimit());
+        assertEquals(BinaryWireCode.U8_ARRAY, bytes.readUnsignedByte(5));
+        assertEquals(0x55, bytes.readUnsignedByte(6));
+    }
+
+    private static void assertTruncatedPadding32PrefixState(Bytes<?> bytes) {
+        assertEquals(1, bytes.readPosition());
+        assertEquals(1, bytes.readLimit());
+        assertEquals(0, bytes.readRemaining());
+        assertTrue(bytes.readPosition() <= bytes.readLimit());
+        assertEquals(BinaryWireCode.PADDING32, bytes.readUnsignedByte(0));
+        assertEquals(0x04, bytes.readUnsignedByte(1));
+        assertEquals(0x00, bytes.readUnsignedByte(2));
+        assertEquals(0x00, bytes.readUnsignedByte(3));
+        assertEquals(0x00, bytes.readUnsignedByte(4));
+    }
+
+    private static void assertTruncatedPadding32BodyPrefixState(Bytes<?> bytes) {
+        assertEquals(0, bytes.readPosition());
+        assertEquals(0, bytes.readLimit());
+        assertEquals(0, bytes.readRemaining());
+        assertTrue(bytes.readPosition() <= bytes.readLimit());
+        assertEquals(0x04, bytes.readUnsignedByte(0));
+        assertEquals(0x00, bytes.readUnsignedByte(1));
+        assertEquals(0x00, bytes.readUnsignedByte(2));
+        assertEquals(0x00, bytes.readUnsignedByte(3));
+    }
+
+    private static void assertTruncatedLength8PrefixState(Bytes<?> bytes) {
+        assertEquals(1, bytes.readPosition());
+        assertEquals(1, bytes.readLimit());
+        assertEquals(0, bytes.readRemaining());
+        assertTrue(bytes.readPosition() <= bytes.readLimit());
+        assertEquals(BinaryWireCode.BYTES_LENGTH8, bytes.readUnsignedByte(0));
+        assertEquals(0x04, bytes.readUnsignedByte(1));
+        assertEquals(BinaryWireCode.U8_ARRAY, bytes.readUnsignedByte(2));
+        assertEquals(0x01, bytes.readUnsignedByte(3));
+        assertEquals(0x02, bytes.readUnsignedByte(4));
+        assertEquals(0x03, bytes.readUnsignedByte(5));
+    }
+
+    private static void assertTruncatedLength16PrefixState(Bytes<?> bytes) {
+        assertEquals(1, bytes.readPosition());
+        assertEquals(1, bytes.readLimit());
+        assertEquals(0, bytes.readRemaining());
+        assertTrue(bytes.readPosition() <= bytes.readLimit());
+        assertEquals(BinaryWireCode.BYTES_LENGTH16, bytes.readUnsignedByte(0));
+        assertEquals(0x04, bytes.readUnsignedByte(1));
+        assertEquals(0x00, bytes.readUnsignedByte(2));
+        assertEquals(BinaryWireCode.U8_ARRAY, bytes.readUnsignedByte(3));
+        assertEquals(0x01, bytes.readUnsignedByte(4));
+        assertEquals(0x02, bytes.readUnsignedByte(5));
+        assertEquals(0x03, bytes.readUnsignedByte(6));
+    }
+
+    private static void assertTruncatedLength32PrefixState(Bytes<?> bytes) {
+        assertEquals(1, bytes.readPosition());
+        assertEquals(1, bytes.readLimit());
+        assertEquals(0, bytes.readRemaining());
+        assertTrue(bytes.readPosition() <= bytes.readLimit());
+        assertEquals(BinaryWireCode.BYTES_LENGTH32, bytes.readUnsignedByte(0));
+        assertEquals(0x04, bytes.readUnsignedByte(1));
+        assertEquals(0x00, bytes.readUnsignedByte(2));
+        assertEquals(0x00, bytes.readUnsignedByte(3));
+        assertEquals(0x00, bytes.readUnsignedByte(4));
+        assertEquals(BinaryWireCode.U8_ARRAY, bytes.readUnsignedByte(5));
+        assertEquals(0x01, bytes.readUnsignedByte(6));
+        assertEquals(0x02, bytes.readUnsignedByte(7));
+        assertEquals(0x03, bytes.readUnsignedByte(8));
+    }
+
+    private static void assertTruncatedTypePrefixStopBitState(Bytes<?> bytes) {
+        assertEquals(1, bytes.readPosition());
+        assertEquals(1, bytes.readLimit());
+        assertEquals(0, bytes.readRemaining());
+        assertTrue(bytes.readPosition() <= bytes.readLimit());
+        assertEquals(BinaryWireCode.TYPE_PREFIX, bytes.readUnsignedByte(0));
+        assertEquals(0x04, bytes.readUnsignedByte(1));
+        assertEquals('t', bytes.readUnsignedByte(2));
+        assertEquals('y', bytes.readUnsignedByte(3));
+        assertEquals('p', bytes.readUnsignedByte(4));
+        assertEquals('e', bytes.readUnsignedByte(5));
+        assertEquals(BinaryWireCode.TRUE, bytes.readUnsignedByte(6));
+    }
+
+    private static void assertStringAnyState(Bytes<?> bytes, long expectedPosition, long expectedLimit) {
+        assertEquals(expectedPosition, bytes.readPosition());
+        assertEquals(expectedLimit, bytes.readLimit());
+        assertTrue(bytes.readPosition() <= bytes.readLimit());
+        assertStringAnyBytes(bytes);
+    }
+
+    private static void assertStringAnyBytes(Bytes<?> bytes) {
+        assertEquals(BinaryWireCode.STRING_ANY, bytes.readUnsignedByte(0));
+        assertEquals(0x04, bytes.readUnsignedByte(1));
+        assertEquals('t', bytes.readUnsignedByte(2));
+        assertEquals('e', bytes.readUnsignedByte(3));
+        assertEquals('s', bytes.readUnsignedByte(4));
+        assertEquals('t', bytes.readUnsignedByte(5));
+        assertEquals(BinaryWireCode.TRUE, bytes.readUnsignedByte(6));
+    }
+
+    private static void assertStringAnyBodyState(Bytes<?> bytes, long expectedPosition, long expectedLimit) {
+        assertEquals(expectedPosition, bytes.readPosition());
+        assertEquals(expectedLimit, bytes.readLimit());
+        assertTrue(bytes.readPosition() <= bytes.readLimit());
+        assertEquals(0x04, bytes.readUnsignedByte(0));
+        assertEquals('t', bytes.readUnsignedByte(1));
+        assertEquals('e', bytes.readUnsignedByte(2));
+        assertEquals('s', bytes.readUnsignedByte(3));
+        assertEquals('t', bytes.readUnsignedByte(4));
+        assertEquals(BinaryWireCode.TRUE, bytes.readUnsignedByte(5));
+    }
+
+    private static void assertCompactStringState(Bytes<?> bytes, long expectedPosition, long expectedLimit) {
+        assertEquals(expectedPosition, bytes.readPosition());
+        assertEquals(expectedLimit, bytes.readLimit());
+        assertTrue(bytes.readPosition() <= bytes.readLimit());
+        assertEquals(BinaryWireCode.STRING_0 + 4, bytes.readUnsignedByte(0));
+        assertEquals('t', bytes.readUnsignedByte(1));
+        assertEquals('e', bytes.readUnsignedByte(2));
+        assertEquals('s', bytes.readUnsignedByte(3));
+        assertEquals('t', bytes.readUnsignedByte(4));
+        assertEquals(BinaryWireCode.TRUE, bytes.readUnsignedByte(5));
+    }
+
+    private static void assertTrailingPaddingAndTrue(Bytes<?> bytes) {
+        assertEquals(BinaryWireCode.PADDING32, bytes.readUnsignedByte(2));
+        assertEquals(0x04, bytes.readUnsignedByte(3));
+        assertEquals(0x00, bytes.readUnsignedByte(4));
+        assertEquals(0x00, bytes.readUnsignedByte(5));
+        assertEquals(0x00, bytes.readUnsignedByte(6));
+        assertEquals(0x00, bytes.readUnsignedByte(7));
+        assertEquals(0x00, bytes.readUnsignedByte(8));
+        assertEquals(0x00, bytes.readUnsignedByte(9));
+        assertEquals(0x00, bytes.readUnsignedByte(10));
+        assertEquals(BinaryWireCode.TRUE, bytes.readUnsignedByte(11));
+    }
+
+    private static void assertTrailingTypePrefixBytes(Bytes<?> bytes) {
+        assertEquals(BinaryWireCode.TYPE_PREFIX, bytes.readUnsignedByte(2));
+        assertEquals(0x03, bytes.readUnsignedByte(3));
+        assertEquals('x', bytes.readUnsignedByte(4));
+        assertEquals('x', bytes.readUnsignedByte(5));
+        assertEquals('x', bytes.readUnsignedByte(6));
+        assertEquals(BinaryWireCode.U8_ARRAY, bytes.readUnsignedByte(7));
+        assertEquals(0x55, bytes.readUnsignedByte(8));
+    }
+
+    @Test
+    public void copyOneStillCopiesValidBytesLength32Sequence() {
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        BinaryWire writer = new BinaryWire(bytes);
+        writer.getValueOut().sequence(v -> {
+            v.text("ok");
+            v.int32(7);
+        });
+
+        assertEquals(BinaryWireCode.BYTES_LENGTH32, bytes.readUnsignedByte(0));
+
+        bytes.readPositionRemaining(0, bytes.writePosition());
+        Bytes<?> outputBytes = Bytes.allocateElasticOnHeap();
+        Wire outputWire = WireType.TEXT.apply(outputBytes);
+
+        new BinaryWire(bytes).copyOne(outputWire);
+
+        String output = outputBytes.toString();
+        assertTrue(output.contains("ok"));
+        assertTrue(output.contains("7"));
+    }
+
+    private static byte[] negativeBytesLength32Payload() {
+        return new byte[]{
+                (byte) BinaryWireCode.BYTES_LENGTH32,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+        };
+    }
+}

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireReadWithLengthTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireReadWithLengthTest.java
@@ -4,9 +4,12 @@
 package net.openhft.chronicle.wire;
 
 import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.core.io.IORuntimeException;
+import net.openhft.chronicle.core.io.InvalidMarshallableException;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Illustrates Chronicle-Queue style copying of binary fragments into a textual representation.
@@ -74,6 +77,120 @@ public class BinaryWireReadWithLengthTest extends WireTestCommon {
 
         assertTrue(output.contains("say: hello"));
         assertTrue(output.contains("number: 42"));
+    }
+
+    @Test
+    public void readWithLengthLongOverloadCopiesMapFragmentToText() {
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        BinaryWire writer = new BinaryWire(bytes);
+        try (DocumentContext dc = writer.writingDocument(false)) {
+            dc.wire().write("map").marshallable(m -> m.write("key").int32(1));
+        }
+
+        bytes.readPositionRemaining(0, bytes.writePosition());
+        int header = bytes.readInt();
+        long len = Wires.lengthOf(header);
+        long bodyPos = bytes.readPosition();
+
+        TextWire target = new TextWire(Bytes.allocateElasticOnHeap());
+        BinaryWire source = new BinaryWire(bytes);
+        source.bytes().readPosition(bodyPos);
+        source.readWithLength(target, len);
+
+        assertTrue(target.bytes().toString().contains("key: 1"));
+    }
+
+    @Test(expected = net.openhft.chronicle.core.io.IORuntimeException.class)
+    public void readWithLengthRejectsNegativeLength() {
+        BinaryWire source = new BinaryWire(Bytes.allocateElasticOnHeap());
+        source.readWithLength(new TextWire(Bytes.allocateElasticOnHeap()), -1);
+    }
+
+    @Test(expected = net.openhft.chronicle.core.io.IORuntimeException.class)
+    public void readWithLengthRejectsOver32BitLength() {
+        BinaryWire source = new BinaryWire(Bytes.allocateElasticOnHeap());
+        source.readWithLength(new TextWire(Bytes.allocateElasticOnHeap()), 1L << 32);
+    }
+
+    @Test
+    public void bytesLength32WithTopBitSetIsReadAsUnsigned() {
+        expectUnsignedLengthRejected(0x80000000L);
+    }
+
+    @Test
+    public void bytesLength32WithMaxUnsignedValueIsReadAsUnsigned() {
+        expectUnsignedLengthRejected(0xFFFFFFFFL);
+    }
+
+    @Test
+    public void uncheckedBytesLength32WithMaxUnsignedValueIsRejectedBeforeReadLimitIsExtended() {
+        Bytes<?> uncheckedBytes = uncheckedBytesLength32(0xFFFFFFFFL);
+        try {
+            BinaryWire source = new BinaryWire(uncheckedBytes);
+            TextWire target = new TextWire(Bytes.allocateElasticOnHeap());
+            try {
+                source.copyOne(target);
+                fail("Expected IORuntimeException for unchecked unsigned 32-bit length");
+            } catch (IORuntimeException e) {
+                assertTrue("Unexpected message: " + e.getMessage(),
+                        e.getMessage().contains("Can't extend the limit"));
+            }
+        } finally {
+            uncheckedBytes.releaseLast();
+        }
+    }
+
+    @Test
+    public void uncheckedObjectWithLength32BeyondHardLimitIsRejectedBeforeReadLimitIsExtended()
+            throws InvalidMarshallableException {
+        Bytes<?> uncheckedBytes = uncheckedBytesLength32(0xFFFFFFFFL, BinaryWireCode.EVENT_NAME);
+        try {
+            BinaryWire source = new BinaryWire(uncheckedBytes);
+            try {
+                source.getValueIn().object();
+                fail("Expected IORuntimeException for unchecked unsigned 32-bit object length");
+            } catch (IORuntimeException e) {
+                assertTrue("Unexpected message: " + e.getMessage(),
+                        e.getMessage().contains("Can't extend the limit"));
+            }
+        } finally {
+            uncheckedBytes.releaseLast();
+        }
+    }
+
+    private Bytes<?> uncheckedBytesLength32(long length, int... payloadCodes) {
+        Bytes<?> encoded = Bytes.allocateElasticOnHeap();
+        encoded.writeUnsignedByte(BinaryWireCode.BYTES_LENGTH32);
+        encoded.writeUnsignedInt(length);
+        for (int payloadCode : payloadCodes)
+            encoded.writeUnsignedByte(payloadCode);
+        byte[] data = encoded.toByteArray();
+        encoded.releaseLast();
+        return Bytes.wrapForRead(data).unchecked(true);
+    }
+
+    /**
+     * Builds a stream of BYTES_LENGTH32 followed by a 4-byte length with the top bit set,
+     * but no payload. The length must be read as unsigned 32-bit, so the (impossibly large)
+     * length fails the read-limit check with "Can't extend the limit". Before the fix,
+     * {@code copyOne} read the length with the signed {@code readInt()}, so the limit check
+     * passed on a negative length and reading continued with a corrupt read limit.
+     */
+    private void expectUnsignedLengthRejected(long length) {
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        bytes.writeUnsignedByte(BinaryWireCode.BYTES_LENGTH32);
+        bytes.writeUnsignedInt(length);
+        bytes.readPositionRemaining(0, bytes.writePosition());
+
+        BinaryWire source = new BinaryWire(bytes);
+        TextWire target = new TextWire(Bytes.allocateElasticOnHeap());
+        try {
+            source.copyOne(target);
+            fail("Expected IORuntimeException for unsigned 32-bit length " + length);
+        } catch (IORuntimeException e) {
+            assertTrue("Unexpected message: " + e.getMessage(),
+                    e.getMessage().contains("Can't extend the limit"));
+        }
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireReadWithLengthTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireReadWithLengthTest.java
@@ -133,7 +133,7 @@ public class BinaryWireReadWithLengthTest extends WireTestCommon {
                 fail("Expected IORuntimeException for unchecked unsigned 32-bit length");
             } catch (IORuntimeException e) {
                 assertTrue("Unexpected message: " + e.getMessage(),
-                        e.getMessage().contains("Can't extend the limit"));
+                        e.getMessage().contains("bytes remaining between readPosition"));
             }
         } finally {
             uncheckedBytes.releaseLast();
@@ -151,7 +151,7 @@ public class BinaryWireReadWithLengthTest extends WireTestCommon {
                 fail("Expected IORuntimeException for unchecked unsigned 32-bit object length");
             } catch (IORuntimeException e) {
                 assertTrue("Unexpected message: " + e.getMessage(),
-                        e.getMessage().contains("Can't extend the limit"));
+                        e.getMessage().contains("bytes remaining between readPosition"));
             }
         } finally {
             uncheckedBytes.releaseLast();
@@ -172,7 +172,7 @@ public class BinaryWireReadWithLengthTest extends WireTestCommon {
     /**
      * Builds a stream of BYTES_LENGTH32 followed by a 4-byte length with the top bit set,
      * but no payload. The length must be read as unsigned 32-bit, so the (impossibly large)
-     * length fails the read-limit check with "Can't extend the limit". Before the fix,
+     * length fails the read-limit check, reporting the bytes remaining. Before the fix,
      * {@code copyOne} read the length with the signed {@code readInt()}, so the limit check
      * passed on a negative length and reading continued with a corrupt read limit.
      */
@@ -189,7 +189,7 @@ public class BinaryWireReadWithLengthTest extends WireTestCommon {
             fail("Expected IORuntimeException for unsigned 32-bit length " + length);
         } catch (IORuntimeException e) {
             assertTrue("Unexpected message: " + e.getMessage(),
-                    e.getMessage().contains("Can't extend the limit"));
+                    e.getMessage().contains("bytes remaining between readPosition"));
         }
     }
 


### PR DESCRIPTION
# WIP: CORE-68 - BinaryWire length-prefixed reads can bypass current logical readLimit under unchecked bytes

## Summary

Fixes `BinaryWire` length-prefixed read paths so decoded lengths are validated against the active logical `readLimit` before they can drive reads, skips, allocations, nested limits, callbacks, or caller-visible output mutation.

This builds on the unsigned `BYTES_LENGTH32` direction by applying the same boundary invariant across related byte, padding, type-prefix, structured, and text payload paths.

## Before

Some `BinaryWire` paths decoded or trusted length-prefixed values before checking whether the declared bytes fit inside the current logical `readLimit`.

Under `unchecked(true)`, malformed input could:

  - advance `readPosition` beyond `readLimit`
  - leave `readRemaining()` negative
  - inspect bytes from the next logical frame
  - skip past the current frame
  - allocate before validating readable bytes
  - expose bytes through `BytesStore` or callbacks
  - mutate caller-provided `Bytes`, `StringBuilder`, or output wires before rejecting

Examples of affected areas included:

  - `BYTES_LENGTH8/16/32` prefix reads
  - `PADDING32` prefix/body skips
  - `TYPE_PREFIX` stop-bit length and type-name reads
  - declared byte-body parsing
  - direct byte APIs such as `bytesStore()`, `bytes(byte[])`, `bytes(BytesOut<?>)`, `bytesSet(...)`, and `bytesMatch(...)`
  - `STRING_ANY`
  - compact string codes `STRING_0..STRING_31`
  - `skipValue()` / `consumeNext()` paths

## After

Wire-decoded lengths are now guarded before they can control parser state or caller-visible side effects.

The updated behavior is:

  - fixed-width length prefixes are checked before decoding
  - stop-bit length prefixes are checked before decoding
  - declared byte bodies are parsed under their declared end boundary
  - nested parsing cannot widen past the active logical `readLimit`
  - direct byte APIs validate before allocation/copy/skip/callback/output mutation
  - malformed inputs reject with `readPosition <= readLimit`
  - caller-provided outputs remain unchanged when malformed input is rejected
  - valid byte/text/padding values continue to read normally

## What Changed

  - Treat `BYTES_LENGTH32` lengths as unsigned and carry decoded lengths as `long`.
  - Added hard runtime validation in `guardedReadLimit(...)`.
  - Guarded fixed-width length prefixes before decoding:
    - `BYTES_LENGTH8`
    - `BYTES_LENGTH16`
    - `BYTES_LENGTH32`
    - `PADDING32`
  - Guarded stop-bit length prefixes before decoding for:
    - `TYPE_PREFIX`
    - `STRING_ANY`
  - Enforced declared-body boundaries for nested byte payload parsing.
  - Guarded direct byte APIs before allocation, copy, skip, pointer exposure, callback invocation, or output mutation.
  - Ensured malformed input does not leave `readPosition > readLimit`.
  - Prevented caller-provided `Bytes`, `StringBuilder`, and output wires from being mutated before malformed payload rejection.
  - Guarded compact string payloads `STRING_0..STRING_31`.
  - Ensured marshallable state is popped when guarded length validation rejects.

## Test Coverage

 Added focused regression coverage for narrowed `readLimit` plus `unchecked(true)` cases, including:

  - `BYTES_LENGTH8/16/32` truncated length prefixes
  - `PADDING32` truncated prefix and body-boundary cases
  - `TYPE_PREFIX` truncated stop-bit prefix and type-name boundary cases
  - `BYTES_LENGTH32 + U8_ARRAY` narrowed-frame cases
  - zero-length declared byte bodies
  - direct byte APIs:
    - `bytesStore()`
    - `bytesStore(Bytes<?>)`
    - `bytes(byte[])`
    - `bytes(BytesOut<?>)`
    - `bytes(ReadBytesMarshallable)`
    - `bytesSet(...)`
    - `bytesMatch(...)`
    - `bytesLiteral(...)`
  - declared-body fallback parsing
  - structured nested readers
  - `skipValue()` and `consumeNext()`
  - `STRING_ANY`
  - compact string codes `STRING_0..STRING_31`
  - output/state preservation on rejection
  - positive controls for valid values
