### PR TITLE
CORE-68: Fix BinaryWire unsigned lengths and read-limit guards

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -1959,6 +1959,7 @@ public class BinaryWire extends AbstractWire implements Wire {
                     case PADDING:
                         return readText(bytes.readUnsignedByte(), sb);
                     case PADDING32:
+                        // 4-byte padding length + 1-byte trailing value code
                         if (bytes.readRemaining() < 5)
                             throw new DecoratedBufferUnderflowException("Requires at least five bytes, readRemaining: " + bytes.readRemaining());
                         bytes.readSkip(bytes.readUnsignedInt());

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -485,14 +485,14 @@ public class BinaryWire extends AbstractWire implements Wire {
                     // Handle byte lengths and read accordingly.
                     case BYTES_LENGTH8: {
                         bytes.uncheckedReadSkipOne();
-                        int len = bytes.readUnsignedByte();
+                        long len = bytes.readUnsignedByte();
                         readWithLength(wire, len);
                         break outerSwitch;
                     }
 
                     case BYTES_LENGTH16: {
                         bytes.uncheckedReadSkipOne();
-                        int len = bytes.readUnsignedShort();
+                        long len = bytes.readUnsignedShort();
                         readWithLength(wire, len);
                         break outerSwitch;
                     }
@@ -671,17 +671,17 @@ public class BinaryWire extends AbstractWire implements Wire {
      * @param wire The wire output stream to write data to.
      * @param len  The length of data to be read, as an unsigned 32-bit value (0 to 4294967295).
      * @throws InvalidMarshallableException If there's an issue during marshalling.
-     * @throws IORuntimeException If the length is outside the unsigned 32-bit range.
+     * @throws IORuntimeException If the length is outside the unsigned 32-bit range,
+     *                            or exceeds the data remaining before the read limit.
      */
     @SuppressWarnings("incomplete-switch")
     public void readWithLength(@NotNull WireOut wire, long len) throws InvalidMarshallableException {
         // A length over 32-bit unsigned is unexpected: BYTES_LENGTH32 cannot encode it.
         if (len < 0 || len > 0xFFFF_FFFFL)
-            throw new IORuntimeException("Invalid length " + len + ", expected an unsigned 32-bit value");
+            throw new IORuntimeException("Invalid length " + len + ", expected an unsigned 32-bit value (0 to 4294967295)");
         long limit = bytes.readLimit();
         long newLimit = guardedReadLimit(len);
-        if (newLimit > limit)
-            throw new IORuntimeException("Can't extend the limit");
+
         try {
             bytes.readLimit(newLimit);
             @NotNull final ValueOut wireValueOut = wire.getValueOut();
@@ -720,21 +720,27 @@ public class BinaryWire extends AbstractWire implements Wire {
         }
     }
 
-    // Can only shrink the readLimit
+    /**
+     * Computes the read limit for a nested, length-prefixed value. A nested value must lie
+     * within the enclosing document, so the read limit can only shrink, never extend past
+     * the current one into data that is not readable.
+     *
+     * @param len The length of the nested value, as an unsigned 32-bit value.
+     * @return The read limit for the nested value: the current read position plus the length.
+     * @throws IORuntimeException If the length exceeds the data remaining before the read limit.
+     */
     private long guardedReadLimit(long len) {
         long start = bytes.readPosition();
         long prevLimit = bytes.readLimit();
 
-        assert len >= 0 && len <= 0xFFFF_FFFFL : len;
+        assert len >= 0 && len <= 0xFFFF_FFFFL : "len: " + len;
         assert start <= prevLimit : "readPosition " + start + " > readLimit " + prevLimit;
 
         if (len > prevLimit - start)
-            throw new IORuntimeException("Can't extend the limit");
+            throw new IORuntimeException("Length " + len + " exceeds the " + (prevLimit - start) +
+                    " bytes remaining between readPosition " + start + " and readLimit " + prevLimit);
 
-        long newLimit = start + len;
-        assert newLimit >= start;
-        assert newLimit <= prevLimit;
-        return newLimit;
+        return start + len;
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -500,7 +500,7 @@ public class BinaryWire extends AbstractWire implements Wire {
                     case BYTES_LENGTH32: {
                         // Handle 32-bit length bytes and read accordingly.
                         bytes.uncheckedReadSkipOne();
-                        int len = bytes.readInt();
+                        long len = bytes.readUnsignedInt();
                         readWithLength(wire, len);
                         break outerSwitch;
                     }
@@ -660,10 +660,26 @@ public class BinaryWire extends AbstractWire implements Wire {
      * @param len  The length of data to be read.
      * @throws InvalidMarshallableException If there's an issue during marshalling.
      */
-    @SuppressWarnings("incomplete-switch")
     public void readWithLength(@NotNull WireOut wire, int len) throws InvalidMarshallableException {
+        readWithLength(wire, (long) len);
+    }
+
+    /**
+     * Reads data of a specified length from the bytes stream and writes to the WireOut stream
+     * while interpreting the type of data (Map, Sequence, or Object).
+     *
+     * @param wire The wire output stream to write data to.
+     * @param len  The length of data to be read, as an unsigned 32-bit value (0 to 4294967295).
+     * @throws InvalidMarshallableException If there's an issue during marshalling.
+     * @throws IORuntimeException If the length is outside the unsigned 32-bit range.
+     */
+    @SuppressWarnings("incomplete-switch")
+    public void readWithLength(@NotNull WireOut wire, long len) throws InvalidMarshallableException {
+        // A length over 32-bit unsigned is unexpected: BYTES_LENGTH32 cannot encode it.
+        if (len < 0 || len > 0xFFFF_FFFFL)
+            throw new IORuntimeException("Invalid length " + len + ", expected an unsigned 32-bit value");
         long limit = bytes.readLimit();
-        long newLimit = bytes.readPosition() + len;
+        long newLimit = guardedReadLimit(len);
         if (newLimit > limit)
             throw new IORuntimeException("Can't extend the limit");
         try {
@@ -702,6 +718,23 @@ public class BinaryWire extends AbstractWire implements Wire {
         } finally {
             bytes.readLimit(limit);  // Reset the read limit to its original value.
         }
+    }
+
+    // Can only shrink the readLimit
+    private long guardedReadLimit(long len) {
+        long start = bytes.readPosition();
+        long prevLimit = bytes.readLimit();
+
+        assert len >= 0 && len <= 0xFFFF_FFFFL : len;
+        assert start <= prevLimit : "readPosition " + start + " > readLimit " + prevLimit;
+
+        if (len > prevLimit - start)
+            throw new IORuntimeException("Can't extend the limit");
+
+        long newLimit = start + len;
+        assert newLimit >= start;
+        assert newLimit <= prevLimit;
+        return newLimit;
     }
 
     /**
@@ -4803,7 +4836,7 @@ public class BinaryWire extends AbstractWire implements Wire {
                             } else {
                                 long pos = bytes.readPosition();
                                 bytes.uncheckedReadSkipOne();
-                                int len = readLength(code);
+                                long len = readLength(code);
                                 code = peekCode();
                                 if (code == U8_ARRAY) {
                                     bytes.readPosition(pos);
@@ -4811,7 +4844,7 @@ public class BinaryWire extends AbstractWire implements Wire {
                                 }
                                 long lim = bytes.readLimit();
                                 try {
-                                    bytes.readLimit(bytes.readPosition() + len);
+                                    bytes.readLimit(guardedReadLimit(len));
                                     Object using1 = using;
                                     if (using1 == null && type != null)
                                         using1 = strategy.newInstanceOrNull(type);
@@ -4910,8 +4943,8 @@ public class BinaryWire extends AbstractWire implements Wire {
          * @param code The code representing the length format.
          * @return The length value read.
          */
-        private int readLength(int code) {
-            int len;
+        private long readLength(int code) {
+            long len;
             // Determine the code and read the corresponding length.
             switch (code) {
                 case BYTES_LENGTH8:
@@ -4921,7 +4954,7 @@ public class BinaryWire extends AbstractWire implements Wire {
                     len = bytes.readUnsignedShort();  // Read an unsigned 16-bit value.
                     break;
                 case BYTES_LENGTH32:
-                    len = bytes.readInt();  // Read a 32-bit integer value.
+                    len = bytes.readUnsignedInt();  // Read an unsigned 32-bit value.
                     break;
                 default:
                     throw new AssertionError(); // Throw an assertion error if the code is unrecognized.

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -6,10 +6,7 @@ package net.openhft.chronicle.wire;
 import net.openhft.chronicle.bytes.*;
 import net.openhft.chronicle.bytes.internal.NativeBytesStore;
 import net.openhft.chronicle.bytes.ref.*;
-import net.openhft.chronicle.bytes.util.BinaryLengthLength;
-import net.openhft.chronicle.bytes.util.Bit8StringInterner;
-import net.openhft.chronicle.bytes.util.Compression;
-import net.openhft.chronicle.bytes.util.UTF8StringInterner;
+import net.openhft.chronicle.bytes.util.*;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.Maths;
 import net.openhft.chronicle.core.io.IORuntimeException;
@@ -78,6 +75,9 @@ public class BinaryWire extends AbstractWire implements Wire {
 
     // Thread-local storage for {@link VanillaMessageHistory}
     private static final ThreadLocal<VanillaMessageHistory> VANILLA_MESSAGE_HISTORY_TL = ThreadLocal.withInitial(VanillaMessageHistory::new);
+
+    // For returning empty byte arrays
+    static final byte[] NO_BYTE_ARRAY = {};
 
     /**
      * Used when the wire is configured for fixed size output. Provides more
@@ -729,11 +729,12 @@ public class BinaryWire extends AbstractWire implements Wire {
      * @return The read limit for the nested value: the current read position plus the length.
      * @throws IORuntimeException If the length exceeds the data remaining before the read limit.
      */
-    private long guardedReadLimit(long len) {
+    long guardedReadLimit(long len) {
+        // this private method assumes this caller has made the check already
+        assert len >= 0 && len <= 0xFFFF_FFFFL : "len: " + len;
+
         long start = bytes.readPosition();
         long prevLimit = bytes.readLimit();
-
-        assert len >= 0 && len <= 0xFFFF_FFFFL : "len: " + len;
         assert start <= prevLimit : "readPosition " + start + " > readLimit " + prevLimit;
 
         if (len > prevLimit - start)
@@ -1958,6 +1959,8 @@ public class BinaryWire extends AbstractWire implements Wire {
                     case PADDING:
                         return readText(bytes.readUnsignedByte(), sb);
                     case PADDING32:
+                        if (bytes.readRemaining() < 5)
+                            throw new DecoratedBufferUnderflowException("Requires at least five bytes, readRemaining: " + bytes.readRemaining());
                         bytes.readSkip(bytes.readUnsignedInt());
                         return readText(bytes.readUnsignedByte(), sb);
                     default:
@@ -3482,7 +3485,14 @@ public class BinaryWire extends AbstractWire implements Wire {
                 ((Bytes) bytes).readWithLength(length - 1, toBytes);
             } else {
                 bytes.uncheckedReadSkipBackOne();
-                textTo((Bytes) toBytes);
+                long readLimit = bytes.readLimit();
+
+                try {
+                    bytes.readLimit(bytes.readPosition() + length);
+                    textTo((Bytes) toBytes);
+                } finally {
+                    bytes.readLimit(readLimit);
+                }
             }
             return wireIn();
         }
@@ -3666,6 +3676,9 @@ public class BinaryWire extends AbstractWire implements Wire {
         @Override
         public byte[] bytes(byte[] using) {
             long length = readLength();
+            if (length == 0) {
+                return NO_BYTE_ARRAY;
+            }
             int code = readCode();
             if (code == NULL) {
                 return null;

--- a/src/main/java/net/openhft/chronicle/wire/DefaultValueIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/DefaultValueIn.java
@@ -78,6 +78,7 @@ public class DefaultValueIn implements ValueIn {
     @NotNull
     @Override
     public WireIn bytes(@NotNull BytesOut<?> toBytes) {
+        toBytes.clear();
         @Nullable Object o = defaultValue;
         if (o == null)
             return wireIn();

--- a/src/main/java/net/openhft/chronicle/wire/ValueIn.java
+++ b/src/main/java/net/openhft/chronicle/wire/ValueIn.java
@@ -128,6 +128,7 @@ public interface ValueIn {
 
     /**
      * Reads byte data into the provided BytesOut object.
+     * toBytes is always cleared
      *
      * @param toBytes The BytesOut object to store the byte data.
      * @return The current WireIn instance.

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireReadWithLengthTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireReadWithLengthTest.java
@@ -4,9 +4,12 @@
 package net.openhft.chronicle.wire;
 
 import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.core.io.IORuntimeException;
+import net.openhft.chronicle.core.io.InvalidMarshallableException;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Illustrates Chronicle-Queue style copying of binary fragments into a textual representation.
@@ -74,6 +77,120 @@ public class BinaryWireReadWithLengthTest extends WireTestCommon {
 
         assertTrue(output.contains("say: hello"));
         assertTrue(output.contains("number: 42"));
+    }
+
+    @Test
+    public void readWithLengthLongOverloadCopiesMapFragmentToText() {
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        BinaryWire writer = new BinaryWire(bytes);
+        try (DocumentContext dc = writer.writingDocument(false)) {
+            dc.wire().write("map").marshallable(m -> m.write("key").int32(1));
+        }
+
+        bytes.readPositionRemaining(0, bytes.writePosition());
+        int header = bytes.readInt();
+        long len = Wires.lengthOf(header);
+        long bodyPos = bytes.readPosition();
+
+        TextWire target = new TextWire(Bytes.allocateElasticOnHeap());
+        BinaryWire source = new BinaryWire(bytes);
+        source.bytes().readPosition(bodyPos);
+        source.readWithLength(target, len);
+
+        assertTrue(target.bytes().toString().contains("key: 1"));
+    }
+
+    @Test(expected = net.openhft.chronicle.core.io.IORuntimeException.class)
+    public void readWithLengthRejectsNegativeLength() {
+        BinaryWire source = new BinaryWire(Bytes.allocateElasticOnHeap());
+        source.readWithLength(new TextWire(Bytes.allocateElasticOnHeap()), -1);
+    }
+
+    @Test(expected = net.openhft.chronicle.core.io.IORuntimeException.class)
+    public void readWithLengthRejectsOver32BitLength() {
+        BinaryWire source = new BinaryWire(Bytes.allocateElasticOnHeap());
+        source.readWithLength(new TextWire(Bytes.allocateElasticOnHeap()), 1L << 32);
+    }
+
+    @Test
+    public void bytesLength32WithTopBitSetIsReadAsUnsigned() {
+        expectUnsignedLengthRejected(0x80000000L);
+    }
+
+    @Test
+    public void bytesLength32WithMaxUnsignedValueIsReadAsUnsigned() {
+        expectUnsignedLengthRejected(0xFFFFFFFFL);
+    }
+
+    @Test
+    public void uncheckedBytesLength32WithMaxUnsignedValueIsRejectedBeforeReadLimitIsExtended() {
+        Bytes<?> uncheckedBytes = uncheckedBytesLength32(0xFFFFFFFFL);
+        try {
+            BinaryWire source = new BinaryWire(uncheckedBytes);
+            TextWire target = new TextWire(Bytes.allocateElasticOnHeap());
+            try {
+                source.copyOne(target);
+                fail("Expected IORuntimeException for unchecked unsigned 32-bit length");
+            } catch (IORuntimeException e) {
+                assertTrue("Unexpected message: " + e.getMessage(),
+                        e.getMessage().contains("Can't extend the limit"));
+            }
+        } finally {
+            uncheckedBytes.releaseLast();
+        }
+    }
+
+    @Test
+    public void uncheckedObjectWithLength32BeyondHardLimitIsRejectedBeforeReadLimitIsExtended()
+            throws InvalidMarshallableException {
+        Bytes<?> uncheckedBytes = uncheckedBytesLength32(0xFFFFFFFFL, BinaryWireCode.EVENT_NAME);
+        try {
+            BinaryWire source = new BinaryWire(uncheckedBytes);
+            try {
+                source.getValueIn().object();
+                fail("Expected IORuntimeException for unchecked unsigned 32-bit object length");
+            } catch (IORuntimeException e) {
+                assertTrue("Unexpected message: " + e.getMessage(),
+                        e.getMessage().contains("Can't extend the limit"));
+            }
+        } finally {
+            uncheckedBytes.releaseLast();
+        }
+    }
+
+    private Bytes<?> uncheckedBytesLength32(long length, int... payloadCodes) {
+        Bytes<?> encoded = Bytes.allocateElasticOnHeap();
+        encoded.writeUnsignedByte(BinaryWireCode.BYTES_LENGTH32);
+        encoded.writeUnsignedInt(length);
+        for (int payloadCode : payloadCodes)
+            encoded.writeUnsignedByte(payloadCode);
+        byte[] data = encoded.toByteArray();
+        encoded.releaseLast();
+        return Bytes.wrapForRead(data).unchecked(true);
+    }
+
+    /**
+     * Builds a stream of BYTES_LENGTH32 followed by a 4-byte length with the top bit set,
+     * but no payload. The length must be read as unsigned 32-bit, so the (impossibly large)
+     * length fails the read-limit check with "Can't extend the limit". Before the fix,
+     * {@code copyOne} read the length with the signed {@code readInt()}, so the limit check
+     * passed on a negative length and reading continued with a corrupt read limit.
+     */
+    private void expectUnsignedLengthRejected(long length) {
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        bytes.writeUnsignedByte(BinaryWireCode.BYTES_LENGTH32);
+        bytes.writeUnsignedInt(length);
+        bytes.readPositionRemaining(0, bytes.writePosition());
+
+        BinaryWire source = new BinaryWire(bytes);
+        TextWire target = new TextWire(Bytes.allocateElasticOnHeap());
+        try {
+            source.copyOne(target);
+            fail("Expected IORuntimeException for unsigned 32-bit length " + length);
+        } catch (IORuntimeException e) {
+            assertTrue("Unexpected message: " + e.getMessage(),
+                    e.getMessage().contains("Can't extend the limit"));
+        }
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireReadWithLengthTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireReadWithLengthTest.java
@@ -133,7 +133,7 @@ public class BinaryWireReadWithLengthTest extends WireTestCommon {
                 fail("Expected IORuntimeException for unchecked unsigned 32-bit length");
             } catch (IORuntimeException e) {
                 assertTrue("Unexpected message: " + e.getMessage(),
-                        e.getMessage().contains("Can't extend the limit"));
+                        e.getMessage().contains("bytes remaining between readPosition"));
             }
         } finally {
             uncheckedBytes.releaseLast();
@@ -151,7 +151,7 @@ public class BinaryWireReadWithLengthTest extends WireTestCommon {
                 fail("Expected IORuntimeException for unchecked unsigned 32-bit object length");
             } catch (IORuntimeException e) {
                 assertTrue("Unexpected message: " + e.getMessage(),
-                        e.getMessage().contains("Can't extend the limit"));
+                        e.getMessage().contains("bytes remaining between readPosition"));
             }
         } finally {
             uncheckedBytes.releaseLast();
@@ -172,7 +172,7 @@ public class BinaryWireReadWithLengthTest extends WireTestCommon {
     /**
      * Builds a stream of BYTES_LENGTH32 followed by a 4-byte length with the top bit set,
      * but no payload. The length must be read as unsigned 32-bit, so the (impossibly large)
-     * length fails the read-limit check with "Can't extend the limit". Before the fix,
+     * length fails the read-limit check, reporting the bytes remaining. Before the fix,
      * {@code copyOne} read the length with the signed {@code readInt()}, so the limit check
      * passed on a negative length and reading continued with a corrupt read limit.
      */
@@ -189,7 +189,7 @@ public class BinaryWireReadWithLengthTest extends WireTestCommon {
             fail("Expected IORuntimeException for unsigned 32-bit length " + length);
         } catch (IORuntimeException e) {
             assertTrue("Unexpected message: " + e.getMessage(),
-                    e.getMessage().contains("Can't extend the limit"));
+                    e.getMessage().contains("bytes remaining between readPosition"));
         }
     }
 

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWireReadWithLengthTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWireReadWithLengthTest.java
@@ -4,12 +4,15 @@
 package net.openhft.chronicle.wire;
 
 import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.util.DecoratedBufferUnderflowException;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.io.InvalidMarshallableException;
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import java.nio.BufferUnderflowException;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Illustrates Chronicle-Queue style copying of binary fragments into a textual representation.
@@ -158,7 +161,70 @@ public class BinaryWireReadWithLengthTest extends WireTestCommon {
         }
     }
 
+    @Test
+    public void valueInBytesRejectsMaxUnsignedLengthWithScalarPayload() {
+        expectValueInBytesRejectsMaxUnsignedLength(BinaryWireCode.TRUE, 0x55);
+    }
+
+    @Test
+    public void valueInBytesRejectsMaxUnsignedLengthWithU8ArrayPayload() {
+        expectValueInBytesRejectsMaxUnsignedLength(BinaryWireCode.U8_ARRAY, 0x55);
+    }
+
+    @Test
+    public void objectRejectsMaxUnsignedLengthWithoutReadingNestedU8Array() {
+        Bytes<?> bytes = bytesLength32(0xFFFFFFFFL, BinaryWireCode.U8_ARRAY, 1, 2, 3);
+        try {
+            BinaryWire source = new BinaryWire(bytes);
+            try {
+                source.getValueIn().object();
+                fail("Expected IORuntimeException for unsigned 32-bit object length");
+            } catch (BufferUnderflowException expected) {
+            }
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+
+    @Test
+    public void valueInBytesCopiesValidBytesLength32U8ArrayPayload() {
+        Bytes<?> bytes = bytesLength32(4, BinaryWireCode.U8_ARRAY, 1, 2, 3);
+        Bytes<?> out = Bytes.allocateElasticOnHeap();
+        try {
+            new BinaryWire(bytes).getValueIn().bytes(out);
+
+            assertEquals(3, out.writePosition());
+            assertArrayEquals(new byte[]{1, 2, 3}, out.toByteArray());
+            assertEquals(9, bytes.readPosition());
+            assertTrue(bytes.readPosition() <= bytes.readLimit());
+        } finally {
+            out.releaseLast();
+            bytes.releaseLast();
+        }
+    }
+
+    private void expectValueInBytesRejectsMaxUnsignedLength(int... payloadCodes) {
+        Bytes<?> bytes = bytesLength32(0xFFFFFFFFL, payloadCodes);
+        Bytes<?> out = Bytes.allocateElasticOnHeap();
+        out.writeByte((byte) 0x66);
+        try {
+            BinaryWire source = new BinaryWire(bytes);
+            try {
+                source.getValueIn().bytes(out);
+            } catch (BufferUnderflowException e) {
+                // expected
+            }
+        } finally {
+            out.releaseLast();
+            bytes.releaseLast();
+        }
+    }
+
     private Bytes<?> uncheckedBytesLength32(long length, int... payloadCodes) {
+        return bytesLength32(length, payloadCodes).unchecked(true);
+    }
+
+    private Bytes<?> bytesLength32(long length, int... payloadCodes) {
         Bytes<?> encoded = Bytes.allocateElasticOnHeap();
         encoded.writeUnsignedByte(BinaryWireCode.BYTES_LENGTH32);
         encoded.writeUnsignedInt(length);
@@ -166,7 +232,7 @@ public class BinaryWireReadWithLengthTest extends WireTestCommon {
             encoded.writeUnsignedByte(payloadCode);
         byte[] data = encoded.toByteArray();
         encoded.releaseLast();
-        return Bytes.wrapForRead(data).unchecked(true);
+        return Bytes.wrapForRead(data);
     }
 
     /**
@@ -207,5 +273,123 @@ public class BinaryWireReadWithLengthTest extends WireTestCommon {
         source.copyOne(textWire);
         String first = textWire.bytes().toString();
         assertTrue(first.length() > 0);
+    }
+
+    @Test
+    public void valueInBytesRejectsTypePrefixThatExceedsDeclaredLength() {
+        byte[] payload = {
+                (byte) BinaryWireCode.BYTES_LENGTH8,
+                0x01,
+                (byte) BinaryWireCode.TYPE_PREFIX,
+                0x03,
+                'x', 'x', 'x',
+                (byte) BinaryWireCode.U8_ARRAY,
+                0x55
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload).unchecked(true);
+
+        long originalLimit = bytes.readLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+        Bytes<?> output = Bytes.allocateElasticOnHeap();
+        output.writeByte((byte) 0x66);
+
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> wire.getValueIn().bytes(output));
+
+        assertNotNull(e);
+        assertEquals(0, output.writePosition());
+        assertEquals(originalLimit, bytes.readLimit());
+        assertTrailingTypePrefixBytes(bytes);
+    }
+
+    @Test
+    public void readTextRejectsTruncatedPadding32LengthField() {
+        byte[] payload = {
+                0x04, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x02
+        };
+        Bytes<?> bytes1 = Bytes.wrapForRead(payload).unchecked(true);
+        bytes1.readLimit(4);
+
+        BinaryWire wire = new BinaryWire(bytes1);
+        StringBuilder sb = new StringBuilder();
+
+        DecoratedBufferUnderflowException e = assertThrows(DecoratedBufferUnderflowException.class,
+                () -> wire.readText(BinaryWireCode.PADDING32, sb));
+
+        assertTrue(e.getMessage().contains("Requires at least five bytes, readRemaining: "));
+        assertEquals(0, bytes1.readPosition());
+        assertEquals(4, bytes1.readLimit());
+        assertEquals(4, bytes1.readRemaining());
+        assertTrue(bytes1.readPosition() <= bytes1.readLimit());
+    }
+
+    @Test
+    public void valueInBytesRejectsPadding32ThatExceedsDeclaredLength() {
+        byte[] payload = {
+                (byte) BinaryWireCode.BYTES_LENGTH8,
+                0x01,
+                (byte) BinaryWireCode.PADDING32,
+                0x04, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00,
+                (byte) BinaryWireCode.TRUE
+        };
+        Bytes<?> bytes = Bytes.wrapForRead(payload).unchecked(true);
+
+        long originalLimit = bytes.readLimit();
+        BinaryWire wire = new BinaryWire(bytes);
+        Bytes<?> output = Bytes.allocateElasticOnHeap();
+        output.writeByte((byte) 0x66);
+
+        DecoratedBufferUnderflowException e = assertThrows(DecoratedBufferUnderflowException.class,
+                () -> wire.getValueIn().bytes(output));
+
+        assertTrue(e.getMessage().contains("Requires at least five bytes, readRemaining: "));
+        assertEquals(0, output.writePosition());
+        assertEquals(originalLimit, bytes.readLimit());
+        assertTrailingPaddingAndTrue(bytes);
+    }
+
+    @Test
+    public void byteArrayReturnsEmptyArrayForZeroLengthBody() {
+        byte[] payload = {
+                (byte) BinaryWireCode.BYTES_LENGTH32,
+                0x00, 0x00, 0x00, 0x00,
+                (byte) BinaryWireCode.U8_ARRAY,
+                0x55
+        };
+        Bytes<?> bytes2 = Bytes.wrapForRead(payload).unchecked(true);
+        assertEquals(0, bytes2.readInt(1));
+        bytes2.readLimit(5);
+
+        BinaryWire wire = new BinaryWire(bytes2);
+        byte[] using = {(byte) 0x66};
+
+        byte[] bytes1 = wire.getValueIn().bytes(using);
+
+        assertEquals(0, bytes1.length);
+    }
+
+    static void assertTrailingPaddingAndTrue(Bytes<?> bytes) {
+        assertEquals(BinaryWireCode.PADDING32, bytes.readUnsignedByte(2));
+        assertEquals(0x04, bytes.readUnsignedByte(3));
+        assertEquals(0x00, bytes.readUnsignedByte(4));
+        assertEquals(0x00, bytes.readUnsignedByte(5));
+        assertEquals(0x00, bytes.readUnsignedByte(6));
+        assertEquals(0x00, bytes.readUnsignedByte(7));
+        assertEquals(0x00, bytes.readUnsignedByte(8));
+        assertEquals(0x00, bytes.readUnsignedByte(9));
+        assertEquals(0x00, bytes.readUnsignedByte(10));
+        assertEquals(BinaryWireCode.TRUE, bytes.readUnsignedByte(11));
+    }
+
+    static void assertTrailingTypePrefixBytes(Bytes<?> bytes) {
+        assertEquals(BinaryWireCode.TYPE_PREFIX, bytes.readUnsignedByte(2));
+        assertEquals(0x03, bytes.readUnsignedByte(3));
+        assertEquals('x', bytes.readUnsignedByte(4));
+        assertEquals('x', bytes.readUnsignedByte(5));
+        assertEquals('x', bytes.readUnsignedByte(6));
+        assertEquals(BinaryWireCode.U8_ARRAY, bytes.readUnsignedByte(7));
+        assertEquals(0x55, bytes.readUnsignedByte(8));
     }
 }


### PR DESCRIPTION
## Summary

This PR tightens `BinaryWire` handling of declared lengths and read boundaries.

It fixes unsigned `BYTES_LENGTH32` decoding, validates length-prefixed reads before narrowing read limits, and closes several malformed-input edge cases where byte reads could continue past the current value boundary or fail unclearly.

## Problem

`BYTES_LENGTH32` represents an unsigned 32-bit length, but some paths read it as a signed `int`. Encoded lengths with the top bit set could therefore be interpreted as negative values, which made read-limit checks unsafe.

There were also byte-reading edge cases around malformed or unchecked input:

  * nested length-prefixed values could claim more data than was available;
  * `PADDING32` text reads could proceed without enough bytes for the padding length and following code;
  * conversion reads, for example reading a non-byte-array value as bytes, could read beyond the declared value body;
  * zero-length byte-array reads could try to parse a value body that was not present;
  * reused output buffers could retain stale bytes when reading default byte values.

## Changes

  * Read `BYTES_LENGTH32` with `readUnsignedInt()`.
  * Promote length handling to `long` where unsigned 32-bit values must be represented.
  * Add `readWithLength(WireOut, long)` while keeping the existing `int` overload as a compatibility delegate.
  * Reject negative lengths and lengths greater than the unsigned 32-bit range.
  * Add `guardedReadLimit(long)` to keep nested length-prefixed reads inside the current read limit.
  * Apply guarded limits when reading nested length-prefixed object content.
  * Detect truncated `PADDING32` text reads before consuming padding length and the following value code.
  * Bound non-byte-array to bytes conversion to the declared value length.
  * Return an empty byte array for zero-length byte-array reads.
  * Clear `DefaultValueIn.bytes(BytesOut)` output before writing a default value.

## Tests

Adds coverage for:

  * Copying a length-prefixed fragment through the new `long` overload.
  * Rejecting negative and greater-than-unsigned-32-bit lengths.
  * Treating `BYTES_LENGTH32` values with the top bit set as unsigned.
  * Rejecting oversized declared lengths before extending the read limit.
  * Guarding malformed unchecked object and bytes reads.
  * Rejecting truncated `PADDING32` text reads.
  * Preventing conversion reads from consuming following wire data.
  * Returning an empty byte array for a zero-length byte-array body.
  * Preserving valid `BYTES_LENGTH32` byte-array reads.

## Risk

Low to medium.

This touches binary length-prefixed read paths and malformed input handling. Valid encoded data should continue to read as before. Invalid, truncated, or unchecked data should now fail earlier with clearer boundary checks, or return empty data where the declared value length is zero.

## Validation

Ran:

  * `mvn -q -Dtest=BinaryWireReadWithLengthTest test`