### PR TITLE
QUEUE-144: Implement wire context listener lifecycle

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/AbstractAnyWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractAnyWire.java
@@ -206,6 +206,15 @@ public abstract class AbstractAnyWire extends AbstractWire implements Wire {
         return wireAcquisition.acquireWire().acquireWritingDocument(metaData);
     }
 
+    // Writes are delegated to the acquired underlying wire, whose listener fields this setter would
+    // never reach - a listener registered here would be silently ignored, so fail loudly instead.
+    @NotNull
+    @Override
+    public <T> WireOut contextListener(@NotNull Class<T> writerType,
+                                       @NotNull MarshallableOut.ContextListener<? super T> listener) {
+        throw new UnsupportedOperationException("contextListener is not supported on a READ_ANY wire");
+    }
+
     @Override
     public String readingPeekYaml() {
         return wireAcquisition.acquireWire().readingPeekYaml();

--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -9,6 +9,7 @@ import net.openhft.chronicle.bytes.BytesUtil;
 import net.openhft.chronicle.bytes.HexDumpBytesDescription;
 import net.openhft.chronicle.bytes.util.DecoratedBufferUnderflowException;
 import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.io.InvalidMarshallableException;
 import net.openhft.chronicle.core.onoes.Slf4jExceptionHandler;
 import net.openhft.chronicle.core.pool.ClassAliasPool;
 import net.openhft.chronicle.core.pool.ClassLookup;
@@ -65,6 +66,7 @@ public abstract class AbstractWire implements Wire, InternalWire {
     private boolean usePadding = DEFAULT_USE_PADDING;
     private boolean generateTuples = GENERATE_TUPLES;
     private int outputContextCount = 1;
+    @NotNull private WireContextListenerLifecycle contextListenerLifecycle = NoOpWireContextListenerLifecycle.UNSET;
 
     /**
      * Constructor for AbstractWire.
@@ -221,6 +223,47 @@ public abstract class AbstractWire implements Wire, InternalWire {
     @Override
     public void commentListener(Consumer<CharSequence> commentListener) {
         this.commentListener = commentListener;
+    }
+
+    @NotNull
+    @Override
+    public <T> WireOut contextListener(@NotNull Class<T> writerType,
+                                       @NotNull MarshallableOut.ContextListener<? super T> listener) {
+        WireContextListenerLifecycle lifecycle = contextListenerLifecycle;
+        if (lifecycle.started())
+            throw new IllegalStateException("Cannot set contextListener after the first output context has started");
+        contextListenerLifecycle = WireContextListenerLifecycle.active(writerType, listener);
+        return this;
+    }
+
+    /**
+     * Fires the listener before the first data document in the current output context. A leading
+     * metadata document may precede the context records.
+     */
+    protected final void notifyContextListenerIfNeeded(boolean metaData) {
+        if (contextListenerLifecycle == NoOpWireContextListenerLifecycle.UNSET) {
+            contextListenerLifecycle = NoOpWireContextListenerLifecycle.SET;
+        }
+        contextListenerLifecycle.beforeDocument(this, metaData);
+    }
+
+    /** Prepares a configured context listener for the next output context. */
+    protected final void resetContextListener() {
+        contextListenerLifecycle.resetContext();
+    }
+
+    // writeDocument writes directly through WireInternal.writeData rather than writingDocument, so
+    // it needs its own notification hook or a context listener would be silently skipped on this path.
+    @Override
+    public void writeDocument(boolean metaData, @NotNull WriteMarshallable writer) throws InvalidMarshallableException {
+        notifyContextListenerIfNeeded(metaData);
+        WireInternal.writeData(this, metaData, false, writer);
+    }
+
+    @Override
+    public void writeNotCompleteDocument(boolean metaData, @NotNull WriteMarshallable writer) throws InvalidMarshallableException {
+        notifyContextListenerIfNeeded(metaData);
+        WireInternal.writeData(this, metaData, true, writer);
     }
 
     @NotNull

--- a/src/main/java/net/openhft/chronicle/wire/ActiveWireContextListenerLifecycle.java
+++ b/src/main/java/net/openhft/chronicle/wire/ActiveWireContextListenerLifecycle.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.wire;
+
+/**
+ * Stateful lifecycle allocated only for a configured context listener.
+ *
+ * <p>If the callback commits partial output and then throws, it is not retried in the same
+ * context.</p>
+ */
+final class ActiveWireContextListenerLifecycle implements WireContextListenerLifecycle {
+    private final Class<?> writerType;
+    private final MarshallableOut.ContextListener<?> listener;
+    private boolean started;
+    private boolean notified;
+
+    ActiveWireContextListenerLifecycle(Class<?> writerType, MarshallableOut.ContextListener<?> listener) {
+        this.writerType = writerType;
+        this.listener = listener;
+    }
+
+    @Override
+    public boolean started() {
+        return started;
+    }
+
+    /**
+     * Fires once per context before the first data document. Metadata may precede the context
+     * records. The notified flag is latched before invoking user code.
+     */
+    @Override
+    public void beforeDocument(AbstractWire wire, boolean metaData) {
+        started = true;
+        if (metaData || notified)
+            return;
+
+        notified = true;
+        notifyListener(wire);
+    }
+
+    @Override
+    public void resetContext() {
+        notified = false;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private void notifyListener(AbstractWire wire) {
+        ((MarshallableOut.ContextListener) listener).onNewContext(wire.methodWriter(writerType));
+    }
+}

--- a/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWire.java
@@ -249,6 +249,7 @@ public class BinaryWire extends AbstractWire implements Wire {
         valueOut.resetState();
         bytes.clear();
         advanceOutputContext();
+        resetContextListener();
     }
 
     @Override
@@ -336,6 +337,7 @@ public class BinaryWire extends AbstractWire implements Wire {
     @NotNull
     @Override
     public DocumentContext writingDocument(boolean metaData) {
+        notifyContextListenerIfNeeded(metaData);
         writeContext.start(metaData);
         return writeContext;
     }

--- a/src/main/java/net/openhft/chronicle/wire/MarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/MarshallableOut.java
@@ -102,6 +102,9 @@ public interface MarshallableOut extends DocumentWritten, RollbackIfNotCompleteN
      * Register before first use on a single thread. Exceptions propagate and the listener is not
      * retried for that context, so it should write complete-or-nothing.
      * <p>
+     * Configure only the outermost output. Combining a listener on a wrapper with one on its
+     * underlying output is unsupported.
+     * <p>
      * For progressive context, expose {@link DocumentWritten}, hold one document context and write
      * missing context only when {@link DocumentContext#contextCount()} increases. This pattern is
      * not supported by queues configured for double buffering.

--- a/src/main/java/net/openhft/chronicle/wire/NoOpWireContextListenerLifecycle.java
+++ b/src/main/java/net/openhft/chronicle/wire/NoOpWireContextListenerLifecycle.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.wire;
+
+/**
+ * Shared, allocation-free lifecycle for listener-free wires. {@link #UNSET} allows configuration;
+ * {@link #SET} records that the first document has started. The empty callback is expected to be
+ * inlined on ordinary writes.
+ */
+enum NoOpWireContextListenerLifecycle implements WireContextListenerLifecycle {
+    UNSET,
+    SET;
+
+    @Override
+    public boolean started() {
+        return this == SET;
+    }
+
+    @Override
+    public void beforeDocument(AbstractWire wire, boolean metaData) {
+        // Deliberately empty; expected to inline on listener-free writes.
+    }
+}

--- a/src/main/java/net/openhft/chronicle/wire/RawWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/RawWire.java
@@ -96,6 +96,7 @@ public class RawWire extends AbstractWire implements Wire {
         bytes.clear();
         lastSB = null;
         advanceOutputContext();
+        resetContextListener();
     }
 
     @Override
@@ -103,13 +104,10 @@ public class RawWire extends AbstractWire implements Wire {
         return true;
     }
 
-    /**
-     * Begins a document for raw value writing. The {@code metaData} flag is
-     * ignored as this format stores no metadata.
-     */
     @NotNull
     @Override
     public DocumentContext writingDocument(boolean metaData) {
+        notifyContextListenerIfNeeded(metaData);
         writeContext.start(metaData);
         return writeContext;
     }

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -377,6 +377,7 @@ public class TextWire extends YamlWireOut<TextWire> {
     @NotNull
     @Override
     public DocumentContext writingDocument(boolean metaData) {
+        notifyContextListenerIfNeeded(metaData);
         if (writeContext == null)
             useTextDocuments();
         writeContext.start(metaData);
@@ -1282,6 +1283,7 @@ public class TextWire extends YamlWireOut<TextWire> {
         valueOut.resetState();
         bytes.clear();
         advanceOutputContext();
+        resetContextListener();
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/wire/WireContextListenerLifecycle.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireContextListenerLifecycle.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.wire;
+
+import org.jetbrains.annotations.NotNull;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Internal lifecycle for a context listener attached to a wire.
+ *
+ * <p>The shared {@link NoOpWireContextListenerLifecycle#SET} instance represents a wire whose first
+ * document has started without a listener. An {@link ActiveWireContextListenerLifecycle} is
+ * allocated only when the advanced context-listener feature is configured.</p>
+ */
+interface WireContextListenerLifecycle {
+    /**
+     * @return whether an output document has already started
+     */
+    boolean started();
+
+    /**
+     * Invoked immediately before a wire starts an output document.
+     *
+     * @param wire     wire starting the document
+     * @param metaData whether the document contains metadata
+     */
+    void beforeDocument(AbstractWire wire, boolean metaData);
+
+    /** Prepares this lifecycle for another output context. */
+    default void resetContext() {
+    }
+
+    static <T> WireContextListenerLifecycle active(@NotNull Class<T> writerType,
+                                                   @NotNull MarshallableOut.ContextListener<? super T> listener) {
+        return new ActiveWireContextListenerLifecycle(requireNonNull(writerType), requireNonNull(listener));
+    }
+}

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -416,6 +416,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     @NotNull
     @Override
     public DocumentContext writingDocument(boolean metaData) {
+        notifyContextListenerIfNeeded(metaData);
         if (writeContext == null)
             useBinaryDocuments();
         writeContext.start(metaData);
@@ -1102,6 +1103,7 @@ public class YamlWire extends YamlWireOut<YamlWire> {
     public void reset() {
         resetState();
         advanceOutputContext();
+        resetContextListener();
     }
 
     private void resetState() {

--- a/src/test/java/net/openhft/chronicle/wire/WireContextListenerLifecycleTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireContextListenerLifecycleTest.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.wire;
+
+import net.openhft.chronicle.bytes.Bytes;
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class WireContextListenerLifecycleTest extends WireTestCommon {
+    private static final WireType[] WRITABLE_WIRE_TYPES = {
+            WireType.BINARY,
+            WireType.TEXT,
+            WireType.YAML,
+            WireType.RAW
+    };
+
+    private final List<Bytes<?>> allocatedBytes = new ArrayList<>();
+
+    @After
+    public void releaseBytes() {
+        allocatedBytes.forEach(Bytes::releaseLast);
+        allocatedBytes.clear();
+    }
+
+    @Test
+    public void contextListenerWaitsForDataAfterMetadataAndWritesDtoOnce() {
+        Wire wire = newWire(WireType.BINARY);
+        AtomicInteger calls = new AtomicInteger();
+        wire.contextListener(ContextEvents.class, writer -> {
+            calls.incrementAndGet();
+            writer.context(new ContextData("schema", 7));
+        });
+
+        try (DocumentContext dc = wire.writingDocument(true)) {
+            dc.wire().write("header").text("metadata");
+        }
+
+        assertEquals(0, calls.get());
+        assertThrows(IllegalStateException.class,
+                () -> wire.contextListener(ContextEvents.class, writer -> {
+                }));
+
+        ContextEvents writer = wire.methodWriter(ContextEvents.class);
+        writer.event(new EventData("one", 1));
+        writer.event(new EventData("two", 2));
+
+        assertEquals(1, calls.get());
+        assertEquals("" +
+                        "--- !!meta-data #binary\n" +
+                        "header: metadata\n" +
+                        "# position: 20, header: 0\n" +
+                        "--- !!data #binary\n" +
+                        "context: {\n" +
+                        "  name: schema,\n" +
+                        "  version: 7\n" +
+                        "}\n" +
+                        "# position: 60, header: 1\n" +
+                        "--- !!data #binary\n" +
+                        "event: {\n" +
+                        "  name: one,\n" +
+                        "  sequence: 1\n" +
+                        "}\n" +
+                        "# position: 96, header: 2\n" +
+                        "--- !!data #binary\n" +
+                        "event: {\n" +
+                        "  name: two,\n" +
+                        "  sequence: 2\n" +
+                        "}\n",
+                Wires.fromSizePrefixedBlobs(wire));
+    }
+
+    @Test
+    public void listenerFailureIsNotRetried() {
+        Wire wire = newWire(WireType.BINARY);
+        AtomicInteger calls = new AtomicInteger();
+        wire.contextListener(ContextEvents.class, writer -> {
+            calls.incrementAndGet();
+            writer.context(new ContextData("schema", 7));
+            throw new IllegalStateException("listener failed");
+        });
+
+        ContextEvents writer = wire.methodWriter(ContextEvents.class);
+        IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                () -> writer.event(new EventData("failed", 1)));
+        assertEquals("listener failed", thrown.getMessage());
+
+        writer.event(new EventData("after", 2));
+
+        assertEquals(1, calls.get());
+        assertEquals("" +
+                        "--- !!data #binary\n" +
+                        "context: {\n" +
+                        "  name: schema,\n" +
+                        "  version: 7\n" +
+                        "}\n" +
+                        "# position: 40, header: 1\n" +
+                        "--- !!data #binary\n" +
+                        "event: {\n" +
+                        "  name: after,\n" +
+                        "  sequence: 2\n" +
+                        "}\n",
+                Wires.fromSizePrefixedBlobs(wire));
+    }
+
+    @Test
+    public void allConcreteWiresInvokeListenerBeforeFirstDataDocument() {
+        for (WireType wireType : WRITABLE_WIRE_TYPES) {
+            Wire wire = newWire(wireType);
+            AtomicInteger calls = new AtomicInteger();
+            wire.contextListener(ContextEvents.class, writer -> {
+                calls.incrementAndGet();
+                writer.context(new ContextData(wireType.name(), 1));
+            });
+
+            assertEquals(wireType.name(), 0, calls.get());
+            try (DocumentContext dc = wire.acquireWritingDocument(false)) {
+                assertEquals(wireType.name(), 1, calls.get());
+                dc.wire().write("value").text("one");
+            }
+            try (DocumentContext dc = wire.writingDocument(false)) {
+                dc.wire().write("value").text("two");
+            }
+
+            wire.reset();
+            try (DocumentContext dc = wire.writingDocument(false)) {
+                dc.wire().write("value").text("three");
+            }
+
+            assertEquals(wireType.name(), 2, calls.get());
+        }
+    }
+
+    @Test
+    public void clearRetainsTheCurrentOutputContext() {
+        for (WireType wireType : WRITABLE_WIRE_TYPES) {
+            Wire wire = newWire(wireType);
+            AtomicInteger calls = new AtomicInteger();
+            wire.contextListener(ContextEvents.class, writer -> {
+                calls.incrementAndGet();
+                writer.context(new ContextData(wireType.name(), 1));
+            });
+
+            ContextEvents writer = wire.methodWriter(ContextEvents.class);
+            writer.event(new EventData("before", 1));
+            wire.clear();
+            writer.event(new EventData("after", 2));
+
+            assertEquals(wireType.name(), 1, calls.get());
+        }
+    }
+
+    @Test
+    public void resetReusesListenerForTheNextOutputContext() {
+        Wire wire = newWire(WireType.BINARY);
+        AtomicInteger calls = new AtomicInteger();
+        wire.contextListener(ContextEvents.class,
+                writer -> writer.context(new ContextData("schema", calls.incrementAndGet())));
+
+        ContextEvents writer = wire.methodWriter(ContextEvents.class);
+        writer.event(new EventData("before", 1));
+
+        wire.reset();
+        writer.event(new EventData("after", 2));
+
+        assertEquals(2, calls.get());
+        assertThrows(IllegalStateException.class,
+                () -> wire.contextListener(ContextEvents.class, ignored -> {
+                }));
+        assertEquals("" +
+                        "--- !!data #binary\n" +
+                        "context: {\n" +
+                        "  name: schema,\n" +
+                        "  version: 2\n" +
+                        "}\n" +
+                        "# position: 40, header: 1\n" +
+                        "--- !!data #binary\n" +
+                        "event: {\n" +
+                        "  name: after,\n" +
+                        "  sequence: 2\n" +
+                        "}\n",
+                Wires.fromSizePrefixedBlobs(wire));
+    }
+
+    @Test
+    public void suppliedMethodWriterCanBeRetainedAfterNotification() {
+        Wire wire = newWire(WireType.BINARY);
+        AtomicInteger calls = new AtomicInteger();
+        AtomicReference<ContextEvents> suppliedWriter = new AtomicReference<>();
+        wire.contextListener(ContextEvents.class, writer -> {
+            calls.incrementAndGet();
+            suppliedWriter.set(writer);
+            writer.context(new ContextData("schema", 7));
+        });
+
+        ContextEvents writer = wire.methodWriter(ContextEvents.class);
+        writer.event(new EventData("one", 1));
+        suppliedWriter.get().event(new EventData("retained", 2));
+
+        assertEquals(1, calls.get());
+        assertEquals("" +
+                        "--- !!data #binary\n" +
+                        "context: {\n" +
+                        "  name: schema,\n" +
+                        "  version: 7\n" +
+                        "}\n" +
+                        "# position: 40, header: 1\n" +
+                        "--- !!data #binary\n" +
+                        "event: {\n" +
+                        "  name: one,\n" +
+                        "  sequence: 1\n" +
+                        "}\n" +
+                        "# position: 76, header: 2\n" +
+                        "--- !!data #binary\n" +
+                        "event: {\n" +
+                        "  name: retained,\n" +
+                        "  sequence: 2\n" +
+                        "}\n",
+                Wires.fromSizePrefixedBlobs(wire));
+    }
+
+    @Test
+    public void listenerFreeWireCannotBeConfiguredAfterFirstUse() {
+        Wire wire = newWire(WireType.BINARY);
+        try (DocumentContext dc = wire.writingDocument(false)) {
+            dc.wire().write("event").text("first");
+        }
+
+        assertThrows(IllegalStateException.class,
+                () -> wire.contextListener(ContextEvents.class, ignored -> {
+                }));
+    }
+
+    @Test
+    public void directWriteEntryPointsInvokeListenerOnce() {
+        Wire completeWire = newWire(WireType.BINARY);
+        AtomicInteger completeCalls = new AtomicInteger();
+        completeWire.contextListener(ContextEvents.class, ignored -> completeCalls.incrementAndGet());
+
+        completeWire.writeDocument(true, wire -> wire.write("header").text("metadata"));
+        assertEquals(0, completeCalls.get());
+        completeWire.writeDocument(false, wire -> wire.write("event").text("complete"));
+        completeWire.writeDocument(false, wire -> wire.write("event").text("second"));
+
+        Wire incompleteWire = newWire(WireType.BINARY);
+        AtomicInteger incompleteCalls = new AtomicInteger();
+        incompleteWire.contextListener(ContextEvents.class, ignored -> incompleteCalls.incrementAndGet());
+
+        incompleteWire.writeNotCompleteDocument(false,
+                wire -> wire.write("event").text("incomplete"));
+
+        Wire incompleteMetadataWire = newWire(WireType.BINARY);
+        AtomicInteger incompleteMetadataCalls = new AtomicInteger();
+        incompleteMetadataWire.contextListener(ContextEvents.class,
+                ignored -> incompleteMetadataCalls.incrementAndGet());
+        incompleteMetadataWire.writeNotCompleteDocument(true,
+                wire -> wire.write("header").text("metadata"));
+
+        assertEquals(1, completeCalls.get());
+        assertEquals(1, incompleteCalls.get());
+        assertEquals(0, incompleteMetadataCalls.get());
+    }
+
+    @Test
+    public void readAnyRejectsContextListeners() {
+        Wire wire = newWire(WireType.READ_ANY);
+
+        assertThrows(UnsupportedOperationException.class,
+                () -> wire.contextListener(ContextEvents.class, ignored -> {
+                }));
+    }
+
+    private Wire newWire(WireType wireType) {
+        Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        allocatedBytes.add(bytes);
+        return wireType.apply(bytes);
+    }
+
+    interface ContextEvents {
+        void context(ContextData context);
+
+        void event(EventData event);
+    }
+
+    static final class ContextData extends SelfDescribingMarshallable {
+        String name;
+        int version;
+
+        ContextData(String name, int version) {
+            this.name = name;
+            this.version = version;
+        }
+    }
+
+    static final class EventData extends SelfDescribingMarshallable {
+        String name;
+        long sequence;
+
+        EventData(String name, long sequence) {
+            this.name = name;
+            this.sequence = sequence;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Implements the context-listener lifecycle for writable Wire implementations.
- Notifies the listener once per output context, immediately before the first data document and after any leading meta-data documents.
- Rearms notification on `Wire.reset()` while preserving the current context across `clear()`.
- Covers document-context and direct-write entry points, listener failure semantics, retained writers, and explicit `READ_ANY` rejection.

## Purpose and stack position

OpenHFT/Chronicle-Wire#1271 defines how an application registers a typed context listener, but deliberately does not decide when that listener runs. This PR supplies that lifecycle for Wire itself so the callback semantics can be reviewed and tested independently of Queue rolls, transport reconnects, and other output wrappers.

The lifecycle latches notification before invoking application code. A listener that writes partial context and then throws is therefore not retried in the same output context. `reset()` starts a new output context and rearms the listener; `clear()` only clears buffered data and does not resend context.

Listener-free wires use shared no-op states so the normal write path adds no per-document allocation. `READ_ANY` rejects listener registration because writes are delegated to an acquired underlying wire and a listener stored on the wrapper would otherwise be silently ignored.

This PR is the third change in the Wire stack:

- OpenHFT/Chronicle-Wire#1270 provides `contextCount()`, reset counting, and the progressive-context contract.
- OpenHFT/Chronicle-Wire#1271 adds the shared listener registration API.
- This PR implements listener notification for Wire.
- OpenHFT/Chronicle-Wire#1273 enables the lifecycle in concrete `MarshallableOut` implementations, including reconnect behaviour.
- OpenHFT/Chronicle-Wire#1274 documents the completed Wire contract.
- OpenHFT/Chronicle-Queue#1725 adds Queue roll-cycle semantics using the shared API.

## Review focus

Review the once-per-context timing, meta-data handling, reset versus clear behaviour, failure/no-retry contract, listener-free hot path, and coverage of write entry points. Output-wrapper and Queue-specific lifecycle decisions belong to the later PRs.

## Validation

- Java 8: `mvn -q clean -DskipTests javadoc:jar`
- Java 11: `mvn -q clean -DskipTests javadoc:jar`
- `mvn -q -Dtest=WireContextListenerLifecycleTest test`
- `mvn -q clean verify`
- `git diff --check`
