### PR TITLE
QUEUE-144: Resolve binary document context default conflicts

### DIFF
--- a/src/main/java/net/openhft/chronicle/wire/BinaryWriteDocumentContext.java
+++ b/src/main/java/net/openhft/chronicle/wire/BinaryWriteDocumentContext.java
@@ -169,6 +169,15 @@ public class BinaryWriteDocumentContext implements WriteDocumentContext {
         return wire;
     }
 
+    @Override
+    public int contextCount() {
+        //! A concrete method resolves the otherwise conflicting MarshallableOut and DocumentContext
+        //! defaults in CQE's DelegatingAppender; compiling unchanged CQE discriminates its absence.
+        //! DocumentContextLifecycleTest#resetAdvancesContextCountWhileClearRetainsIt preserves normal
+        //! Wire/document identity as integration evidence, not a discriminator for this declaration.
+        return WriteDocumentContext.super.contextCount();
+    }
+
     /**
      * Retrieves the current position in the wire where the document starts.
      *


### PR DESCRIPTION
## Minimal downstream compilation repair

Declare `contextCount()` concretely in `BinaryWriteDocumentContext`, delegating directly to
`WriteDocumentContext.super.contextCount()`.

Following #1280, a subclass combining `BinaryWriteDocumentContext` and `MarshallableOut` inherits unrelated
`contextCount()` defaults. CQE's `DelegatingAppender`, `BufferedAppender` and `AsyncBufferedAppender` consequently fail to compile.
A concrete superclass method resolves that conflict without requiring CQE to add its own temporary implementation.

- One production file, nine added lines including the adjacent `//!` justification.
- No `UnsupportedOperationException`, conditional wrapper guard, new test, or POM change.
- Existing document-to-Wire context-count delegation is unchanged.
- A buffered output inherits its temporary Wire's context count. This does not implement Queue roll-cycle identity;
  CQE's later context-identity implementation still needs its own override.

This replaces the CQE-local workaround in ChronicleEnterprise/Chronicle-Queue-Enterprise#965.
Base is Wire `develop` at `3dd7fe5983c0133703ee72f57bced9a25270eb6f`.

## Validation

- **Wire, Java 11:** full `mvn clean verify` passes: 11,398 tests reported, zero failures/errors, 294 skipped.
  Checkstyle, Javadocs, packaging and the binary-compatibility gate also pass.
- **Before/after discriminator:** unchanged CQE production/test sources at
  `8c329d4f1f41dde1e1e8dd6df7970483c2b5c482` reproduce the three compiler errors with the base Wire JAR.
  Replacing only that dependency with the locally built patched Wire JAR fixes compilation.
- **CQE, Java 8 and Java 11:** clean focused `verify` passes with the existing
  `EnterpriseChronicleQueueTest#testSimpleByteTest*`: seven parameter combinations in each of the two Surefire executions,
  zero failures/errors/skips. Checkstyle, packaging and binary compatibility pass.
- `git diff --check` and the 144-character added-line check pass.

The CQE dependency override was temporary and has been removed; no downstream source changes or installed-JAR replacement
were needed. Wire's existing lifecycle tests preserve normal document semantics; the downstream compiler failure, not those
already-passing tests, discriminates the added declaration.

The complete CQE suite and the full TeamCity Build All pipeline were not run locally. CI must rerun against the updated Wire artifact.
