### PR TITLE
QUEUE-144: Source branch for split Wire context-listener PRs [do not merge]

### DIFF
--- a/src/main/docs/decision-log.adoc
+++ b/src/main/docs/decision-log.adoc
@@ -55,3 +55,32 @@ Impact & Consequences ::
 Notes/Links ::
 ** `operational-requirements.adoc`
 ** `functional-requirements.adoc`
+
+=== [NF-F-003] MarshallableOut Context Listener
+
+Date :: 2026-07-23
+Context ::
+* Chronicle Queue needed a way to write a per-roll-file preamble (a schema/session header)
+  before the first application excerpt, generalising an earlier roll-file-specific listener.
+* The same hook is useful at the wire level (first use), for file outputs and for transports
+  (connect / reconnect), so it belongs on `MarshallableOut` rather than in Queue.
+Decision Statement :: Add `MarshallableOut.ContextListener<T>` and
+`contextListener(Class<T>, ContextListener)`, fired once before the first data document of a new
+context, receiving a preset method writer.
+Alternatives Considered ::
+* Keep the listener in Queue only. ::
+  ** Pros: Smaller surface.
+  ** Cons: Duplicates the notify-once machinery; other outputs cannot reuse it.
+* Fire on every document. ::
+  ** Pros: Simpler state.
+  ** Cons: Wrong semantics - the preamble must appear once per context, not per message.
+Rationale for Decision ::
+* One choke point per layer (`AbstractWire`) keeps the semantics consistent across wire formats.
+* A leading metadata document is allowed to precede the context so stream framing is preserved.
+Impact & Consequences ::
+* The listener is at-most-once: a listener that throws is not retried, so it must be
+  complete-or-nothing and must not re-enter the output during the callback.
+* Must be configured before first use; setting it afterwards throws `IllegalStateException`.
+Notes/Links ::
+** `interface-control.adoc`
+** `functional-requirements.adoc`

--- a/src/main/docs/interface-control.adoc
+++ b/src/main/docs/interface-control.adoc
@@ -32,6 +32,26 @@ applications.
 |`net.openhft.chronicle.wire.converter.LongConverter`
 |Maps textual encodings to numeric values without intermediate allocation.
 |Consumers may supply custom implementations so the SPI contract is documented in code comments.
+
+|`net.openhft.chronicle.wire.MarshallableOut.ContextListener`
+|Callback fired at most once per output context (first wire use, a new queue roll file, a transport
+ connection), receiving a preset method writer whose calls are written before the first data
+ document. A leading metadata document may precede the context records.
+|Must be registered before the first document; registering later throws `IllegalStateException`.
+ At-most-once on failure: a listener that throws is not retried for that context, so listeners
+ should be complete-or-nothing. Outputs that cannot honour the contract (`READ_ANY` wires,
+ overwrite-mode file outputs) reject registration with `UnsupportedOperationException`.
+
+|`net.openhft.chronicle.wire.DocumentContext#contextCount()`
+|Identifier of the output context a document belongs to, letting DTOs with transient state write
+ large static context progressively - once per context - and resend it when the context changes.
+ Queue returns the roll cycle number; single-context outputs return `1`; channel-like outputs
+ return the one-based connection count (HTTP increments per POST).
+|Valid counts are positive and never `0` with a real clock (a test time provider at the epoch can
+ yield roll cycle `0` - a test-only value); unknown/absent/closed contexts return a negative value.
+ Compare with equality only - the value is an identifier, not an ordinal. For a queue it never goes
+ backwards (EOF-marked cycles are never reused). A Queue configured for double buffering throws
+ `IllegalStateException` - progressive usage and double buffering are not supported together.
 |===
 
 == Document Lifecycle

--- a/src/main/docs/interface-control.adoc
+++ b/src/main/docs/interface-control.adoc
@@ -46,7 +46,8 @@ applications.
 |Identifier of the output context a document belongs to, letting DTOs with transient state write
  large static context progressively - once per context - and resend it when the context changes.
  Queue returns the roll cycle number; single-context outputs return `1`; channel-like outputs
- return the one-based connection count (HTTP increments per POST).
+ return the one-based connection count (HTTP increments per POST). The value is an `int` because
+ supported context identifiers, including Queue roll cycles, are inherently `int`-valued.
 |Valid counts are positive and never `0` with a real clock (a test time provider at the epoch can
  yield roll cycle `0` - a test-only value); unknown/absent/closed contexts return a negative value.
  Compare with equality only - the value is an identifier, not an ordinal. For a queue it never goes

--- a/src/main/java/net/openhft/chronicle/wire/AbstractAnyWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractAnyWire.java
@@ -206,6 +206,15 @@ public abstract class AbstractAnyWire extends AbstractWire implements Wire {
         return wireAcquisition.acquireWire().acquireWritingDocument(metaData);
     }
 
