### PR TITLE
QUEUE-143: Scope EOF replacement to validated recovery

### DIFF
--- a/src/main/docs/decision-log.adoc
+++ b/src/main/docs/decision-log.adoc
@@ -103,8 +103,15 @@ Impact & Consequences ::
   Chronicle Queue catches it for both ordinary document headers and sequential
   byte appends, rolls forward without replacing EOF, and does not expose it
   through its ordinary appender APIs.
-* The internal recovery operation reports whether and where it replaced the
-  marker; the coordinating storage layer emits the contextual warning.
+* The internal recovery operation performs one compare-and-swap at the current
+  write position and reports whether it replaced the marker. It does not search
+  or reposition. The coordinating storage layer validates and positions the
+  Wire first, then relies on the CAS result without a preliminary header read.
+  EOF is used with padded Wires, so the caller aligns the selected position
+  before the CAS. It emits the contextual warning with that position.
+  The CAS is a defensive invariant check rather than a concurrency protocol:
+  callers hold the storage write lock and only one recovery coordinator may
+  backfill the target at a time.
 * Wire, Queue, and Queue Enterprise changes must be validated together. Wire is
   released first, followed by Queue and Queue Enterprise, and the supported BOM
   is updated only after the coordinated combination passes its compatibility

--- a/src/main/docs/decision-log.adoc
+++ b/src/main/docs/decision-log.adoc
@@ -103,15 +103,13 @@ Impact & Consequences ::
   Chronicle Queue catches it for both ordinary document headers and sequential
   byte appends, rolls forward without replacing EOF, and does not expose it
   through its ordinary appender APIs.
-* The internal recovery operation performs one compare-and-swap at the current
-  write position and reports whether it replaced the marker. It does not search
-  or reposition. The coordinating storage layer validates and positions the
-  Wire first, then relies on the CAS result without a preliminary header read.
-  EOF is used with padded Wires, so the caller aligns the selected position
-  before the CAS. It emits the contextual warning with that position.
-  The CAS is a defensive invariant check rather than a concurrency protocol:
-  callers hold the storage write lock and only one recovery coordinator may
-  backfill the target at a time.
+* Wire exposes no EOF-recovery operation. The coordinating storage layer owns
+  recovery: it validates and aligns the padded header position, then performs
+  one compare-and-swap on the underlying Bytes without a preliminary header
+  read. It emits the contextual warning with that position. The CAS is a
+  defensive invariant check rather than a concurrency protocol: callers hold
+  the storage write lock and only one recovery coordinator may backfill the
+  target at a time.
 * Wire, Queue, and Queue Enterprise changes must be validated together. Wire is
   released first, followed by Queue and Queue Enterprise, and the supported BOM
   is updated only after the coordinated combination passes its compatibility

--- a/src/main/docs/decision-log.adoc
+++ b/src/main/docs/decision-log.adoc
@@ -91,14 +91,12 @@ Rationale for Decision ::
 Impact & Consequences ::
 * Ordinary `enterHeader` callers continue to receive `WriteAfterEOFException`.
   `WireOut.enterHeader` is marked for internal use, but its implementation hook
-  is declared on a public interface. The exception remains public and directly
-  extends checked `Exception`, so existing broad `IOException` or
-  `StreamCorruptedException` handling cannot consume it accidentally. Each
-  storage caller must handle or declare the seal condition specifically.
-  Returning a special `long` could be ignored and then treated as a valid header
-  position. This deliberately changes the former runtime-exception contract: a
-  Wire change must now fail compilation in Queue until Queue handles it, rather
-  than surface later through Queue Enterprise.
+  is declared on a public interface. The exception remains public and extends
+  `IllegalStateException`: EOF at a selected write position is an invalid state
+  unless a rolling storage boundary deliberately handles it. Returning a special
+  `long` could be ignored and then treated as a valid header position. Internal
+  paths whose ordering guarantees an unsealed position allow the exception to
+  surface as an invariant failure rather than adding defensive adapters.
 * Rolling storage implementations translate the seal signal at their boundary.
   Chronicle Queue catches it for both ordinary document headers and sequential
   byte appends, rolls forward without replacing EOF, and does not expose it

--- a/src/main/docs/decision-log.adoc
+++ b/src/main/docs/decision-log.adoc
@@ -56,7 +56,7 @@ Notes/Links ::
 ** `operational-requirements.adoc`
 ** `functional-requirements.adoc`
 
-=== [FN-003] Treat End-of-Data as Replaceable Recovery State
+=== [FN-003] Replace End-of-Data Only During Validated Recovery
 
 Date :: 2026-08-20
 Context ::
@@ -65,8 +65,9 @@ Context ::
   holds entries missing from that roll.
 * An end-of-data marker reflects the target's local state. It is not a
   consensus decision that data retained by another replica may be discarded.
