### PR TITLE
QUEUE-144: Add document context count contract

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -64,7 +64,7 @@ public abstract class AbstractWire implements Wire, InternalWire {
     private HeadNumberChecker headNumberChecker;
     private boolean usePadding = DEFAULT_USE_PADDING;
     private boolean generateTuples = GENERATE_TUPLES;
-    private int outputContextCount = 1;
+    private int outputContextCount;
 
     /**
      * Constructor for AbstractWire.
@@ -79,11 +79,28 @@ public abstract class AbstractWire implements Wire, InternalWire {
         notCompleteIsNotPresent = bytes.sharedMemory();
     }
 
-    final int outputContextCount() {
+    @Override
+    public final int contextCount() {
         return outputContextCount;
     }
 
+    /**
+     * Sets a non-negative context count so package-local tests can exercise lifecycle boundaries
+     * without performing billions of resets.
+     */
+    final void outputContextCountForTesting(int outputContextCount) {
+        if (outputContextCount < 0)
+            throw new IllegalArgumentException("outputContextCount must not be negative");
+        this.outputContextCount = outputContextCount;
+    }
+
+    protected final void checkCanAdvanceOutputContext() {
+        if (outputContextCount == Integer.MAX_VALUE)
+            throw new IllegalStateException("Output context count exhausted");
+    }
+
     protected final void advanceOutputContext() {
+        checkCanAdvanceOutputContext();
         outputContextCount++;
     }
 

--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -64,6 +64,7 @@ public abstract class AbstractWire implements Wire, InternalWire {
     private HeadNumberChecker headNumberChecker;
     private boolean usePadding = DEFAULT_USE_PADDING;
     private boolean generateTuples = GENERATE_TUPLES;
+    private int outputContextCount = 1;
 
     /**
      * Constructor for AbstractWire.
@@ -76,6 +77,14 @@ public abstract class AbstractWire implements Wire, InternalWire {
         this.bytes = bytes;
         this.use8bit = use8bit;
         notCompleteIsNotPresent = bytes.sharedMemory();
+    }
+
+    final int outputContextCount() {
+        return outputContextCount;
+    }
+
+    protected final void advanceOutputContext() {
+        outputContextCount++;
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -243,6 +243,7 @@ public class BinaryWire extends AbstractWire implements Wire {
      */
     @Override
     public void reset() {
+        checkCanAdvanceOutputContext();
         writeContext.reset();
         readContext.reset();
         valueIn.resetState();

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -248,6 +248,7 @@ public class BinaryWire extends AbstractWire implements Wire {
         valueIn.resetState();
         valueOut.resetState();
         bytes.clear();
+        advanceOutputContext();
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/wire/DocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/DocumentContext.java
@@ -69,30 +69,14 @@ public interface DocumentContext extends Closeable, SourceContext {
     }
 
     /**
-     * Returns an identifier for the output context of this document. Values from successive open
-     * documents are non-decreasing. Context need only be written again when this value increases;
-     * an unchanged value means that the previously written context still applies.
-     * <p>
-     * Callers may initialise the last written count to {@code 0} or {@code -1} and compare values
-     * directly. A returned {@code -1} is not an increase and needs no special handling.
-     * Context data can implement {@link ProgressiveContext} to standardise this comparison.
-     * {@link DocumentContextHolder} returns {@code -1} after close and
-     * {@link NoDocumentContext} always returns {@code -1}.
-     * <p>
-     * Writable Wire implementations start at {@code 1}; {@link Wire#reset()} advances the count
-     * while {@link Wire#clear()} leaves it unchanged. Queue implementations return the roll cycle,
-     * and connection-based outputs should return a one-based connection count. Read it from an
-     * open document on its writing thread. Implementations may throw
-     * {@link IllegalStateException} when the output context is not yet known, such as when using
-     * double buffering.
+     * Returns the associated output's {@link MarshallableOut#contextCount() context count}, or
+     * {@code -1} when this context has no Wire. Read it from an open document on its writing thread.
      *
-     * @return the output context count, or a negative value if unavailable
+     * @return the output context count, or {@code -1} if unavailable
      */
     default int contextCount() {
         Wire wire = wire();
-        return wire instanceof AbstractWire
-                ? ((AbstractWire) wire).outputContextCount()
-                : 1;
+        return wire == null ? -1 : wire.contextCount();
     }
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/DocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/DocumentContext.java
@@ -69,6 +69,33 @@ public interface DocumentContext extends Closeable, SourceContext {
     }
 
     /**
+     * Returns an identifier for the output context of this document. Values from successive open
+     * documents are non-decreasing. Context need only be written again when this value increases;
+     * an unchanged value means that the previously written context still applies.
+     * <p>
+     * Callers may initialise the last written count to {@code 0} or {@code -1} and compare values
+     * directly. A returned {@code -1} is not an increase and needs no special handling.
+     * Context data can implement {@link ProgressiveContext} to standardise this comparison.
+     * {@link DocumentContextHolder} returns {@code -1} after close and
+     * {@link NoDocumentContext} always returns {@code -1}.
+     * <p>
+     * Writable Wire implementations start at {@code 1}; {@link Wire#reset()} advances the count
+     * while {@link Wire#clear()} leaves it unchanged. Queue implementations return the roll cycle,
+     * and connection-based outputs should return a one-based connection count. Read it from an
+     * open document on its writing thread. Implementations may throw
+     * {@link IllegalStateException} when the output context is not yet known, such as when using
+     * double buffering.
+     *
+     * @return the output context count, or a negative value if unavailable
+     */
+    default int contextCount() {
+        Wire wire = wire();
+        return wire instanceof AbstractWire
+                ? ((AbstractWire) wire).outputContextCount()
+                : 1;
+    }
+
+    /**
      * Invoked to signal an error condition in the current context.
      * This ensures that upon closing the context, any changes made during its lifecycle
      * are rolled back rather than committing a potentially erroneous state.

--- a/src/main/java/net/openhft/chronicle/wire/DocumentContextHolder.java
+++ b/src/main/java/net/openhft/chronicle/wire/DocumentContextHolder.java
@@ -37,6 +37,14 @@ public class DocumentContextHolder implements DocumentContext, WriteDocumentCont
         return dc.isNotComplete();
     }
 
+    @Override
+    public int contextCount() {
+        // dc == null is the holder's documented closed state - report "no known context" rather
+        // than NPE or a valid-looking value
+        DocumentContext dc = this.dc;
+        return dc == null ? -1 : dc.contextCount();
+    }
+
     /**
      * Retrieves the encapsulated {@link DocumentContext} instance.
      *

--- a/src/main/java/net/openhft/chronicle/wire/MarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableOut.java
@@ -37,6 +37,31 @@ public interface MarshallableOut extends DocumentWritten, RollbackIfNotCompleteN
     }
 
     /**
+     * Returns an identifier for this output's current context. Values from successive output
+     * contexts are non-decreasing. Context need only be written again when this value increases;
+     * an unchanged value means that the previously written context still applies.
+     * <p>
+     * Callers initialise the last written count to {@code -1} and compare values directly. Zero is
+     * a valid first context, for example Queue cycle zero. A returned {@code -1} is not an increase
+     * and needs no special handling. Context data can implement {@link ProgressiveContext} to
+     * standardise this comparison.
+     * <p>
+     * The default is {@code -1}, indicating that the implementation does not expose an output
+     * context. Writable Wire implementations start at {@code 0}; {@link Wire#reset()} advances the
+     * count while {@link Wire#clear()} leaves it unchanged. Queue implementations return the roll
+     * cycle, and connection-based outputs should return a one-based connection count.
+     * Implementations may throw {@link IllegalStateException} when the output context is not yet
+     * known, such as when using double buffering. Implementations whose count cannot advance without
+     * overflowing must throw {@link IllegalStateException} before opening the next output context
+     * rather than wrap into the negative range.
+     *
+     * @return the output context count, or a negative value if unavailable
+     */
+    default int contextCount() {
+        return -1;
+    }
+
+    /**
      * Start a document which is completed when DocumentContext.close() is called. You can use a
      * <pre>
      * try(DocumentContext dc = appender.writingDocument()) {

--- a/src/main/java/net/openhft/chronicle/wire/NoDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/NoDocumentContext.java
@@ -47,6 +47,12 @@ public enum NoDocumentContext implements DocumentContext {
     }
 
     @Override
+    public int contextCount() {
+        // no document, so no context: a negative value, never a valid-looking count
+        return -1;
+    }
+
+    @Override
     public boolean isNotComplete() {
         return false;
     }

--- a/src/main/java/net/openhft/chronicle/wire/ProgressiveContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/ProgressiveContext.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.wire;
+
+/**
+ * Context data that tracks whether it must be written for an output context.
+ * <p>
+ * Implementations normally keep the last written count in a transient field:
+ * <pre>
+ * final class SchemaContext extends SelfDescribingMarshallable implements ProgressiveContext {
+ *     private String schema;
+ *     private transient int lastContextCount = -1;
+ *
+ *     &#64;Override
+ *     public boolean needsResending(int contextCount) {
+ *         if (contextCount &lt;= lastContextCount)
+ *             return false;
+ *         lastContextCount = contextCount;
+ *         return true;
+ *     }
+ * }
+ * </pre>
+ * Call this method with {@link DocumentContext#contextCount()} immediately before writing the
+ * context in the same held document.
+ */
+public interface ProgressiveContext {
+
+    /**
+     * Records a strictly higher context count and reports whether this context must be written.
+     *
+     * @param contextCount count from an open document context
+     * @return true only when {@code contextCount} is greater than the previously recorded count
+     */
+    boolean needsResending(int contextCount);
+}

--- a/src/main/java/net/openhft/chronicle/wire/ProgressiveContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/ProgressiveContext.java
@@ -21,8 +21,9 @@ package net.openhft.chronicle.wire;
  *     }
  * }
  * </pre>
- * Call this method with {@link DocumentContext#contextCount()} immediately before writing the
- * context in the same held document.
+ * Call this method with {@link MarshallableOut#contextCount()} or the equivalent
+ * {@link DocumentContext#contextCount()} immediately before writing the context in the same held
+ * document.
  */
 public interface ProgressiveContext {
 

--- a/src/main/java/net/openhft/chronicle/wire/RawWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/RawWire.java
@@ -95,6 +95,7 @@ public class RawWire extends AbstractWire implements Wire {
         readContext.reset();
         bytes.clear();
         lastSB = null;
+        advanceOutputContext();
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/wire/RawWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/RawWire.java
@@ -89,6 +89,7 @@ public class RawWire extends AbstractWire implements Wire {
 
     @Override
     public void reset() {
+        checkCanAdvanceOutputContext();
         valueIn.resetState();
         valueOut.resetState();
         writeContext.reset();

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -1274,6 +1274,7 @@ public class TextWire extends YamlWireOut<TextWire> {
 
     @Override
     public void reset() {
+        checkCanAdvanceOutputContext();
         writeContext.reset();
         readContext.reset();
         sb.setLength(0);

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -1281,6 +1281,7 @@ public class TextWire extends YamlWireOut<TextWire> {
         valueIn.resetState();
         valueOut.resetState();
         bytes.clear();
+        advanceOutputContext();
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/wire/WrappedDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/WrappedDocumentContext.java
@@ -68,6 +68,11 @@ public abstract class WrappedDocumentContext implements DocumentContext {
     }
 
     @Override
+    public int contextCount() {
+        return dc.contextCount();
+    }
+
+    @Override
     public void close() {
         dc.close();
     }

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -1100,6 +1100,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
      * Resets the state of the YamlWire instance, clearing all buffers and contexts.
      */
     public void reset() {
+        checkCanAdvanceOutputContext();
         resetState();
         advanceOutputContext();
     }

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -931,7 +931,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
 
     @Override
     public void clear() {
-        reset();
+        resetState();
     }
 
     /**
@@ -1100,6 +1100,11 @@ public class YamlWire extends YamlWireOut<YamlWire> {
      * Resets the state of the YamlWire instance, clearing all buffers and contexts.
      */
     public void reset() {
+        resetState();
+        advanceOutputContext();
+    }
+
+    private void resetState() {
         // Reset reading and writing contexts if they exist
         if (readContext != null)
             readContext.reset();

--- a/src/test/java/net/openhft/chronicle/wire/DocumentContextLifecycleTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/DocumentContextLifecycleTest.java
@@ -12,12 +12,19 @@ import static org.junit.Assert.*;
  * Verifies lifecycle of writingDocument/readingDocument across Binary and Text wires.
  */
 public class DocumentContextLifecycleTest extends WireTestCommon {
+    private static final WireType[] WRITABLE_WIRE_TYPES = {
+            WireType.BINARY,
+            WireType.TEXT,
+            WireType.YAML,
+            WireType.RAW
+    };
 
     @Test
     public void binaryReadWriteAndExhaust() {
         Wire w = WireType.BINARY.apply(Bytes.allocateElasticOnHeap(256));
         // write two docs
         try (DocumentContext dc = w.writingDocument()) {
+            assertEquals(1, dc.contextCount());
             dc.wire().write("a").int32(1);
         }
         try (DocumentContext dc = w.writingDocument()) {
@@ -43,6 +50,7 @@ public class DocumentContextLifecycleTest extends WireTestCommon {
     public void textUseTextDocumentsLifecycle() {
         Wire w = new TextWire(Bytes.allocateElasticOnHeap(256)).useTextDocuments();
         try (DocumentContext dc = w.writingDocument()) {
+            assertEquals(1, dc.contextCount());
             dc.wire().write("x").int64(11L);
         }
         try (DocumentContext dc = w.writingDocument(true)) { // meta document allowed
@@ -62,4 +70,115 @@ public class DocumentContextLifecycleTest extends WireTestCommon {
         }
         assertTrue(w.writingIsComplete());
     }
+
+    @Test
+    public void holderAndWrapperDelegateContextCount() {
+        DocumentContext delegate = new DocumentContextHolder() {
+            @Override
+            public int contextCount() {
+                return 42;
+            }
+        };
+        DocumentContextHolder holder = new DocumentContextHolder();
+        WrappedDocumentContext wrapper = new WrappedDocumentContext(delegate) {
+            @Override
+            public void reset() {
+            }
+        };
+
+        assertEquals(-1, holder.contextCount());
+        holder.documentContext(delegate);
+        assertEquals(42, holder.contextCount());
+        assertEquals(42, wrapper.contextCount());
+    }
+
+    @Test
+    public void noDocumentContextReturnsNegativeContextCount() {
+        assertEquals(-1, NoDocumentContext.INSTANCE.contextCount());
+    }
+
+    @Test
+    public void resetAdvancesContextCountWhileClearRetainsIt() {
+        for (WireType wireType : WRITABLE_WIRE_TYPES) {
+            Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+            try {
+                Wire wire = wireType.apply(bytes);
+                int first = writeAndReadContextCount(wire);
+
+                wire.clear();
+                assertEquals(wireType.name(), first, writeAndReadContextCount(wire));
+
+                wire.reset();
+                assertEquals(wireType.name(), first + 1, writeAndReadContextCount(wire));
+            } finally {
+                bytes.releaseLast();
+            }
+        }
+    }
+
+    @Test
+    public void resetMakesProgressiveContextEligibleAgain() {
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        try {
+            Wire wire = WireType.BINARY.apply(bytes);
+            SchemaContext context = new SchemaContext("schema-v1");
+
+            assertTrue(writeContextWhenMissing(wire, context));
+            assertFalse(writeContextWhenMissing(wire, context));
+
+            wire.reset();
+
+            assertTrue(writeContextWhenMissing(wire, context));
+            assertEquals(2, context.writeCount);
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+
+    @Test
+    public void progressiveContextOnlyNeedsResendingForHigherCounts() {
+        SchemaContext context = new SchemaContext("schema-v1");
+
+        assertFalse(context.needsResending(-1));
+        assertTrue(context.needsResending(1));
+        assertFalse(context.needsResending(1));
+        assertFalse(context.needsResending(0));
+        assertTrue(context.needsResending(2));
+        assertEquals(2, context.writeCount);
+    }
+
+    private static int writeAndReadContextCount(Wire wire) {
+        try (DocumentContext dc = wire.writingDocument()) {
+            return dc.contextCount();
+        }
+    }
+
+    private static boolean writeContextWhenMissing(Wire wire, SchemaContext context) {
+        try (DocumentContext dc = wire.writingDocument()) {
+            if (!context.needsResending(dc.contextCount()))
+                return false;
+            dc.wire().write("context").marshallable(context);
+            return true;
+        }
+    }
+
+    static final class SchemaContext extends SelfDescribingMarshallable implements ProgressiveContext {
+        private final String schema;
+        private transient int lastContextCount = -1;
+        private transient int writeCount;
+
+        SchemaContext(String schema) {
+            this.schema = schema;
+        }
+
+        @Override
+        public boolean needsResending(int contextCount) {
+            if (contextCount <= lastContextCount)
+                return false;
+            lastContextCount = contextCount;
+            writeCount++;
+            return true;
+        }
+    }
+
 }

--- a/src/test/java/net/openhft/chronicle/wire/DocumentContextLifecycleTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/DocumentContextLifecycleTest.java
@@ -22,9 +22,10 @@ public class DocumentContextLifecycleTest extends WireTestCommon {
     @Test
     public void binaryReadWriteAndExhaust() {
         Wire w = WireType.BINARY.apply(Bytes.allocateElasticOnHeap(256));
+        assertEquals(0, w.contextCount());
         // write two docs
         try (DocumentContext dc = w.writingDocument()) {
-            assertEquals(1, dc.contextCount());
+            assertEquals(w.contextCount(), dc.contextCount());
             dc.wire().write("a").int32(1);
         }
         try (DocumentContext dc = w.writingDocument()) {
@@ -49,8 +50,9 @@ public class DocumentContextLifecycleTest extends WireTestCommon {
     @Test
     public void textUseTextDocumentsLifecycle() {
         Wire w = new TextWire(Bytes.allocateElasticOnHeap(256)).useTextDocuments();
+        assertEquals(0, w.contextCount());
         try (DocumentContext dc = w.writingDocument()) {
-            assertEquals(1, dc.contextCount());
+            assertEquals(w.contextCount(), dc.contextCount());
             dc.wire().write("x").int64(11L);
         }
         try (DocumentContext dc = w.writingDocument(true)) { // meta document allowed
@@ -98,6 +100,23 @@ public class DocumentContextLifecycleTest extends WireTestCommon {
     }
 
     @Test
+    public void marshallableOutWithoutContextTrackingReturnsNegativeContextCount() {
+        MarshallableOut output = new MarshallableOut() {
+            @Override
+            public DocumentContext writingDocument(boolean metaData) {
+                return NoDocumentContext.INSTANCE;
+            }
+
+            @Override
+            public DocumentContext acquireWritingDocument(boolean metaData) {
+                return NoDocumentContext.INSTANCE;
+            }
+        };
+
+        assertEquals(-1, output.contextCount());
+    }
+
+    @Test
     public void resetAdvancesContextCountWhileClearRetainsIt() {
         for (WireType wireType : WRITABLE_WIRE_TYPES) {
             Bytes<?> bytes = Bytes.allocateElasticOnHeap();
@@ -113,6 +132,21 @@ public class DocumentContextLifecycleTest extends WireTestCommon {
             } finally {
                 bytes.releaseLast();
             }
+        }
+    }
+
+    @Test
+    public void testSeamAcceptsZeroButNotUnavailableCount() {
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        try {
+            AbstractWire wire = (AbstractWire) WireType.BINARY.apply(bytes);
+
+            wire.outputContextCountForTesting(0);
+
+            assertEquals(0, wire.contextCount());
+            assertThrows(IllegalArgumentException.class, () -> wire.outputContextCountForTesting(-1));
+        } finally {
+            bytes.releaseLast();
         }
     }
 
@@ -136,20 +170,67 @@ public class DocumentContextLifecycleTest extends WireTestCommon {
     }
 
     @Test
+    public void resetRejectsContextCountOverflowBeforeMutation() {
+        for (WireType wireType : WRITABLE_WIRE_TYPES) {
+            Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+            try {
+                AbstractWire wire = (AbstractWire) wireType.apply(bytes);
+                wire.outputContextCountForTesting(Integer.MAX_VALUE - 1);
+                SchemaContext context = new SchemaContext("schema-v1");
+
+                int penultimate = writePayloadAndReadContextCount(wire, "penultimate");
+                assertEquals(wireType.name(), Integer.MAX_VALUE - 1, penultimate);
+                assertTrue(wireType.name(), context.needsResending(penultimate));
+
+                wire.reset();
+
+                int last = writePayloadAndReadContextCount(wire, "last");
+                assertEquals(wireType.name(), Integer.MAX_VALUE, last);
+                assertTrue(wireType.name(), context.needsResending(last));
+
+                byte[] contentsBeforeRejectedReset = bytes.toByteArray();
+                long readPositionBeforeRejectedReset = bytes.readPosition();
+                long writePositionBeforeRejectedReset = bytes.writePosition();
+
+                IllegalStateException exception = assertThrows(IllegalStateException.class, wire::reset);
+
+                assertEquals(wireType.name(), "Output context count exhausted", exception.getMessage());
+                assertEquals(wireType.name(), Integer.MAX_VALUE, wire.contextCount());
+                assertArrayEquals(wireType.name(), contentsBeforeRejectedReset, bytes.toByteArray());
+                assertEquals(wireType.name(), readPositionBeforeRejectedReset, bytes.readPosition());
+                assertEquals(wireType.name(), writePositionBeforeRejectedReset, bytes.writePosition());
+                assertEquals(wireType.name(), 2, context.writeCount);
+            } finally {
+                bytes.releaseLast();
+            }
+        }
+    }
+
+    @Test
     public void progressiveContextOnlyNeedsResendingForHigherCounts() {
         SchemaContext context = new SchemaContext("schema-v1");
 
         assertFalse(context.needsResending(-1));
+        assertTrue(context.needsResending(0));
+        assertFalse(context.needsResending(0));
         assertTrue(context.needsResending(1));
         assertFalse(context.needsResending(1));
         assertFalse(context.needsResending(0));
         assertTrue(context.needsResending(2));
-        assertEquals(2, context.writeCount);
+        assertEquals(3, context.writeCount);
     }
 
     private static int writeAndReadContextCount(Wire wire) {
         try (DocumentContext dc = wire.writingDocument()) {
             return dc.contextCount();
+        }
+    }
+
+    private static int writePayloadAndReadContextCount(Wire wire, String payload) {
+        try (DocumentContext dc = wire.writingDocument()) {
+            int contextCount = dc.contextCount();
+            dc.wire().write("payload").text(payload);
+            return contextCount;
         }
     }
 


### PR DESCRIPTION
QUEUE-143: Wire prerequisite for the Queue/CQE integration programme

## Summary

- Adds the `int DocumentContext.contextCount()` contract and propagates it through document context holders and wrappers.
- Advances writable Wire counts on `reset()` while `clear()` retains the current count; closed or unavailable contexts return `-1`.
- Adds `ProgressiveContext` with guidance for keeping the last count in a transient DTO field and writing context only when the count increases.

## Purpose and stack position

Context data must be resent when an output moves to a new context, such as after a Wire reset, a transport reconnect, or a Queue roll. Callers need to detect that change without depending on the concrete output implementation. The non-decreasing `contextCount()` contract provides that signal: an unchanged count means the existing context still applies, while an increased count means it must be sent again.

This contract is isolated in the first PR so its semantics and `int` representation can be reviewed independently of listener registration and lifecycle code. This PR does not notify listeners itself. It is the base for Wire #1271, #1272, #1273 and #1274; Queue #1725 maps `contextCount()` to Queue roll cycles and adds Queue context listeners.

## Review notes

`int` is intentional: the count is inherently bounded by Queue's `int` roll-cycle/context domain. All examined implementations and `ProgressiveContext.needsResending(int)` use `int`; no `long contextCount()` exists in this stack.

## Validation

- Java 8: `mvn -q clean -DskipTests javadoc:jar`
- Java 11: `mvn -q clean -DskipTests javadoc:jar`
- `mvn -q clean verify`
- Focused `DocumentContextLifecycleTest` - pass.
- All twelve reported Wire TeamCity configurations were successful at `e2077afab` during the detailed review.
- `git diff --check` - pass.
