### PR TITLE
[#414] Enforce final-field safety at deserialisation writes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -434,6 +434,32 @@
             </properties>
         </profile>
 
+        <!--
+          Migration gate for #414. The allow-list contains exact legacy DTO type
+          names; every other test fails before a final-field reference write.
+          Remove a type when its read strategy is migrated.
+        -->
+        <profile>
+            <id>strict-final-fields</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables combine.children="append">
+                                <wire.strictFinalFields>true</wire.strictFinalFields>
+                                <wire.strictFinalFields.allowlist>java.math.MathContext,java.rmi.server.ObjID,java.rmi.server.UID,java.security.AllPermission,java.time.ZoneRegion,java.util.Currency,java.util.SimpleTimeZone,net.openhft.chronicle.wire.FloatDtoTest$Value,net.openhft.chronicle.wire.ForwardAndBackwardCompatibilityMarshallableTest$MDTO2,net.openhft.chronicle.wire.Issue341Test$MyComparableSerializable,net.openhft.chronicle.wire.JsonWireDoubleAndFloatSpecialValuesAcceptanceTests$DoubleDto,net.openhft.chronicle.wire.JsonWireDoubleAndFloatSpecialValuesAcceptanceTests$FloatDto,net.openhft.chronicle.wire.MethodReaderArgumentsRecycleTest$MyDto,net.openhft.chronicle.wire.MyTypes,net.openhft.chronicle.wire.OverrideAValueTest$ParentHolder,net.openhft.chronicle.wire.TestJsonIssue467$ResponseItem467,net.openhft.chronicle.wire.TextWireTest$FieldWithEnum,net.openhft.chronicle.wire.UsingTestMarshallableTest$MarshableFilter,net.openhft.chronicle.wire.WiresTest$EnumThing,net.openhft.chronicle.wire.bytesmarshallable.NestedGenericTest$ValueHolder,net.openhft.chronicle.wire.bytesmarshallable.NestedGenericTest$ValueHolderDef,net.openhft.chronicle.wire.dynenum.WireDynamicEnumTest$WDENum2,net.openhft.chronicle.wire.dynenum.WireDynamicEnumTest$WDENums,net.openhft.chronicle.wire.method.VanillaMethodReaderTest$MRT1,net.openhft.chronicle.wire.method.VanillaMethodReaderTest$MRT2,net.openhft.chronicle.wire.recursive.ReferToBaseClass,net.openhft.chronicle.wire.recursive.ReferToSameClass,net.openhft.chronicle.wire.serializable.MonetaTest$NonScalarComparable</wire.strictFinalFields.allowlist>
+                            </systemPropertyVariables>
+                            <excludes>
+                                <exclude>**/FinalFieldWarningTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <profile>
             <id>run-benchmarks</id>
             <build>

--- a/src/main/docs/decision-log.adoc
+++ b/src/main/docs/decision-log.adoc
@@ -55,3 +55,38 @@ Impact & Consequences ::
 Notes/Links ::
 ** `operational-requirements.adoc`
 ** `functional-requirements.adoc`
+
+=== [RISK-004] Enforce Final-Field Safety at the Mutation Boundary
+
+Date :: 2026-08-22
+Context ::
+* Field-based deserialisation can change `final` fields through Unsafe or
+  reflection, allowing JVM constant folding to expose a stale value.
+* A cached marshaller is also used for serialisation, and future immutable
+  support may construct values without mutating final fields.
+Decision Statement :: Cache field metadata, but evaluate final-field policy
+immediately before field-based deserialisation writes a final field. Warn once
+per target class by default and evaluate strict mode before every such write.
+Alternatives Considered ::
+* Check when a marshaller is created. ::
+  ** Pros: Simple and performed once.
+  ** Cons: Warns on writes, can consume the warning before a read, and lets a
+  cached marshaller bypass a later strict-mode change.
+* Reject every type that declares a final field. ::
+  ** Pros: Conservative type-level rule.
+  ** Cons: Rejects safe constructor materialisation and final collection
+  references whose contents can be updated without replacing the reference.
+Rationale for Decision ::
+* The policy now observes the hazardous action rather than type discovery.
+* Constructor-based readers do not use the field-write path and therefore do
+  not produce a false warning.
+Impact & Consequences ::
+* Serialisation and direct `WireMarshaller.of` calls do not warn.
+* A missing field does not warn with `overwrite=false`; resetting it from a
+  default with `overwrite=true` does warn or fail before the write.
+* Throwable marshallers use the same policy.
+* Tests retain an exact legacy DTO type allow-list. The `strict-final-fields`
+  Maven profile still runs their owning tests, permits only those named types,
+  and fails on any new unsafe final-field reference write.
+Notes/Links ::
+** `https://github.com/OpenHFT/Chronicle-Wire/issues/414`

--- a/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
+++ b/src/main/java/net/openhft/chronicle/wire/WireMarshaller.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.*;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -43,6 +44,19 @@ public class WireMarshaller<T> {
     private static final Class[] UNEXPECTED_FIELDS_PARAMETER_TYPES = {Object.class, ValueIn.class};
     // An empty array of {@link FieldAccess}, used for classes that have no marshallable fields such as interfaces or some enum types
     private static final FieldAccess[] NO_FIELDS = {};
+    /**
+     * Chronicle-Wire#414: deserialisation overwrites marshallable {@code final} fields via Unsafe.
+     * That is a hazard - the JVM is permitted to treat {@code final} fields as trusted constants and
+     * constant-fold reads of them, so after a wire read a reader may observe the pre-read value.
+     * When {@code true}, field-based deserialisation fails immediately before changing a
+     * {@code final} field; when {@code false} (the default) it warns once per class at that same
+     * boundary. Marshaller discovery and serialisation do not evaluate this policy. Defaults from
+     * the {@code wire.strictFinalFields} system property.
+     */
+    private static volatile boolean strictFinalFields = Jvm.getBoolean("wire.strictFinalFields");
+    private static final Set<String> STRICT_FINAL_FIELD_ALLOWLIST = strictFinalFieldAllowlist();
+    private static final ClassValue<AtomicBoolean> FINAL_FIELD_WARNING_EMITTED =
+            ClassLocal.withInitial(ignored -> new AtomicBoolean());
     // Reflection accessor for {@link Class#isRecord()} available on Java 14+
     private static Method isRecord;
     // One entry per marshallable field of {@code T}. The ordering is preserved so that field writers can honour input order hints if provided
@@ -138,6 +152,59 @@ public class WireMarshaller<T> {
         return overridesUnexpectedFields(tClass)
                 ? new WireMarshallerForUnexpectedFields<>(fields, isLeaf, defaultObject)
                 : new WireMarshaller<>(fields, isLeaf, defaultObject);
+    }
+
+    /**
+     * Sets whether Chronicle Wire should fail immediately before field-based deserialisation
+     * changes a {@code final} field. The policy is evaluated for every read, including reads made
+     * through a previously cached marshaller.
+     *
+     * @param strict {@code true} to throw {@link IllegalStateException} before the field write,
+     *               {@code false} (default) to warn once per class
+     * @see #strictFinalFields()
+     */
+    public static void strictFinalFields(boolean strict) {
+        strictFinalFields = strict;
+    }
+
+    /**
+     * @return whether strict final-field checking is enabled
+     * @see #strictFinalFields(boolean)
+     */
+    public static boolean strictFinalFields() {
+        return strictFinalFields;
+    }
+
+    private static void beforeFinalFieldWrite(@NotNull Object target, @NotNull Field field) {
+        final Class<?> targetType = target.getClass();
+        final String message = targetType.getName() + " final field '" + field.getName() + "' is about " +
+                "to be changed by field-based deserialisation. Writing a final field via Unsafe or " +
+                "reflection is unsafe: the JVM may treat final fields as constants and constant-fold " +
+                "reads of them. Use a constructor-based deserialisation strategy, make the field " +
+                "non-final, or mark it transient. Set system property 'wire.strictFinalFields' or " +
+                "call WireMarshaller.strictFinalFields(true) to fail before the write.";
+        if (strictFinalFields && !STRICT_FINAL_FIELD_ALLOWLIST.contains(targetType.getName()))
+            throw new FinalFieldWriteException(message);
+        if (FINAL_FIELD_WARNING_EMITTED.get(targetType).compareAndSet(false, true))
+            Jvm.warn().on(targetType, message);
+    }
+
+    private static Set<String> strictFinalFieldAllowlist() {
+        final String configured = Jvm.getProperty("wire.strictFinalFields.allowlist");
+        if (configured == null || configured.trim().isEmpty())
+            return Collections.emptySet();
+        return Collections.unmodifiableSet(Stream.of(configured.split(","))
+                .map(String::trim)
+                .filter(name -> !name.isEmpty())
+                .collect(Collectors.toSet()));
+    }
+
+    private static final class FinalFieldWriteException extends IllegalStateException {
+        private static final long serialVersionUID = 0L;
+
+        private FinalFieldWriteException(String message) {
+            super(message);
+        }
     }
 
     /**
@@ -976,6 +1043,7 @@ public class WireMarshaller<T> {
         @NotNull
         final Field field;
         final long offset;
+        final boolean finalField;
         @NotNull
         final WireKey key;
 
@@ -999,6 +1067,7 @@ public class WireMarshaller<T> {
          */
         FieldAccess(@NotNull Field field, Boolean isLeaf) {
             this.field = field;
+            finalField = Modifier.isFinal(field.getModifiers());
 
             offset = unsafeObjectFieldOffset(field);
             key = field::getName;
@@ -1290,12 +1359,15 @@ public class WireMarshaller<T> {
         protected void readValue(Object o, Object defaults, ValueIn read, boolean overwrite) throws IllegalAccessException, InvalidMarshallableException {
             if (!read.isPresent()) {
                 if (overwrite && defaults != null)
-                    copy(Objects.requireNonNull(defaults), o);
+                    setDefaultValue(Objects.requireNonNull(defaults), o);
             } else {
                 long pos = read.wireIn().bytes().readPosition();
                 try {
+                    if (!managesFinalFieldWritePolicy())
+                        beforeFieldWrite(o);
                     setValue(o, read, overwrite);
-                } catch (UnexpectedFieldHandlingException | ClassCastException | ClassNotFoundRuntimeException e) {
+                } catch (UnexpectedFieldHandlingException | ClassCastException |
+                         ClassNotFoundRuntimeException | FinalFieldWriteException e) {
                     Jvm.rethrow(e);
                 } catch (Exception e) {
                     read.wireIn().bytes().readPosition(pos);
@@ -1304,9 +1376,22 @@ public class WireMarshaller<T> {
                         read.text(sb);
                         Jvm.warn().on(getClass(), "Failed to read '" + this.field.getName() + "' with '" + sb + "' taking default", e);
                     }
-                    copy(defaults, o);
+                    setDefaultValue(defaults, o);
                 }
             }
+        }
+
+        /**
+         * @return whether this accessor checks immediately before each reference replacement,
+         * allowing it to update an existing mutable value without reporting a final-field write
+         */
+        protected boolean managesFinalFieldWritePolicy() {
+            return false;
+        }
+
+        protected final void beforeFieldWrite(Object target) {
+            if (finalField)
+                beforeFinalFieldWrite(target, field);
         }
 
         /**
@@ -1328,6 +1413,7 @@ public class WireMarshaller<T> {
          * @param o             Object to reset the value in.
          */
         protected void setDefaultValue(Object defaultObject, Object o) throws IllegalAccessException {
+            beforeFieldWrite(o);
             copy(defaultObject, o);
         }
 
@@ -1383,9 +1469,15 @@ public class WireMarshaller<T> {
             IntValue f = (IntValue) field.get(o);
             if (f == null) {
                 f = read.wireIn().newIntReference();
+                beforeFieldWrite(o);
                 field.set(o, f);
             }
             read.int32(f);
+        }
+
+        @Override
+        protected boolean managesFinalFieldWritePolicy() {
+            return true;
         }
 
         @Override
@@ -1421,9 +1513,15 @@ public class WireMarshaller<T> {
             LongValue f = (LongValue) field.get(o);
             if (f == null) {
                 f = read.wireIn().newLongReference();
+                beforeFieldWrite(o);
                 field.set(o, f);
             }
             read.int64(f);
+        }
+
+        @Override
+        protected boolean managesFinalFieldWritePolicy() {
+            return true;
         }
 
         @Override
@@ -1474,7 +1572,8 @@ public class WireMarshaller<T> {
         protected void setValue(Object o, @NotNull ValueIn read, boolean overwrite) throws IllegalAccessException {
             long pos = read.wireIn().bytes().readPosition();
             try {
-                @Nullable Object using = ObjectUtils.isImmutable(type) == ObjectUtils.Immutability.NO ? field.get(o) : null;
+                final Object previous = field.get(o);
+                @Nullable Object using = ObjectUtils.isImmutable(type) == ObjectUtils.Immutability.NO ? previous : null;
 
                 Object object = null;
                 try {
@@ -1495,16 +1594,30 @@ public class WireMarshaller<T> {
 
                 if (object instanceof SingleThreadedChecked)
                     ((SingleThreadedChecked) object).singleThreadedCheckReset();
-                field.set(o, object);
+                if (object != previous) {
+                    beforeFieldWrite(o);
+                    field.set(o, object);
+                }
 
-            } catch (UnexpectedFieldHandlingException | ClassCastException | ClassNotFoundRuntimeException e) {
+            } catch (UnexpectedFieldHandlingException | ClassCastException |
+                     ClassNotFoundRuntimeException | FinalFieldWriteException e) {
                 Jvm.rethrow(e);
             } catch (Exception e) {
                 read.wireIn().bytes().readPosition(pos);
                 Jvm.warn().on(getClass(), "Unable to parse field: " + field.getName() + ", as a marshallable as it is " + read.objectBestEffort(), e);
-                if (overwrite)
-                    field.set(o, ObjectUtils.defaultValue(field.getType()));
+                if (overwrite) {
+                    final Object defaultValue = ObjectUtils.defaultValue(field.getType());
+                    if (field.get(o) != defaultValue) {
+                        beforeFieldWrite(o);
+                        field.set(o, defaultValue);
+                    }
+                }
             }
+        }
+
+        @Override
+        protected boolean managesFinalFieldWritePolicy() {
+            return true;
         }
 
         @Override
@@ -1583,10 +1696,18 @@ public class WireMarshaller<T> {
             StringBuilder sb = unsafeGetObject(o, offset);
             if (sb == null) {
                 sb = new StringBuilder();
+                beforeFieldWrite(o);
                 unsafePutObject(o, offset, sb);
             }
-            if (read.textTo(sb) == null)
+            if (read.textTo(sb) == null) {
+                beforeFieldWrite(o);
                 unsafePutObject(o, offset, null);
+            }
+        }
+
+        @Override
+        protected boolean managesFinalFieldWritePolicy() {
+            return true;
         }
 
         @Override
@@ -1601,6 +1722,7 @@ public class WireMarshaller<T> {
                 return;
             if (sb == null) {
                 sb = new StringBuilder();
+                beforeFieldWrite(o);
                 unsafePutObject(o, offset, sb);
             }
             sb.setLength(0);
@@ -1661,8 +1783,10 @@ public class WireMarshaller<T> {
         @Override
         protected void setValue(Object o, @NotNull ValueIn read, boolean overwrite) {
             @NotNull Bytes<?> bytes = unsafeGetObject(o, offset);
-            if (bytes == null)
+            if (bytes == null) {
+                beforeFieldWrite(o);
                 unsafePutObject(o, offset, bytes = Bytes.allocateElasticOnHeap(128));
+            }
             WireIn wireIn = read.wireIn();
             if (wireIn instanceof TextWire) {
                 wireIn.consumePadding();
@@ -1671,10 +1795,37 @@ public class WireMarshaller<T> {
                     return;
                 }
             }
-            if (read.textTo(bytes) == null)
+            if (read.textTo(bytes) == null) {
+                beforeFieldWrite(o);
                 unsafePutObject(o, offset, null);
-            else
+            } else
                 bytes.singleThreadedCheckReset();
+        }
+
+        @Override
+        protected boolean managesFinalFieldWritePolicy() {
+            return true;
+        }
+
+        @Override
+        protected void setDefaultValue(Object defaultObject, Object o) {
+            final Bytes<?> fromBytes = unsafeGetObject(defaultObject, offset);
+            Bytes<?> toBytes = unsafeGetObject(o, offset);
+            if (fromBytes == toBytes)
+                return;
+            if (fromBytes == null) {
+                if (toBytes != null) {
+                    beforeFieldWrite(o);
+                    unsafePutObject(o, offset, null);
+                }
+                return;
+            }
+            if (toBytes == null) {
+                beforeFieldWrite(o);
+                unsafePutObject(o, offset, toBytes = Bytes.allocateElasticOnHeap());
+            }
+            toBytes.clear();
+            toBytes.write(fromBytes);
         }
 
         /**
@@ -1757,8 +1908,10 @@ public class WireMarshaller<T> {
         protected void setValue(Object o, @NotNull ValueIn read, boolean overwrite) throws IllegalAccessException {
             final Object arr = field.get(o);
             if (read.isNull()) {
-                if (arr != null)
+                if (arr != null) {
+                    beforeFieldWrite(o);
                     field.set(o, null);
+                }
                 return;
             }
             @NotNull List list = new ArrayList();
@@ -1769,7 +1922,13 @@ public class WireMarshaller<T> {
             Object arr2 = Array.newInstance(componentType, list.size());
             for (int i = 0; i < list.size(); i++)
                 Array.set(arr2, i, list.get(i));
+            beforeFieldWrite(o);
             field.set(o, arr2);
+        }
+
+        @Override
+        protected boolean managesFinalFieldWritePolicy() {
+            return true;
         }
 
         @Override
@@ -1831,13 +1990,22 @@ public class WireMarshaller<T> {
         protected void setValue(Object o, @NotNull ValueIn read, boolean overwrite) throws IllegalAccessException {
             final Object arr = field.get(o);
             if (read.isNull()) {
-                if (arr != null)
+                if (arr != null) {
+                    beforeFieldWrite(o);
                     field.set(o, null);
+                }
                 return;
             }
             byte[] arr2 = read.bytes((byte[]) arr);
-            if (arr2 != arr)
+            if (arr2 != arr) {
+                beforeFieldWrite(o);
                 field.set(o, arr2);
+            }
+        }
+
+        @Override
+        protected boolean managesFinalFieldWritePolicy() {
+            return true;
         }
 
         @Override
@@ -1953,12 +2121,14 @@ public class WireMarshaller<T> {
             EnumSet coll = (EnumSet) field.get(o);
             if (coll == null) {
                 coll = enumSetSupplier.get();
+                beforeFieldWrite(o);
                 field.set(o, coll);
             }
 
             if (!read.sequence(coll, addAll)) {
                 Collection defaultColl = (Collection) field.get(defaults);
                 if (defaultColl == null) {
+                    beforeFieldWrite(o);
                     field.set(o, null);
                 } else {
                     coll.clear();
@@ -2157,6 +2327,7 @@ public class WireMarshaller<T> {
             Collection coll = (Collection) field.get(o);
             if (coll == null) {
                 coll = collectionSupplier.get();
+                beforeFieldWrite(o);
                 field.set(o, coll);
             }
             if (!read.sequence(coll, (c, in2) -> {
@@ -2167,6 +2338,7 @@ public class WireMarshaller<T> {
             })) {
                 Collection defaultColl = (Collection) field.get(defaults);
                 if (defaultColl == null) {
+                    beforeFieldWrite(o);
                     field.set(o, null);
                 } else {
                     coll.clear();
@@ -2292,12 +2464,14 @@ public class WireMarshaller<T> {
             Collection coll = (Collection) field.get(o);
             if (coll == null) {
                 coll = collectionSupplier.get();
+                beforeFieldWrite(o);
                 field.set(o, coll);
             } else if (!coll.isEmpty()) {
                 coll.clear();
             }
             boolean sequenced = read.sequence(coll, seqConsumer);
             if (overwrite && !sequenced) {
+                beforeFieldWrite(o);
                 field.set(o, null);
             }
         }
@@ -2403,12 +2577,15 @@ public class WireMarshaller<T> {
             Map map = (Map) field.get(o);
             if (map == null) {
                 map = collectionSupplier.get();
+                beforeFieldWrite(o);
                 field.set(o, map);
             } else if (!map.isEmpty()) {
                 map.clear();
             }
-            if (read.marshallableAsMap(keyType, valueType, map) == null)
+            if (read.marshallableAsMap(keyType, valueType, map) == null) {
+                beforeFieldWrite(o);
                 field.set(o, null);
+            }
         }
 
         @Override

--- a/src/test/java/net/openhft/chronicle/wire/FinalFieldWarningTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/FinalFieldWarningTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.wire;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.core.Jvm;
+import net.openhft.chronicle.core.io.InvalidMarshallableException;
+import net.openhft.chronicle.core.onoes.ExceptionKey;
+import net.openhft.chronicle.core.onoes.LogLevel;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static net.openhft.chronicle.wire.WireMarshaller.WIRE_MARSHALLER_CL;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class FinalFieldWarningTest {
+
+    @Before
+    public void useWarningModeByDefault() {
+        WireMarshaller.strictFinalFields(false);
+    }
+
+    @After
+    public void reset() {
+        WireMarshaller.strictFinalFields(false);
+        Jvm.resetExceptionHandlers();
+    }
+
+    @Test
+    public void serialisingFinalFieldDoesNotWarn() {
+        final Map<ExceptionKey, Integer> exceptions = Jvm.recordExceptions();
+        final Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        try {
+            new WriteOnlyFinal(7).writeMarshallable(WireType.TEXT.apply(bytes));
+        } finally {
+            bytes.releaseLast();
+            Jvm.resetExceptionHandlers();
+        }
+
+        assertEquals(0, warningCount(exceptions, WriteOnlyFinal.class));
+    }
+
+    @Test
+    public void actualReadWarnsOncePerClass() throws InvalidMarshallableException {
+        final Map<ExceptionKey, Integer> exceptions = Jvm.recordExceptions();
+        try {
+            read(new ReadWarnFinal(1), "id: 2\n", true);
+            read(new ReadWarnFinal(3), "id: 4\n", true);
+        } finally {
+            Jvm.resetExceptionHandlers();
+        }
+
+        assertEquals(1, warningCount(exceptions, ReadWarnFinal.class));
+    }
+
+    @Test
+    public void strictModeIsAppliedAfterMarshallerWasCached() {
+        assertNotNull(WIRE_MARSHALLER_CL.get(StrictAfterCache.class));
+        final StrictAfterCache target = new StrictAfterCache(1);
+        WireMarshaller.strictFinalFields(true);
+
+        final IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                () -> read(target, "id: 9\n", true));
+
+        assertTrue(thrown.getMessage().contains("final field 'id'"));
+        assertEquals(1, target.id);
+    }
+
+    @Test
+    public void missingFinalFieldDoesNotWarnWhenOverwriteIsFalse() throws InvalidMarshallableException {
+        final Map<ExceptionKey, Integer> exceptions = Jvm.recordExceptions();
+        final MissingFinal target = new MissingFinal(7);
+        try {
+            read(target, "name: changed\n", false);
+        } finally {
+            Jvm.resetExceptionHandlers();
+        }
+
+        assertEquals(0, warningCount(exceptions, MissingFinal.class));
+        assertEquals(7, target.id);
+    }
+
+    @Test
+    public void missingFinalFieldWarnsWhenOverwriteResetsIt() throws InvalidMarshallableException {
+        final Map<ExceptionKey, Integer> exceptions = Jvm.recordExceptions();
+        final ResetMissingFinal target = new ResetMissingFinal(7);
+        try {
+            read(target, "name: changed\n", true);
+        } finally {
+            Jvm.resetExceptionHandlers();
+        }
+
+        assertEquals(1, warningCount(exceptions, ResetMissingFinal.class));
+    }
+
+    @Test
+    public void mutatingContentsOfFinalCollectionDoesNotFailStrictMode() throws InvalidMarshallableException {
+        final FinalCollection target = new FinalCollection();
+        WireMarshaller.strictFinalFields(true);
+
+        read(target, "values: [ one, two ]\n", true);
+
+        assertEquals(2, target.values.size());
+        assertEquals("one", target.values.get(0));
+    }
+
+    @Test
+    public void mutatingContentsOfFinalStringBuilderDoesNotFailStrictMode() throws InvalidMarshallableException {
+        final FinalStringBuilder target = new FinalStringBuilder();
+        WireMarshaller.strictFinalFields(true);
+
+        read(target, "text: changed\n", true);
+
+        assertEquals("changed", target.text.toString());
+    }
+
+    @Test
+    public void throwableMarshallerUsesTheSameReadPolicy() {
+        assertNotNull(WIRE_MARSHALLER_CL.get(FinalFieldException.class));
+        WireMarshaller.strictFinalFields(true);
+
+        assertThrows(IllegalStateException.class,
+                () -> read(new FinalFieldException(1), "code: 2\n", true));
+    }
+
+    @Test
+    public void classWithoutFinalFieldsReadsInStrictMode() throws InvalidMarshallableException {
+        final NoFinalField target = new NoFinalField();
+        WireMarshaller.strictFinalFields(true);
+
+        read(target, "id: 2\n", true);
+
+        assertEquals(2, target.id);
+    }
+
+    private static void read(Object target, String text, boolean overwrite) throws InvalidMarshallableException {
+        final Bytes<?> bytes = Bytes.from(text);
+        try {
+            Wires.readMarshallable(target, WireType.TEXT.apply(bytes), overwrite);
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+
+    private static int warningCount(Map<ExceptionKey, Integer> exceptions, Class<?> type) {
+        return exceptions.entrySet().stream()
+                .filter(e -> e.getKey().level == LogLevel.WARN)
+                .filter(e -> e.getKey().message != null)
+                .filter(e -> e.getKey().message.contains(type.getName()))
+                .filter(e -> e.getKey().message.contains("field-based deserialisation"))
+                .mapToInt(Map.Entry::getValue)
+                .sum();
+    }
+
+    static class WriteOnlyFinal extends SelfDescribingMarshallable {
+        final int id;
+
+        WriteOnlyFinal(int id) {
+            this.id = id;
+        }
+    }
+
+    static class ReadWarnFinal extends SelfDescribingMarshallable {
+        final int id;
+
+        ReadWarnFinal(int id) {
+            this.id = id;
+        }
+    }
+
+    static class StrictAfterCache extends SelfDescribingMarshallable {
+        final int id;
+
+        StrictAfterCache(int id) {
+            this.id = id;
+        }
+    }
+
+    static class MissingFinal extends SelfDescribingMarshallable {
+        final int id;
+        String name;
+
+        MissingFinal(int id) {
+            this.id = id;
+        }
+    }
+
+    static class ResetMissingFinal extends SelfDescribingMarshallable {
+        final int id;
+        String name;
+
+        ResetMissingFinal() {
+            this(0);
+        }
+
+        ResetMissingFinal(int id) {
+            this.id = id;
+        }
+    }
+
+    static class FinalCollection extends SelfDescribingMarshallable {
+        final List<String> values = new ArrayList<>();
+    }
+
+    static class FinalStringBuilder extends SelfDescribingMarshallable {
+        final StringBuilder text = new StringBuilder("initial");
+    }
+
+    static class FinalFieldException extends RuntimeException {
+        private static final long serialVersionUID = 0L;
+        final int code;
+
+        FinalFieldException(int code) {
+            this.code = code;
+        }
+    }
+
+    static class NoFinalField extends SelfDescribingMarshallable {
+        int id;
+    }
+}

--- a/src/test/java/net/openhft/chronicle/wire/WireTestCommon.java
+++ b/src/test/java/net/openhft/chronicle/wire/WireTestCommon.java
@@ -15,9 +15,13 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -25,6 +29,42 @@ import static org.junit.Assert.assertEquals;
 
 @SuppressWarnings({"this-escape"})
 public class WireTestCommon {
+
+    /**
+     * Known test DTOs that still exercise field-based writes to final fields.
+     * New types are deliberately not matched and therefore fail their owning test.
+     */
+    private static final Set<String> LEGACY_FINAL_FIELD_READ_ALLOWLIST =
+            Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(
+                    "java.math.MathContext",
+                    "java.rmi.server.ObjID",
+                    "java.rmi.server.UID",
+                    "java.security.AllPermission",
+                    "java.time.ZoneRegion",
+                    "java.util.Currency",
+                    "java.util.SimpleTimeZone",
+                    "net.openhft.chronicle.wire.FloatDtoTest$Value",
+                    "net.openhft.chronicle.wire.ForwardAndBackwardCompatibilityMarshallableTest$MDTO2",
+                    "net.openhft.chronicle.wire.Issue341Test$MyComparableSerializable",
+                    "net.openhft.chronicle.wire.JsonWireDoubleAndFloatSpecialValuesAcceptanceTests$DoubleDto",
+                    "net.openhft.chronicle.wire.JsonWireDoubleAndFloatSpecialValuesAcceptanceTests$FloatDto",
+                    "net.openhft.chronicle.wire.MethodReaderArgumentsRecycleTest$MyDto",
+                    "net.openhft.chronicle.wire.MyTypes",
+                    "net.openhft.chronicle.wire.OverrideAValueTest$ParentHolder",
+                    "net.openhft.chronicle.wire.TestJsonIssue467$ResponseItem467",
+                    "net.openhft.chronicle.wire.TextWireTest$FieldWithEnum",
+                    "net.openhft.chronicle.wire.UsingTestMarshallableTest$MarshableFilter",
+                    "net.openhft.chronicle.wire.WiresTest$EnumThing",
+                    "net.openhft.chronicle.wire.bytesmarshallable.NestedGenericTest$ValueHolder",
+                    "net.openhft.chronicle.wire.bytesmarshallable.NestedGenericTest$ValueHolderDef",
+                    "net.openhft.chronicle.wire.dynenum.WireDynamicEnumTest$WDENum2",
+                    "net.openhft.chronicle.wire.dynenum.WireDynamicEnumTest$WDENums",
+                    "net.openhft.chronicle.wire.method.VanillaMethodReaderTest$MRT1",
+                    "net.openhft.chronicle.wire.method.VanillaMethodReaderTest$MRT2",
+                    "net.openhft.chronicle.wire.recursive.ReferToBaseClass",
+                    "net.openhft.chronicle.wire.recursive.ReferToSameClass",
+                    "net.openhft.chronicle.wire.serializable.MonetaTest$NonScalarComparable"
+            )));
 
     // A thread dump to monitor thread states and detect unwanted thread creation
     private ThreadDump threadDump;
@@ -46,6 +86,18 @@ public class WireTestCommon {
         ignoreException("The incubating features are subject to change");
         ignoreException("NamedThreadFactory created here");
         ignoreException("Unable to find suitable cleaner service, falling back to using reflection");
+        ignoreException(k -> k.level == LogLevel.WARN && isAllowlistedFinalFieldRead(k.message),
+                "an explicitly allow-listed legacy final-field read");
+    }
+
+    private static boolean isAllowlistedFinalFieldRead(String message) {
+        if (message == null || !message.contains("field-based deserialisation"))
+            return false;
+        for (String type : LEGACY_FINAL_FIELD_READ_ALLOWLIST) {
+            if (message.startsWith(type + " final field '"))
+                return true;
+        }
+        return false;
     }
 
     // Activates the reference tracing before executing tests


### PR DESCRIPTION
## Refresh on 12 September 2026

Merged develop `42879cf5979950b5176efe368944eab1e6aa6c13` into the existing branch with normal forward commits. Updated head: `4cdba7ba19f3997d0e7bf3a0eebd2f53987b8b5f`. Both develop `42879cf5979950b5176efe368944eab1e6aa6c13` and the declared parent are ancestors of this head; both missing-commit counts are zero.

Retained current listener/EOF and textual-Wire changes. The default Java 21 test phase passed (11,412 reported tests, 298 skipped), then licence-header verification failed. Correcting the test copyright header made packaging pass. The final opt-in strict profile verification passed: 11,403 reported tests, 298 skipped. The decision log rendered with existing standalone heading-level warnings.

Default compatibility and opt-in strict read boundaries remain distinct contracts. Supported-JVM/platform CI is still required.

Local runs used Linux x86-64 and OpenJDK 21.0.12 unless Java 8 is explicitly stated (8u502). Reported test counts include skips. Commands requested zero Surefire reruns. Draft status and declared target are retained.

Earlier implementation/review notes follow. Earlier validation and performance claims apply only to their stated revisions and are superseded by the current receipt above where they differ.

---

## What changed

- Final-field policy is evaluated at the deserialisation mutation boundary, not when a cached marshaller is created.
- Serialisation and `WireMarshaller.of(...)` are silent.
- Runtime strict mode is checked before every field reference write, including through marshallers cached before strict mode was enabled.
- Warning mode reports once per target class on reads; strict mode throws before mutation.
- Missing-field behavior is explicit for `overwrite=false` and `overwrite=true`.
- Mutable final references can update their existing contents without a false warning; replacement of the reference is still guarded.
- Throwable and specialised collection/map/reference paths use the same policy.
- The test harness uses an exact legacy DTO type inventory. The `strict-final-fields` profile runs the owning tests and permits only those named migration exceptions.

## Design

The policy is attached to the deserialisation strategy. A future constructor-based immutable reader will not traverse the field-write boundary and will therefore not warn or fail merely because a type declares final fields.

## Validation

- `mvn -q -o -Dtest=FinalFieldWarningTest test`
- `mvn -q -o -Pstrict-final-fields test`
- Full default suite
- `git diff --check`

Fixes #414.