-Decision Statement :: Permit a subsequent header to replace an end-of-data
-marker and emit a warning whenever this occurs.
+Decision Statement :: Keep ordinary writes sealed at end-of-data. Permit marker
+replacement only through an explicit internal recovery operation, after the
+storage layer holds its write lock and validates the exact recovery index.
 Alternatives Considered ::
 * Reject every write after end-of-data. ::
   ** Pros: Treats a sealed store as immutable.
@@ -76,16 +77,25 @@ Alternatives Considered ::
   ** Pros: Lets operators retain strict rejection.
   ** Cons: Requires clients to predict a rare failover condition and can make
   recovery depend on which differently configured node becomes leader.
+* Replace end-of-data from every header entry. ::
+  ** Pros: Restores the pre-2023 Wire behaviour with minimal code.
+  ** Cons: Cannot distinguish coordinated back-fill from an accidental write to
+  an archived, corrupt, or deliberately sealed store.
 Rationale for Decision ::
 * Available replicated data is authoritative; a marker inferred from
   incomplete local state must not cause that data to be lost.
-* A warning preserves evidence that a previously sealed position was reopened
-  without turning recovery correctness into a client configuration choice.
+* An explicit operation preserves the normal seal contract while allowing the
+  Queue exact-index path to recover authoritative replicated data.
+* Queue and its replication caller can report the queue, cycle, index and peer
+  context that Wire does not have.
 Impact & Consequences ::
-* Callers that encounter end-of-data can continue writing at that position.
-* Each actual replacement produces a warning containing the byte position.
-* Higher layers remain responsible for adding queue, cycle, index, and peer
-  context where it is available.
+* Ordinary `enterHeader` callers continue to receive `WriteAfterEOFException`.
+* The internal recovery operation reports whether and where it replaced the
+  marker; the coordinating storage layer emits the contextual warning.
+* Wire, Queue, and Queue Enterprise changes must be validated together. Wire is
+  released first, followed by Queue and Queue Enterprise, and the supported BOM
+  is updated only after the coordinated combination passes its compatibility
+  tests. Older Queue versions do not call the new operation and stay strict.
 Notes/Links ::
 ** `https://github.com/OpenHFT/Chronicle-Wire/issues/618`
 ** `https://github.com/OpenHFT/Chronicle-Wire/pull/619`

--- a/src/main/docs/decision-log.adoc
+++ b/src/main/docs/decision-log.adoc
@@ -90,6 +90,19 @@ Rationale for Decision ::
   context that Wire does not have.
 Impact & Consequences ::
 * Ordinary `enterHeader` callers continue to receive `WriteAfterEOFException`.
+  `WireOut.enterHeader` is marked for internal use, but its implementation hook
+  is declared on a public interface. The exception remains public and directly
+  extends checked `Exception`, so existing broad `IOException` or
+  `StreamCorruptedException` handling cannot consume it accidentally. Each
+  storage caller must handle or declare the seal condition specifically.
+  Returning a special `long` could be ignored and then treated as a valid header
+  position. This deliberately changes the former runtime-exception contract: a
+  Wire change must now fail compilation in Queue until Queue handles it, rather
+  than surface later through Queue Enterprise.
+* Rolling storage implementations translate the seal signal at their boundary.
+  Chronicle Queue catches it for both ordinary document headers and sequential
+  byte appends, rolls forward without replacing EOF, and does not expose it
+  through its ordinary appender APIs.
 * The internal recovery operation reports whether and where it replaced the
   marker; the coordinating storage layer emits the contextual warning.
 * Wire, Queue, and Queue Enterprise changes must be validated together. Wire is

--- a/src/main/docs/decision-log.adoc
+++ b/src/main/docs/decision-log.adoc
@@ -55,3 +55,37 @@ Impact & Consequences ::
 Notes/Links ::
 ** `operational-requirements.adoc`
 ** `functional-requirements.adoc`