+    // Writes are delegated to the acquired underlying wire, whose listener fields this setter would
+    // never reach - a listener registered here would be silently ignored, so fail loudly instead.
+    @NotNull
+    @Override
+    public <T> WireOut contextListener(@NotNull Class<T> writerType,
+                                       @NotNull MarshallableOut.ContextListener<? super T> listener) {
+        throw new UnsupportedOperationException("contextListener is not supported on a READ_ANY wire");
+    }
+
     @Override
     public String readingPeekYaml() {
         return wireAcquisition.acquireWire().readingPeekYaml();

--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -9,6 +9,7 @@ import net.openhft.chronicle.bytes.BytesUtil;
 import net.openhft.chronicle.bytes.HexDumpBytesDescription;
 import net.openhft.chronicle.bytes.util.DecoratedBufferUnderflowException;
 import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.io.InvalidMarshallableException;
 import net.openhft.chronicle.core.onoes.Slf4jExceptionHandler;
 import net.openhft.chronicle.core.pool.ClassAliasPool;
 import net.openhft.chronicle.core.pool.ClassLookup;
@@ -21,6 +22,7 @@ import org.jetbrains.annotations.NotNull;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.StreamCorruptedException;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
@@ -64,6 +66,14 @@ public abstract class AbstractWire implements Wire, InternalWire {
     private HeadNumberChecker headNumberChecker;
     private boolean usePadding = DEFAULT_USE_PADDING;
     private boolean generateTuples = GENERATE_TUPLES;
+    private Class<?> contextListenerWriterType;
+    private MarshallableOut.ContextListener<?> contextListener;
+    private boolean contextListenerNotified;
+    private boolean notifyingContextListener;
+    // Latched by the first document of any kind so a context listener cannot be installed once
+    // output has begun. Distinct from contextListenerNotified, which tracks whether the listener
+    // has actually fired (a listener-free wire still latches this on its first write).
+    private boolean firstDocumentStarted;
 
     /**
      * Constructor for AbstractWire.
@@ -212,6 +222,60 @@ public abstract class AbstractWire implements Wire, InternalWire {
     @Override
     public void commentListener(Consumer<CharSequence> commentListener) {
         this.commentListener = commentListener;
+    }
+
+    @NotNull
+    @Override
+    public <T> WireOut contextListener(@NotNull Class<T> writerType,
+                                       @NotNull MarshallableOut.ContextListener<? super T> listener) {
+        if (firstDocumentStarted)
+            throw new IllegalStateException("Cannot set contextListener after the first output context has started");
+        contextListenerWriterType = Objects.requireNonNull(writerType);
+        contextListener = Objects.requireNonNull(listener);
+        return this;
+    }
+
+    /**
+     * Fires the context listener at most once, before the first data document. A leading metadata
+     * document (a stream header/framing) is allowed to precede the context records, so notification
+     * is skipped while {@code metaData} is true and happens before the first data document instead.
+     * The notified flag is set before the listener runs, so a listener that writes some records and
+     * then throws is not retried - avoiding duplicate, half-written context records.
+     */
+    protected final void notifyContextListenerIfNeeded(boolean metaData) {
+        firstDocumentStarted = true;
+        if (metaData || contextListenerNotified || notifyingContextListener
+                || contextListener == null || contextListenerWriterType == null)
+            return;
+        contextListenerNotified = true;
+        notifyingContextListener = true;
+        try {
+            notifyContextListener(contextListener, contextListenerWriterType);
+        } finally {
+            notifyingContextListener = false;
+        }
+    }
+
+    // On a plain wire a listener writing via the wire directly during the callback is harmless
+    // (the notified flag is already latched), so no reentrancy policing is needed here - the
+    // supplied writer is a plain method writer.
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private void notifyContextListener(MarshallableOut.ContextListener listener, Class writerType) {
+        listener.onNewContext(methodWriter(writerType));
+    }
+
+    // writeDocument writes directly through WireInternal.writeData rather than writingDocument, so
+    // it needs its own notification hook or a context listener would be silently skipped on this path.
+    @Override
+    public void writeDocument(boolean metaData, @NotNull WriteMarshallable writer) throws InvalidMarshallableException {
+        notifyContextListenerIfNeeded(metaData);
+        WireInternal.writeData(this, metaData, false, writer);
+    }
+
+    @Override
+    public void writeNotCompleteDocument(boolean metaData, @NotNull WriteMarshallable writer) throws InvalidMarshallableException {
+        notifyContextListenerIfNeeded(metaData);
+        WireInternal.writeData(this, metaData, true, writer);
     }
 
     @NotNull

--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -66,14 +66,7 @@ public abstract class AbstractWire implements Wire, InternalWire {
     private HeadNumberChecker headNumberChecker;
     private boolean usePadding = DEFAULT_USE_PADDING;
     private boolean generateTuples = GENERATE_TUPLES;
-    private Class<?> contextListenerWriterType;
-    private MarshallableOut.ContextListener<?> contextListener;
-    private boolean contextListenerNotified;
-    private boolean notifyingContextListener;
-    // Latched by the first document of any kind so a context listener cannot be installed once
-    // output has begun. Distinct from contextListenerNotified, which tracks whether the listener
-    // has actually fired (a listener-free wire still latches this on its first write).
-    private boolean firstDocumentStarted;
+    private WireContextListenerLifecycle contextListenerLifecycle;
 
     /**
      * Constructor for AbstractWire.
@@ -228,10 +221,10 @@ public abstract class AbstractWire implements Wire, InternalWire {
     @Override
     public <T> WireOut contextListener(@NotNull Class<T> writerType,
                                        @NotNull MarshallableOut.ContextListener<? super T> listener) {
-        if (firstDocumentStarted)
+        WireContextListenerLifecycle lifecycle = contextListenerLifecycle;
+        if (lifecycle != null && lifecycle.started())
             throw new IllegalStateException("Cannot set contextListener after the first output context has started");
-        contextListenerWriterType = Objects.requireNonNull(writerType);
-        contextListener = Objects.requireNonNull(listener);
+        contextListenerLifecycle = WireContextListenerLifecycle.active(writerType, listener);
         return this;
     }
 
@@ -239,29 +232,22 @@ public abstract class AbstractWire implements Wire, InternalWire {
      * Fires the context listener at most once, before the first data document. A leading metadata
      * document (a stream header/framing) is allowed to precede the context records, so notification
      * is skipped while {@code metaData} is true and happens before the first data document instead.
-     * The notified flag is set before the listener runs, so a listener that writes some records and
-     * then throws is not retried - avoiding duplicate, half-written context records.
+     * A listener-free wire transitions once from a configurable {@code null} lifecycle to the
+     * shared no-op lifecycle. Thereafter ordinary users pay one field read and a predictable
+     * identity check; the no-op entry point itself is skipped.
      */
     protected final void notifyContextListenerIfNeeded(boolean metaData) {
-        firstDocumentStarted = true;
-        if (metaData || contextListenerNotified || notifyingContextListener
-                || contextListener == null || contextListenerWriterType == null)
-            return;
-        contextListenerNotified = true;
-        notifyingContextListener = true;
-        try {
-            notifyContextListener(contextListener, contextListenerWriterType);
-        } finally {
-            notifyingContextListener = false;
+        WireContextListenerLifecycle lifecycle = contextListenerLifecycle;
+        if (lifecycle == null) {
+            contextListenerLifecycle = WireContextListenerLifecycle.NO_OP;
+        } else if (lifecycle != WireContextListenerLifecycle.NO_OP) {
+            lifecycle.beforeDocument(this, metaData);
         }
     }
 
-    // On a plain wire a listener writing via the wire directly during the callback is harmless
-    // (the notified flag is already latched), so no reentrancy policing is needed here - the
-    // supplied writer is a plain method writer.
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    private void notifyContextListener(MarshallableOut.ContextListener listener, Class writerType) {
-        listener.onNewContext(methodWriter(writerType));
+    /** Package-private injection point for lifecycle integration tests. */
+    final void contextListenerLifecycle(WireContextListenerLifecycle lifecycle) {
+        contextListenerLifecycle = Objects.requireNonNull(lifecycle);
     }
 
     // writeDocument writes directly through WireInternal.writeData rather than writingDocument, so

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -335,6 +335,7 @@ public class BinaryWire extends AbstractWire implements Wire {
     @NotNull
     @Override
     public DocumentContext writingDocument(boolean metaData) {
+        notifyContextListenerIfNeeded(metaData);
         writeContext.start(metaData);
         return writeContext;
     }

--- a/src/main/java/net/openhft/chronicle/wire/DocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/DocumentContext.java
@@ -83,6 +83,8 @@ public interface DocumentContext extends Closeable, SourceContext {
      *       this only makes sense in tests and is not a production value.) A context whose count is
      *       unknown (no document present, or the context has been closed) returns a
      *       <em>negative</em> value.</li>
+     *   <li>The value is bounded to the {@code int} range because supported context identifiers,
+     *       including Queue roll cycles, are inherently {@code int}-valued.</li>
      *   <li>Compare counts with equality only. The value is an identifier, not an ordinal:
      *       Queue implementations return the roll cycle number for the document (which may have
      *       gaps), implementations without multiple output contexts return {@code 1}, and
@@ -103,7 +105,7 @@ public interface DocumentContext extends Closeable, SourceContext {
      *
      * @return the context count for this document, or a negative value if not known
      */
-    default long contextCount() {
+    default int contextCount() {
         return 1;
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/DocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/DocumentContext.java
@@ -69,6 +69,45 @@ public interface DocumentContext extends Closeable, SourceContext {
     }
 
     /**
+     * Returns the output context count associated with this document.
+     * <p>
+     * This allows DTOs with transient state to decide whether static context has already been
+     * written to the current output context before writing an event that relies on it: remember
+     * the count when the static context is written, and rewrite it when a document reports a
+     * different count.
+     * <p>
+     * Contract:
+     * <ul>
+     *   <li>A valid count is always positive; {@code 0} is never returned with a real clock. (A
+     *       Queue driven by a test time provider set at the epoch can produce roll cycle {@code 0};
+     *       this only makes sense in tests and is not a production value.) A context whose count is
+     *       unknown (no document present, or the context has been closed) returns a
+     *       <em>negative</em> value.</li>
+     *   <li>Compare counts with equality only. The value is an identifier, not an ordinal:
+     *       Queue implementations return the roll cycle number for the document (which may have
+     *       gaps), implementations without multiple output contexts return {@code 1}, and
+     *       channel-like outputs should return the one-based connection count.</li>
+     *   <li>For a given queue the value never goes backwards: a rolled-past cycle has an
+     *       end-of-file marker and is never reused - a write with an earlier clock is refused
+     *       rather than written to an earlier cycle.</li>
+     *   <li>Implementations may throw {@link IllegalStateException} when the final context is not
+     *       yet known; in particular a Queue configured for double buffering rejects this call
+     *       (the target roll is selected only when the buffer is flushed), so progressive-DTO
+     *       usage is not supported with double buffering.</li>
+     *   <li>If a write fails after the caller has recorded the count, the recorded state may be
+     *       ahead of the output; such failures are generally not retryable, so no attempt is made
+     *       to make the count transactional with the write.</li>
+     *   <li>Read the value from an open document on the writing thread; it is not thread-safe and
+     *       is unspecified for a context object retained after close.</li>
+     * </ul>
+     *
+     * @return the context count for this document, or a negative value if not known
+     */
+    default long contextCount() {
+        return 1;
+    }
+
+    /**
      * Invoked to signal an error condition in the current context.
      * This ensures that upon closing the context, any changes made during its lifecycle
      * are rolled back rather than committing a potentially erroneous state.

--- a/src/main/java/net/openhft/chronicle/wire/DocumentContextHolder.java
+++ b/src/main/java/net/openhft/chronicle/wire/DocumentContextHolder.java
@@ -37,6 +37,14 @@ public class DocumentContextHolder implements DocumentContext, WriteDocumentCont
         return dc.isNotComplete();
     }
 
+    @Override
+    public long contextCount() {
+        // dc == null is the holder's documented closed state - report "no known context" rather
+        // than NPE or a valid-looking value
+        DocumentContext dc = this.dc;
+        return dc == null ? -1 : dc.contextCount();
+    }
+
     /**
      * Retrieves the encapsulated {@link DocumentContext} instance.
      *

--- a/src/main/java/net/openhft/chronicle/wire/DocumentContextHolder.java
+++ b/src/main/java/net/openhft/chronicle/wire/DocumentContextHolder.java
@@ -38,7 +38,7 @@ public class DocumentContextHolder implements DocumentContext, WriteDocumentCont
     }
 
     @Override
-    public long contextCount() {
+    public int contextCount() {
         // dc == null is the holder's documented closed state - report "no known context" rather
         // than NPE or a valid-looking value
         DocumentContext dc = this.dc;

--- a/src/main/java/net/openhft/chronicle/wire/MarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableOut.java
@@ -27,6 +27,22 @@ import java.util.stream.Stream;
 public interface MarshallableOut extends DocumentWritten, RollbackIfNotCompleteNotifier {
 
     /**
+     * Receives a callback when a {@link MarshallableOut} starts a new output context.
+     * The meaning of a context is implementation specific.
+     *
+     * @param <T> event interface type used by the supplied method writer
+     */
+    @FunctionalInterface
+    interface ContextListener<T> {
+        /**
+         * Called before the first application document is written in the new output context.
+         *
+         * @param writer preset method writer for writing context records
+         */
+        void onNewContext(T writer);
+    }
+
+    /**
      * Creates and returns a new instance of {@link MarshallableOutBuilder} initialized with the provided URL.
      *
      * @param url The URL which will dictate the specific type of {@code MarshallableOut} to create.
@@ -73,6 +89,67 @@ public interface MarshallableOut extends DocumentWritten, RollbackIfNotCompleteN
      * Start or reuse an existing a DocumentContext, optionally call close() when done.
      */
     DocumentContext acquireWritingDocument(boolean metaData) throws UnrecoverableTimeoutException;
+
+    /**
+     * Sets a listener to be called when this output starts a new implementation-defined context.
+     * <p>
+     * The listener receives a preset method writer for {@code writerType}. Method calls made by the
+     * listener are written before the first application document in that context. Implementations
+     * define what starts a new context, for example first wire use, queue roll-file creation or
+     * transport connection. A leading metadata document (a stream header) is written before the
+     * context records; the context precedes the first <em>data</em> document.
+     * <p>
+     * Context records are synthetic and do not record {@link MessageHistory} by default. A listener
+     * may write history explicitly if that context has a real causal history, but normal usage
+     * assumes no history is written.
+     * <p>
+     * If an implementation creates the first output context lazily, the listener is called on first
+     * use as well as on later context changes. Context that must exist before that first write is
+     * application state and must be written by the application as it is built; this is not a
+     * construction-time callback. Listener implementations should track what context they have
+     * assumed was already sent and emit any still-required records again when called. If there is
+     * no context to write for a given callback, the listener may return without writing anything;
+     * writing no placeholder record is the safest and most consistent behaviour.
+     * <p>
+     * The supplied writer emits normal method-writer documents. Do not enable this listener on an
+     * output whose readers require one fixed raw payload format unless those readers explicitly
+     * tolerate the context records.
+     * <p>
+     * Contract:
+     * <ul>
+     *   <li>Must be set before the first document is written; setting it afterwards throws
+     *       {@link IllegalStateException}.</li>
+     *   <li>The listener must write only through the supplied writer. It must not open a document on,
+     *       mutate, or otherwise re-enter, this output during the callback.</li>
+     *   <li>The supplied writer is scoped to the callback. Retaining it or using it after
+     *       {@link ContextListener#onNewContext(Object)} returns is unsupported; implementations may
+     *       reject this usage.</li>
+     *   <li>If the listener throws, the exception is propagated to the caller. Retry policy after a
+     *       failure before any context record is implementation-specific. Listener implementations
+     *       should be idempotent and complete-or-nothing (do not throw after writing records).</li>
+     *   <li>For low-latency resends, clear any local "already sent" assumptions first and then write
+     *       the missing context while one document context is held, if the supplied method writer also
+     *       exposes {@link DocumentWritten}. {@link DocumentContext#contextCount()} is the
+     *       comparison key (compare with equality only) for deciding whether static context has
+     *       already been written in that output context. Note that on a Queue configured for double
+     *       buffering {@code contextCount()} throws {@link IllegalStateException} - progressive
+     *       resends and double buffering are not supported together. This is the same pattern as a
+     *       writer created with {@code methodWriter(EventType.class, DocumentWritten.class)}.</li>
+     *   <li>Not thread-safe: configure it on a single thread before the output is used.</li>
+     * </ul>
+     *
+     * @param writerType event interface type for the supplied method writer
+     * @param listener   listener to call for new output contexts
+     * @param <T>        event interface type
+     * @return this output
+     * @throws UnsupportedOperationException if this output does not support context listeners
+     * @throws IllegalStateException         if set after the first output context has started
+     */
+    @NotNull
+    default <T> MarshallableOut contextListener(@NotNull Class<T> writerType,
+                                                @NotNull ContextListener<? super T> listener) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * @return true if this output is configured to expect the history of the message to be written

--- a/src/main/java/net/openhft/chronicle/wire/NoDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/NoDocumentContext.java
@@ -47,6 +47,12 @@ public enum NoDocumentContext implements DocumentContext {
     }
 
     @Override
+    public long contextCount() {
+        // no document, so no context: a negative value, never a valid-looking count
+        return -1;
+    }
+
+    @Override
     public boolean isNotComplete() {
         return false;
     }

--- a/src/main/java/net/openhft/chronicle/wire/NoDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/NoDocumentContext.java
@@ -47,7 +47,7 @@ public enum NoDocumentContext implements DocumentContext {
     }
 
     @Override
-    public long contextCount() {
+    public int contextCount() {
         // no document, so no context: a negative value, never a valid-looking count
         return -1;
     }

--- a/src/main/java/net/openhft/chronicle/wire/RawWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/RawWire.java
@@ -102,13 +102,10 @@ public class RawWire extends AbstractWire implements Wire {
         return true;
     }
 
-    /**
-     * Begins a document for raw value writing. The {@code metaData} flag is
-     * ignored as this format stores no metadata.
-     */
     @NotNull
     @Override
     public DocumentContext writingDocument(boolean metaData) {
+        notifyContextListenerIfNeeded(metaData);
         writeContext.start(metaData);
         return writeContext;
     }

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -377,6 +377,7 @@ public class TextWire extends YamlWireOut<TextWire> {
     @NotNull
     @Override
     public DocumentContext writingDocument(boolean metaData) {
+        notifyContextListenerIfNeeded(metaData);
         if (writeContext == null)
             useTextDocuments();
         writeContext.start(metaData);

--- a/src/main/java/net/openhft/chronicle/wire/WireContextListenerLifecycle.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireContextListenerLifecycle.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.wire;
+
+import org.jetbrains.annotations.NotNull;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Internal lifecycle for a context listener attached to a wire.
+ *
+ * <p>The shared {@link #NO_OP} instance represents a wire whose first document has already started
+ * without a listener. An {@link ActiveWireContextListenerLifecycle} is allocated only when the
+ * advanced context-listener feature is configured.</p>
+ */
+interface WireContextListenerLifecycle {
+    WireContextListenerLifecycle NO_OP = NoOpWireContextListenerLifecycle.INSTANCE;
+
+    /**
+     * @return whether an output document has already started
+     */
+    boolean started();
+
+    /**
+     * Invoked immediately before a wire starts an output document.
+     *
+     * @param wire     wire starting the document
+     * @param metaData whether the document contains metadata
+     */
+    void beforeDocument(AbstractWire wire, boolean metaData);
+
+    static <T> WireContextListenerLifecycle active(@NotNull Class<T> writerType,
+                                                   @NotNull MarshallableOut.ContextListener<? super T> listener) {
+        return new ActiveWireContextListenerLifecycle(requireNonNull(writerType), requireNonNull(listener));
+    }
+}
+
+/**
+ * Shared, allocation-free lifecycle used when no listener was configured before first use.
+ *
+ * <p>{@link AbstractWire} identifies this instance before dispatch, leaving this implementation as
+ * the explicit frozen state while avoiding an interface call for listener-free writes.</p>
+ */
+enum NoOpWireContextListenerLifecycle implements WireContextListenerLifecycle {
+    INSTANCE;
+
+    @Override
+    public boolean started() {
+        return true;
+    }
+
+    @Override
+    public void beforeDocument(AbstractWire wire, boolean metaData) {
+        // Deliberately empty; useful to lifecycle tests and callers that dispatch directly.
+    }
+}
+
+/**
+ * Stateful lifecycle allocated only for a configured context listener.
+ *
+ * <p>The callback is latched before user code runs. If it commits partial output and then throws,
+ * a later document therefore cannot duplicate the already committed context records.</p>
+ */
+final class ActiveWireContextListenerLifecycle implements WireContextListenerLifecycle {
+    private final Class<?> writerType;
+    private final MarshallableOut.ContextListener<?> listener;
+    private boolean started;
+    private boolean notified;
+    private boolean notifying;
+
+    ActiveWireContextListenerLifecycle(Class<?> writerType, MarshallableOut.ContextListener<?> listener) {
+        this.writerType = writerType;
+        this.listener = listener;
+    }
+
+    @Override
+    public boolean started() {
+        return started;
+    }
+
+    /**
+     * Fires at most once, before the first data document. Metadata may precede the context records.
+     * The notified flag is latched before invoking user code so a partial listener failure is not
+     * retried and duplicated.
+     */
+    @Override
+    public void beforeDocument(AbstractWire wire, boolean metaData) {
+        started = true;
+        if (metaData || notified || notifying)
+            return;
+
+        notified = true;
+        notifying = true;
+        try {
+            notifyListener(wire);
+        } finally {
+            notifying = false;
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private void notifyListener(AbstractWire wire) {
+        ((MarshallableOut.ContextListener) listener).onNewContext(wire.methodWriter(writerType));
+    }
+}

--- a/src/main/java/net/openhft/chronicle/wire/WireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireOut.java
@@ -225,6 +225,14 @@ public interface WireOut extends WireCommon, MarshallableOut {
      */
     DocumentContext acquireWritingDocument(boolean metaData);
 
+    @NotNull
+    @Override
+    default <T> WireOut contextListener(@NotNull Class<T> writerType,
+                                        @NotNull MarshallableOut.ContextListener<? super T> listener) {
+        MarshallableOut.super.contextListener(writerType, listener);
+        return this;
+    }
+
     /**
      * Writes a document to the wire without marking its completion. This is primarily used in
      * networking scenarios, but no longer used for queues.

--- a/src/main/java/net/openhft/chronicle/wire/WrappedDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/WrappedDocumentContext.java
@@ -68,7 +68,7 @@ public abstract class WrappedDocumentContext implements DocumentContext {
     }
 
     @Override
-    public long contextCount() {
+    public int contextCount() {
         return dc.contextCount();
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/WrappedDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/WrappedDocumentContext.java
@@ -68,6 +68,11 @@ public abstract class WrappedDocumentContext implements DocumentContext {
     }
 
     @Override
+    public long contextCount() {
+        return dc.contextCount();
+    }
+
+    @Override
     public void close() {
         dc.close();
     }

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -416,6 +416,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     @NotNull
     @Override
     public DocumentContext writingDocument(boolean metaData) {
+        notifyContextListenerIfNeeded(metaData);
         if (writeContext == null)
             useBinaryDocuments();
         writeContext.start(metaData);

--- a/src/main/java/net/openhft/chronicle/wire/internal/FileMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/FileMarshallableOut.java
@@ -116,4 +116,17 @@ public class FileMarshallableOut implements MarshallableOut {
     static class FMOOptions extends SelfDescribingMarshallable {
         boolean append; // Indicates if data should be appended to the existing file
     }
+    @Override
+    public <T> MarshallableOut contextListener(Class<T> writerType,
+                                               MarshallableOut.ContextListener<? super T> listener) {
+        // In overwrite mode every document atomically replaces the file, so context records written
+        // with the first document would be lost from the surviving output - fail loudly instead.
+        if (!options.append)
+            throw new UnsupportedOperationException(
+                    "contextListener requires append mode (add ?append=true to the file URL): "
+                            + "in overwrite mode each document replaces the file, discarding the context records");
+        wire.contextListener(writerType, listener);
+        return this;
+    }
+
 }

--- a/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
@@ -32,8 +32,17 @@ public class HTTPMarshallableOut implements MarshallableOut {
     // The encapsulated Wire object for serialization
     private final Wire wire;
 
+    // One-based count of the POST currently being built: each document is delivered over its own
+    // HTTP connection, so each is a distinct output context for DocumentContext.contextCount().
+    private long connectionCount = 1;
+
     // Document context holder for managing the wire and the HTTP communication
     private final DocumentContextHolder dcHolder = new DocumentContextHolder() {
+
+        @Override
+        public long contextCount() {
+            return connectionCount;
+        }
 
         // Inline comment about override functionality
         @Override
@@ -73,6 +82,7 @@ public class HTTPMarshallableOut implements MarshallableOut {
                 throw new IORuntimeException(ioe);
             }
             startWire();
+            connectionCount++; // the next document goes over a new connection
         }
     };
 
@@ -118,4 +128,11 @@ public class HTTPMarshallableOut implements MarshallableOut {
         dcHolder.documentContext(wire.acquireWritingDocument(metaData));
         return dcHolder;
     }
+    @Override
+    public <T> MarshallableOut contextListener(Class<T> writerType,
+                                               MarshallableOut.ContextListener<? super T> listener) {
+        wire.contextListener(writerType, listener);
+        return this;
+    }
+
 }

--- a/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
@@ -34,13 +34,13 @@ public class HTTPMarshallableOut implements MarshallableOut {
 
     // One-based count of the POST currently being built: each document is delivered over its own
     // HTTP connection, so each is a distinct output context for DocumentContext.contextCount().
-    private long connectionCount = 1;
+    private int connectionCount = 1;
 
     // Document context holder for managing the wire and the HTTP communication
     private final DocumentContextHolder dcHolder = new DocumentContextHolder() {
 
         @Override
-        public long contextCount() {
+        public int contextCount() {
             return connectionCount;
         }
 

--- a/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
@@ -131,8 +131,8 @@ public class HTTPMarshallableOut implements MarshallableOut {
     @Override
     public <T> MarshallableOut contextListener(Class<T> writerType,
                                                MarshallableOut.ContextListener<? super T> listener) {
-        wire.contextListener(writerType, listener);
-        return this;
+        throw new UnsupportedOperationException(
+                "contextListener is not supported for HTTP output: each POST is a new output context");
     }
 
 }

--- a/src/main/java/net/openhft/chronicle/wire/internal/StringConsumerMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/StringConsumerMarshallableOut.java
@@ -60,4 +60,11 @@ public class StringConsumerMarshallableOut implements MarshallableOut {
         dcHolder.documentContext(wire.acquireWritingDocument(metaData));
         return dcHolder;
     }
+    @Override
+    public <T> MarshallableOut contextListener(Class<T> writerType,
+                                               MarshallableOut.ContextListener<? super T> listener) {
+        wire.contextListener(writerType, listener);
+        return this;
+    }
+
 }

--- a/src/test/java/net/openhft/chronicle/wire/BinaryWire2Test.java
+++ b/src/test/java/net/openhft/chronicle/wire/BinaryWire2Test.java
@@ -6,6 +6,7 @@ package net.openhft.chronicle.wire;
 import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.bytes.BytesStore;
 import net.openhft.chronicle.bytes.HexDumpBytes;
+import net.openhft.chronicle.bytes.MethodReader;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import org.jetbrains.annotations.NotNull;
@@ -57,6 +58,28 @@ public class BinaryWire2Test extends WireTestCommon {
         @NotNull BinaryWire wire = new BinaryWire(bytes, false, false, false, 32, "lzw");
         wire.usePadding(usePadding);
         return wire;
+    }
+
+    @Test
+    public void contextListenerWritesBeforeFirstBinaryDocument() {
+        BinaryWire wire = createWire();
+        wire.contextListener(ContextEvents.class, writer -> writer.event("context"));
+
+        ContextEvents writer = wire.methodWriter(ContextEvents.class);
+        writer.event("one");
+        writer.event("two");
+
+        wire.bytes().readPosition(0);
+        List<String> events = new ArrayList<>();
+        MethodReader reader = wire.methodReader((ContextEvents) events::add);
+        while (reader.readOne()) {
+            // drain
+        }
+        assertEquals(Arrays.asList("context", "one", "two"), events);
+    }
+
+    interface ContextEvents {
+        void event(String value);
     }
 
     // Test writing an object that is not marshallable and expecting an IllegalArgumentException

--- a/src/test/java/net/openhft/chronicle/wire/DocumentContextLifecycleTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/DocumentContextLifecycleTest.java
@@ -18,6 +18,7 @@ public class DocumentContextLifecycleTest extends WireTestCommon {
         Wire w = WireType.BINARY.apply(Bytes.allocateElasticOnHeap(256));
         // write two docs
         try (DocumentContext dc = w.writingDocument()) {
+            assertEquals(1, dc.contextCount());
             dc.wire().write("a").int32(1);
         }
         try (DocumentContext dc = w.writingDocument()) {
@@ -43,6 +44,7 @@ public class DocumentContextLifecycleTest extends WireTestCommon {
     public void textUseTextDocumentsLifecycle() {
         Wire w = new TextWire(Bytes.allocateElasticOnHeap(256)).useTextDocuments();
         try (DocumentContext dc = w.writingDocument()) {
+            assertEquals(1, dc.contextCount());
             dc.wire().write("x").int64(11L);
         }
         try (DocumentContext dc = w.writingDocument(true)) { // meta document allowed

--- a/src/test/java/net/openhft/chronicle/wire/MarshallableOutContextListenerTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MarshallableOutContextListenerTest.java
@@ -395,7 +395,7 @@ public class MarshallableOutContextListenerTest extends WireTestCommon {
         // interface default (a plain-wire delegate would make 1 == 1 pass either way).
         DocumentContext stub = new DocumentContext() {
             @Override
-            public long contextCount() {
+            public int contextCount() {
                 return 42;
             }
 
@@ -465,7 +465,7 @@ public class MarshallableOutContextListenerTest extends WireTestCommon {
             URL url = new URL("http://localhost:" + server.getAddress().getPort() + "/ctx");
             MarshallableOut out = MarshallableOut.builder(url).wireType(WireType.JSON_ONLY).get();
 
-            List<Long> counts = new ArrayList<>();
+            List<Integer> counts = new ArrayList<>();
             for (int i = 0; i < 3; i++) {
                 try (DocumentContext dc = out.writingDocument()) {
                     counts.add(dc.contextCount());
@@ -473,7 +473,7 @@ public class MarshallableOutContextListenerTest extends WireTestCommon {
                 }
             }
             assertEquals("each HTTP document is a separate delivery and must report a distinct " +
-                    "one-based connection count", Arrays.asList(1L, 2L, 3L), counts);
+                    "one-based connection count", Arrays.asList(1, 2, 3), counts);
             assertEquals(3, posts.size());
         } finally {
             server.stop(0);

--- a/src/test/java/net/openhft/chronicle/wire/MarshallableOutContextListenerTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MarshallableOutContextListenerTest.java
@@ -1,0 +1,486 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.wire;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.wire.internal.StringConsumerMarshallableOut;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class MarshallableOutContextListenerTest extends WireTestCommon {
+
+    interface ContextEvents {
+        void event(String value);
+    }
+
+    // Reads every document in write order, recording the first field's value of each.
+    private static List<String> readOrdered(Wire wire) {
+        wire.bytes().readPosition(0);
+        List<String> out = new ArrayList<>();
+        while (true) {
+            try (DocumentContext dc = wire.readingDocument()) {
+                if (!dc.isPresent())
+                    break;
+                StringBuilder sb = new StringBuilder();
+                String val = dc.wire().read(sb).text();
+                out.add(val);
+            }
+        }
+        return out;
+    }
+
+    private static long count(List<String> list, String value) {
+        return list.stream().filter(value::equals).count();
+    }
+
+    // Drains method-writer events via a methodReader (works for fieldless formats such as RAW).
+    private static List<String> drainEvents(Wire wire) {
+        wire.bytes().readPosition(0);
+        List<String> events = new ArrayList<>();
+        net.openhft.chronicle.bytes.MethodReader reader = wire.methodReader((ContextEvents) events::add);
+        while (reader.readOne()) {
+            // drain
+        }
+        return events;
+    }
+
+    // ------------------------------------------------------------------
+    // 1. T-P1-5 (AbstractWire:231)
+    // ------------------------------------------------------------------
+    @Test
+    public void tP15_cannotSetListenerAfterFirstDocument() {
+        Wire wire = WireType.BINARY.apply(Bytes.allocateElasticOnHeap());
+        try (DocumentContext dc = wire.writingDocument(false)) {
+            dc.wire().write("msg").text("one");
+        }
+        assertThrows(IllegalStateException.class,
+                () -> wire.contextListener(ContextEvents.class, w -> w.event("late")));
+    }
+
+    // ------------------------------------------------------------------
+    // 2. T-P1-8 (BinaryWire:339) - metadata-first ordering
+    // ------------------------------------------------------------------
+    @Test
+    public void tP18_metadataBeforeContextEvent_binary() {
+        Wire wire = WireType.BINARY.apply(Bytes.allocateElasticOnHeap());
+        wire.contextListener(ContextEvents.class, w -> w.event("ctx"));
+        // A leading metadata document (stream header/framing) must come first, then the context
+        // records, then the first data document: header -> context -> data.
+        try (DocumentContext dc = wire.writingDocument(true)) {
+            dc.wire().write("event").text("meta");
+        }
+        try (DocumentContext dc = wire.writingDocument(false)) {
+            dc.wire().write("event").text("d");
+        }
+        assertEquals(Arrays.asList("meta", "ctx", "d"), readOrdered(wire));
+    }
+
+    @Test
+    public void tP18_metadataBeforeContextEvent_text() {
+        Wire wire = WireType.TEXT.apply(Bytes.allocateElasticOnHeap());
+        wire.contextListener(ContextEvents.class, w -> w.event("ctx"));
+        try (DocumentContext dc = wire.writingDocument(true)) {
+            dc.wire().write("event").text("meta");
+        }
+        try (DocumentContext dc = wire.writingDocument(false)) {
+            dc.wire().write("event").text("d");
+        }
+        // TextWire's metadata read-back does not round-trip through readingDocument cleanly, so
+        // assert ordering on the serialized text directly: header -> context -> data.
+        String text = wire.bytes().toString();
+        int meta = text.indexOf("meta"), ctx = text.indexOf("ctx"), d = text.indexOf("\"d\"");
+        if (d < 0) d = text.lastIndexOf("d");
+        assertTrue("expected meta before ctx before d but was:\n" + text,
+                meta >= 0 && ctx > meta && d > ctx);
+    }
+
+    // ------------------------------------------------------------------
+    // 3. T-P1-25 (WireOut.writeDocument bypass)
+    // ------------------------------------------------------------------
+    @Test
+    public void tP125_writeDocumentNotifiesContextListener() {
+        Wire wire = WireType.BINARY.apply(Bytes.allocateElasticOnHeap());
+        wire.contextListener(ContextEvents.class, w -> w.event("ctx"));
+        wire.writeDocument(false, w -> w.write("msg").text("one"));
+
+        List<String> events = readOrdered(wire);
+        assertTrue("expected context event 'ctx' in output but was " + events,
+                events.contains("ctx"));
+    }
+
+    @Test
+    public void tP125_writeNotCompleteDocumentNotifiesContextListener() {
+        Wire wire = WireType.BINARY.apply(Bytes.allocateElasticOnHeap());
+        wire.contextListener(ContextEvents.class, w -> w.event("ctx"));
+        wire.writeNotCompleteDocument(false, w -> w.write("msg").text("one"));
+
+        List<String> events = readOrdered(wire);
+        assertTrue("expected context event 'ctx' in output but was " + events,
+                events.contains("ctx"));
+    }
+
+    // ------------------------------------------------------------------
+    // 4. T-P1-6w (AbstractWire:238) - no rollback / duplication on retry
+    // ------------------------------------------------------------------
+    @Test
+    public void tP16w_contextEventNotDuplicatedAfterListenerThrows() {
+        Wire wire = WireType.BINARY.apply(Bytes.allocateElasticOnHeap());
+        AtomicInteger n = new AtomicInteger();
+        wire.contextListener(ContextEvents.class, w -> {
+            w.event("a");
+            if (n.getAndIncrement() == 0)
+                throw new IllegalStateException("boom");
+        });
+
+        boolean threw = false;
+        try {
+            try (DocumentContext dc = wire.writingDocument(false)) {
+                dc.wire().write("msg").text("one");
+            }
+        } catch (IllegalStateException expected) {
+            // first attempt: listener wrote event("a") then threw
+            threw = true;
+        }
+        assertTrue("the listener's exception must propagate to the caller", threw);
+
+        try (DocumentContext dc = wire.writingDocument(false)) {
+            dc.wire().write("msg").text("two");
+        }
+
+        List<String> events = readOrdered(wire);
+        assertEquals("context event should appear exactly once but was " + events,
+                1, count(events, "a"));
+    }
+
+    @Test
+    public void tP26_directWritingDocumentInsideListenerFailsDeterministically() {
+        // On a plain wire a listener writing via the wire directly is harmless (the notify-once flag
+        // is already latched), so it is permitted rather than policed: no guard machinery.
+        Wire wire = WireType.BINARY.apply(Bytes.allocateElasticOnHeap());
+        wire.contextListener(ContextEvents.class, writer -> {
+            writer.event("ctx");
+            try (DocumentContext dc = wire.writingDocument(false)) {
+                dc.wire().write("event").text("direct");
+            }
+        });
+
+        wire.methodWriter(ContextEvents.class).event("one");
+
+        assertEquals(Arrays.asList("ctx", "direct", "one"), readOrdered(wire));
+    }
+
+    // A chained method writer whose chained return type is @DontChain is served by a generated
+    // sub-writer; the listener must be able to use it through the supplied writer.
+    interface ChainStart {
+        ChainEnd start(String id);
+    }
+
+    @net.openhft.chronicle.core.annotation.DontChain
+    interface ChainEnd {
+        void end(String value);
+    }
+
+    @Test
+    public void tChained_dontChainSubWriterUsableInsideListener() {
+        Wire wire = WireType.BINARY.apply(Bytes.allocateElasticOnHeap());
+        wire.contextListener(ChainStart.class, w -> w.start("ctx").end("v"));
+
+        wire.methodWriter(ChainStart.class).start("one").end("w");
+
+        // The point under test: using the generated @DontChain sub-writer INSIDE the listener must
+        // not be rejected as a re-entrant write (it previously threw IllegalStateException). The
+        // start events round-trip; the end-event read-back is a pre-existing @DontChain
+        // reader-dispatch quirk unrelated to context listeners (end:w, written outside the
+        // listener, is equally affected), so it is not asserted here.
+        expectException("Unknown method-name='end'");
+        List<String> events = new ArrayList<>();
+        wire.bytes().readPosition(0);
+        net.openhft.chronicle.bytes.MethodReader reader = wire.methodReader(
+                (ChainStart) id -> {
+                    events.add("start:" + id);
+                    return value -> events.add("end:" + value);
+                },
+                (ChainEnd) value -> events.add("end:" + value));
+        while (reader.readOne()) {
+            // drain
+        }
+        assertEquals("the listener's chained write and the application write must both be present",
+                Arrays.asList("start:ctx", "start:one"),
+                events.stream().filter(e -> e.startsWith("start:")).collect(java.util.stream.Collectors.toList()));
+    }
+
+    // RawWire must preserve the caller's metadata flag - a plain public-API invariant, listener or not.
+    @Test
+    public void tRaw_writingDocumentPreservesMetadataFlag() {
+        Wire wire = WireType.RAW.apply(Bytes.allocateElasticOnHeap());
+        try (DocumentContext dc = wire.writingDocument(true)) {
+            dc.wire().bytes().writeUtf8("header");
+        }
+        wire.bytes().readPosition(0);
+        try (DocumentContext dc = wire.readingDocument()) {
+            assertTrue(dc.isPresent());
+            assertTrue("RawWire must keep the META_DATA header bit for writingDocument(true)",
+                    dc.isMetaData());
+        }
+    }
+
+    // READ_ANY delegates writes to an underlying wire whose listener fields are never set, so a
+    // listener registered on the outer wire would be silently ignored - fail loudly instead.
+    @Test
+    public void tAnyWire_contextListenerIsRejected() {
+        Wire any = WireType.READ_ANY.apply(Bytes.allocateElasticOnHeap());
+        assertThrows(UnsupportedOperationException.class,
+                () -> any.contextListener(ContextEvents.class, w -> w.event("ctx")));
+    }
+
+    // In overwrite mode every document atomically replaces the file, so the context records written
+    // with the first document are lost - registering a listener there must fail loudly.
+    @SuppressWarnings("deprecation")
+    @Test
+    public void tFile_overwriteModeRejectsContextListener() throws Exception {
+        File file = File.createTempFile("ctxlistener-overwrite", ".yaml");
+        file.deleteOnExit();
+        URL url = new URL("file:" + file.getAbsolutePath());
+        MarshallableOut out = MarshallableOut.builder(url).wireType(WireType.YAML_ONLY).get();
+        assertThrows(UnsupportedOperationException.class,
+                () -> out.contextListener(ContextEvents.class, w -> w.event("hdr")));
+    }
+
+    // ------------------------------------------------------------------
+    // 5. T-P0-4 (delegating outs) - one context event per output, not per document
+    // ------------------------------------------------------------------
+    @Test
+    public void tP04_stringConsumerContextEventOncePerOutput() {
+        List<String> chunks = new ArrayList<>();
+        MarshallableOut out = new StringConsumerMarshallableOut(chunks::add, WireType.YAML_ONLY);
+        out.contextListener(ContextEvents.class, w -> w.event("hdr"));
+
+        ContextEvents w = out.methodWriter(ContextEvents.class);
+        w.event("one");
+        w.event("two");
+        w.event("three");
+
+        String all = String.join("", chunks);
+        long hdrs = all.split("hdr", -1).length - 1;
+        assertEquals("context event 'hdr' should appear once per output but output was:\n" + all,
+                1, hdrs);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void tP04_fileContextEventOncePerOutput() throws Exception {
+        File file = File.createTempFile("ctxlistener", ".yaml");
+        file.deleteOnExit();
+        // append=true so every document is retained (default overwrite mode would hide the bug)
+        URL url = new URL("file:" + file.getAbsolutePath() + "?append=true");
+        MarshallableOut out = MarshallableOut.builder(url).wireType(WireType.YAML_ONLY).get();
+        out.contextListener(ContextEvents.class, w -> w.event("hdr"));
+
+        ContextEvents w = out.methodWriter(ContextEvents.class);
+        w.event("one");
+        w.event("two");
+        w.event("three");
+
+        byte[] bytes = java.nio.file.Files.readAllBytes(file.toPath());
+        String all = new String(bytes, java.nio.charset.StandardCharsets.ISO_8859_1);
+        long hdrs = all.split("hdr", -1).length - 1;
+        assertEquals("context event 'hdr' should appear once per output but file was:\n" + all,
+                1, hdrs);
+    }
+
+    // NOTE: HTTPMarshallableOut is the third delegating out but is skipped here: it POSTs on
+    // document close and requires a live HTTP endpoint returning 2xx, adding an in-test HttpServer
+    // and network flakiness. It shares the identical per-document wire.clear() mechanism as the
+    // File/StringConsumer outs above, which already demonstrate the T-P0-4 bug.
+
+    // ------------------------------------------------------------------
+    // 6. T-cov (coverage, not necessarily bugs)
+    // ------------------------------------------------------------------
+    // COVERAGE T-cov (Text): context event precedes the first data document.
+    @Test
+    public void tCov_contextEventPrecedesFirstDocument_text() {
+        Wire wire = WireType.TEXT.apply(Bytes.allocateElasticOnHeap());
+        wire.contextListener(ContextEvents.class, w -> w.event("ctx"));
+        ContextEvents w = wire.methodWriter(ContextEvents.class);
+        w.event("one");
+        w.event("two");
+        assertEquals(Arrays.asList("ctx", "one", "two"), readOrdered(wire));
+    }
+
+    // COVERAGE T-cov (Raw): context event precedes the first data document.
+    @Test
+    public void tCov_contextEventPrecedesFirstDocument_raw() {
+        Wire wire = WireType.RAW.apply(Bytes.allocateElasticOnHeap());
+        wire.contextListener(ContextEvents.class, w -> w.event("ctx"));
+        ContextEvents w = wire.methodWriter(ContextEvents.class);
+        w.event("one");
+        w.event("two");
+        assertEquals(Arrays.asList("ctx", "one", "two"), drainEvents(wire));
+    }
+
+    @Test
+    public void tCov_rawWireMetadataFirstThenContextThenData() {
+        // Same contract as the other wires: a leading metadata document precedes the context
+        // records, which precede the first data document. RawWire's reader cannot skip metadata
+        // documents, so assert ordering structurally from the raw documents instead of a
+        // methodReader: doc 1 metadata (meta), doc 2 data (ctx), doc 3 data (data).
+        Wire wire = WireType.RAW.apply(Bytes.allocateElasticOnHeap());
+        wire.contextListener(ContextEvents.class, w -> w.event("ctx"));
+
+        ContextEvents metadataWriter = wire.methodWriterBuilder(true, ContextEvents.class).build();
+        metadataWriter.event("meta");
+        wire.methodWriter(ContextEvents.class).event("data");
+
+        wire.bytes().readPosition(0);
+        List<String> docs = new ArrayList<>();
+        while (true) {
+            try (DocumentContext dc = wire.readingDocument()) {
+                if (!dc.isPresent())
+                    break;
+                Bytes<?> b = dc.wire().bytes();
+                StringBuilder sb = new StringBuilder();
+                for (long i = b.readPosition(); i < b.readLimit(); i++) {
+                    byte c = b.readByte(i);
+                    sb.append(c >= 32 && c < 127 ? (char) c : '.');
+                }
+                String body = sb.toString();
+                String tag = body.contains("meta") ? "meta" : body.contains("ctx") ? "ctx"
+                        : body.contains("data") ? "data" : "?";
+                docs.add((dc.isMetaData() ? "M:" : "D:") + tag);
+                b.readPosition(b.readLimit());
+            }
+        }
+        assertEquals(Arrays.asList("M:meta", "D:ctx", "D:data"), docs);
+    }
+
+    // Rulings: a valid context count is positive and never 0; unknown/closed contexts report a
+    // negative count (never an exception the interface does not document, and never a
+    // valid-looking 1).
+    @Test
+    public void closedDocumentContextHolderReportsNegativeContextCount() {
+        DocumentContextHolder holder = new DocumentContextHolder();
+        // closed state: dc == null by design - must not NPE and must not claim a valid count
+        assertTrue("closed holder must report a negative context count",
+                holder.contextCount() < 0);
+    }
+
+    @Test
+    public void noDocumentContextReportsNegativeContextCount() {
+        assertTrue("the absent-document sentinel must not claim membership of a real context",
+                NoDocumentContext.INSTANCE.contextCount() < 0);
+    }
+
+    @Test
+    public void holderAndWrapperForwardContextCount() {
+        // A stub with a distinctive value proves the wrappers forward rather than inherit the
+        // interface default (a plain-wire delegate would make 1 == 1 pass either way).
+        DocumentContext stub = new DocumentContext() {
+            @Override
+            public long contextCount() {
+                return 42;
+            }
+
+            @Override
+            public boolean isMetaData() {
+                return false;
+            }
+
+            @Override
+            public boolean isPresent() {
+                return true;
+            }
+
+            @Override
+            public Wire wire() {
+                return null;
+            }
+
+            @Override
+            public boolean isNotComplete() {
+                return false;
+            }
+
+            @Override
+            public int sourceId() {
+                return 0;
+            }
+
+            @Override
+            public long index() {
+                return 0;
+            }
+
+            @Override
+            public void close() {
+            }
+
+            @Override
+            public void reset() {
+            }
+        };
+        DocumentContextHolder holder = new DocumentContextHolder();
+        holder.documentContext(stub);
+        assertEquals(42, holder.contextCount());
+    }
+
+    // W1: HTTP delivers each document over a new connection, so per the DocumentContext contract
+    // ("channel-like outputs should return the one-based connection count") each document must
+    // report a distinct count - otherwise a progressive DTO never resends its static context to a
+    // receiver that never saw the earlier delivery.
+    @SuppressWarnings("deprecation")
+    @Test
+    public void httpDocumentsReportOneBasedConnectionCounts() throws Exception {
+        com.sun.net.httpserver.HttpServer server =
+                com.sun.net.httpserver.HttpServer.create(new java.net.InetSocketAddress(0), 0);
+        List<String> posts = new ArrayList<>();
+        server.createContext("/ctx", exchange -> {
+            byte[] body = net.openhft.chronicle.core.io.IOTools.readAsBytes(exchange.getRequestBody());
+            synchronized (posts) {
+                posts.add(new String(body, java.nio.charset.StandardCharsets.ISO_8859_1));
+            }
+            exchange.sendResponseHeaders(200, 0);
+            exchange.close();
+        });
+        server.start();
+        try {
+            URL url = new URL("http://localhost:" + server.getAddress().getPort() + "/ctx");
+            MarshallableOut out = MarshallableOut.builder(url).wireType(WireType.JSON_ONLY).get();
+
+            List<Long> counts = new ArrayList<>();
+            for (int i = 0; i < 3; i++) {
+                try (DocumentContext dc = out.writingDocument()) {
+                    counts.add(dc.contextCount());
+                    dc.wire().write("msg").text("m" + i);
+                }
+            }
+            assertEquals("each HTTP document is a separate delivery and must report a distinct " +
+                    "one-based connection count", Arrays.asList(1L, 2L, 3L), counts);
+            assertEquals(3, posts.size());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    // COVERAGE T-cov (acquire): acquireWritingDocument also fires the context listener.
+    @Test
+    public void tCov_contextEventViaAcquireWritingDocument() {
+        Wire wire = WireType.BINARY.apply(Bytes.allocateElasticOnHeap());
+        wire.contextListener(ContextEvents.class, w -> w.event("ctx"));
+        try (DocumentContext dc = wire.acquireWritingDocument(false)) {
+            dc.wire().write("event").text("one");
+        }
+        assertEquals(Arrays.asList("ctx", "one"), readOrdered(wire));
+    }
+}

--- a/src/test/java/net/openhft/chronicle/wire/MarshallableOutContextListenerTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MarshallableOutContextListenerTest.java
@@ -300,10 +300,17 @@ public class MarshallableOutContextListenerTest extends WireTestCommon {
                 1, hdrs);
     }
 
-    // NOTE: HTTPMarshallableOut is the third delegating out but is skipped here: it POSTs on
-    // document close and requires a live HTTP endpoint returning 2xx, adding an in-test HttpServer
-    // and network flakiness. It shares the identical per-document wire.clear() mechanism as the
-    // File/StringConsumer outs above, which already demonstrate the T-P0-4 bug.
+    @SuppressWarnings("deprecation")
+    @Test
+    public void httpOutputRejectsContextListenerBecauseEveryPostIsANewContext() throws Exception {
+        MarshallableOut out = MarshallableOut.builder(new URL("http://localhost/context-listener-test"))
+                .wireType(WireType.JSON_ONLY)
+                .get();
+
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+                () -> out.contextListener(ContextEvents.class, w -> w.event("ctx")));
+        assertTrue(exception.getMessage().contains("each POST is a new output context"));
+    }
 
     // ------------------------------------------------------------------
     // 6. T-cov (coverage, not necessarily bugs)

--- a/src/test/java/net/openhft/chronicle/wire/WireContextListenerLifecycleTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireContextListenerLifecycleTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.wire;
+
+import net.openhft.chronicle.bytes.Bytes;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class WireContextListenerLifecycleTest extends WireTestCommon {
+
+    @Test
+    public void recordingLifecycleReceivesWritingDocumentEntryPoint() {
+        AbstractWire wire = newWire();
+        RecordingWireContextListenerLifecycle lifecycle = new RecordingWireContextListenerLifecycle();
+        wire.contextListenerLifecycle(lifecycle);
+
+        try (DocumentContext dc = wire.writingDocument(true)) {
+            dc.wire().write("meta").text("header");
+        }
+        try (DocumentContext dc = wire.acquireWritingDocument(false)) {
+            dc.wire().write("data").text("event");
+        }
+
+        assertEquals(2, lifecycle.documentCalls);
+        assertEquals(java.util.Arrays.asList(true, false), lifecycle.metadata);
+        assertTrue(lifecycle.started());
+    }
+
+    @Test
+    public void recordingLifecycleReceivesDirectWriteEntryPoints() {
+        AbstractWire completeWire = newWire();
+        RecordingWireContextListenerLifecycle completeLifecycle = new RecordingWireContextListenerLifecycle();
+        completeWire.contextListenerLifecycle(completeLifecycle);
+        completeWire.writeDocument(false, wire -> wire.write("event").text("complete"));
+
+        AbstractWire incompleteWire = newWire();
+        RecordingWireContextListenerLifecycle incompleteLifecycle = new RecordingWireContextListenerLifecycle();
+        incompleteWire.contextListenerLifecycle(incompleteLifecycle);
+        incompleteWire.writeNotCompleteDocument(false, wire -> wire.write("event").text("incomplete"));
+
+        assertEquals(1, completeLifecycle.documentCalls);
+        assertEquals(1, incompleteLifecycle.documentCalls);
+    }
+
+    @Test
+    public void startedTestLifecycleFreezesListenerConfiguration() {
+        AbstractWire wire = newWire();
+        RecordingWireContextListenerLifecycle lifecycle = new RecordingWireContextListenerLifecycle();
+        wire.contextListenerLifecycle(lifecycle);
+        try (DocumentContext dc = wire.writingDocument(false)) {
+            dc.wire().write("event").text("start");
+        }
+
+        assertThrows(IllegalStateException.class,
+                () -> wire.contextListener(Runnable.class, Runnable::run));
+    }
+
+    private static AbstractWire newWire() {
+        return (AbstractWire) WireType.BINARY.apply(Bytes.allocateElasticOnHeap());
+    }
+
+    /** Test fake proving lifecycle entry points can be exercised without a real context listener. */
+    private static final class RecordingWireContextListenerLifecycle implements WireContextListenerLifecycle {
+        private final List<Boolean> metadata = new ArrayList<>();
+        private int documentCalls;
+        private boolean started;
+
+        @Override
+        public boolean started() {
+            return started;
+        }
+
+        @Override
+        public void beforeDocument(AbstractWire wire, boolean metaData) {
+            started = true;
+            documentCalls++;
+            metadata.add(metaData);
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/wire/YamlWireTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/YamlWireTest.java
@@ -59,6 +59,46 @@ public class YamlWireTest extends WireTestCommon {
         this.usePadding = usePadding;
     }
 
+    @Test
+    public void contextListenerWritesOnFirstUseOnly() {
+        Wire wire = Wire.newYamlWireOnHeap(); // fresh local wire: shared static wire would leak the listener into later tests
+        AtomicInteger calls = new AtomicInteger();
+        wire.contextListener(ContextEvents.class, writer -> {
+            calls.incrementAndGet();
+            writer.event("context");
+        });
+
+        ContextEvents writer = wire.methodWriter(ContextEvents.class);
+        writer.event("one");
+        writer.event("two");
+
+        assertEquals(1, calls.get());
+        assertEquals(Arrays.asList("context", "one", "two"), readContextEvents(wire));
+    }
+
+    @Test
+    public void contextListenerCannotBeSetAfterFirstUse() {
+        Wire wire = Wire.newYamlWireOnHeap(); // fresh local wire: shared static wire would leak the listener into later tests
+        wire.methodWriter(ContextEvents.class).event("one");
+
+        assertThrows(IllegalStateException.class,
+                () -> wire.contextListener(ContextEvents.class, writer -> writer.event("late")));
+    }
+
+    private static List<String> readContextEvents(Wire wire) {
+        wire.bytes().readPosition(0);
+        List<String> events = new ArrayList<>();
+        MethodReader reader = wire.methodReader((ContextEvents) events::add);
+        while (reader.readOne()) {
+            // drain
+        }
+        return events;
+    }
+
+    interface ContextEvents {
+        void event(String value);
+    }
+
     // Defines the set of parameters to be used for the test
     @Parameterized.Parameters(name = "usePadding={0}")
     public static Collection<Object[]> wireTypes() {


### PR DESCRIPTION
## Source branch only - do not merge

This draft is the original QUEUE-144 source branch. Review and merge the split PR stack instead:

1. OpenHFT/Chronicle-Wire#1270 - `int DocumentContext.contextCount()` and `ProgressiveContext`.
2. OpenHFT/Chronicle-Wire#1271 - shared context-listener API.
3. OpenHFT/Chronicle-Wire#1272 - Wire listener lifecycle.
4. OpenHFT/Chronicle-Wire#1273 - concrete `MarshallableOut` adapters.
5. OpenHFT/Chronicle-Wire#1274 - contract documentation.

The branch is retained as provenance for the extracted commits and any remaining assurance comparison. It is currently 0 commits behind `develop`, but it combines all five review units and should not be used as the release path.

Commit `18647d0b2` mirrors the reviewed #1270 representation by keeping `contextCount()` as an `int`. Supported context identifiers, including Queue roll cycles, are inherently `int`-valued; Queue consumers should depend on the split stack rather than this umbrella.

## Validation of the latest source-branch correction

- `mvn -q -o -Dtest=DocumentContextLifecycleTest,MarshallableOutContextListenerTest test` - pass.
- `/usr/bin/time -p mvn -q -o clean verify` - pass in 42.71 seconds.
- `git diff --check` - pass.
