### PR TITLE
Disable automatic unit-test retries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <!-- //! A fail-first probe must run once even when CI requests retries; a Maven property would allow overrides. -->
+                    <rerunFailingTestsCount>0</rerunFailingTestsCount>
                     <!-- required for Issue327Test.date -->
                     <systemPropertyVariables>
                         <user.timezone>UTC</user.timezone>

--- a/src/main/docs/decision-log.adoc
+++ b/src/main/docs/decision-log.adoc
@@ -118,3 +118,18 @@ Impact & Consequences ::
 Notes/Links ::
 ** `https://github.com/OpenHFT/Chronicle-Wire/issues/618`
 ** `https://github.com/OpenHFT/Chronicle-Wire/pull/619`
+
+=== [TEST-004] Preserve First-Attempt Unit-Test Failures
+
+Date :: 2026-09-12
+Decision Statement ::
+* Set Surefire `rerunFailingTestsCount` to the literal value `0`.
+* Command-line properties, including `-Dsurefire.rerunFailingTestsCount=3`, must not enable automatic retries.
+Rationale for Decision ::
+* An intermittent failure must retain its original outcome for investigation.
+Validation ::
+* A probe that fails first and would pass on retry must execute once and leave Maven failed.
+* Check inherited profiles in the effective POM and retain first-attempt results from lifecycle verification.
+Impact & Consequences ::
+* Explicitly recorded, bounded repeat runs remain useful for diagnosis.
+* CI must still handle reported failures when `maven.test.failure.ignore` allows later build steps to continue.


### PR DESCRIPTION
Shared CI command lines can enable Surefire retries and turn a first-attempt failure into a successful build. Set `rerunFailingTestsCount` to a literal `0`, so `-Dsurefire.rerunFailingTestsCount=3` cannot enable automatic reruns. Record the policy in TEST-004. This follows OpenHFT/Chronicle-Core#870.

Validation used Maven 3.9.11, Surefire 3.1.2 and OpenJDK 21.0.12 with isolated baseline/candidate Maven repositories:

- Ordinary JUnit 4, ordinary JUnit 5 and dynamic JUnit 5 fail-first probes: develop invoked each twice and succeeded; this branch invoked each once and failed as intended, despite three retries requested.
- Effective default, Sonar and assertions configurations retain zero retries.
- `mvn -q clean verify -Dsurefire.rerunFailingTestsCount=3` passed: 11,403 tests reported, 298 skipped, zero failures, errors or retries.

The optional `run-benchmarks` effective-POM check could not resolve an uncached Maven Invoker plugin version in offline mode. That profile's test-skipping behaviour is unchanged. Platform CI and reviewer approval remain separate merge requirements.
