### PR TITLE
[#227] Proposal: Constructor-based immutable DTO and record reads

### DIFF
--- a/src/main/docs/decision-log.adoc
+++ b/src/main/docs/decision-log.adoc
@@ -55,3 +55,42 @@ Impact & Consequences ::
 Notes/Links ::
 ** `operational-requirements.adoc`
 ** `functional-requirements.adoc`
+
+=== [FN-006] Propose Consumer-Gated Constructor Materialisation
+
+Date :: 2026-08-22
+Status :: Proposed; no implementation is accepted or shipped.
+Context ::
+* Issue #227 proposes a broad Manager abstraction, while the only bounded
+  candidate currently identified is constructor-based immutable reading.
+* No named consumer, carrier shape, mapping contract or compatibility rules
+  have yet passed the product gate.
+Decision Statement :: Keep constructor materialisation as a proposal until a
+consumer supplies its exact DTO shape and required mapping rules. Do not treat
+an ignored exploratory test as an accepted deliverable and do not close #227.
+Alternatives Considered ::
+* Implement the full Manager abstraction. ::
+  ** Pros: Covers creation, reading, writing, access, reuse and migration.
+  ** Cons: Its scope and value have not been established by a current consumer.
+* Implement records first. ::
+  ** Pros: Component names, order and canonical constructor are language-defined.
+  ** Cons: Requires reflective Java-version gating while the module targets Java 8.
+* Support ordinary immutable classes by inferred constructor parameters. ::
+  ** Pros: Supports Java 8 carriers.
+  ** Cons: Parameter names are not a class-file contract without `-parameters`;
+  overloaded constructors, aliases and missing values remain ambiguous.
+Rationale for Decision ::
+* The consumer must determine whether records alone suffice or ordinary classes
+  require explicit registration or annotations.
+* Constructor exceptions, aliases, missing required values and defaults must be
+  defined before implementation because constructor invocation exists to retain
+  invariants rather than bypass them.
+Impact & Consequences ::
+* The exploratory contract uses a plain carrier with a transient constructor-only
+  invariant, so the current allocate-and-set path cannot satisfy it.
+* Any future constructor strategy is treated as safe by the final-field policy;
+  only field-based mutation warns or fails.
+* If no consumer passes the gate, close #227 as not planned.
+Notes/Links ::
+** `immutable-dto-record-support-227.adoc`
+** `https://github.com/OpenHFT/Chronicle-Wire/issues/227`

--- a/src/main/docs/immutable-dto-record-support-227.adoc
+++ b/src/main/docs/immutable-dto-record-support-227.adoc
@@ -1,0 +1,59 @@
+= Immutable DTO and Record Reading Proposal (Issue #227)
+:toc:
+:sectnums:
+:lang: en-GB
+:source-highlighter: rouge
+
+Status: *Proposed and consumer-gated*. No constructor-based reader or Manager
+API is accepted or shipped by this change.
+
+== Product gate
+
+Implementation requires a named consumer to provide:
+
+* the exact carrier shape and supported Java versions;
+* whether records alone are sufficient;
+* examples covering aliases, missing values, defaults and schema evolution;
+* the required exception behaviour when constructor validation fails; and
+* compatibility expectations for existing field-based readers and writers.
+
+Without that evidence, issue #227 should be closed as not planned rather than
+turning this proposal into a general framework.
+
+== Current behaviour
+
+Chronicle Wire allocates ordinary objects and populates fields. For immutable
+classes this can bypass constructors and write final fields. Records are rejected.
+The current path therefore cannot prove or preserve constructor invariants.
+
+The exploratory ignored test uses a plain carrier with no Chronicle superclass
+or interface. Its transient checksum and validation rule are observable only if
+the constructor executes, so Unsafe allocation followed by writes to `x` and `y`
+cannot satisfy the contract.
+
+== Candidate mapping choices
+
+Records provide language-defined component names, order and a canonical
+constructor. They are the least ambiguous first slice, discovered reflectively
+when running on a supported Java version.
+
+Ordinary Java 8 immutable classes do not have a language-level canonical
+constructor. Parameter names are not normally retained in class files unless the
+class was compiled with `-parameters`. If a consumer requires these classes, the
+proposal must choose explicit registration or an annotation that defines:
+
+* constructor selection and component order;
+* wire names and aliases;
+* required and optional values;
+* primitive and reference defaults; and
+* propagation or wrapping of constructor exceptions.
+
+Matching constructors by debug metadata or parameter type alone is not an
+acceptable contract.
+
+== Relationship to final-field safety
+
+Final-field policy belongs to the deserialisation strategy. The existing
+field-based strategy warns or fails immediately before an unsafe final-field
+write. A future constructor strategy assigns final fields normally and must not
+emit that warning.

--- a/src/test/java/net/openhft/chronicle/wire/ImmutableDtoRecordSupportTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/ImmutableDtoRecordSupportTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.chronicle.wire;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * Exploratory constructor-materialisation contract for Chronicle-Wire#227.
+ * This is not an accepted implementation test until the consumer gate in
+ * {@code src/main/docs/immutable-dto-record-support-227.adoc} is satisfied.
+ */
+public class ImmutableDtoRecordSupportTest {
+
+    @Ignore("Chronicle-Wire#227: proposed contract awaits a named consumer and mapping rules")
+    @Test
+    public void plainImmutableDtoIsCreatedThroughItsConstructor() {
+        final ImmutablePoint point = WireType.TEXT.fromString(
+                ImmutablePoint.class, "{ x: 3, y: 4 }");
+
+        assertEquals(3, point.x());
+        assertEquals(4, point.y());
+        assertEquals(97, point.constructorChecksum());
+        assertThrows(IllegalArgumentException.class, () -> WireType.TEXT.fromString(
+                ImmutablePoint.class, "{ x: -1, y: 4 }"));
+    }
+
+    /**
+     * Plain external-style carrier: no Chronicle superclass or interface.
+     * The transient checksum cannot be populated by field deserialisation.
+     */
+    static final class ImmutablePoint {
+        private final int x;
+        private final int y;
+        private final transient int constructorChecksum;
+
+        ImmutablePoint(int x, int y) {
+            if (x < 0 || y < 0)
+                throw new IllegalArgumentException("coordinates must be non-negative");
+            this.x = x;
+            this.y = y;
+            constructorChecksum = x * 31 + y;
+        }
+
+        int x() {
+            return x;
+        }
+
+        int y() {
+            return y;
+        }
+
+        int constructorChecksum() {
+            return constructorChecksum;
+        }
+    }
+}


### PR DESCRIPTION
Deferred after the 11 September 2026 maintainer review. The proposed constructor-read test is ignored and supplies no DTO or record implementation. Issue #227 still has no named production consumer or bounded DTO contract. Revisit this proposal when those requirements exist; the original branch and discussion are preserved.

## Scope

This is a proposed, consumer-gated specification for constructor-based immutable DTO and record reading. It does not implement or claim acceptance of the broader `Manager<T>` abstraction from #227.

## What changed

- Records the proposal in the repository's existing AsciiDoc decision log; the duplicate Markdown decision system was removed from the branch history.
- Keeps status as **Proposed**: no implementation is accepted or shipped.
- Uses a plain external-style DTO with no Chronicle superclass or interface.
- The ignored contract test proves constructor invocation through a transient final checksum and a constructor-only rejection invariant, so `Unsafe.allocateInstance` plus final-field population cannot satisfy it.
- Defines records as the first unambiguous shape. Ordinary Java 8 immutable classes require explicit constructor/component registration or annotation rather than relying on absent `-parameters` metadata, debug information, or type guesses.
- Enumerates unresolved aliases, missing/default values, overloaded constructors, and constructor exception semantics.

## Gate

Identify a real consumer and exact DTO shape before implementation. If no consumer is identified, close #227 as not planned. Any implementation should be split into a bounded constructor-read issue rather than presented as the full Manager proposal.

## Validation

- `mvn -q -o -Dtest=ImmutableDtoRecordSupportTest test` (ignored specification compiles)
- `git diff --check`

Related to #227; this PR deliberately does not close it.
