### PR TITLE
CORE-75: Preserve a null Collection<String> when overwrite is false

### DIFF
--- a/src/main/docs/wire-schema-evolution.adoc
+++ b/src/main/docs/wire-schema-evolution.adoc
@@ -22,6 +22,14 @@ Evolution is managed by how these class definitions change and how the chosen `W
 
 This document delves into the mechanisms Chronicle Wire employs for schema evolution, the role of different wire formats and annotations, and strategies for managing data model changes effectively.
 
+== Null Collection and Map Fields
+
+For an explicitly null collection or map, `Wires.readMarshallable` sets the field
+to null when `overwrite` is `true`. When `overwrite` is `false`, it restores the
+field's default value, which may be null, empty or populated. This applies to
+String collections, other collections, EnumSets and Maps. Empty input containers
+remain empty rather than restoring defaults.
+
 == Mechanisms in Self-Describing Formats
 
 ifdef::env-github[[source,mermaid]

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -2296,9 +2296,16 @@ public class WireMarshaller<T> {
             } else if (!coll.isEmpty()) {
                 coll.clear();
             }
-            boolean sequenced = read.sequence(coll, seqConsumer);
-            if (overwrite && !sequenced) {
-                field.set(o, null);
+            if (!read.sequence(coll, seqConsumer)) {
+                // A null in the input must survive; with overwrite there is no default to fall back to
+                Collection defaultColl = overwrite ? null : (Collection) field.get(defaults);
+                if (defaultColl == null) {
+                    field.set(o, null);
+                } else {
+                    coll.clear();
+                    if (!defaultColl.isEmpty())
+                        coll.addAll(defaultColl);
+                }
             }
         }
 

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -1950,6 +1950,10 @@ public class WireMarshaller<T> {
 
         @Override
         protected void readValue(Object o, Object defaults, ValueIn read, boolean overwrite) throws IllegalAccessException {
+            if (!read.isPresent()) {
+                super.readValue(o, defaults, read, overwrite);
+                return;
+            }
             EnumSet coll = (EnumSet) field.get(o);
             if (coll == null) {
                 coll = enumSetSupplier.get();
@@ -1957,7 +1961,7 @@ public class WireMarshaller<T> {
             }
 
             if (!read.sequence(coll, addAll)) {
-                Collection defaultColl = (Collection) field.get(defaults);
+                Collection defaultColl = overwrite ? null : (Collection) field.get(defaults);
                 if (defaultColl == null) {
                     field.set(o, null);
                 } else {
@@ -2154,6 +2158,10 @@ public class WireMarshaller<T> {
 
         @Override
         protected void readValue(Object o, Object defaults, ValueIn read, boolean overwrite) throws IllegalAccessException {
+            if (!read.isPresent()) {
+                super.readValue(o, defaults, read, overwrite);
+                return;
+            }
             Collection coll = (Collection) field.get(o);
             if (coll == null) {
                 coll = collectionSupplier.get();
@@ -2165,7 +2173,7 @@ public class WireMarshaller<T> {
                 while (in2.hasNextSequenceItem())
                     c.add(in2.object(componentType));
             })) {
-                Collection defaultColl = (Collection) field.get(defaults);
+                Collection defaultColl = overwrite ? null : (Collection) field.get(defaults);
                 if (defaultColl == null) {
                     field.set(o, null);
                 } else {
@@ -2289,6 +2297,10 @@ public class WireMarshaller<T> {
 
         @Override
         protected void readValue(Object o, Object defaults, ValueIn read, boolean overwrite) throws IllegalAccessException {
+            if (!read.isPresent()) {
+                super.readValue(o, defaults, read, overwrite);
+                return;
+            }
             Collection coll = (Collection) field.get(o);
             if (coll == null) {
                 coll = collectionSupplier.get();
@@ -2297,7 +2309,6 @@ public class WireMarshaller<T> {
                 coll.clear();
             }
             if (!read.sequence(coll, seqConsumer)) {
-                // A null in the input must survive; with overwrite there is no default to fall back to
                 Collection defaultColl = overwrite ? null : (Collection) field.get(defaults);
                 if (defaultColl == null) {
                     field.set(o, null);
@@ -2407,6 +2418,10 @@ public class WireMarshaller<T> {
 
         @Override
         protected void readValue(Object o, Object defaults, ValueIn read, boolean overwrite) throws IllegalAccessException, InvalidMarshallableException {
+            if (!read.isPresent()) {
+                super.readValue(o, defaults, read, overwrite);
+                return;
+            }
             Map map = (Map) field.get(o);
             if (map == null) {
                 map = collectionSupplier.get();
@@ -2414,8 +2429,16 @@ public class WireMarshaller<T> {
             } else if (!map.isEmpty()) {
                 map.clear();
             }
-            if (read.marshallableAsMap(keyType, valueType, map) == null)
-                field.set(o, null);
+            if (read.marshallableAsMap(keyType, valueType, map) == null) {
+                Map defaultMap = overwrite ? null : (Map) field.get(defaults);
+                if (defaultMap == null) {
+                    field.set(o, null);
+                } else {
+                    map.clear();
+                    if (!defaultMap.isEmpty())
+                        map.putAll(defaultMap);
+                }
+            }
         }
 
         @Override

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/NullCollectionWithOverwriteFalseTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/NullCollectionWithOverwriteFalseTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.wire.marshallable;
+
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.io.IORuntimeException;
+import net.openhft.chronicle.wire.*;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeFalse;
+
+/**
+ * Test class to validate that a null collection survives a round trip when overwriting is disabled.
+ *
+ * @see MarshallableWithOverwriteFalseTest
+ */
+public class NullCollectionWithOverwriteFalseTest extends WireTestCommon {
+
+    /**
+     * A null {@code Set<String>} remains null after a round trip.
+     */
+    @Test
+    public void nullStringSetSurvivesRoundTrip() {
+        assumeFalse(Jvm.maxDirectMemory() == 0);
+
+        MyStringSetDto dto = new MyStringSetDto();
+        assertNull(dto.strings);
+
+        // The field must be written as present-and-null; an absent field never reaches readValue
+        String cs = dto.toString();
+        assertTrue(cs, cs.contains("!!null"));
+
+        MyStringSetDto o = Marshallable.fromString(MyStringSetDto.class, cs);
+        assertNull(o.strings);
+    }
+
+    /**
+     * A null {@code List<String>} remains null after a round trip.
+     */
+    @Test
+    public void nullStringListSurvivesRoundTrip() {
+        assumeFalse(Jvm.maxDirectMemory() == 0);
+
+        MyStringListDto dto = new MyStringListDto();
+        assertNull(dto.strings);
+
+        String cs = dto.toString();
+        assertTrue(cs, cs.contains("!!null"));
+
+        MyStringListDto o = Marshallable.fromString(MyStringListDto.class, cs);
+        assertNull(o.strings);
+    }
+
+    /**
+     * A field initialised inline resolves to empty rather than null, as before.
+     */
+    @Test
+    public void inlineInitialisedListResolvesToEmpty() {
+        assumeFalse(Jvm.maxDirectMemory() == 0);
+
+        MyInitialisedListDto dto = new MyInitialisedListDto();
+        dto.strings = null;
+
+        String cs = dto.toString();
+        assertTrue(cs, cs.contains("!!null"));
+
+        MyInitialisedListDto o = Marshallable.fromString(MyInitialisedListDto.class, cs);
+        assertNotNull(o.strings);
+        assertEquals(0, o.strings.size());
+    }
+
+    /**
+     * A non-String component type routes to CollectionFieldAccess and is expected to pass already.
+     */
+    @Test
+    public void nullIntegerSetSurvivesRoundTrip() {
+        assumeFalse(Jvm.maxDirectMemory() == 0);
+
+        MyIntegerSetDto dto = new MyIntegerSetDto();
+        assertNull(dto.numbers);
+
+        String cs = dto.toString();
+        assertTrue(cs, cs.contains("!!null"));
+
+        MyIntegerSetDto o = Marshallable.fromString(MyIntegerSetDto.class, cs);
+        assertNull(o.numbers);
+    }
+
+    /**
+     * Reading with overwrite enabled is expected to pass already.
+     */
+    @Test
+    public void nullStringSetSurvivesRoundTripWithOverwrite() {
+        assumeFalse(Jvm.maxDirectMemory() == 0);
+
+        MyOverwriteTrueDto dto = new MyOverwriteTrueDto();
+        assertNull(dto.strings);
+
+        String cs = dto.toString();
+        assertTrue(cs, cs.contains("!!null"));
+
+        MyOverwriteTrueDto o = Marshallable.fromString(MyOverwriteTrueDto.class, cs);
+        assertNull(o.strings);
+    }
+
+    /**
+     * Pins the current behaviour of an inline-initialised field read with overwrite enabled,
+     * which no other test states. Mirroring CollectionFieldAccess would resolve this to empty.
+     */
+    @Test
+    public void inlineInitialisedListWithOverwrite() {
+        assumeFalse(Jvm.maxDirectMemory() == 0);
+
+        MyInitialisedListOverwriteTrueDto dto = new MyInitialisedListOverwriteTrueDto();
+        dto.strings = null;
+
+        String cs = dto.toString();
+        assertTrue(cs, cs.contains("!!null"));
+
+        MyInitialisedListOverwriteTrueDto o = Marshallable.fromString(MyInitialisedListOverwriteTrueDto.class, cs);
+        assertNull(o.strings);
+    }
+
+    /**
+     * Inner class with an uninitialised {@code Set<String>} and overwrite disabled.
+     */
+    static class MyStringSetDto extends SelfDescribingMarshallable {
+        Set<String> strings;
+
+        public void readMarshallable(@NotNull WireIn wire) throws IORuntimeException {
+            Wires.readMarshallable(this, wire, false);
+        }
+    }
+
+    /**
+     * Inner class with an uninitialised {@code List<String>} and overwrite disabled.
+     */
+    static class MyStringListDto extends SelfDescribingMarshallable {
+        List<String> strings;
+
+        public void readMarshallable(@NotNull WireIn wire) throws IORuntimeException {
+            Wires.readMarshallable(this, wire, false);
+        }
+    }
+
+    /**
+     * Inner class whose list is initialised inline, as in {@link MarshallableWithOverwriteFalseTest}.
+     */
+    static class MyInitialisedListDto extends SelfDescribingMarshallable {
+        List<String> strings = new ArrayList<>();
+
+        public void readMarshallable(@NotNull WireIn wire) throws IORuntimeException {
+            Wires.readMarshallable(this, wire, false);
+        }
+    }
+
+    /**
+     * Inner class with an uninitialised {@code Set<Integer>} and overwrite disabled.
+     */
+    static class MyIntegerSetDto extends SelfDescribingMarshallable {
+        Set<Integer> numbers;
+
+        public void readMarshallable(@NotNull WireIn wire) throws IORuntimeException {
+            Wires.readMarshallable(this, wire, false);
+        }
+    }
+
+    /**
+     * Inner class with an uninitialised {@code Set<String>} and overwrite enabled.
+     */
+    static class MyOverwriteTrueDto extends SelfDescribingMarshallable {
+        Set<String> strings;
+
+        public void readMarshallable(@NotNull WireIn wire) throws IORuntimeException {
+            Wires.readMarshallable(this, wire, true);
+        }
+    }
+
+    /**
+     * Inner class whose list is initialised inline, read with overwrite enabled.
+     */
+    static class MyInitialisedListOverwriteTrueDto extends SelfDescribingMarshallable {
+        List<String> strings = new ArrayList<>();
+
+        public void readMarshallable(@NotNull WireIn wire) throws IORuntimeException {
+            Wires.readMarshallable(this, wire, true);
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/wire/marshallable/NullCollectionWithOverwriteFalseTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/marshallable/NullCollectionWithOverwriteFalseTest.java
@@ -3,15 +3,15 @@
  */
 package net.openhft.chronicle.wire.marshallable;
 
+import net.openhft.chronicle.bytes.Bytes;
 import net.openhft.chronicle.core.Jvm;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.wire.*;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
+import java.lang.reflect.Field;
+import java.util.*;
 
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeFalse;
@@ -111,8 +111,7 @@ public class NullCollectionWithOverwriteFalseTest extends WireTestCommon {
     }
 
     /**
-     * Pins the current behaviour of an inline-initialised field read with overwrite enabled,
-     * which no other test states. Mirroring CollectionFieldAccess would resolve this to empty.
+     * Explicit null replaces an inline-initialised field when overwrite is enabled.
      */
     @Test
     public void inlineInitialisedListWithOverwrite() {
@@ -126,6 +125,120 @@ public class NullCollectionWithOverwriteFalseTest extends WireTestCommon {
 
         MyInitialisedListOverwriteTrueDto o = Marshallable.fromString(MyInitialisedListOverwriteTrueDto.class, cs);
         assertNull(o.strings);
+    }
+
+    /**
+     * Explicit null replaces every container default when overwrite is enabled.
+     */
+    @Test
+    public void nullContainersWithOverwrite() throws Exception {
+        checkContainers(true, true);
+    }
+
+    /**
+     * Explicit null restores null, empty or populated defaults when overwrite is disabled.
+     */
+    @Test
+    public void nullContainersWithoutOverwrite() throws Exception {
+        checkContainers(false, true);
+    }
+
+    /**
+     * Present containers replace stale contents in both modes, including on destination reuse.
+     */
+    @Test
+    public void emptyAndPopulatedContainersReplacePreviousContents() throws Exception {
+        checkContainers(false, false);
+        checkContainers(true, false);
+    }
+
+    /**
+     * Missing fields restore defaults with overwrite enabled and retain existing contents otherwise.
+     */
+    @Test
+    public void absentContainersRespectOverwrite() throws Exception {
+        for (WireType type : new WireType[]{WireType.TEXT, WireType.BINARY}) {
+            for (boolean overwrite : new boolean[]{false, true}) {
+                Containers target = new Containers();
+                target.strings.add("stale");
+                target.numbers.add(99);
+                target.states.add(Thread.State.TERMINATED);
+                target.map.put("stale", 99);
+                Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+                try {
+                    Wires.readMarshallable(target, type.apply(bytes), overwrite);
+                    Containers defaults = new Containers();
+                    if (!overwrite) {
+                        defaults.strings.add("stale");
+                        defaults.numbers.add(99);
+                        defaults.states.add(Thread.State.TERMINATED);
+                        defaults.map.put("stale", 99);
+                    }
+                    for (Field field : Containers.class.getDeclaredFields())
+                        assertEquals(type + " absent " + field.getName(), field.get(defaults), field.get(target));
+                } finally {
+                    bytes.releaseLast();
+                }
+            }
+        }
+    }
+
+    private void checkContainers(boolean overwrite, boolean nullInput) throws Exception {
+        for (WireType type : new WireType[]{WireType.TEXT, WireType.BINARY}) {
+            Containers source = new Containers();
+            Containers target = new Containers();
+            Containers defaults = new Containers();
+            for (Field field : Containers.class.getDeclaredFields()) {
+                if (nullInput)
+                    field.set(source, null);
+            }
+            target.emptyStrings.add("stale");
+            target.strings.add("stale");
+            target.emptyNumbers.add(99);
+            target.numbers.add(99);
+            target.emptyStates.add(Thread.State.TERMINATED);
+            target.states.add(Thread.State.TERMINATED);
+            target.emptyMap.put("stale", 99);
+            target.map.put("stale", 99);
+            Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+            try {
+                Wire wire = type.apply(bytes);
+                source.writeMarshallable(wire);
+                Wires.readMarshallable(target, wire, overwrite);
+                for (Field field : Containers.class.getDeclaredFields()) {
+                    Object expected = nullInput && overwrite ? null : field.get(defaults);
+                    assertEquals(type + " " + field.getName(), expected, field.get(target));
+                }
+                // Reuse the destination after a read that may have cleared its fields.
+                bytes.clear();
+                defaults.writeMarshallable(wire);
+                Wires.readMarshallable(target, wire, overwrite);
+                for (Field field : Containers.class.getDeclaredFields())
+                    assertEquals(type + " reused " + field.getName(), field.get(defaults), field.get(target));
+            } finally {
+                bytes.releaseLast();
+            }
+        }
+    }
+
+    /**
+     * Null, empty and populated defaults exercise the String collection, general collection,
+     * EnumSet and Map readers. Tests use separate input, destination and default instances
+     * with text and binary wires; Thread.State supplies enum values only.
+     */
+    static class Containers extends SelfDescribingMarshallable {
+        List<String> nullStrings;
+        List<String> emptyStrings = new ArrayList<>();
+        List<String> strings = new ArrayList<>(Collections.singletonList("default"));
+        List<Integer> nullNumbers;
+        List<Integer> emptyNumbers = new ArrayList<>();
+        List<Integer> numbers = new ArrayList<>(Collections.singletonList(1));
+        EnumSet<Thread.State> nullStates;
+        EnumSet<Thread.State> emptyStates = EnumSet.noneOf(Thread.State.class);
+        EnumSet<Thread.State> states = EnumSet.of(Thread.State.NEW);
+        Map<String, Integer> nullMap;
+        Map<String, Integer> emptyMap = new LinkedHashMap<>();
+        Map<String, Integer> map = new LinkedHashMap<>(Collections.singletonMap("default", 1));
     }
 
     /**


### PR DESCRIPTION
## CORE-75: Preserve a null Collection<String> when overwrite is false                                                                                                                                              
                                                                                                                                                                                                                      
  ### Issue                                                                                                                                                                                                         
  `StringCollectionFieldAccess.readValue` assigned a fresh collection before reading and only restored null when `overwrite` was true. A field serialised as `collection: !!null ""` therefore came back as an empty collection under `Wires.readMarshallable(this, wire, false)`, so a null `Set<String>`/`List<String>` did not survive a round trip. Only `String` component types were affected; `CollectionFieldAccess` and  `MapFieldAccess` already handled this correctly.                                                                                                                                                                    
                                                                                                                                                                                                                      
  ### Fix                                                                                                                                                                                                             
  Fall back to the `defaults` instance when the value is not a sequence, as `CollectionFieldAccess.readValue` already does. Consulting `defaults` rather than setting plain null keeps inline-initialised fields (`= new ArrayList<>()`) resolving to empty. 