+
+=== [FN-003] Treat End-of-Data as Replaceable Recovery State
+
+Date :: 2026-08-20
+Context ::
+* Replicas can receive different prefixes before a leader fails. A newly
+  elected node can therefore seal an older roll while another replica still
+  holds entries missing from that roll.
+* An end-of-data marker reflects the target's local state. It is not a
+  consensus decision that data retained by another replica may be discarded.
+Decision Statement :: Permit a subsequent header to replace an end-of-data
+marker and emit a warning whenever this occurs.
+Alternatives Considered ::
+* Reject every write after end-of-data. ::
+  ** Pros: Treats a sealed store as immutable.
+  ** Cons: Prevents exact-index back-fill from recovering data held by a more
+  complete replica after asymmetric replication and leader election.
+* Make replacement configurable by each replication deployment. ::
+  ** Pros: Lets operators retain strict rejection.
+  ** Cons: Requires clients to predict a rare failover condition and can make
+  recovery depend on which differently configured node becomes leader.
+Rationale for Decision ::
+* Available replicated data is authoritative; a marker inferred from
+  incomplete local state must not cause that data to be lost.
+* A warning preserves evidence that a previously sealed position was reopened
+  without turning recovery correctness into a client configuration choice.
+Impact & Consequences ::
+* Callers that encounter end-of-data can continue writing at that position.
+* Each actual replacement produces a warning containing the byte position.
+* Higher layers remain responsible for adding queue, cycle, index, and peer
+  context where it is available.
+Notes/Links ::
+** `https://github.com/OpenHFT/Chronicle-Wire/issues/618`
+** `https://github.com/OpenHFT/Chronicle-Wire/pull/619`

