### PR TITLE
[#477] Add opt-in minimal quoting for leading-digit strings

### DIFF
--- a/src/main/docs/decision-log.adoc
+++ b/src/main/docs/decision-log.adoc
@@ -55,3 +55,34 @@ Impact & Consequences ::
 Notes/Links ::
 ** `operational-requirements.adoc`
 ** `functional-requirements.adoc`
+
+=== [UX-005] Make Minimal String Quoting Opt-In
+
+Date :: 2026-08-22
+Context ::
+* The existing text writer quotes every string beginning with a digit, including
+  unambiguous values such as `1st`.
+* Exact text is externally visible, while removing quotes from an implicitly
+  typed scalar can change an `Object` read from String to number, boolean, null,
+  date or time.
+Decision Statement :: Preserve existing output by default. Provide opt-in
+minimal quoting that omits quotes only when the YAML reader classifies the plain
+scalar as text, and quotes ambiguous text values to preserve String typing.
+Alternatives Considered ::
+* Treat round-trip through `text()` as the only contract. ::
+  ** Pros: No production change.
+  ** Cons: Does not address unnecessary output quoting and cannot detect dynamic
+  scalar type changes.
+* Remove every leading digit from the quote rule. ::
+  ** Pros: Small implementation.
+  ** Cons: Emits numeric and date-like strings as implicitly typed scalars.
+Rationale for Decision ::
+* Opt-in preserves the established default representation.
+* Reusing the reader's scalar classification keeps writer and reader decisions
+  aligned.
+Impact & Consequences ::
+* `useMinimalQuoting(true)` emits `1st`, `123abc` and `3D-model2` without quotes.
+* Numeric, boolean, null and date-like text remains quoted and reads dynamically
+  as String.
+Notes/Links ::
+** `https://github.com/OpenHFT/Chronicle-Wire/issues/477`

--- a/src/main/java/net/openhft/chronicle/wire/TextWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/TextWire.java
@@ -2958,6 +2958,8 @@ public class TextWire extends YamlWireOut<TextWire> {
             @Nullable String text = valueIn.text();
             if (text == null || Enum.class.isAssignableFrom(strategy.type()))
                 return text;
+            if (code == '\'' || code == '"')
+                return text;
             switch (text) {
                 // Interpretation for boolean values.
                 case "true":

--- a/src/main/java/net/openhft/chronicle/wire/YamlWire.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWire.java
@@ -2400,9 +2400,9 @@ public class YamlWire extends YamlWireOut<YamlWire> {
             @Nullable StringBuilder s = textTo0(acquireStringBuilder());
             if (yt.current() == YamlToken.LITERAL)
                 return s;
-            if (StringUtils.isEqual(s, "true"))
+            if (blockQuoteChar == 0 && StringUtils.isEqual(s, "true"))
                 return true;
-            if (StringUtils.isEqual(s, "false"))
+            if (blockQuoteChar == 0 && StringUtils.isEqual(s, "false"))
                 return false;
             return readNumberOrTextFrom(blockQuoteChar, s);
         }

--- a/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
+++ b/src/main/java/net/openhft/chronicle/wire/YamlWireOut.java
@@ -17,6 +17,7 @@ import net.openhft.chronicle.core.Maths;
 import net.openhft.chronicle.core.io.IORuntimeException;
 import net.openhft.chronicle.core.io.IOTools;
 import net.openhft.chronicle.core.io.InvalidMarshallableException;
+import net.openhft.chronicle.core.util.StringUtils;
 import net.openhft.chronicle.core.pool.ClassLookup;
 import net.openhft.chronicle.core.values.*;
 import org.jetbrains.annotations.NotNull;
@@ -73,6 +74,7 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
     protected final StringBuilder sb = new StringBuilder();
     private boolean addTimeStamps = false;
     private boolean trimFirstCurly = true;
+    private boolean useMinimalQuoting;
 
     /**
      * Constructs a new instance of YamlWireOut with specified bytes and 8-bit flag.
@@ -103,6 +105,19 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
      */
     public T addTimeStamps(boolean addTimeStamps) {
         this.addTimeStamps = addTimeStamps;
+        return (T) this;
+    }
+
+    /**
+     * Selects an opt-in text quoting mode that leaves unambiguous plain strings
+     * such as {@code 1st} unquoted while quoting values that the YAML reader would
+     * infer as a number, date, boolean or null.
+     *
+     * @param useMinimalQuoting whether to minimise quotes without changing String typing
+     * @return this wire
+     */
+    public T useMinimalQuoting(boolean useMinimalQuoting) {
+        this.useMinimalQuoting = useMinimalQuoting;
         return (T) this;
     }
 
@@ -347,8 +362,12 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         if (cs.length() == 0)
             return Quotes.DOUBLE;
 
+        if (useMinimalQuoting && hasImplicitNonStringType(cs))
+            return Quotes.DOUBLE;
+
         // If string starts with special characters or ends with whitespace, use double quoteStyle.
-        if (STARTS_QUOTE_CHARS.get(cs.charAt(0)) ||
+        if ((STARTS_QUOTE_CHARS.get(cs.charAt(0)) &&
+                !(useMinimalQuoting && Character.isDigit(cs.charAt(0)))) ||
                 Character.isWhitespace(cs.charAt(cs.length() - 1)))
             return Quotes.DOUBLE;
         boolean hasSingleQuote = false;
@@ -375,6 +394,17 @@ public abstract class YamlWireOut<T extends YamlWireOut<T>> extends AbstractWire
         if (hasSingleQuote)
             return Quotes.NONE;
         return quoteStyle;
+    }
+
+    private static boolean hasImplicitNonStringType(@NotNull CharSequence value) {
+        if (StringUtils.isEqual(value, "true") ||
+                StringUtils.isEqual(value, "false") ||
+                StringUtils.isEqual(value, "null"))
+            return true;
+
+        final Object parsed = YamlWire.readNumberOrTextFrom((char) 0,
+                new StringBuilder(value));
+        return !(parsed instanceof CharSequence);
     }
 
     /**

--- a/src/test/java/net/openhft/chronicle/wire/MinimalQuotingTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MinimalQuotingTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.wire;
+
+import net.openhft.chronicle.bytes.Bytes;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MinimalQuotingTest extends WireTestCommon {
+
+    private static final Object[][] CASES = {
+            {"hello", "hello"},
+            {"1st", "1st"},
+            {"123abc", "123abc"},
+            {"3D-model2", "3D-model2"},
+            {"1234", "\"1234\""},
+            {"true", "\"true\""},
+            {"false", "\"false\""},
+            {"null", "\"null\""},
+            {"2026-08-22", "\"2026-08-22\""}
+    };
+
+    @Test
+    public void minimalQuotingHasExactOutputAndPreservesDynamicStringType() {
+        for (WireType wireType : new WireType[]{WireType.TEXT, WireType.YAML}) {
+            for (Object[] testCase : CASES)
+                assertMinimalQuoting(wireType, (String) testCase[0], (String) testCase[1]);
+        }
+    }
+
+    @Test
+    public void existingLeadingDigitOutputRemainsTheDefault() {
+        for (WireType wireType : new WireType[]{WireType.TEXT, WireType.YAML}) {
+            final Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+            try {
+                wireType.apply(bytes).getValueOut().text("1st");
+                assertEquals(wireType + " default output", "\"1st\"\n", bytes.toString());
+            } finally {
+                bytes.releaseLast();
+            }
+        }
+    }
+
+    private static void assertMinimalQuoting(WireType wireType, String value, String expectedText) {
+        final Bytes<?> bytes = Bytes.allocateElasticOnHeap();
+        try {
+            final Wire wire = wireType.apply(bytes);
+            ((YamlWireOut<?>) wire).useMinimalQuoting(true);
+            wire.getValueOut().text(value);
+
+            assertEquals(wireType + " output for " + value, expectedText + "\n", bytes.toString());
+            final Object read = wire.getValueIn().object(Object.class);
+            assertEquals(wireType + " dynamic type for " + value, String.class, read.getClass());
+            assertEquals(wireType + " value for " + value, value, read);
+        } finally {
+            bytes.releaseLast();
+        }
+    }
+}


### PR DESCRIPTION
## Refresh on 12 September 2026

Merged develop `42879cf5979950b5176efe368944eab1e6aa6c13` into the existing branch with normal forward commits. Updated head: `5a148f1f46bf94105805f8894d320751ccf0dddb`. Both develop `42879cf5979950b5176efe368944eab1e6aa6c13` and the declared parent are ancestors of this head; both missing-commit counts are zero.

Retained current listener/EOF and textual-Wire changes. Java 21 tests passed: 11,405 reported tests, 298 skipped; the test licence header was then corrected and packaging passed. A disposable composition with current #1286 and #1284 passed 51 reported quoting/type/YAML cases, one skipped. Conflicts with #1286 require retaining default Boolean-string quoting before applying the opt-in minimal-quoting rule.

The temporary integration commits were not imported into this independent PR. Coordinate the final quote-guard composition with #1286/#1284; do not deliver duplicate or regressed Boolean/numeric-string handling. Decision-log rendering retains existing standalone heading warnings.

Local runs used Linux x86-64 and OpenJDK 21.0.12 unless Java 8 is explicitly stated (8u502). Reported test counts include skips. Commands requested zero Surefire reruns. Draft status and declared target are retained.

Earlier implementation/review notes follow. Earlier validation and performance claims apply only to their stated revisions and are superseded by the current receipt above where they differ.

---

## What changed

- Added opt-in `YamlWireOut.useMinimalQuoting(boolean)` formatting.
- Default output remains unchanged for compatibility.
- In minimal mode, leading-digit alphanumeric strings such as `1st`, `123abc`, and `3D-model2` are emitted without unnecessary quotes only when YAML scalar inference still identifies them as text.
- Ambiguous values such as numbers, booleans, null, and date-like scalars remain quoted.
- Corrected dynamic object reads so quoted boolean-looking values remain `String` values.

## Contract tests

The regression test asserts both exact emitted text and `object(Object.class)` typing. It covers the reported leading-digit cases as well as `1234`, `true`, `false`, `null`, and a date-like boundary.

## Validation

- `mvn -q -o -Dtest=MinimalQuotingTest,TextWireTest,YamlWireTest test`
- `git diff --check`

Fixes #477 as an opt-in formatting improvement; this is not merely a round-trip test of the previous quoted output.
