### PR TITLE
QUEUE-144: Support context listeners in marshallable outputs

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/internal/FileMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/FileMarshallableOut.java
@@ -116,4 +116,17 @@ public class FileMarshallableOut implements MarshallableOut {
     static class FMOOptions extends SelfDescribingMarshallable {
         boolean append; // Indicates if data should be appended to the existing file
     }
+    @Override
+    public <T> MarshallableOut contextListener(Class<T> writerType,
+                                               MarshallableOut.ContextListener<? super T> listener) {
+        // In overwrite mode every document atomically replaces the file, so context records written
+        // with the first document would be lost from the surviving output - fail loudly instead.
+        if (!options.append)
+            throw new UnsupportedOperationException(
+                    "contextListener requires append mode (add ?append=true to the file URL): "
+                            + "in overwrite mode each document replaces the file, discarding the context records");
+        wire.contextListener(writerType, listener);
+        return this;
+    }
+
 }

--- a/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/HTTPMarshallableOut.java
@@ -32,8 +32,16 @@ public class HTTPMarshallableOut implements MarshallableOut {
     // The encapsulated Wire object for serialization
     private final Wire wire;
 
+    // Each top-level writable document is delivered over its own HTTP connection.
+    private int connectionCount;
+
     // Document context holder for managing the wire and the HTTP communication
     private final DocumentContextHolder dcHolder = new DocumentContextHolder() {
+
+        @Override
+        public int contextCount() {
+            return connectionCount;
+        }
 
         // Inline comment about override functionality
         @Override
@@ -95,7 +103,7 @@ public class HTTPMarshallableOut implements MarshallableOut {
 
     // Method for resetting the wire state
     void startWire() {
-        wire.clear();
+        wire.reset();
     }
 
     // Method for finalizing the wire content
@@ -109,13 +117,26 @@ public class HTTPMarshallableOut implements MarshallableOut {
 
     @Override
     public DocumentContext writingDocument(boolean metaData) throws UnrecoverableTimeoutException {
-        dcHolder.documentContext(wire.writingDocument(metaData));
-        return dcHolder;
+        return openedDocument(wire.writingDocument(metaData));
     }
 
     @Override
     public DocumentContext acquireWritingDocument(boolean metaData) throws UnrecoverableTimeoutException {
-        dcHolder.documentContext(wire.acquireWritingDocument(metaData));
+        return openedDocument(wire.acquireWritingDocument(metaData));
+    }
+
+    private DocumentContext openedDocument(DocumentContext documentContext) {
+        if (dcHolder.isClosed())
+            connectionCount++;
+        dcHolder.documentContext(documentContext);
         return dcHolder;
     }
+
+    @Override
+    public <T> MarshallableOut contextListener(Class<T> writerType,
+                                               MarshallableOut.ContextListener<? super T> listener) {
+        wire.contextListener(writerType, listener);
+        return this;
+    }
+
 }

--- a/src/main/java/net/openhft/chronicle/wire/internal/StringConsumerMarshallableOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/internal/StringConsumerMarshallableOut.java
@@ -60,4 +60,11 @@ public class StringConsumerMarshallableOut implements MarshallableOut {
         dcHolder.documentContext(wire.acquireWritingDocument(metaData));
         return dcHolder;
     }
+    @Override
+    public <T> MarshallableOut contextListener(Class<T> writerType,
+                                               MarshallableOut.ContextListener<? super T> listener) {
+        wire.contextListener(writerType, listener);
+        return this;
+    }
+
 }

--- a/src/test/java/net/openhft/chronicle/wire/MarshallableOutContextListenerTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MarshallableOutContextListenerTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.wire;
+
+import com.sun.net.httpserver.HttpServer;
+import net.openhft.chronicle.core.io.IOTools;
+import net.openhft.chronicle.wire.internal.StringConsumerMarshallableOut;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class MarshallableOutContextListenerTest extends WireTestCommon {
+    private static final String CONTEXT_AND_FIRST_EVENT = "" +
+            "context: {\n" +
+            "  name: schema,\n" +
+            "  version: 7\n" +
+            "}\n" +
+            "...\n" +
+            "event: {\n" +
+            "  name: one,\n" +
+            "  sequence: 1\n" +
+            "}\n" +
+            "...\n";
+    private static final String SECOND_EVENT = "" +
+            "event: {\n" +
+            "  name: two,\n" +
+            "  sequence: 2\n" +
+            "}\n" +
+            "...\n";
+    private static final String THIRD_EVENT = "" +
+            "event: {\n" +
+            "  name: three,\n" +
+            "  sequence: 3\n" +
+            "}\n" +
+            "...\n";
+
+    @Test
+    public void stringConsumerWritesContextOnceBeforeEvents() {
+        List<String> chunks = new ArrayList<>();
+        MarshallableOut out = new StringConsumerMarshallableOut(chunks::add, WireType.YAML_ONLY);
+        ContextEvents writer = contextWriter(out);
+
+        writer.event(new EventData("one", 1));
+        writer.event(new EventData("two", 2));
+        writer.event(new EventData("three", 3));
+
+        assertEquals(Arrays.asList(CONTEXT_AND_FIRST_EVENT, SECOND_EVENT, THIRD_EVENT), chunks);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void appendFileWritesContextOnceBeforeEvents() throws Exception {
+        File file = File.createTempFile("context-listener", ".yaml");
+        try {
+            URL url = new URL(file.toURI().toURL() + "?append=true");
+            MarshallableOut out = MarshallableOut.builder(url)
+                    .wireType(WireType.YAML_ONLY)
+                    .get();
+            ContextEvents writer = contextWriter(out);
+
+            writer.event(new EventData("one", 1));
+            writer.event(new EventData("two", 2));
+            writer.event(new EventData("three", 3));
+
+            assertEquals(CONTEXT_AND_FIRST_EVENT + SECOND_EVENT + THIRD_EVENT,
+                    new String(Files.readAllBytes(file.toPath()), StandardCharsets.ISO_8859_1));
+        } finally {
+            Files.deleteIfExists(file.toPath());
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void overwriteFileRejectsContextListener() throws Exception {
+        File file = File.createTempFile("context-listener-overwrite", ".yaml");
+        try {
+            MarshallableOut out = MarshallableOut.builder(file.toURI().toURL())
+                    .wireType(WireType.YAML_ONLY)
+                    .get();
+
+            UnsupportedOperationException thrown = assertThrows(UnsupportedOperationException.class,
+                    () -> out.contextListener(ContextEvents.class,
+                            writer -> writer.context(new ContextData("schema", 7))));
+            assertEquals("contextListener requires append mode (add ?append=true to the file URL): " +
+                            "in overwrite mode each document replaces the file, discarding the context records",
+                    thrown.getMessage());
+        } finally {
+            Files.deleteIfExists(file.toPath());
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void httpWritesContextIntoEveryPostAndIncreasesCountOnlyOnOpen() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        List<String> posts = Collections.synchronizedList(new ArrayList<>());
+        server.createContext("/context", exchange -> {
+            byte[] body = IOTools.readAsBytes(exchange.getRequestBody());
+            posts.add(new String(body, StandardCharsets.ISO_8859_1));
+            exchange.sendResponseHeaders(204, -1);
+            exchange.close();
+        });
+        server.start();
+        try {
+            URL url = new URL("http://localhost:" + server.getAddress().getPort() + "/context");
+            MarshallableOut out = MarshallableOut.builder(url)
+                    .wireType(WireType.JSON_ONLY)
+                    .get();
+            out.contextListener(ContextEvents.class,
+                    writer -> writer.context(new ContextData("schema", 7)));
+
+            List<Integer> openContextCounts = new ArrayList<>();
+            List<Integer> closedContextCounts = new ArrayList<>();
+            String[] names = {"one", "two", "three"};
+            for (int i = 0; i < names.length; i++) {
+                DocumentContext dc = out.writingDocument();
+                try {
+                    openContextCounts.add(dc.contextCount());
+                    dc.wire().write("event").marshallable(new EventData(names[i], i + 1));
+                } finally {
+                    dc.close();
+                }
+                closedContextCounts.add(dc.contextCount());
+            }
+
+            assertEquals(Arrays.asList(1, 2, 3), openContextCounts);
+            assertEquals(openContextCounts, closedContextCounts);
+            assertEquals(Arrays.asList(
+                    "{\"context\":{\"name\":\"schema\",\"version\":7}}" +
+                            "{\"event\":{\"name\":\"one\",\"sequence\":1}}\n",
+                    "{\"context\":{\"name\":\"schema\",\"version\":7}}" +
+                            "{\"event\":{\"name\":\"two\",\"sequence\":2}}\n",
+                    "{\"context\":{\"name\":\"schema\",\"version\":7}}" +
+                            "{\"event\":{\"name\":\"three\",\"sequence\":3}}\n"),
+                    posts);
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    private static ContextEvents contextWriter(MarshallableOut out) {
+        out.contextListener(ContextEvents.class,
+                writer -> writer.context(new ContextData("schema", 7)));
+        return out.methodWriter(ContextEvents.class);
+    }
+
+    interface ContextEvents {
+        void context(ContextData context);
+
+        void event(EventData event);
+    }
+
+    static final class ContextData extends SelfDescribingMarshallable {
+        String name;
+        int version;
+
+        ContextData(String name, int version) {
+            this.name = name;
+            this.version = version;
+        }
+    }
+
+    static final class EventData extends SelfDescribingMarshallable {
+        String name;
+        long sequence;
+
+        EventData(String name, long sequence) {
+            this.name = name;
+            this.sequence = sequence;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Enables `contextListener(...)` for append-mode file, string-consumer, and HTTP `MarshallableOut` implementations.
- Treats append files and string consumers as one logical output context across buffer clears.
- Treats each top-level HTTP document as a new output context, so every independent POST contains the context needed to interpret it.
- Rejects context listeners for overwrite-mode files because each document replaces the file and would discard context written by an earlier document.
- Tests complete serialised output with representative context and event DTOs.

## Purpose

OpenHFT/Chronicle-Wire#1272 implements once-per-output-context listener notification on writable Wire instances. The wrappers changed here must define what an output context means for their destination and pass listener registration to the backing Wire.

Without this adapter-specific handling, HTTP can send later standalone requests without the context required to interpret them, while overwrite-mode files can appear to support context listeners even though the surviving file no longer contains that context.

## Lifecycle decisions

- **String consumer:** buffer clearing does not create a new output context, so context is emitted once before the first event.
- **Append file:** appended documents share one output context and retain the first context record in the file.
- **Overwrite file:** context listeners are rejected with an explanatory exception.
- **HTTP:** each top-level writable document represents one POST. Its one-based context count advances only when that document opens, remains unchanged when it closes, and does not advance for a nested acquired document. After a successful POST, the backing Wire is reset so its listener is rearmed before the next document.

## Stack position

This PR is stacked on OpenHFT/Chronicle-Wire#1272 and deliberately contains only concrete `MarshallableOut` adapter behaviour. It does not change the shared listener API or the core Wire lifecycle.

OpenHFT/Chronicle-Wire#1274 documents the completed Wire contract, and OpenHFT/Chronicle-Queue#1725 applies the same API to Queue roll cycles.

## Review focus

Review the chosen output-context boundaries, HTTP open/close counting, reset-versus-clear behaviour, overwrite-file rejection, and the full-output assertions.

## Validation

- `mvn -q -Dtest=DocumentContextLifecycleTest,MarshallableOutContextListenerTest test`
- `mvn -q clean verify`