--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -352,10 +352,12 @@ public abstract class AbstractWire implements Wire, InternalWire {
                 break;
 
             if (isNotComplete(header)) {
-                if (header != END_OF_DATA)
+                if (header != END_OF_DATA) {
                     Jvm.warn().on(getClass(), new Exception("Incomplete header found at pos: " + pos + ": " + Integer.toHexString(header) + ", overwriting"));
-                else
-                    throw new WriteAfterEOFException();
+                } else {
+                    Jvm.warn().on(getClass(), "Overwriting an end-of-data marker at pos: " + pos
+                            + ". This can occur when recovering replicated data after the target was sealed from incomplete local state.");
+                }
                 bytes.writeVolatileInt(pos, NOT_INITIALIZED);
                 break;
             }

--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -330,7 +330,7 @@ public abstract class AbstractWire implements Wire, InternalWire {
     }
 
     @Override
-    public long enterHeader(long safeLength) {
+    public long enterHeader(long safeLength) throws WriteAfterEOFException {
         if (safeLength > bytes.writeRemaining()) {
             if (bytes.isElastic()) {
                 long l = bytes.writeLimit();

--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -352,11 +352,11 @@ public abstract class AbstractWire implements Wire, InternalWire {
                 break;
 
             if (isNotComplete(header)) {
-                if (header != END_OF_DATA) {
+                if (header != END_OF_DATA)
                     Jvm.warn().on(getClass(), new Exception("Incomplete header found at pos: " + pos + ": " + Integer.toHexString(header) + ", overwriting"));
-                } else {
-                    Jvm.warn().on(getClass(), "Overwriting an end-of-data marker at pos: " + pos
-                            + ". This can occur when recovering replicated data after the target was sealed from incomplete local state.");
+                else {
+                    insideHeader = false;
+                    throw new WriteAfterEOFException();
                 }
                 bytes.writeVolatileInt(pos, NOT_INITIALIZED);
                 break;
@@ -366,6 +366,25 @@ public abstract class AbstractWire implements Wire, InternalWire {
         }
         bytes.writePositionRemaining(pos + SPB_HEADER_SIZE, safeLength);
         return pos;
+    }
+
+    @Override
+    public long recoverFromEndOfData() {
+        long position = bytes.writePosition();
+        for (; ; ) {
+            if (usePadding)
+                position += BytesUtil.padOffset(position);
+
+            final int header = bytes.readVolatileInt(position);
+            if (header == END_OF_DATA) {
+                bytes.writeVolatileInt(position, NOT_INITIALIZED);
+                return position;
+            }
+            if (header == NOT_INITIALIZED || isNotComplete(header))
+                return -1;
+
+            position += lengthOf(header) + SPB_HEADER_SIZE;
+        }
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -369,11 +369,6 @@ public abstract class AbstractWire implements Wire, InternalWire {
     }
 
     @Override
-    public boolean recoverFromEndOfData() {
-        return bytes.compareAndSwapInt(bytes.writePosition(), END_OF_DATA, NOT_INITIALIZED);
-    }
-
-    @Override
     public void updateHeader(final long position, final boolean metaData, int expectedHeader) throws StreamCorruptedException {
         if (position <= 0)
             invalidPosition(position);

--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -369,22 +369,8 @@ public abstract class AbstractWire implements Wire, InternalWire {
     }
 
     @Override
-    public long recoverFromEndOfData() {
-        long position = bytes.writePosition();
-        for (; ; ) {
-            if (usePadding)
-                position += BytesUtil.padOffset(position);
-
-            final int header = bytes.readVolatileInt(position);
-            if (header == END_OF_DATA) {
-                bytes.writeVolatileInt(position, NOT_INITIALIZED);
-                return position;
-            }
-            if (header == NOT_INITIALIZED || isNotComplete(header))
-                return -1;
-
-            position += lengthOf(header) + SPB_HEADER_SIZE;
-        }
+    public boolean recoverFromEndOfData() {
+        return bytes.compareAndSwapInt(bytes.writePosition(), END_OF_DATA, NOT_INITIALIZED);
     }
 
     @Override

--- a/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/AbstractWire.java
@@ -330,7 +330,7 @@ public abstract class AbstractWire implements Wire, InternalWire {
     }
 
     @Override
-    public long enterHeader(long safeLength) throws WriteAfterEOFException {
+    public long enterHeader(long safeLength) {
         if (safeLength > bytes.writeRemaining()) {
             if (bytes.isElastic()) {
                 long l = bytes.writeLimit();

--- a/src/main/java/net/openhft/chronicle/wire/WireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireOut.java
@@ -246,13 +246,11 @@ public interface WireOut extends WireCommon, MarshallableOut {
     /**
      * INTERNAL METHOD, call writingDocument instead
      * <p>
-     * Start a header for a document. If the position contains an end-of-data
-     * marker, the marker is replaced and a warning is emitted. This permits a
-     * higher layer to recover replicated data that arrived after the target
-     * inferred the end of its locally available data.
+     * Start a header for a document.
      *
      * @param safeLength ensure there is at least this much space
      * @return the position of the header
+     * @throws WriteAfterEOFException if the target position is sealed by an end-of-data marker
      */
     long enterHeader(long safeLength);
 

--- a/src/main/java/net/openhft/chronicle/wire/WireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireOut.java
@@ -246,13 +246,18 @@ public interface WireOut extends WireCommon, MarshallableOut {
     /**
      * INTERNAL METHOD, call writingDocument instead
      * <p>
-     * Start a header for a document.
+     * Start a header for a document. Although this implementation hook is on a public interface, it
+     * is not an application API. The distinct exception forces storage implementations to handle an
+     * end-of-data marker as a hard seal; returning a special header position would allow a caller to
+     * ignore the condition accidentally. A rolling output should catch the exception at its storage
+     * boundary and move to a writable context; application code should use
+     * {@link #writingDocument()} rather than call this method directly.
      *
      * @param safeLength ensure there is at least this much space
      * @return the position of the header
      * @throws WriteAfterEOFException if the target position is sealed by an end-of-data marker
      */
-    long enterHeader(long safeLength);
+    long enterHeader(long safeLength) throws WriteAfterEOFException;
 
     /**
      * INTERNAL METHOD, call writingDocument instead

--- a/src/main/java/net/openhft/chronicle/wire/WireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireOut.java
@@ -246,11 +246,13 @@ public interface WireOut extends WireCommon, MarshallableOut {
     /**
      * INTERNAL METHOD, call writingDocument instead
      * <p>
-     * Start a header for a document
+     * Start a header for a document. If the position contains an end-of-data
+     * marker, the marker is replaced and a warning is emitted. This permits a
+     * higher layer to recover replicated data that arrived after the target
+     * inferred the end of its locally available data.
      *
      * @param safeLength ensure there is at least this much space
      * @return the position of the header
-     * @throws WriteAfterEOFException if you attempt to append an excerpt after an EOF has been written
      */
     long enterHeader(long safeLength);
 

--- a/src/main/java/net/openhft/chronicle/wire/WireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireOut.java
@@ -247,17 +247,17 @@ public interface WireOut extends WireCommon, MarshallableOut {
      * INTERNAL METHOD, call writingDocument instead
      * <p>
      * Start a header for a document. Although this implementation hook is on a public interface, it
-     * is not an application API. The distinct exception forces storage implementations to handle an
-     * end-of-data marker as a hard seal; returning a special header position would allow a caller to
-     * ignore the condition accidentally. A rolling output should catch the exception at its storage
-     * boundary and move to a writable context; application code should use
+     * is not an application API. The distinct exception identifies an end-of-data marker as a hard
+     * seal; returning a special header position would allow a caller to ignore the condition
+     * accidentally. A rolling output should catch the exception at its storage boundary and move to
+     * a writable context; application code should use
      * {@link #writingDocument()} rather than call this method directly.
      *
      * @param safeLength ensure there is at least this much space
      * @return the position of the header
      * @throws WriteAfterEOFException if the target position is sealed by an end-of-data marker
      */
-    long enterHeader(long safeLength) throws WriteAfterEOFException;
+    long enterHeader(long safeLength);
 
     /**
      * INTERNAL METHOD, call writingDocument instead

--- a/src/main/java/net/openhft/chronicle/wire/WriteAfterEOFException.java
+++ b/src/main/java/net/openhft/chronicle/wire/WriteAfterEOFException.java
@@ -7,8 +7,15 @@ package net.openhft.chronicle.wire;
  * Thrown when an ordinary document write attempts to replace an end-of-data marker.
  * Validated recovery code uses a separate internal operation and therefore does not
  * weaken this contract for normal writers.
+ * <p>
+ * This type remains public because the internal-use {@link WireOut#enterHeader(long)} implementation
+ * hook is part of a public interface. This direct checked {@link Exception} requires each storage
+ * caller to handle a sealed position explicitly and cannot be absorbed by existing broad
+ * {@code IOException} handling; a special return value could be ignored and then used as a header
+ * position. Rolling outputs such as Chronicle Queue translate this signal into their own lifecycle
+ * behaviour rather than expose it through ordinary append APIs.
  */
-public class WriteAfterEOFException extends IllegalStateException {
+public class WriteAfterEOFException extends Exception {
     private static final long serialVersionUID = 0L;
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/WriteAfterEOFException.java
+++ b/src/main/java/net/openhft/chronicle/wire/WriteAfterEOFException.java
@@ -9,13 +9,13 @@ package net.openhft.chronicle.wire;
  * weaken this contract for normal writers.
  * <p>
  * This type remains public because the internal-use {@link WireOut#enterHeader(long)} implementation
- * hook is part of a public interface. This direct checked {@link Exception} requires each storage
- * caller to handle a sealed position explicitly and cannot be absorbed by existing broad
- * {@code IOException} handling; a special return value could be ignored and then used as a header
- * position. Rolling outputs such as Chronicle Queue translate this signal into their own lifecycle
- * behaviour rather than expose it through ordinary append APIs.
+ * hook is part of a public interface. Encountering EOF at a selected write position is an illegal
+ * storage state unless a rolling output explicitly handles the signal by moving to another context.
+ * A distinct exception preserves that signal without using a special header position that could be
+ * ignored and then used as valid. Rolling outputs such as Chronicle Queue translate it into their
+ * own lifecycle behaviour rather than expose it through ordinary append APIs.
  */
-public class WriteAfterEOFException extends Exception {
+public class WriteAfterEOFException extends IllegalStateException {
     private static final long serialVersionUID = 0L;
 
     /**

--- a/src/main/java/net/openhft/chronicle/wire/WriteAfterEOFException.java
+++ b/src/main/java/net/openhft/chronicle/wire/WriteAfterEOFException.java
@@ -4,15 +4,15 @@
 package net.openhft.chronicle.wire;
 
 /**
- * Legacy exception retained for source and binary compatibility with callers
- * that handled strict end-of-data behaviour. Wire now warns and replaces an
- * end-of-data marker when a subsequent header is entered.
+ * Thrown when an ordinary document write attempts to replace an end-of-data marker.
+ * Validated recovery code uses a separate internal operation and therefore does not
+ * weaken this contract for normal writers.
  */
 public class WriteAfterEOFException extends IllegalStateException {
     private static final long serialVersionUID = 0L;
 
     /**
-     * Constructs the legacy exception with its original message.
+     * Constructs the exception with its established message.
      */
     public WriteAfterEOFException() {
         super("You should not be able to write at EOF");

--- a/src/main/java/net/openhft/chronicle/wire/WriteAfterEOFException.java
+++ b/src/main/java/net/openhft/chronicle/wire/WriteAfterEOFException.java
@@ -4,16 +4,15 @@
 package net.openhft.chronicle.wire;
 
 /**
- * This is the WriteAfterEOFException class extending IllegalStateException.
- * The exception is thrown when there's an attempt to write data after the End-Of-File (EOF) marker.
- * This is typically used to safeguard against improper file manipulation and to maintain data integrity.
+ * Legacy exception retained for source and binary compatibility with callers
+ * that handled strict end-of-data behaviour. Wire now warns and replaces an
+ * end-of-data marker when a subsequent header is entered.
  */
 public class WriteAfterEOFException extends IllegalStateException {
     private static final long serialVersionUID = 0L;
 
     /**
-     * Constructs a new instance of WriteAfterEOFException with a default error message.
-     * The message indicates that writing after EOF is not permitted.
+     * Constructs the legacy exception with its original message.
      */
     public WriteAfterEOFException() {
         super("You should not be able to write at EOF");

--- a/src/main/java/net/openhft/chronicle/wire/domestic/InternalWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/domestic/InternalWire.java
@@ -5,20 +5,4 @@ package net.openhft.chronicle.wire.domestic;
 
 public interface InternalWire {
     void forceNotInsideHeader();
-
-    /**
-     * Replaces an end-of-data marker at the current write position with one compare-and-swap.
-     * End-of-data markers are used with padded Wires. Callers must hold their storage write lock,
-     * align and position the Wire at the validated recovery target, and ensure that write position
-     * is correct before invoking this operation. This method does not search for an end-of-data
-     * marker or adjust the write position. The compare-and-swap is a defensive invariant check, not
-     * coordination between concurrent recovery writers; the storage layer must permit only one
-     * active recovery coordinator for the target.
-     *
-     * @return {@code true} if the marker was replaced, or {@code false} if the current write
-     * position did not contain an end-of-data marker
-     */
-    default boolean recoverFromEndOfData() {
-        throw new UnsupportedOperationException("End-of-data recovery is not supported by this Wire");
-    }
 }

--- a/src/main/java/net/openhft/chronicle/wire/domestic/InternalWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/domestic/InternalWire.java
@@ -5,4 +5,15 @@ package net.openhft.chronicle.wire.domestic;
 
 public interface InternalWire {
     void forceNotInsideHeader();
+
+    /**
+     * Replaces an end-of-data marker encountered from the current write position.
+     * Callers must hold their storage write lock and validate the recovery target
+     * before invoking this operation, then use ordinary strict header entry.
+     *
+     * @return the replaced marker's byte position, or {@code -1} if none was present
+     */
+    default long recoverFromEndOfData() {
+        throw new UnsupportedOperationException("End-of-data recovery is not supported by this Wire");
+    }
 }

--- a/src/main/java/net/openhft/chronicle/wire/domestic/InternalWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/domestic/InternalWire.java
@@ -7,13 +7,18 @@ public interface InternalWire {
     void forceNotInsideHeader();
 
     /**
-     * Replaces an end-of-data marker encountered from the current write position.
-     * Callers must hold their storage write lock and validate the recovery target
-     * before invoking this operation, then use ordinary strict header entry.
+     * Replaces an end-of-data marker at the current write position with one compare-and-swap.
+     * End-of-data markers are used with padded Wires. Callers must hold their storage write lock,
+     * align and position the Wire at the validated recovery target, and ensure that write position
+     * is correct before invoking this operation. This method does not search for an end-of-data
+     * marker or adjust the write position. The compare-and-swap is a defensive invariant check, not
+     * coordination between concurrent recovery writers; the storage layer must permit only one
+     * active recovery coordinator for the target.
      *
-     * @return the replaced marker's byte position, or {@code -1} if none was present
+     * @return {@code true} if the marker was replaced, or {@code false} if the current write
+     * position did not contain an end-of-data marker
      */
-    default long recoverFromEndOfData() {
+    default boolean recoverFromEndOfData() {
         throw new UnsupportedOperationException("End-of-data recovery is not supported by this Wire");
     }
 }

--- a/src/test/java/net/openhft/chronicle/wire/WriteOverEOFTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WriteOverEOFTest.java
@@ -33,7 +33,8 @@ public class WriteOverEOFTest extends WireTestCommon {
     }
 
     @Test
-    public void explicitRecoveryReplacesEOFAndRemainsUsable() throws StreamCorruptedException {
+    public void explicitRecoveryReplacesEOFAndRemainsUsable()
+            throws StreamCorruptedException, WriteAfterEOFException {
         final Bytes<?> bytes = Bytes.allocateElasticOnHeap();
         try {
             final Wire wire = WireType.BINARY.apply(bytes);
@@ -59,7 +60,8 @@ public class WriteOverEOFTest extends WireTestCommon {
         }
     }
 
-    private static void writeFramed(Wire wire, String value) throws StreamCorruptedException {
+    private static void writeFramed(Wire wire, String value)
+            throws StreamCorruptedException, WriteAfterEOFException {
         final long headerPosition = wire.enterHeader(128);
         wire.write("value").text(value);
         wire.updateHeader(headerPosition, false, 0);

--- a/src/test/java/net/openhft/chronicle/wire/WriteOverEOFTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WriteOverEOFTest.java
@@ -21,6 +21,7 @@ public class WriteOverEOFTest extends WireTestCommon {
         final Bytes<?> bytes = Bytes.allocateElasticOnHeap();
         try {
             final Wire wire = WireType.BINARY.apply(bytes);
+            wire.usePadding(true);
             final long eofPosition = 64;
             bytes.writePosition(eofPosition);
             bytes.writeInt(eofPosition, END_OF_DATA);
@@ -38,13 +39,14 @@ public class WriteOverEOFTest extends WireTestCommon {
         final Bytes<?> bytes = Bytes.allocateElasticOnHeap();
         try {
             final Wire wire = WireType.BINARY.apply(bytes);
+            wire.usePadding(true);
             final long eofPosition = 64;
             bytes.writePosition(eofPosition);
             bytes.writeInt(eofPosition, END_OF_DATA);
 
-            assertEquals(eofPosition, ((net.openhft.chronicle.wire.domestic.InternalWire) wire)
+            assertTrue(((net.openhft.chronicle.wire.domestic.InternalWire) wire)
                     .recoverFromEndOfData());
-            assertEquals(-1, ((net.openhft.chronicle.wire.domestic.InternalWire) wire)
+            assertFalse(((net.openhft.chronicle.wire.domestic.InternalWire) wire)
                     .recoverFromEndOfData());
             writeFramed(wire, "recovered");
             writeFramed(wire, "after-recovery");
@@ -55,6 +57,28 @@ public class WriteOverEOFTest extends WireTestCommon {
             try (DocumentContext context = wire.readingDocument()) {
                 assertFalse(context.isPresent());
             }
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+
+    @Test
+    public void recoveryDoesNotSearchPastTheCurrentWritePosition() {
+        final Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        try {
+            final Wire wire = WireType.BINARY.apply(bytes);
+            wire.usePadding(true);
+            final long currentPosition = 64;
+            final long laterEofPosition = 72;
+            bytes.writeInt(currentPosition, 4);
+            bytes.writeInt(currentPosition + Integer.BYTES, 0x12345678);
+            bytes.writeInt(laterEofPosition, END_OF_DATA);
+            bytes.writePosition(currentPosition);
+
+            assertFalse(((net.openhft.chronicle.wire.domestic.InternalWire) wire)
+                    .recoverFromEndOfData());
+            assertEquals(END_OF_DATA, bytes.readVolatileInt(laterEofPosition));
+            assertEquals(currentPosition, bytes.writePosition());
         } finally {
             bytes.releaseLast();
         }

--- a/src/test/java/net/openhft/chronicle/wire/WriteOverEOFTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WriteOverEOFTest.java
@@ -44,10 +44,8 @@ public class WriteOverEOFTest extends WireTestCommon {
             bytes.writePosition(eofPosition);
             bytes.writeInt(eofPosition, END_OF_DATA);
 
-            assertTrue(((net.openhft.chronicle.wire.domestic.InternalWire) wire)
-                    .recoverFromEndOfData());
-            assertFalse(((net.openhft.chronicle.wire.domestic.InternalWire) wire)
-                    .recoverFromEndOfData());
+            assertTrue(bytes.compareAndSwapInt(eofPosition, END_OF_DATA, Wires.NOT_INITIALIZED));
+            assertFalse(bytes.compareAndSwapInt(eofPosition, END_OF_DATA, Wires.NOT_INITIALIZED));
             writeFramed(wire, "recovered");
             writeFramed(wire, "after-recovery");
 
@@ -57,28 +55,6 @@ public class WriteOverEOFTest extends WireTestCommon {
             try (DocumentContext context = wire.readingDocument()) {
                 assertFalse(context.isPresent());
             }
-        } finally {
-            bytes.releaseLast();
-        }
-    }
-
-    @Test
-    public void recoveryDoesNotSearchPastTheCurrentWritePosition() {
-        final Bytes<?> bytes = Bytes.allocateElasticOnHeap();
-        try {
-            final Wire wire = WireType.BINARY.apply(bytes);
-            wire.usePadding(true);
-            final long currentPosition = 64;
-            final long laterEofPosition = 72;
-            bytes.writeInt(currentPosition, 4);
-            bytes.writeInt(currentPosition + Integer.BYTES, 0x12345678);
-            bytes.writeInt(laterEofPosition, END_OF_DATA);
-            bytes.writePosition(currentPosition);
-
-            assertFalse(((net.openhft.chronicle.wire.domestic.InternalWire) wire)
-                    .recoverFromEndOfData());
-            assertEquals(END_OF_DATA, bytes.readVolatileInt(laterEofPosition));
-            assertEquals(currentPosition, bytes.writePosition());
         } finally {
             bytes.releaseLast();
         }

--- a/src/test/java/net/openhft/chronicle/wire/WriteOverEOFTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WriteOverEOFTest.java
@@ -35,7 +35,7 @@ public class WriteOverEOFTest extends WireTestCommon {
 
     @Test
     public void explicitRecoveryReplacesEOFAndRemainsUsable()
-            throws StreamCorruptedException, WriteAfterEOFException {
+            throws StreamCorruptedException {
         final Bytes<?> bytes = Bytes.allocateElasticOnHeap();
         try {
             final Wire wire = WireType.BINARY.apply(bytes);
@@ -61,7 +61,7 @@ public class WriteOverEOFTest extends WireTestCommon {
     }
 
     private static void writeFramed(Wire wire, String value)
-            throws StreamCorruptedException, WriteAfterEOFException {
+            throws StreamCorruptedException {
         final long headerPosition = wire.enterHeader(128);
         wire.write("value").text(value);
         wire.updateHeader(headerPosition, false, 0);

--- a/src/test/java/net/openhft/chronicle/wire/WriteOverEOFTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WriteOverEOFTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.wire;
+
+import net.openhft.chronicle.bytes.Bytes;
+import org.junit.Test;
+
+import java.io.StreamCorruptedException;
+
+import static net.openhft.chronicle.wire.Wires.END_OF_DATA;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class WriteOverEOFTest extends WireTestCommon {
+
+    @Test
+    public void overwritesEOFWithWarningAndRemainsUsable() throws StreamCorruptedException {
+        final Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        try {
+            final Wire wire = WireType.BINARY.apply(bytes);
+            final long eofPosition = 64;
+            bytes.writePosition(eofPosition);
+            bytes.writeInt(eofPosition, END_OF_DATA);
+
+            expectException("Overwriting an end-of-data marker at pos: " + eofPosition);
+            writeFramed(wire, "recovered");
+            writeFramed(wire, "after-recovery");
+
+            bytes.readPosition(eofPosition);
+            assertEquals("recovered", read(wire));
+            assertEquals("after-recovery", read(wire));
+            try (DocumentContext context = wire.readingDocument()) {
+                assertFalse(context.isPresent());
+            }
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+
+    private static void writeFramed(Wire wire, String value) throws StreamCorruptedException {
+        final long headerPosition = wire.enterHeader(128);
+        wire.write("value").text(value);
+        wire.updateHeader(headerPosition, false, 0);
+    }
+
+    private static String read(Wire wire) {
+        try (DocumentContext context = wire.readingDocument()) {
+            assertTrue(context.isPresent());
+            return context.wire().read("value").text();
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/wire/WriteOverEOFTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/WriteOverEOFTest.java
@@ -11,12 +11,13 @@ import java.io.StreamCorruptedException;
 import static net.openhft.chronicle.wire.Wires.END_OF_DATA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class WriteOverEOFTest extends WireTestCommon {
 
     @Test
-    public void overwritesEOFWithWarningAndRemainsUsable() throws StreamCorruptedException {
+    public void ordinaryWriteRemainsSealedAtEOF() {
         final Bytes<?> bytes = Bytes.allocateElasticOnHeap();
         try {
             final Wire wire = WireType.BINARY.apply(bytes);
@@ -24,7 +25,26 @@ public class WriteOverEOFTest extends WireTestCommon {
             bytes.writePosition(eofPosition);
             bytes.writeInt(eofPosition, END_OF_DATA);
 
-            expectException("Overwriting an end-of-data marker at pos: " + eofPosition);
+            assertThrows(WriteAfterEOFException.class, () -> wire.enterHeader(128));
+            assertFalse(((AbstractWire) wire).isInsideHeader());
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+
+    @Test
+    public void explicitRecoveryReplacesEOFAndRemainsUsable() throws StreamCorruptedException {
+        final Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        try {
+            final Wire wire = WireType.BINARY.apply(bytes);
+            final long eofPosition = 64;
+            bytes.writePosition(eofPosition);
+            bytes.writeInt(eofPosition, END_OF_DATA);
+
+            assertEquals(eofPosition, ((net.openhft.chronicle.wire.domestic.InternalWire) wire)
+                    .recoverFromEndOfData());
+            assertEquals(-1, ((net.openhft.chronicle.wire.domestic.InternalWire) wire)
+                    .recoverFromEndOfData());
             writeFramed(wire, "recovered");
             writeFramed(wire, "after-recovery");
 


### PR DESCRIPTION
## Why

Exact-index replication can need to restore authoritative data into an older cycle that the target sealed from incomplete local state. Normal writes must not acquire the same permission: an EOF marker can also represent an archived, deliberately sealed, or corrupt store.

## What changed

- Ordinary `enterHeader` calls remain strict and continue to throw `WriteAfterEOFException` at EOF.
- `InternalWire.recoverFromEndOfData()` is the explicit recovery-only primitive. It reports the replaced byte position and is not exposed through generic `WireOut`.
- The decision log requires Queue to hold its write lock and validate the exact recovery index before invoking the primitive.
- Wire no longer claims that EOF is an unconditional soft marker or that `WriteAfterEOFException` is legacy.
- Focused tests distinguish an ordinary rejected write from explicit recovery and verify later documents remain readable.

## Coordination and compatibility

This change is intended to ship only with OpenHFT/Chronicle-Queue#1732 and ChronicleEnterprise/Chronicle-Queue-Enterprise#945. Queue owns exact-index validation, contextual warnings, dirty-cycle tracking, and EOF restoration; CQE owns the replication trigger and peer context. The supported BOM must be updated only after that combination passes.

Older Queue versions never call the new internal operation and therefore remain strict with this Wire version.

## Validation

- `mvn -q -o -Dtest=WriteOverEOFTest test`
- Queue recovery, normalisation, and ordinary-write focused tests
- CQE production-path A/B/C replication recovery test
- `git diff --check` across all three repositories

Depends on the coordinated Queue and CQE changes above.
