### PR TITLE
QUEUE-144: Add marshallable output context listener API

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/MarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableOut.java
@@ -27,6 +27,22 @@ import java.util.stream.Stream;
 public interface MarshallableOut extends DocumentWritten, RollbackIfNotCompleteNotifier {
 
     /**
+     * Receives a callback when a {@link MarshallableOut} starts a new output context.
+     * The meaning of a context is implementation specific.
+     *
+     * @param <T> event interface type used by the supplied method writer
+     */
+    @FunctionalInterface
+    interface ContextListener<T> {
+        /**
+         * Called before the first application document is written in the new output context.
+         *
+         * @param writer preset method writer for writing context records
+         */
+        void onNewContext(T writer);
+    }
+
+    /**
      * Creates and returns a new instance of {@link MarshallableOutBuilder} initialized with the provided URL.
      *
      * @param url The URL which will dictate the specific type of {@code MarshallableOut} to create.
@@ -73,6 +89,35 @@ public interface MarshallableOut extends DocumentWritten, RollbackIfNotCompleteN
      * Start or reuse an existing a DocumentContext, optionally call close() when done.
      */
     DocumentContext acquireWritingDocument(boolean metaData) throws UnrecoverableTimeoutException;
+
+    /**
+     * Registers a listener that writes context records before the first application data document
+     * in each implementation-defined output context, such as first wire use, a queue roll file or a
+     * transport connection. A leading meta-data document may be written first.
+     * <p>
+     * The supplied method writer is not callback-scoped and may be retained for normal use. During
+     * notification, the listener must use this writer rather than open another output document. Its
+     * calls write normal method-writer documents and omit {@link MessageHistory} unless the listener writes it explicitly.
+     * <p>
+     * Register before first use on a single thread. Exceptions propagate and the listener is not
+     * retried for that context, so it should write complete-or-nothing.
+     * <p>
+     * For progressive context, expose {@link DocumentWritten}, hold one document context and write
+     * missing context only when {@link DocumentContext#contextCount()} increases. This pattern is
+     * not supported by queues configured for double buffering.
+     *
+     * @param writerType event interface type for the supplied method writer
+     * @param listener   listener to call for new output contexts
+     * @param <T>        event interface type
+     * @return this output
+     * @throws UnsupportedOperationException if this output does not support context listeners
+     * @throws IllegalStateException         if set after the first output context has started
+     */
+    @NotNull
+    default <T> MarshallableOut contextListener(@NotNull Class<T> writerType,
+                                                @NotNull ContextListener<? super T> listener) {
+        throw new UnsupportedOperationException("Context listeners are not supported by this output");
+    }
 
     /**
      * @return true if this output is configured to expect the history of the message to be written

--- a/src/main/java/net/openhft/chronicle/wire/WireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireOut.java
@@ -225,6 +225,14 @@ public interface WireOut extends WireCommon, MarshallableOut {
      */
     DocumentContext acquireWritingDocument(boolean metaData);
 
+    @NotNull
+    @Override
+    default <T> WireOut contextListener(@NotNull Class<T> writerType,
+                                        @NotNull MarshallableOut.ContextListener<? super T> listener) {
+        MarshallableOut.super.contextListener(writerType, listener);
+        return this;
+    }
+
     /**
      * Writes a document to the wire without marking its completion. This is primarily used in
      * networking scenarios, but no longer used for queues.


### PR DESCRIPTION
## Summary

- Adds the shared `MarshallableOut.ContextListener` callback API.
- Adds `MarshallableOut.contextListener(...)` as an opt-in operation that defaults to unsupported.
- Adds the covariant `WireOut.contextListener(...)` entry point for fluent Wire configuration.

## Purpose and stack position

OpenHFT/Chronicle-Wire#1270 lets callers detect that an output context has changed, but it does not provide a way for an application to register context-writing behaviour. This PR adds that common registration contract so Queue, Wire and connection-based outputs can expose the same typed callback rather than defining product-specific listener interfaces.

The callback receives a preset method writer. This keeps context records on the normal serialization path and lets each output control its document and locking lifecycle. The default method remains unsupported so existing `MarshallableOut` implementations are source-compatible and can opt in explicitly.

This PR deliberately defines only the public API and its behavioural contract. It does not track contexts or invoke listeners. That separation keeps the API review focused before implementation is added by the remaining stack:

- OpenHFT/Chronicle-Wire#1270 provides the underlying `contextCount()` contract.
- OpenHFT/Chronicle-Wire#1272 implements listener notification lifecycle for Wire.
- OpenHFT/Chronicle-Wire#1273 enables the lifecycle in concrete `MarshallableOut` implementations.
- OpenHFT/Chronicle-Wire#1274 documents the completed Wire behaviour.
- OpenHFT/Chronicle-Queue#1725 implements Queue roll-cycle listeners using this shared API.

## Review focus

Review the callback timing, supplied-writer contract, failure and retry semantics, registration timing, and unsupported-by-default compatibility. Runtime lifecycle and output-specific behaviour belong to the later PRs.
