### PR TITLE
QUEUE-144: Document wire context listener contract

### DIFF
--- a/src/main/docs/decision-log.adoc
+++ b/src/main/docs/decision-log.adoc
@@ -55,3 +55,41 @@ Impact & Consequences ::
 Notes/Links ::
 ** `operational-requirements.adoc`
 ** `functional-requirements.adoc`
+
+=== [FN-008] MarshallableOut Context Listener
+
+Date :: 2026-07-23
+Context ::
+* Chronicle Queue needed to write a per-roll-file preamble before the first application excerpt,
+  generalising an earlier roll-file-specific listener.
+* The same contract applies to Wire reuse, persistent outputs and transports, but each output owns
+  different context boundaries.
+Decision Statement :: Add `MarshallableOut.ContextListener<T>` and
+`contextListener(Class<T>, ContextListener)`. Make one notification attempt before the first
+application data document in each implementation-defined output context, using a preset method
+writer.
+Alternatives Considered ::
+* Keep the listener in Queue only. ::
+  ** Pros: Smaller Wire API.
+  ** Cons: Other outputs would need separate, incompatible listener contracts.
+* Fire on every document. ::
+  ** Pros: No context lifecycle state.
+  ** Cons: A preamble belongs to the output context, not every message within it.
+Rationale for Decision ::
+* `MarshallableOut` provides the common API while the output that defines the context owns its
+  lifecycle. `AbstractWire` handles Wire generations, Queue handles roll files, and transports
+  handle request or connection generations.
+* A leading metadata document may precede the context records without changing their ordering
+  relative to application data.
+Impact & Consequences ::
+* A listener is attempted at most once per context. Failure is propagated and is not retried, so
+  listeners should write complete-or-nothing.
+* The supplied method writer is not callback-scoped and may be retained. During notification, the
+  listener writes through it rather than opening another output document.
+* Configure the listener on the outermost output before first application use. Combining listeners
+  on a wrapper and its underlying output is unsupported.
+* `Wire.reset()` starts another output context and advances `contextCount()`; `Wire.clear()`
+  retains the current context and count.
+Notes/Links ::
+** `interface-control.adoc`
+** `functional-requirements.adoc`

--- a/src/main/docs/functional-requirements.adoc
+++ b/src/main/docs/functional-requirements.adoc
@@ -60,6 +60,14 @@ depends on `chronicle-bytes` to expand buffers in zero-copy fashion (see
 xref:system-architecture.adoc#cross_cutting_concerns[System Architecture – Cross-Cutting Concerns]).
 |`src/test/java/net/openhft/chronicle/wire/ElasticBytesCapacityTest.java`,
 `src/test/java/net/openhft/chronicle/wire/ElasticByteBufferTest.java`.
+
+|FN-008
+|Notify a configured `MarshallableOut.ContextListener` before the first application data document
+of each output-owned context, and expose a `DocumentContext.contextCount()` that is non-decreasing
+across successive open documents so progressive state is resent only when the context changes.
+|`src/test/java/net/openhft/chronicle/wire/WireContextListenerLifecycleTest.java`,
+`src/test/java/net/openhft/chronicle/wire/DocumentContextLifecycleTest.java`, and
+`src/test/java/net/openhft/chronicle/wire/MarshallableOutContextListenerTest.java`.
 |===
 
 == Traceability and Updates

--- a/src/main/docs/interface-control.adoc
+++ b/src/main/docs/interface-control.adoc
@@ -32,6 +32,26 @@ applications.
 |`net.openhft.chronicle.wire.converter.LongConverter`
 |Maps textual encodings to numeric values without intermediate allocation.
 |Consumers may supply custom implementations so the SPI contract is documented in code comments.
+
+|`net.openhft.chronicle.wire.MarshallableOut.ContextListener`
+|Callback attempted at most once per output context. Contexts include first Wire use and each
+`Wire.reset()`, a Queue roll file, each HTTP POST, and each connection generation on supported
+connection-oriented outputs. The supplied method writer emits context records before the first
+application data document; leading metadata may precede them.
+|Register on the outermost output before first application use. The writer is not callback-scoped
+and emits normal method-writer documents without `MessageHistory` unless written explicitly.
+Failure is propagated and not retried for that context. Unsupported outputs, including `READ_ANY`
+wires and overwrite-mode files, reject registration with `UnsupportedOperationException`.
+
+|`net.openhft.chronicle.wire.DocumentContext#contextCount()`
+|Non-decreasing identifier of the output context containing an open document. DTOs with transient
+state can write large static context progressively and resend it only when this value increases.
+Wire starts at `1` and increments on `reset()`; Queue returns its roll cycle; HTTP counts POSTs;
+supported connection-oriented outputs count connection generations.
+|Initialise the previous count to `0` or `-1` and rewrite context only when the current value is
+greater. `clear()` and further documents in the same context leave the count unchanged; a negative
+value does not trigger a rewrite. Queue double buffering throws `IllegalStateException`, so it
+cannot be combined with progressive context-count use.
 |===
 
 == Document Lifecycle


### PR DESCRIPTION
Documents the Wire context-listener and context-count contract in the decision log and interface-control documentation.

## Why this contract exists

Some streams carry a large, stable description followed by many small value updates. Repeating the description in every document is expensive; emitting it only once globally makes independently retained or delivered contexts impossible to interpret. The contract allows an application to write context once per output-defined context - such as a Wire generation, Queue roll, HTTP request, or connection generation - so compact data remains interpretable at those boundaries.

## Direction, not scope

A future telemetry layer could use this primitive to emit source or series definitions and projection checkpoints at output-context boundaries, then write compact value events that refer to them. This PR does not define that layer, its identifiers, or its replay and checkpoint policy. It documents only the generic lifecycle needed by Queue, FIX, Services, and similar consumers.

## Review Notes

Stacked on #1273. This is kept last so implementation reviewers can focus on code before reviewing contract prose.
